### PR TITLE
feat(server, client): support abort signal

### DIFF
--- a/packages/client/src/router.test.ts
+++ b/packages/client/src/router.test.ts
@@ -1,3 +1,4 @@
+import type { CallerOptions } from '@orpc/server'
 import { oc } from '@orpc/contract'
 import { os } from '@orpc/server'
 import { createORPCHandler, handleFetchRequest } from '@orpc/server/fetch'
@@ -45,18 +46,18 @@ describe('createRouterClient', () => {
 
     const client = createRouterClient<typeof router>({} as any)
 
-    expectTypeOf(client.ping).toEqualTypeOf<
-      (input: { value: string }) => Promise<unknown>
+    expectTypeOf(client.ping).toMatchTypeOf<
+      (input: { value: string }, options?: CallerOptions) => Promise<unknown>
     >()
-    expectTypeOf(client.pong).toEqualTypeOf<
-      (input: unknown) => Promise<{ value: string }>
+    expectTypeOf(client.pong).toMatchTypeOf<
+      (input: unknown, options?: CallerOptions) => Promise<{ value: string }>
     >()
-    expectTypeOf(client.peng).toEqualTypeOf<
-      (input: unknown) => Promise<unknown>
+    expectTypeOf(client.peng).toMatchTypeOf<
+      (input: unknown, options?: CallerOptions) => Promise<unknown>
     >()
 
-    expectTypeOf(client.nested.unique).toEqualTypeOf<
-      (input: { value: string }) => Promise<unknown>
+    expectTypeOf(client.nested.unique).toMatchTypeOf<
+      (input: { value: string }, options?: CallerOptions) => Promise<unknown>
     >()
   })
 
@@ -79,17 +80,17 @@ describe('createRouterClient', () => {
 
     const client = createRouterClient<typeof router>({} as any)
 
-    expectTypeOf(client.ping).toEqualTypeOf<
-      (input: { value: string }) => Promise<string>
+    expectTypeOf(client.ping).toMatchTypeOf<
+      (input: { value: string }, options?: CallerOptions) => Promise<string>
     >()
-    expectTypeOf(client.pong).toEqualTypeOf<
-      (input: unknown) => Promise<{ value: string }>
+    expectTypeOf(client.pong).toMatchTypeOf<
+      (input: unknown, options?: CallerOptions) => Promise<{ value: string }>
     >()
-    expectTypeOf(client.peng).toEqualTypeOf<
-      (input: unknown) => Promise<{ age: number }>
+    expectTypeOf(client.peng).toMatchTypeOf<
+      (input: unknown, options?: CallerOptions) => Promise<{ age: number }>
     >()
-    expectTypeOf(client.nested.unique).toEqualTypeOf<
-      (input: { value: string }) => Promise<string>
+    expectTypeOf(client.nested.unique).toMatchTypeOf<
+      (input: { value: string }, options?: CallerOptions) => Promise<string>
     >()
   })
 

--- a/packages/openapi/src/fetch/base-handler.ts
+++ b/packages/openapi/src/fetch/base-handler.ts
@@ -72,7 +72,7 @@ export function createOpenAPIHandler(createHonoRouter: () => Routing): FetchHand
         path,
       })
 
-      const output = await caller(mergedInput)
+      const output = await caller(mergedInput, { signal: options.signal })
 
       const { body, headers } = serializer.serialize(output)
 
@@ -88,7 +88,9 @@ export function createOpenAPIHandler(createHonoRouter: () => Routing): FetchHand
         hooks: options,
         execute: handler,
         input: options.request,
-        meta: undefined,
+        meta: {
+          signal: options.signal,
+        },
       })
     }
     catch (e) {

--- a/packages/openapi/src/fetch/server-handler.test.ts
+++ b/packages/openapi/src/fetch/server-handler.test.ts
@@ -194,4 +194,34 @@ describe.each(handlers)('openAPIServerHandler', (handler) => {
       ],
     })
   })
+
+  it('abort signal', async () => {
+    const controller = new AbortController()
+    const signal = controller.signal
+
+    const func = vi.fn()
+    const onSuccess = vi.fn()
+
+    const ping = os.func(func)
+
+    const response = await handler({
+      router: { ping },
+      request: new Request('http://localhost/ping', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ }),
+      }),
+      signal,
+      onSuccess,
+    })
+
+    expect(response?.status).toEqual(200)
+
+    expect(func).toBeCalledTimes(1)
+    expect(func.mock.calls[0]![2].signal).toBe(signal)
+    expect(onSuccess).toBeCalledTimes(1)
+    expect(func.mock.calls[0]![2].signal).toBe(signal)
+  })
 })

--- a/packages/react/src/procedure-hooks.ts
+++ b/packages/react/src/procedure-hooks.ts
@@ -171,7 +171,7 @@ export function createProcedureHooks<
       return useQuery(
         {
           queryKey: getQueryKeyFromPath(options.path, { input, type: 'query' }),
-          queryFn: () => client(input),
+          queryFn: ({ signal }) => client(input, { signal }),
           ...options_,
         },
         context.queryClient,
@@ -187,8 +187,8 @@ export function createProcedureHooks<
             input,
             type: 'infinite',
           }),
-          queryFn: ({ pageParam }) =>
-            client({ ...(input as any), cursor: pageParam }),
+          queryFn: ({ pageParam, signal }) =>
+            client({ ...(input as any), cursor: pageParam }, { signal }),
           ...(rest as any),
         },
         context.queryClient,
@@ -201,7 +201,7 @@ export function createProcedureHooks<
       return useSuspenseQuery(
         {
           queryKey: getQueryKeyFromPath(options.path, { input, type: 'query' }),
-          queryFn: () => client(input),
+          queryFn: ({ signal }) => client(input, { signal }),
           ...options_,
         },
         context.queryClient,
@@ -217,8 +217,8 @@ export function createProcedureHooks<
             input,
             type: 'infinite',
           }),
-          queryFn: ({ pageParam }) =>
-            client({ ...(input as any), cursor: pageParam }),
+          queryFn: ({ pageParam, signal }) =>
+            client({ ...(input as any), cursor: pageParam }, { signal }),
           ...(rest as any),
         },
         context.queryClient,
@@ -231,7 +231,7 @@ export function createProcedureHooks<
       return usePrefetchQuery(
         {
           queryKey: getQueryKeyFromPath(options.path, { input, type: 'query' }),
-          queryFn: () => client(input),
+          queryFn: ({ signal }) => client(input, { signal }),
           ...options_,
         },
         context.queryClient,
@@ -247,8 +247,8 @@ export function createProcedureHooks<
             input,
             type: 'infinite',
           }),
-          queryFn: ({ pageParam }) =>
-            client({ ...(input as any), cursor: pageParam }),
+          queryFn: ({ pageParam, signal }) =>
+            client({ ...(input as any), cursor: pageParam }, { signal }),
           ...(rest as any),
         },
         context.queryClient,

--- a/packages/react/src/procedure-utils.ts
+++ b/packages/react/src/procedure-utils.ts
@@ -188,7 +188,7 @@ export function createProcedureUtils<
     fetchQuery(input, options_) {
       return options.queryClient.fetchQuery({
         queryKey: getQueryKeyFromPath(options.path, { input, type: 'query' }),
-        queryFn: () => options.client(input),
+        queryFn: ({ signal }) => options.client(input, { signal }),
         ...options_,
       })
     },
@@ -199,8 +199,8 @@ export function createProcedureUtils<
           input,
           type: 'infinite',
         }),
-        queryFn: ({ pageParam }) => {
-          return options.client({ ...(input as any), pageParam } as any)
+        queryFn: ({ pageParam, signal }) => {
+          return options.client({ ...(input as any), pageParam } as any, { signal })
         },
         ...(rest as any),
       })
@@ -212,7 +212,7 @@ export function createProcedureUtils<
           input,
           type: 'query',
         }),
-        queryFn: () => options.client(input),
+        queryFn: ({ signal }) => options.client(input, { signal }),
         ...options_,
       })
     },
@@ -223,8 +223,8 @@ export function createProcedureUtils<
           input,
           type: 'infinite',
         }),
-        queryFn: ({ pageParam }) => {
-          return options.client({ ...(input as any), cursor: pageParam } as any)
+        queryFn: ({ pageParam, signal }) => {
+          return options.client({ ...(input as any), cursor: pageParam } as any, { signal })
         },
         ...(rest as any),
       })
@@ -253,7 +253,7 @@ export function createProcedureUtils<
           input,
           type: 'query',
         }),
-        queryFn: () => options.client(input),
+        queryFn: ({ signal }) => options.client(input, { signal }),
         ...options_,
       })
     },
@@ -264,8 +264,8 @@ export function createProcedureUtils<
           input,
           type: 'infinite',
         }),
-        queryFn: ({ pageParam }) => {
-          return options.client({ ...(input as any), pageParam } as any)
+        queryFn: ({ pageParam, signal }) => {
+          return options.client({ ...(input as any), pageParam } as any, { signal })
         },
         ...(rest as any),
       })

--- a/packages/react/src/use-queries/builder.ts
+++ b/packages/react/src/use-queries/builder.ts
@@ -64,7 +64,7 @@ export function createUseQueriesBuilder<
   return (input, options_) => {
     return {
       queryKey: getQueryKeyFromPath(options.path, { input, type: 'query' }),
-      queryFn: () => options.client(input),
+      queryFn: ({ signal }) => options.client(input, { signal }),
       ...options_,
     }
   }

--- a/packages/react/src/use-queries/builders.test.tsx
+++ b/packages/react/src/use-queries/builders.test.tsx
@@ -15,7 +15,7 @@ it('createUseQueriesBuilders', async () => {
 
   expect(e1.queryKey).toEqual(a1.queryKey)
 
-  expect(await (e1 as any).queryFn()).toEqual(await (a1 as any).queryFn())
+  expect(await (e1 as any).queryFn({})).toEqual(await (a1 as any).queryFn({}))
 
   const e2 = builder.user.list({})
   const a2 = createUseQueriesBuilder({
@@ -25,5 +25,5 @@ it('createUseQueriesBuilders', async () => {
 
   expect(e2.queryKey).toEqual(a2.queryKey)
 
-  expect(await (e2 as any).queryFn()).toEqual(await (a2 as any).queryFn())
+  expect(await (e2 as any).queryFn({})).toEqual(await (a2 as any).queryFn({}))
 })

--- a/packages/server/src/fetch/handle.test.ts
+++ b/packages/server/src/fetch/handle.test.ts
@@ -637,3 +637,34 @@ it('hooks', async () => {
   expect(onError).toHaveBeenCalledTimes(1)
   expect(onError).toBeCalledWith({ input: errorRequest, error: expect.any(Error), status: 'error' }, context, undefined)
 })
+
+it('abort signal', async () => {
+  const controller = new AbortController()
+  const signal = controller.signal
+
+  const func = vi.fn()
+  const onSuccess = vi.fn()
+
+  const ping = os.func(func)
+
+  const response = await handleFetchRequest({
+    router: { ping },
+    request: new Request('http://localhost/ping', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ value: '123' }),
+    }),
+    signal,
+    onSuccess,
+    handlers: [createOpenAPIServerHandler()],
+  })
+
+  expect(response?.status).toEqual(200)
+
+  expect(func).toBeCalledTimes(1)
+  expect(func.mock.calls[0]![2].signal).toBe(signal)
+  expect(onSuccess).toBeCalledTimes(1)
+  expect(func.mock.calls[0]![2].signal).toBe(signal)
+})

--- a/packages/server/src/fetch/handle.test.ts
+++ b/packages/server/src/fetch/handle.test.ts
@@ -609,7 +609,7 @@ it('hooks', async () => {
 
   expect(response.status).toEqual(200)
   expect(onSuccess).toHaveBeenCalledTimes(1)
-  expect(onSuccess).toBeCalledWith({ input: request, output: response, status: 'success' }, context, undefined)
+  expect(onSuccess).toBeCalledWith({ input: request, output: response, status: 'success' }, context, {})
   expect(onError).toHaveBeenCalledTimes(0)
 
   onSuccess.mockClear()
@@ -635,7 +635,7 @@ it('hooks', async () => {
   expect(errorResponse.status).toEqual(400)
   expect(onSuccess).toHaveBeenCalledTimes(0)
   expect(onError).toHaveBeenCalledTimes(1)
-  expect(onError).toBeCalledWith({ input: errorRequest, error: expect.any(Error), status: 'error' }, context, undefined)
+  expect(onError).toBeCalledWith({ input: errorRequest, error: expect.any(Error), status: 'error' }, context, {})
 })
 
 it('abort signal', async () => {

--- a/packages/server/src/fetch/handler.test.ts
+++ b/packages/server/src/fetch/handler.test.ts
@@ -209,4 +209,34 @@ describe('oRPCHandler', () => {
       meta: [],
     })
   })
+
+  it('abort signal', async () => {
+    const controller = new AbortController()
+    const signal = controller.signal
+
+    const func = vi.fn()
+    const onSuccess = vi.fn()
+
+    const ping = os.func(func)
+
+    const response = await handler({
+      router: { ping },
+      request: new Request('http://localhost/ping', {
+        method: 'POST',
+        headers: {
+          [ORPC_HEADER]: ORPC_HEADER_VALUE,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ data: { value: '123' }, meta: [] }),
+      }),
+      signal,
+      onSuccess,
+    })
+
+    expect(response?.status).toEqual(200)
+    expect(func).toBeCalledTimes(1)
+    expect(func.mock.calls[0]![2].signal).toBe(signal)
+    expect(onSuccess).toBeCalledTimes(1)
+    expect(func.mock.calls[0]![2].signal).toBe(signal)
+  })
 })

--- a/packages/server/src/fetch/handler.ts
+++ b/packages/server/src/fetch/handler.ts
@@ -38,7 +38,7 @@ export function createORPCHandler(): FetchHandler {
         path: match.path,
       })
 
-      const output = await caller(input)
+      const output = await caller(input, { signal: options.signal })
 
       const { body, headers } = serializer.serialize(output)
 
@@ -54,7 +54,9 @@ export function createORPCHandler(): FetchHandler {
         context: context as any,
         execute: handler,
         input: options.request,
-        meta: undefined,
+        meta: {
+          signal: options.signal,
+        },
       })
     }
     catch (e) {

--- a/packages/server/src/fetch/types.ts
+++ b/packages/server/src/fetch/types.ts
@@ -2,6 +2,7 @@
 
 import type { Hooks, PartialOnUndefinedDeep, Value } from '@orpc/shared'
 import type { Router } from '../router'
+import type { CallerOptions } from '../types'
 
 export type FetchHandlerOptions<
   TRouter extends Router<any>,
@@ -31,7 +32,9 @@ export type FetchHandlerOptions<
   context: Value<
     TRouter extends Router<infer UContext> ? UContext : never
   >
-}> & Hooks<Request, Response, TRouter extends Router<infer UContext> ? UContext : never, undefined>
+}>
+& CallerOptions
+& Hooks<Request, Response, TRouter extends Router<infer UContext> ? UContext : never, CallerOptions>
 
 export type FetchHandler = <TRouter extends Router<any>>(
   options: FetchHandlerOptions<TRouter>

--- a/packages/server/src/procedure-caller.test.ts
+++ b/packages/server/src/procedure-caller.test.ts
@@ -236,4 +236,25 @@ describe('createProcedureCaller', () => {
     expect(onFinish).toBeCalledTimes(1)
     expect(onFinish).toBeCalledWith({ input: 123, error: error2, status: 'error' }, context, meta2)
   })
+
+  it('abort signal', async () => {
+    const controller = new AbortController()
+    const signal = controller.signal
+
+    const procedure = os
+      .use(async (_, __, meta) => {
+        expect(meta.signal).toBe(signal)
+
+        return meta.next({})
+      })
+      .func((_, __, meta) => {
+        expect(meta.signal).toBe(signal)
+      })
+
+    const caller = createProcedureCaller({
+      procedure,
+    })
+
+    await caller(undefined, { signal })
+  })
 })

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -7,7 +7,15 @@ export type MergeContext<
   TB extends Context,
 > = TA extends undefined ? TB : TB extends undefined ? TA : TA & TB
 
-export interface Meta {
+export interface CallerOptions {
+  signal?: AbortSignal
+}
+
+export interface Caller<TInput, TOutput> {
+  (...opts: [input: TInput, options?: CallerOptions] | (undefined extends TInput ? [] : never)): Promise<TOutput>
+}
+
+export interface Meta extends CallerOptions {
   path: string[]
   procedure: WELL_DEFINED_PROCEDURE
 }

--- a/packages/shared/src/hook.ts
+++ b/packages/shared/src/hook.ts
@@ -9,7 +9,7 @@ export interface BaseHookMeta<TOutput> {
   next: () => Promise<TOutput>
 }
 
-export interface Hooks<TInput, TOutput, TContext, TMeta extends (Record<string, unknown> & { next?: never }) | undefined> {
+export interface Hooks<TInput, TOutput, TContext, TMeta extends (Record<string, any> & { next?: never }) | undefined> {
   execute?: Arrayable<(input: TInput, context: TContext, meta: (TMeta extends undefined ? unknown : TMeta) & BaseHookMeta<TOutput>) => Promise<TOutput>>
   onStart?: Arrayable<(state: OnStartState<TInput>, context: TContext, meta: TMeta) => Promisable<void>>
   onSuccess?: Arrayable<(state: OnSuccessState<TInput, TOutput>, context: TContext, meta: TMeta) => Promisable<void>>


### PR DESCRIPTION
Every caller, client now accept signal

```ts
const controller = new AbortController()
const signal = controller.signal
    
getting('input', { signal })
client.getting('input', { signal })
caller.getting('input', { signal })
```