### PR TITLE
feat(server)!: redesign middleware+handler parameters

### DIFF
--- a/apps/content/content/docs/client/react-query.mdx
+++ b/apps/content/content/docs/client/react-query.mdx
@@ -145,7 +145,7 @@ const router = {
   user: {
     list: os
       .input(z.object({ cursor: z.number(), limit: z.number() }))
-      .handler((input) => ({
+      .handler(({ input }) => ({
         nextCursor: input.cursor + input.limit,
         users: [], // Fetch your actual data here
       })),

--- a/apps/content/content/docs/client/react.mdx
+++ b/apps/content/content/docs/client/react.mdx
@@ -92,7 +92,7 @@ const router = {
     user: {
         list: os
         .input(z.object({ cursor: z.number(), limit: z.number() }))
-        .handler((input) => {
+        .handler(({ input }) => {
             return {
                 nextCursor: input.cursor + input.limit,
                 users: []

--- a/apps/content/content/docs/client/vue-query.mdx
+++ b/apps/content/content/docs/client/vue-query.mdx
@@ -85,7 +85,7 @@ const router = {
   user: {
     list: os
       .input(z.object({ cursor: z.number(), limit: z.number() }))
-      .handler((input) => ({
+      .handler(({ input }) => ({
         nextCursor: input.cursor + input.limit,
         users: [], // Fetch your actual data here
       })),

--- a/apps/content/content/docs/contract-first.mdx
+++ b/apps/content/content/docs/contract-first.mdx
@@ -92,9 +92,9 @@ import { contract } from 'examples/contract'
 
 export const pub = os.contract(contract) // Ensure every implement must be match contract
 export const authed = os
-  .use((input, context, meta) => {
+  .use(({ context, path, next }, input) => {
     /** put auth logic here */
-    return meta.next({})
+    return next({})
   })
   .contract(contract)
 

--- a/apps/content/content/docs/contract-first.mdx
+++ b/apps/content/content/docs/contract-first.mdx
@@ -99,7 +99,7 @@ export const authed = os
   .contract(contract)
 
 export const router = pub.router({
-  getUser: pub.getUser.handler((input, context, meta) => {
+  getUser: pub.getUser.handler(({ input, context }) => {
     return {
       username: 'example',
       avatar: 'example',
@@ -108,7 +108,7 @@ export const router = pub.router({
 
   posts: {
     getPost: pub.posts.getPost
-      .handler((input, context, meta) => {
+      .handler(({ input, context }) => {
         return {
           id: 'example',
           title: 'example',
@@ -116,7 +116,7 @@ export const router = pub.router({
         }
       }),
 
-    createPost: authed.posts.createPost.handler((input, context, meta) => {
+    createPost: authed.posts.createPost.handler(({ input, context }) => {
       return {
         id: 'example',
         title: input.title,

--- a/apps/content/content/docs/index.mdx
+++ b/apps/content/content/docs/index.mdx
@@ -59,9 +59,9 @@ export type Context = { user?: { id: string } }
 
 // global pub, authed completely optional
 export const pub = os.context<Context>()
-export const authed = pub.use((input, context, meta) => {
+export const authed = pub.use(({ context, path, next }, input) => {
   /** put auth logic here */
-  return meta.next({})
+  return next({})
 })
 
 export const router = pub.router({
@@ -92,14 +92,14 @@ export const router = pub.router({
           description: z.string(),
         }),
       )
-      .use(async (input, context, meta) => {
+      .use(async ({ context, path, next }, input) => {
         if (!context.user) {
           throw new ORPCError({
             code: 'UNAUTHORIZED',
           })
         }
 
-        const result = await meta.next({
+        const result = await next({
           context: {
             user: context.user, // from now user not undefined-able
           },

--- a/apps/content/content/docs/index.mdx
+++ b/apps/content/content/docs/index.mdx
@@ -71,7 +71,7 @@ export const router = pub.router({
         id: z.string(),
       }),
     )
-    .handler(async (input, context, meta) => {
+    .handler(async ({ input, context }) => {
       return {
         username: 'example',
         avatar: 'example',
@@ -109,7 +109,7 @@ export const router = pub.router({
 
         return result
       })
-      .handler((input, context, meta) => {
+      .handler(({ input, context }) => {
         return {
           id: 'example',
           title: 'example',
@@ -125,7 +125,7 @@ export const router = pub.router({
           thumb: oz.file().type('image/*'),
         }),
       )
-      .handler(async (input, context, meta) => {
+      .handler(async ({ input, context }) => {
         input.thumb // file upload out of the box
 
         return {

--- a/apps/content/content/docs/openapi/generator.mdx
+++ b/apps/content/content/docs/openapi/generator.mdx
@@ -20,9 +20,9 @@ export type Context = { user?: { id: string } }
 
 // global pub, authed completely optional
 export const pub = os.context<Context>()
-export const authed = pub.use((input, context, meta) => {
+export const authed = pub.use(({ context, path, next }, input) => {
   /** put auth logic here */
-  return meta.next({})
+  return next({})
 })
 
 export const router = pub.router({

--- a/apps/content/content/docs/openapi/generator.mdx
+++ b/apps/content/content/docs/openapi/generator.mdx
@@ -32,7 +32,7 @@ export const router = pub.router({
         id: z.string(),
       }),
     )
-    .handler(async (input, context, meta) => {
+    .handler(async ({ input, context }) => {
       return {
         id: input.id,
         name: 'example',
@@ -57,7 +57,7 @@ export const router = pub.router({
           description: z.string(),
         }),
       )
-      .handler((input, context, meta) => {
+      .handler(({ input, context }) => {
         return {
           id: 'example',
           title: 'example',
@@ -73,7 +73,7 @@ export const router = pub.router({
           thumb: oz.file().type('image/*'),
         }),
       )
-      .handler(async (input, context, meta) => {
+      .handler(async ({ input, context }) => {
         input.thumb // file upload out of the box
 
         return {

--- a/apps/content/content/docs/openapi/inout-structure.mdx
+++ b/apps/content/content/docs/openapi/inout-structure.mdx
@@ -32,7 +32,7 @@ const procedure = os.route({
     body: z.object({ description: z.string() }).optional(),
     headers: z.object({ 'content-type': z.string() }), // please use lowercase
   }))
-  .handler((input, context, meta) => {
+  .handler(({ input, context }) => {
     return {
       body: 'the body',
       headers: {

--- a/apps/content/content/docs/server/client.mdx
+++ b/apps/content/content/docs/server/client.mdx
@@ -22,7 +22,7 @@ const e2 = os.context<{ auth: boolean } | undefined>().handler(() => 'pong')
 const o2 = await e2() // Ok, output is 'pong'
 
 // ✅ Can call this procedure directly because undefined is assignable to 'Context'
-const getting = os.input(z.object({ name: z.string() })).handler(({ name }) => `Hello, ${name}!`)
+const getting = os.input(z.object({ name: z.string() })).handler(({ input }) => `Hello, ${input.name}!`)
 
 const router = os.router({
     getting

--- a/apps/content/content/docs/server/context.mdx
+++ b/apps/content/content/docs/server/context.mdx
@@ -20,11 +20,11 @@ import { headers } from 'next/headers'
 type ORPCContext = { db: 'fake-db', user?: { id: string } }
 const base = os.context<ORPCContext>() // define `initial context`
 
-const pub = os.context<ORPCContext>().use(async (input, context, meta) => {
+const pub = os.context<ORPCContext>().use(async ({ context, path, next }, input) => {
     const headersList = await headers()
 
     // the `user` is `middleware context`, because it is created by middleware
-    return meta.next({
+    return next({
         context: {
             user: headersList.get('Authorization') ? { id: 'example' } : undefined,
         }
@@ -48,15 +48,15 @@ If your procedure only depends on `Middleware Context`, you can
 import { os, ORPCError } from '@orpc/server'
 import { headers } from 'next/headers'
 
-const base = os.use(async (input, context, meta) => {
-    return meta.next({
+const base = os.use(async ({ context, path, next }, input) => {
+    return next({
         context: {
             db: 'fake-db',
         }
     })
 })
 
-const authMid = base.middleware(async (input, context, meta) => {
+const authMid = base.middleware(async ({ context, next, path }, input) => {
     const headersList = await headers()
     const user = headersList.get('Authorization') ? { id: 'example' } : undefined
 
@@ -64,7 +64,7 @@ const authMid = base.middleware(async (input, context, meta) => {
         throw new ORPCError({ code: 'UNAUTHORIZED' })
     }
 
-    return meta.next({
+    return next({
         context: {
             user,
         }
@@ -108,12 +108,12 @@ type ORPCContext = { user?: { id: string }, db: 'fake-db' }
 
 const base = os.context<ORPCContext>()
 
-const authMid = base.middleware((input, context, meta) => {
+const authMid = base.middleware(({ context, next, path }, input) => {
     if(!context.user) {
         throw new ORPCError({ code: 'UNAUTHORIZED' })
     }
 
-    return meta.next({
+    return next({
         context: {
             user: context.user
         }

--- a/apps/content/content/docs/server/context.mdx
+++ b/apps/content/content/docs/server/context.mdx
@@ -32,7 +32,7 @@ const pub = os.context<ORPCContext>().use(async (input, context, meta) => {
 })
 
 export const router = pub.router({
-    getUser: pub.handler((input, context, meta) => {
+    getUser: pub.handler(({ input, context }) => {
         // ^ context is combined from `initial context` and `middleware context`
     }),
 })
@@ -74,7 +74,7 @@ const authMid = base.middleware(async (input, context, meta) => {
 export const router = base.router({
     getUser: base
         .use(authMid)
-        .handler((input, context, meta) => {
+        .handler(({ input, context }) => {
             // ^ context is fully typed
         }),
 })
@@ -123,7 +123,7 @@ const authMid = base.middleware((input, context, meta) => {
 export const router = base.router({
     getUser: base
         .use(authMid)
-        .handler((input, context, meta) => {
+        .handler(({ input, context }) => {
             // ^ context is fully typed
         }),
 })

--- a/apps/content/content/docs/server/contract.mdx
+++ b/apps/content/content/docs/server/contract.mdx
@@ -85,9 +85,9 @@ export type Context = { user?: { id: string } }
 export const base = os.context<Context>()
 export const pub = base.contract(contract) // Ensure every implement must be match contract
 export const authed = base
-  .use((input, context, meta) => {
+  .use(({ context, path, next }, input) => {
     /** put auth logic here */
-    return meta.next({})
+    return next({})
   })
   .contract(contract)
 

--- a/apps/content/content/docs/server/contract.mdx
+++ b/apps/content/content/docs/server/contract.mdx
@@ -92,7 +92,7 @@ export const authed = base
   .contract(contract)
 
 export const router = pub.router({
-  getUser: pub.getUser.handler((input, context, meta) => {
+  getUser: pub.getUser.handler(({ input, context }) => {
     return {
       username: 'example',
       avatar: 'example',
@@ -101,7 +101,7 @@ export const router = pub.router({
 
   posts: {
     getPost: pub.posts.getPost
-      .handler((input, context, meta) => {
+      .handler(({ input, context }) => {
         return {
           id: 'example',
           title: 'example',
@@ -109,7 +109,7 @@ export const router = pub.router({
         }
       }),
 
-    createPost: authed.posts.createPost.handler((input, context, meta) => {
+    createPost: authed.posts.createPost.handler(({ input, context }) => {
       return {
         id: 'example',
         title: input.title,

--- a/apps/content/content/docs/server/error-handling.mdx
+++ b/apps/content/content/docs/server/error-handling.mdx
@@ -7,9 +7,9 @@ description: How to intercept, handle or log errors inside oRPC
 import { ORPCError, os } from '@orpc/server'
 
 const ping = os
-    .use(async (input, context, meta) => {
+    .use(async ({ context, path, next }, input) => {
         try {
-            const result = await meta.next({})
+            const result = await next({})
             const _output = result.output // do something on success
             return result
         } catch (e) {

--- a/apps/content/content/docs/server/error-handling.mdx
+++ b/apps/content/content/docs/server/error-handling.mdx
@@ -19,7 +19,7 @@ const ping = os
             // do something on finish
         }
     })
-    .handler((input, context, meta) => {
+    .handler(({ input, context }) => {
         throw new ORPCError({
             code: 'NOT_FOUND',
             message: 'Not found',

--- a/apps/content/content/docs/server/middleware.mdx
+++ b/apps/content/content/docs/server/middleware.mdx
@@ -114,7 +114,7 @@ export const authed = pub
             }
         })
     })
-    .handler(async (input, context, meta) => {
+    .handler(async ({ input, context }) => {
         
         const _expect1: NonNullable<typeof context['user']> = context.user
         const _expect2: string = context.say

--- a/apps/content/content/docs/server/middleware.mdx
+++ b/apps/content/content/docs/server/middleware.mdx
@@ -47,7 +47,7 @@ import { os, ORPCError } from '@orpc/server'
 import { z } from 'zod' 
 
 const canEditPostMiddleware = os
-    .middleware(async ({ context }, input: { id: string }) => { 
+    .middleware(async ({ context, next }, input: { id: string }) => { 
         // Now you can specify the input type for middleware
         return next({})
     })

--- a/apps/content/content/docs/server/middleware.mdx
+++ b/apps/content/content/docs/server/middleware.mdx
@@ -14,7 +14,7 @@ export type Context = { user?: { id: string } }
 
 export const pub = os.context<Context>()
 
-const authMiddleware = pub.middleware(async (input, context, meta) => {
+const authMiddleware = pub.middleware(async ({ context, next, path }, input) => {
     if (!context.user) {
         throw new ORPCError({
             code: 'UNAUTHORIZED',
@@ -22,7 +22,7 @@ const authMiddleware = pub.middleware(async (input, context, meta) => {
         })
     }
 
-    const result = await meta.next({
+    const result = await next({
         context: {
             user: context.user,
         }
@@ -49,7 +49,7 @@ import { z } from 'zod'
 const canEditPostMiddleware = os
     .middleware(async (input: {id: string}, context, meta) => { 
         // Now you can specify the input type for middleware
-        return meta.next({})
+        return next({})
     })
 
 os
@@ -65,12 +65,12 @@ You can merge or extend middlewares using concatenation:
 ```ts twoslash
 import { os } from '@orpc/server'
 
-const auth = os.middleware(async (input, context, meta) => meta.next({}))
-const can = os.middleware(async (input, context, meta) => meta.next({}))
+const auth = os.middleware(async ({ context, next, path }, input) => next({}))
+const can = os.middleware(async ({ context, next, path }, input) => next({}))
 
 const authAndCan = auth.concat(can) // Merge middleware
 
-const authAndCan2 = auth.concat((input, context, meta) => meta.next({})) // Extend middleware
+const authAndCan2 = auth.concat((input, context, meta) => next({})) // Extend middleware
 ```
 
 ## Extra Context
@@ -90,12 +90,12 @@ export const pub = os.context<Context>()
 
 // Any procedure using this middleware will infer context.user as NonNullable<typeof context['user']>
 const authMiddleware = pub
-    .middleware(async (input, context, meta) => {
+    .middleware(async ({ context, next, path }, input) => {
         if (!context.user) {
             throw new ORPCError({ code: 'UNAUTHORIZED' })
         }
 
-        return meta.next({
+        return next({
             context: {
                 user: context.user
             }
@@ -104,11 +104,11 @@ const authMiddleware = pub
 
 export const authed = pub
     .use(authMiddleware)
-    .use((input, context, meta) => {
+    .use(({ context, path, next }, input) => {
 
         const _expect: NonNullable<typeof context['user']> = context.user
 
-        return meta.next({
+        return next({
             context: {
                 say: 'hi'
             }
@@ -132,14 +132,14 @@ import { os } from '@orpc/server'
 
 const fakeCache = new Map<string, unknown>()
 
-const cacheMid = os.middleware(async (input, context, meta) => {
-    const cacheKey = meta.path.join('/') + JSON.stringify(input) /* stringify is not ideal, but it's just an example */
+const cacheMid = os.middleware(async ({ context, next, path }, input) => {
+    const cacheKey = path.join('/') + JSON.stringify(input) /* stringify is not ideal, but it's just an example */
 
     if (fakeCache.has(cacheKey)) {
         return meta.output(fakeCache.get(cacheKey))
     }
 
-    const result = await meta.next({})
+    const result = await next({})
     fakeCache.set(cacheKey, result.output)
     return result
 })

--- a/apps/content/content/docs/server/middleware.mdx
+++ b/apps/content/content/docs/server/middleware.mdx
@@ -47,7 +47,7 @@ import { os, ORPCError } from '@orpc/server'
 import { z } from 'zod' 
 
 const canEditPostMiddleware = os
-    .middleware(async (input: {id: string}, context, meta) => { 
+    .middleware(async ({ context }, input: { id: string }) => { 
         // Now you can specify the input type for middleware
         return next({})
     })
@@ -70,7 +70,7 @@ const can = os.middleware(async ({ context, next, path }, input) => next({}))
 
 const authAndCan = auth.concat(can) // Merge middleware
 
-const authAndCan2 = auth.concat((input, context, meta) => next({})) // Extend middleware
+const authAndCan2 = auth.concat(({ context, next, path }, input) => next({})) // Extend middleware
 ```
 
 ## Extra Context
@@ -132,11 +132,11 @@ import { os } from '@orpc/server'
 
 const fakeCache = new Map<string, unknown>()
 
-const cacheMid = os.middleware(async ({ context, next, path }, input) => {
+const cacheMid = os.middleware(async ({ context, next, path }, input, output) => {
     const cacheKey = path.join('/') + JSON.stringify(input) /* stringify is not ideal, but it's just an example */
 
     if (fakeCache.has(cacheKey)) {
-        return meta.output(fakeCache.get(cacheKey))
+        return output(fakeCache.get(cacheKey))
     }
 
     const result = await next({})

--- a/apps/content/content/docs/server/procedure.mdx
+++ b/apps/content/content/docs/server/procedure.mdx
@@ -52,7 +52,7 @@ const getUser = pub
     })
     
     // Define handler with business logic
-    .handler(async (input, context, meta) => {
+    .handler(async ({ input, context }) => {
         // Implement your business logic here
         
         return {

--- a/apps/content/content/docs/server/procedure.mdx
+++ b/apps/content/content/docs/server/procedure.mdx
@@ -26,7 +26,7 @@ const getUser = pub
     .route({ method: 'GET', path: '/{id}' }) // Optional: if you want custom api under OpenAPI Specifications
     .input(z.object({ id: z.string() })) // Optional
     .output(z.object({ id: z.string(), name: z.string() })) // Optional
-    .use(async (input, context, meta) => { // Optional
+    .use(async ({ context, path, next }, input) => { // Optional
         // Middleware runs before the handler
         // input, context, and meta are fully typed
         
@@ -39,7 +39,7 @@ const getUser = pub
         }
 
         // Modify context for next middleware/handler
-        const result = await meta.next({
+        const result = await next({
             context: {
                 user: context.user // TypeScript will infer user as NonNullable
             }

--- a/apps/content/content/docs/server/router.mdx
+++ b/apps/content/content/docs/server/router.mdx
@@ -19,9 +19,9 @@ export const usersRouter = os.prefix('/users').router({
 export const appRouter = os.router({
     users: os
         .prefix('/users')  // Prefix will be concatenated with paths defined in route(...)
-        .use((input, context, meta) => {
+        .use(({ context, path, next }, input) => {
             /* Logic applies for all routes in this router */
-            return meta.next({})
+            return next({})
         })
         .router(usersRouter),
 })
@@ -50,9 +50,9 @@ Apply middleware to all procedures in a router:
 ```ts twoslash
 import { os } from '@orpc/server'
 
-const authMiddleware = os.middleware(async (input, context, meta) => {
+const authMiddleware = os.middleware(async ({ context, next, path }, input) => {
     // ...
-    return meta.next({})
+    return next({})
 })
 
 const protectedRouter = os

--- a/apps/content/content/docs/server/server-action.mdx
+++ b/apps/content/content/docs/server/server-action.mdx
@@ -57,7 +57,7 @@ export const updateUser = os
       }),
     }),
   )
-  .handler((input, context, meta) => {
+  .handler(({ input, context }) => {
     // ^ context.user is automatically injected
      redirect('/some-where') // or return some thing
   })

--- a/apps/content/content/docs/server/server-action.mdx
+++ b/apps/content/content/docs/server/server-action.mdx
@@ -31,7 +31,7 @@ import { headers } from 'next/headers'
 import { redirect } from "next/navigation"
 import { oz } from '@orpc/zod'
 
-const authMid = os.middleware(async (input, context, meta) => {
+const authMid = os.middleware(async ({ context, next, path }, input) => {
       const headersList = await headers()
       const user = headersList.get('Authorization') ? { id: 'example' } : undefined
 
@@ -39,7 +39,7 @@ const authMid = os.middleware(async (input, context, meta) => {
           throw new ORPCError({ code: 'UNAUTHORIZED' })
       }
 
-      return meta.next({
+      return next({
           context: {
               user,
           }

--- a/apps/content/content/docs/server/server-action.mdx
+++ b/apps/content/content/docs/server/server-action.mdx
@@ -189,7 +189,7 @@ type Context = { user?: { id: string } }
 const getting = os
 .context<Context>()
 .input(z.object({ name: z.string() }))
-.handler(({ name }) => `Hello, ${name}!`)
+.handler(({ input }) => `Hello, ${input.name}!`)
 
 // @errors: 2349
 getting({ name: 'Unnoq' }) // ❌ cannot call this procedure directly, and cannot be used as a server action

--- a/apps/content/content/home/landing.mdx
+++ b/apps/content/content/home/landing.mdx
@@ -142,7 +142,7 @@ const createPost = pub
 			}
 		})
 	})
-	.handler((input, context, meta) => {
+	.handler(({ input, context }) => {
 		// ^ context.user is now guaranteed to be defined
 	})
 ```

--- a/apps/content/content/home/landing.mdx
+++ b/apps/content/content/home/landing.mdx
@@ -131,12 +131,12 @@ type ORPCContext = { db: DB, user?: { id: string } }
 const pub = os.context<ORPCContext>()
 
 const createPost = pub
-	.use((input, context, meta) => {
+	.use(({ context, path, next }, input) => {
 		if(!context.user){
 			throw new ORPCError({ code: 'UNAUTHORIZED' })
 		}
 		
-		return meta.next({
+		return next({
 			context: {
 				user: context.user // modify user context
 			}

--- a/apps/content/examples/contract.ts
+++ b/apps/content/examples/contract.ts
@@ -78,7 +78,7 @@ export const authed = base
   .contract(contract)
 
 export const router = pub.router({
-  getUser: pub.getUser.handler((input, context, meta) => {
+  getUser: pub.getUser.handler(({ input, context }) => {
     return {
       username: `user_${input.id}`,
       avatar: `avatar_${input.id}.png`,
@@ -104,7 +104,7 @@ export const router = pub.router({
 
         return result
       })
-      .handler((input, context, meta) => {
+      .handler(({ input, context }) => {
         return {
           id: 'example',
           title: 'example',
@@ -112,7 +112,7 @@ export const router = pub.router({
         }
       }),
 
-    createPost: authed.posts.createPost.handler((input, context, meta) => {
+    createPost: authed.posts.createPost.handler(({ input, context }) => {
       return {
         id: 'example',
         title: input.title,

--- a/apps/content/examples/contract.ts
+++ b/apps/content/examples/contract.ts
@@ -71,9 +71,9 @@ export type Context = { user?: { id: string } }
 export const base = os.context<Context>()
 export const pub = base.contract(contract) // Ensure every implement must be match contract
 export const authed = base
-  .use((input, context, meta) => {
+  .use(({ context, path, next }, input) => {
     /** put auth logic here */
-    return meta.next({})
+    return next({})
   })
   .contract(contract)
 
@@ -87,14 +87,14 @@ export const router = pub.router({
 
   posts: {
     getPost: pub.posts.getPost
-      .use(async (input, context, meta) => {
+      .use(async ({ context, path, next }, input) => {
         if (!context.user) {
           throw new ORPCError({
             code: 'UNAUTHORIZED',
           })
         }
 
-        const result = await meta.next({
+        const result = await next({
           context: {
             user: context.user, // from now user not undefined-able
           },

--- a/apps/content/examples/server-action.tsx
+++ b/apps/content/examples/server-action.tsx
@@ -8,7 +8,7 @@ import { redirect } from 'next/navigation'
 import * as React from 'react'
 import { z } from 'zod'
 
-const authMid = os.middleware(async (input, context, meta) => {
+const authMid = os.middleware(async ({ context, next, path }, input) => {
   const headersList = await headers()
   const user = headersList.get('Authorization') ? { id: 'example' } : undefined
 
@@ -16,7 +16,7 @@ const authMid = os.middleware(async (input, context, meta) => {
     throw new ORPCError({ code: 'UNAUTHORIZED' })
   }
 
-  return meta.next({
+  return next({
     context: {
       user,
     },

--- a/apps/content/examples/server-action.tsx
+++ b/apps/content/examples/server-action.tsx
@@ -34,7 +34,7 @@ export const updateUser = os
       }),
     }),
   )
-  .handler((input, context, meta) => {
+  .handler(({ input, context }) => {
     // ^ context.user is automatically injected
     // do something
   })

--- a/apps/content/examples/server.ts
+++ b/apps/content/examples/server.ts
@@ -7,9 +7,9 @@ export type Context = { user?: { id: string } } | undefined
 
 // global pub, authed completely optional
 export const pub = os.context<Context>()
-export const authed = pub.use((input, context, meta) => {
+export const authed = pub.use(({ context, path, next }, input) => {
   /** put auth logic here */
-  return meta.next({})
+  return next({})
 })
 
 export const router = pub.router({
@@ -44,14 +44,14 @@ export const router = pub.router({
           description: z.string(),
         }),
       )
-      .use(async (input, context, meta) => {
+      .use(async ({ context, path, next }, input) => {
         if (!context?.user) {
           throw new ORPCError({
             code: 'UNAUTHORIZED',
           })
         }
 
-        const result = await meta.next({
+        const result = await next({
           context: {
             user: context.user, // from now user not undefined-able
           },

--- a/apps/content/examples/server.ts
+++ b/apps/content/examples/server.ts
@@ -19,7 +19,7 @@ export const router = pub.router({
         id: z.string(),
       }),
     )
-    .handler(async (input, context, meta) => {
+    .handler(async ({ input, context }) => {
       return {
         id: input.id,
         name: 'example',
@@ -61,7 +61,7 @@ export const router = pub.router({
 
         return result
       })
-      .handler((input, context, meta) => {
+      .handler(({ input, context }) => {
         return {
           id: 'example',
           title: 'example',
@@ -77,7 +77,7 @@ export const router = pub.router({
           thumb: oz.file().type('image/*'),
         }),
       )
-      .handler(async (input, context, meta) => {
+      .handler(async ({ input, context }) => {
         const _thumb = input.thumb // file upload out of the box
 
         return {

--- a/packages/client/tests/helpers.ts
+++ b/packages/client/tests/helpers.ts
@@ -18,7 +18,7 @@ export const UserFindInputSchema = z
 export const userFind = orpcServer
   .input(UserFindInputSchema)
   .output(UserSchema)
-  .handler((input) => {
+  .handler(({ input }) => {
     return {
       data: {
         id: input.data.id,
@@ -44,7 +44,7 @@ export const UserListOutputSchema = z
 export const userList = orpcServer
   .input(UserListInputSchema)
   .output(UserListOutputSchema)
-  .handler((input) => {
+  .handler(({ input }) => {
     return {
       data: {
         nextCursor: input.data.cursor + 2,
@@ -72,7 +72,7 @@ export const UserCreateInputSchema = z
 export const userCreate = orpcServer
   .input(UserCreateInputSchema)
   .output(UserSchema)
-  .handler((input) => {
+  .handler(({ input }) => {
     return {
       data: {
         id: '28aa6286-48e9-4f23-adea-3486c86acd55',
@@ -81,7 +81,7 @@ export const userCreate = orpcServer
     }
   })
 
-const countFileSize = os.input(z.instanceof(Blob)).handler((input) => {
+const countFileSize = os.input(z.instanceof(Blob)).handler(({ input }) => {
   return input.size
 })
 

--- a/packages/next/src/action-form.test.ts
+++ b/packages/next/src/action-form.test.ts
@@ -6,7 +6,7 @@ import { createFormAction } from './action-form'
 describe('createFormAction', () => {
   const procedure = os.input(z.object({
     big: z.bigint(),
-  })).handler(async ({ big }) => big)
+  })).handler(async ({ input }) => input.big)
 
   it('should accept form data and auto-convert types', async () => {
     const onSuccess = vi.fn()

--- a/packages/next/src/action-safe.test.ts
+++ b/packages/next/src/action-safe.test.ts
@@ -5,7 +5,7 @@ import { createSafeAction } from './action-safe'
 describe('createSafeAction', () => {
   const procedure = os.input(z.object({
     name: z.string(),
-  })).handler(async ({ name }) => name)
+  })).handler(async ({ input }) => input.name)
 
   it('should work and catch error', () => {
     const safe = createSafeAction({ procedure, path: ['name'] })

--- a/packages/next/src/client/action-hooks.test.tsx
+++ b/packages/next/src/client/action-hooks.test.tsx
@@ -4,9 +4,9 @@ import { z } from 'zod'
 import { useAction } from './action-hooks'
 
 describe('useAction', () => {
-  const procedure = os.input(z.object({ value: z.string() })).handler(async ({ value }) => {
+  const procedure = os.input(z.object({ value: z.string() })).handler(async ({ input }) => {
     await new Promise(resolve => setTimeout(resolve, 100))
-    return value
+    return input.value
   })
 
   it('should work - on success', async () => {

--- a/packages/next/src/client/action-safe-hooks.test.tsx
+++ b/packages/next/src/client/action-safe-hooks.test.tsx
@@ -5,9 +5,9 @@ import { createSafeAction } from '../action-safe'
 import { useSafeAction } from './action-safe-hooks'
 
 describe('useSafeAction', () => {
-  const procedure = os.input(z.object({ value: z.string() })).handler(async ({ value }) => {
+  const procedure = os.input(z.object({ value: z.string() })).handler(async ({ input }) => {
     await new Promise(resolve => setTimeout(resolve, 100))
-    return value
+    return input.value
   })
 
   const safeAction = createSafeAction({ procedure })

--- a/packages/react-query/src/utils-router.test-d.ts
+++ b/packages/react-query/src/utils-router.test-d.ts
@@ -15,7 +15,7 @@ const contractRouter = oc.router({
   pong: pongContract,
 })
 
-const ping = os.contract(pingContract).handler(({ name }) => `ping ${name}`)
+const ping = os.contract(pingContract).handler(({ input }) => `ping ${input.name}`)
 const pong = os.contract(pongContract).handler(num => `pong ${num}`)
 
 const router = os.contract(contractRouter).router({

--- a/packages/react-query/tests/helpers.tsx
+++ b/packages/react-query/tests/helpers.tsx
@@ -20,7 +20,7 @@ export const UserFindInputSchema = z
 export const userFind = orpcServer
   .input(UserFindInputSchema)
   .output(UserSchema)
-  .handler((input) => {
+  .handler(({ input }) => {
     return {
       data: {
         id: input.data.id,
@@ -46,7 +46,7 @@ export const UserListOutputSchema = z
 export const userList = orpcServer
   .input(UserListInputSchema)
   .output(UserListOutputSchema)
-  .handler((input) => {
+  .handler(({ input }) => {
     return {
       data: {
         nextCursor: input.data.cursor + 2,
@@ -74,7 +74,7 @@ export const UserCreateInputSchema = z
 export const userCreate = orpcServer
   .input(UserCreateInputSchema)
   .output(UserSchema)
-  .handler((input) => {
+  .handler(({ input }) => {
     return {
       data: {
         id: '28aa6286-48e9-4f23-adea-3486c86acd55',

--- a/packages/react/tests/orpc.tsx
+++ b/packages/react/tests/orpc.tsx
@@ -22,7 +22,7 @@ export const UserFindInputSchema = z
 export const userFind = orpcServer
   .input(UserFindInputSchema)
   .output(UserSchema)
-  .handler((input) => {
+  .handler(({ input }) => {
     return {
       data: {
         id: input.data.id,
@@ -48,7 +48,7 @@ export const UserListOutputSchema = z
 export const userList = orpcServer
   .input(UserListInputSchema)
   .output(UserListOutputSchema)
-  .handler((input) => {
+  .handler(({ input }) => {
     return {
       data: {
         nextCursor: input.data.cursor + 2,
@@ -76,7 +76,7 @@ export const UserCreateInputSchema = z
 export const userCreate = orpcServer
   .input(UserCreateInputSchema)
   .output(UserSchema)
-  .handler((input) => {
+  .handler(({ input }) => {
     return {
       data: {
         id: '28aa6286-48e9-4f23-adea-3486c86acd55',

--- a/packages/server/src/builder.test-d.ts
+++ b/packages/server/src/builder.test-d.ts
@@ -6,7 +6,7 @@ import type { ANY_PROCEDURE, Procedure } from './procedure'
 import type { ProcedureBuilder } from './procedure-builder'
 import type { DecoratedProcedure } from './procedure-decorated'
 import type { AdaptedRouter, RouterBuilder } from './router-builder'
-import type { Meta, WELL_CONTEXT } from './types'
+import type { WELL_CONTEXT } from './types'
 import { oc } from '@orpc/contract'
 import { z } from 'zod'
 import { Builder } from './builder'
@@ -117,10 +117,12 @@ describe('to ProcedureBuilder', () => {
 
 describe('to DecoratedProcedure', () => {
   it('handler', () => {
-    expectTypeOf(builder.handler((input, context, meta) => {
+    expectTypeOf(builder.handler(({ input, context, procedure, path, signal }) => {
       expectTypeOf(input).toEqualTypeOf<unknown>()
       expectTypeOf(context).toEqualTypeOf<{ auth: boolean } & { db: string }>()
-      expectTypeOf(meta).toEqualTypeOf<Meta>()
+      expectTypeOf(procedure).toEqualTypeOf<ANY_PROCEDURE>()
+      expectTypeOf(path).toEqualTypeOf<string[]>()
+      expectTypeOf(signal).toEqualTypeOf<undefined | InstanceType<typeof AbortSignal>>()
 
       return 456
     })).toMatchTypeOf<

--- a/packages/server/src/builder.test-d.ts
+++ b/packages/server/src/builder.test-d.ts
@@ -1,6 +1,6 @@
 import type { ChainableImplementer } from './implementer-chainable'
 import type { DecoratedLazy } from './lazy-decorated'
-import type { Middleware, MiddlewareMeta } from './middleware'
+import type { Middleware, MiddlewareOutputFn } from './middleware'
 import type { DecoratedMiddleware } from './middleware-decorated'
 import type { ANY_PROCEDURE, Procedure } from './procedure'
 import type { ProcedureBuilder } from './procedure-builder'
@@ -52,12 +52,14 @@ describe('self chainable', () => {
 
 describe('create middleware', () => {
   it('works', () => {
-    const mid = builder.middleware((input, context, meta) => {
+    const mid = builder.middleware(({ context, next, path, procedure }, input, output) => {
       expectTypeOf(input).toEqualTypeOf<unknown>()
       expectTypeOf(context).toEqualTypeOf<{ auth: boolean } & { db: string }>()
-      expectTypeOf(meta).toEqualTypeOf<MiddlewareMeta<any>>()
+      expectTypeOf(path).toEqualTypeOf<string[]>()
+      expectTypeOf(procedure).toEqualTypeOf<ANY_PROCEDURE>()
+      expectTypeOf(output).toEqualTypeOf<MiddlewareOutputFn<any>>()
 
-      return meta.next({
+      return next({
         context: {
           dev: true,
         },
@@ -69,7 +71,7 @@ describe('create middleware', () => {
     >()
 
     // @ts-expect-error - conflict extra context and context
-    builder.middleware((input, context, meta) => meta.next({
+    builder.middleware(({ context, next, path }, input) => next({
       context: {
         auth: 'invalid',
       },

--- a/packages/server/src/builder.ts
+++ b/packages/server/src/builder.ts
@@ -8,7 +8,7 @@ import type { Context, MergeContext, WELL_CONTEXT } from './types'
 import { ContractProcedure } from '@orpc/contract'
 import { type ChainableImplementer, createChainableImplementer } from './implementer-chainable'
 import { decorateMiddleware } from './middleware-decorated'
-import { Procedure, type ProcedureFunc } from './procedure'
+import { Procedure, type ProcedureHandler } from './procedure'
 import { ProcedureBuilder } from './procedure-builder'
 import { type DecoratedProcedure, decorateProcedure } from './procedure-decorated'
 import { RouterBuilder } from './router-builder'
@@ -103,7 +103,7 @@ export class Builder<TContext extends Context, TExtraContext extends Context> {
   }
 
   handler<UFuncOutput = undefined>(
-    handler: ProcedureFunc<TContext, TExtraContext, undefined, undefined, UFuncOutput>,
+    handler: ProcedureHandler<TContext, TExtraContext, undefined, undefined, UFuncOutput>,
   ): DecoratedProcedure<TContext, TExtraContext, undefined, undefined, UFuncOutput> {
     return decorateProcedure(new Procedure({
       middlewares: this['~orpc'].middlewares,

--- a/packages/server/src/middleware.ts
+++ b/packages/server/src/middleware.ts
@@ -1,16 +1,28 @@
 import type { Promisable } from '@orpc/shared'
-import type { Context, Meta } from './types'
+import type { ANY_PROCEDURE } from './procedure'
+import type { Context } from './types'
 
 export type MiddlewareResult<TExtraContext extends Context, TOutput> = Promisable<{
   output: TOutput
   context: TExtraContext
 }>
 
-export interface MiddlewareMeta<TOutput> extends Meta {
-  next: <UExtraContext extends Context = undefined>(
+export interface MiddlewareNextFn<TOutput> {
+  <UExtraContext extends Context = undefined>(
     options: UExtraContext extends undefined ? { context?: UExtraContext } : { context: UExtraContext }
-  ) => MiddlewareResult<UExtraContext, TOutput>
-  output: <UOutput>(output: UOutput) => MiddlewareResult<undefined, UOutput>
+  ): MiddlewareResult<UExtraContext, TOutput>
+}
+
+export interface MiddlewareOutputFn<TOutput> {
+  (output: TOutput): MiddlewareResult<undefined, TOutput>
+}
+
+export interface MiddlewareOptions<TContext extends Context, TOutput> {
+  context: TContext
+  path: string[]
+  procedure: ANY_PROCEDURE
+  signal?: AbortSignal
+  next: MiddlewareNextFn<TOutput>
 }
 
 export interface Middleware<
@@ -20,9 +32,9 @@ export interface Middleware<
   TOutput,
 > {
   (
+    options: MiddlewareOptions<TContext, TOutput>,
     input: TInput,
-    context: TContext,
-    meta: MiddlewareMeta<TOutput>,
+    output: MiddlewareOutputFn<TOutput>,
   ): Promisable<
     MiddlewareResult<TExtraContext, TOutput>
   >

--- a/packages/server/src/procedure-builder.test-d.ts
+++ b/packages/server/src/procedure-builder.test-d.ts
@@ -1,8 +1,9 @@
 import type { RouteOptions } from '@orpc/contract'
 import type { Middleware } from './middleware'
+import type { ANY_PROCEDURE } from './procedure'
 import type { DecoratedProcedure } from './procedure-decorated'
 import type { ProcedureImplementer } from './procedure-implementer'
-import type { Meta, WELL_CONTEXT } from './types'
+import type { WELL_CONTEXT } from './types'
 import { ContractProcedure } from '@orpc/contract'
 import { z } from 'zod'
 import { ProcedureBuilder } from './procedure-builder'
@@ -158,10 +159,12 @@ describe('to DecoratedProcedure', () => {
   })
 
   it('handler', () => {
-    const procedure = builder.handler(async (input, context, meta) => {
+    const procedure = builder.handler(async ({ input, context, path, procedure, signal }) => {
       expectTypeOf(context).toEqualTypeOf<{ id?: string } | undefined>()
       expectTypeOf(input).toEqualTypeOf<{ id: number }>()
-      expectTypeOf(meta).toEqualTypeOf<Meta>()
+      expectTypeOf(procedure).toEqualTypeOf<ANY_PROCEDURE>()
+      expectTypeOf(path).toEqualTypeOf<string[]>()
+      expectTypeOf(signal).toEqualTypeOf<undefined | InstanceType<typeof AbortSignal>>()
 
       return { id: '1' }
     })
@@ -171,9 +174,9 @@ describe('to DecoratedProcedure', () => {
     >()
 
     // @ts-expect-error - invalid output
-    builder.handler(async (input, context, meta) => ({ id: 1 }))
+    builder.handler(async ({ input, context }) => ({ id: 1 }))
 
     // @ts-expect-error - invalid output
-    builder.handler(async (input, context, meta) => (true))
+    builder.handler(async ({ input, context }) => (true))
   })
 })

--- a/packages/server/src/procedure-builder.test.ts
+++ b/packages/server/src/procedure-builder.test.ts
@@ -77,13 +77,13 @@ describe('to ProcedureImplementer', () => {
     map_input.mockReturnValueOnce('__input__')
     mid.mockReturnValueOnce('__mid__')
 
-    expect((implementer as any)['~orpc'].middlewares[1]('input')).toBe('__mid__')
+    expect((implementer as any)['~orpc'].middlewares[1]({}, 'input', '__output__')).toBe('__mid__')
 
     expect(map_input).toBeCalledTimes(1)
     expect(map_input).toBeCalledWith('input')
 
     expect(mid).toBeCalledTimes(1)
-    expect(mid).toBeCalledWith('__input__')
+    expect(mid).toBeCalledWith({}, '__input__', '__output__')
   })
 })
 

--- a/packages/server/src/procedure-builder.ts
+++ b/packages/server/src/procedure-builder.ts
@@ -11,7 +11,7 @@ import {
 } from '@orpc/contract'
 import {
   Procedure,
-  type ProcedureFunc,
+  type ProcedureHandler,
 } from './procedure'
 import { decorateProcedure } from './procedure-decorated'
 import { ProcedureImplementer } from './procedure-implementer'
@@ -122,7 +122,7 @@ export class ProcedureBuilder<
   }
 
   handler<UFuncOutput extends SchemaInput<TOutputSchema>>(
-    handler: ProcedureFunc<TContext, TExtraContext, TInputSchema, TOutputSchema, UFuncOutput>,
+    handler: ProcedureHandler<TContext, TExtraContext, TInputSchema, TOutputSchema, UFuncOutput>,
   ): DecoratedProcedure<TContext, TExtraContext, TInputSchema, TOutputSchema, UFuncOutput > {
     return decorateProcedure(new Procedure({
       middlewares: this['~orpc'].middlewares,

--- a/packages/server/src/procedure-client.test.ts
+++ b/packages/server/src/procedure-client.test.ts
@@ -8,8 +8,8 @@ import { createProcedureClient } from './procedure-client'
 const schema = z.object({ val: z.string().transform(v => Number(v)) })
 
 const handler = vi.fn(() => ({ val: '123' }))
-const mid1 = vi.fn((_, __, meta) => meta.next({}))
-const mid2 = vi.fn((_, __, meta) => meta.next({}))
+const mid1 = vi.fn(({ next }, input, output) => next({}))
+const mid2 = vi.fn(({ next }, input, output) => next({}))
 
 const procedure = new Procedure<WELL_CONTEXT, undefined, typeof schema, typeof schema, { val: string }>({
   contract: new ContractProcedure({
@@ -43,10 +43,20 @@ describe.each(procedureCases)('createProcedureClient - case %s', async (_, proce
     expect(handler).toBeCalledWith({ input: { val: 123 }, context: undefined, path: [], procedure: unwrappedProcedure })
 
     expect(mid1).toBeCalledTimes(1)
-    expect(mid1).toBeCalledWith({ val: 123 }, undefined, expect.objectContaining({ path: [], procedure: unwrappedProcedure, next: expect.any(Function), output: expect.any(Function) }))
+    expect(mid1).toBeCalledWith(expect.objectContaining({
+      path: [],
+      procedure: unwrappedProcedure,
+      next: expect.any(Function),
+      context: undefined,
+    }), { val: 123 }, expect.any(Function))
 
     expect(mid2).toBeCalledTimes(1)
-    expect(mid2).toBeCalledWith({ val: 123 }, undefined, expect.objectContaining({ path: [], procedure: unwrappedProcedure, next: expect.any(Function), output: expect.any(Function) }))
+    expect(mid2).toBeCalledWith(expect.objectContaining({
+      path: [],
+      procedure: unwrappedProcedure,
+      next: expect.any(Function),
+      context: undefined,
+    }), { val: 123 }, expect.any(Function))
   })
 
   it('validate input and output', () => {
@@ -108,16 +118,16 @@ describe.each(procedureCases)('createProcedureClient - case %s', async (_, proce
       procedure,
     })
 
-    mid1.mockImplementationOnce((input, context, meta) => {
-      return meta.next({
+    mid1.mockImplementationOnce(({ next }) => {
+      return next({
         context: {
           extra1: '__extra1__',
         },
       })
     })
 
-    mid2.mockImplementationOnce((input, context, meta) => {
-      return meta.next({
+    mid2.mockImplementationOnce(({ next }) => {
+      return next({
         context: {
           extra2: '__extra2__',
         },
@@ -127,10 +137,12 @@ describe.each(procedureCases)('createProcedureClient - case %s', async (_, proce
     await expect(client({ val: '123' })).resolves.toEqual({ val: 123 })
 
     expect(mid1).toBeCalledTimes(1)
-    expect(mid1).toHaveBeenCalledWith(expect.any(Object), undefined, expect.any(Object))
+    expect(mid1).toHaveBeenCalledWith(expect.objectContaining({ context: undefined }), expect.any(Object), expect.any(Function))
 
     expect(mid2).toBeCalledTimes(1)
-    expect(mid2).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({ extra1: '__extra1__' }), expect.any(Object))
+    expect(mid2).toHaveBeenCalledWith(expect.objectContaining({
+      context: expect.objectContaining({ extra1: '__extra1__' }),
+    }), expect.any(Object), expect.any(Function))
 
     expect(handler).toBeCalledTimes(1)
     expect(handler).toHaveBeenCalledWith(expect.objectContaining({ context: { extra1: '__extra1__', extra2: '__extra2__' } }))
@@ -142,16 +154,16 @@ describe.each(procedureCases)('createProcedureClient - case %s', async (_, proce
       context: { userId: '123' },
     })
 
-    mid1.mockImplementationOnce((input, context, meta) => {
-      return meta.next({
+    mid1.mockImplementationOnce(({ next }) => {
+      return next({
         context: {
           userId: '__override1__',
         },
       })
     })
 
-    mid2.mockImplementationOnce((input, context, meta) => {
-      return meta.next({
+    mid2.mockImplementationOnce(({ next }) => {
+      return next({
         context: {
           userId: '__override2__',
         },
@@ -161,10 +173,14 @@ describe.each(procedureCases)('createProcedureClient - case %s', async (_, proce
     await expect(client({ val: '123' })).resolves.toEqual({ val: 123 })
 
     expect(mid1).toBeCalledTimes(1)
-    expect(mid1).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({ userId: '123' }), expect.any(Object))
+    expect(mid1).toHaveBeenCalledWith(expect.objectContaining({
+      context: expect.objectContaining({ userId: '123' }),
+    }), expect.any(Object), expect.any(Function))
 
     expect(mid2).toBeCalledTimes(1)
-    expect(mid2).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({ userId: '__override1__' }), expect.any(Object))
+    expect(mid2).toHaveBeenCalledWith(expect.objectContaining({
+      context: expect.objectContaining({ userId: '__override1__' }),
+    }), expect.any(Object), expect.any(Function))
 
     expect(handler).toBeCalledTimes(1)
     expect(handler).toHaveBeenCalledWith(expect.objectContaining({ context: expect.objectContaining({ userId: '__override2__' }) }))
@@ -185,10 +201,18 @@ describe.each(procedureCases)('createProcedureClient - case %s', async (_, proce
     await client({ val: '123' })
 
     expect(mid1).toBeCalledTimes(1)
-    expect(mid1).toBeCalledWith(expect.any(Object), { val: '__val__' }, expect.any(Object))
+    expect(mid1).toBeCalledWith(
+      expect.objectContaining({ context: { val: '__val__' } }),
+      expect.any(Object),
+      expect.any(Function),
+    )
 
     expect(mid2).toBeCalledTimes(1)
-    expect(mid2).toBeCalledWith(expect.any(Object), { val: '__val__' }, expect.any(Object))
+    expect(mid2).toBeCalledWith(
+      expect.objectContaining({ context: { val: '__val__' } }),
+      expect.any(Object),
+      expect.any(Function),
+    )
 
     expect(handler).toBeCalledTimes(1)
     expect(handler).toBeCalledWith(expect.objectContaining({ context: { val: '__val__' } }))
@@ -255,10 +279,10 @@ describe.each(procedureCases)('createProcedureClient - case %s', async (_, proce
     await client({ val: '123' })
 
     expect(mid1).toBeCalledTimes(1)
-    expect(mid1).toHaveBeenCalledWith(expect.any(Object), undefined, expect.objectContaining({ path: ['users'] }))
+    expect(mid1).toHaveBeenCalledWith(expect.objectContaining({ path: ['users'] }), expect.any(Object), expect.any(Function))
 
     expect(mid2).toBeCalledTimes(1)
-    expect(mid2).toHaveBeenCalledWith(expect.any(Object), undefined, expect.objectContaining({ path: ['users'] }))
+    expect(mid2).toHaveBeenCalledWith(expect.objectContaining({ path: ['users'] }), expect.any(Object), expect.any(Function))
 
     expect(handler).toBeCalledTimes(1)
     expect(handler).toHaveBeenCalledWith(expect.objectContaining({ path: ['users'] }))
@@ -282,10 +306,10 @@ describe.each(procedureCases)('createProcedureClient - case %s', async (_, proce
     await client({ val: '123' }, { signal })
 
     expect(mid1).toBeCalledTimes(1)
-    expect(mid1).toHaveBeenCalledWith(expect.any(Object), expect.any(Object), expect.objectContaining({ signal }))
+    expect(mid1).toHaveBeenCalledWith(expect.objectContaining({ signal }), expect.any(Object), expect.any(Function))
 
     expect(mid2).toBeCalledTimes(1)
-    expect(mid2).toHaveBeenCalledWith(expect.any(Object), expect.any(Object), expect.objectContaining({ signal }))
+    expect(mid2).toHaveBeenCalledWith(expect.objectContaining({ signal }), expect.any(Object), expect.any(Function))
 
     expect(handler).toBeCalledTimes(1)
     expect(handler).toHaveBeenCalledWith(expect.objectContaining({ signal }))
@@ -360,8 +384,8 @@ it('has helper `output` in meta', async () => {
     procedure,
   })
 
-  mid2.mockImplementationOnce((input, context, meta) => {
-    return meta.output({ val: '99990' })
+  mid2.mockImplementationOnce((_, __, output) => {
+    return output({ val: '99990' })
   })
 
   await expect(client({ val: '123' })).resolves.toEqual({ val: 99990 })

--- a/packages/server/src/procedure-client.test.ts
+++ b/packages/server/src/procedure-client.test.ts
@@ -40,13 +40,13 @@ describe.each(procedureCases)('createProcedureClient - case %s', async (_, proce
     await expect(client({ val: '123' })).resolves.toEqual({ val: 123 })
 
     expect(handler).toBeCalledTimes(1)
-    expect(handler).toBeCalledWith({ val: 123 }, undefined, { path: [], procedure: unwrappedProcedure })
+    expect(handler).toBeCalledWith({ input: { val: 123 }, context: undefined, path: [], procedure: unwrappedProcedure })
 
     expect(mid1).toBeCalledTimes(1)
-    expect(mid1).toBeCalledWith({ val: 123 }, undefined, { path: [], procedure: unwrappedProcedure, next: expect.any(Function), output: expect.any(Function) })
+    expect(mid1).toBeCalledWith({ val: 123 }, undefined, expect.objectContaining({ path: [], procedure: unwrappedProcedure, next: expect.any(Function), output: expect.any(Function) }))
 
     expect(mid2).toBeCalledTimes(1)
-    expect(mid2).toBeCalledWith({ val: 123 }, undefined, { path: [], procedure: unwrappedProcedure, next: expect.any(Function), output: expect.any(Function) })
+    expect(mid2).toBeCalledWith({ val: 123 }, undefined, expect.objectContaining({ path: [], procedure: unwrappedProcedure, next: expect.any(Function), output: expect.any(Function) }))
   })
 
   it('validate input and output', () => {
@@ -133,7 +133,7 @@ describe.each(procedureCases)('createProcedureClient - case %s', async (_, proce
     expect(mid2).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({ extra1: '__extra1__' }), expect.any(Object))
 
     expect(handler).toBeCalledTimes(1)
-    expect(handler).toHaveBeenCalledWith(expect.any(Object), { extra1: '__extra1__', extra2: '__extra2__' }, expect.any(Object))
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ context: { extra1: '__extra1__', extra2: '__extra2__' } }))
   })
 
   it('middleware can override context', async () => {
@@ -167,7 +167,7 @@ describe.each(procedureCases)('createProcedureClient - case %s', async (_, proce
     expect(mid2).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({ userId: '__override1__' }), expect.any(Object))
 
     expect(handler).toBeCalledTimes(1)
-    expect(handler).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({ userId: '__override2__' }), expect.any(Object))
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ context: expect.objectContaining({ userId: '__override2__' }) }))
   })
 
   const contextCases = [
@@ -191,7 +191,7 @@ describe.each(procedureCases)('createProcedureClient - case %s', async (_, proce
     expect(mid2).toBeCalledWith(expect.any(Object), { val: '__val__' }, expect.any(Object))
 
     expect(handler).toBeCalledTimes(1)
-    expect(handler).toBeCalledWith(expect.any(Object), { val: '__val__' }, expect.any(Object))
+    expect(handler).toBeCalledWith(expect.objectContaining({ context: { val: '__val__' } }))
   })
 
   it.each(contextCases)('can accept hooks - context: %s', async (_, context) => {
@@ -261,7 +261,7 @@ describe.each(procedureCases)('createProcedureClient - case %s', async (_, proce
     expect(mid2).toHaveBeenCalledWith(expect.any(Object), undefined, expect.objectContaining({ path: ['users'] }))
 
     expect(handler).toBeCalledTimes(1)
-    expect(handler).toHaveBeenCalledWith(expect.any(Object), undefined, expect.objectContaining({ path: ['users'] }))
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ path: ['users'] }))
 
     expect(onSuccess).toBeCalledTimes(1)
     expect(onSuccess).toHaveBeenCalledWith(expect.any(Object), undefined, expect.objectContaining({ path: ['users'] }))
@@ -288,7 +288,7 @@ describe.each(procedureCases)('createProcedureClient - case %s', async (_, proce
     expect(mid2).toHaveBeenCalledWith(expect.any(Object), expect.any(Object), expect.objectContaining({ signal }))
 
     expect(handler).toBeCalledTimes(1)
-    expect(handler).toHaveBeenCalledWith(expect.any(Object), expect.any(Object), expect.objectContaining({ signal }))
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ signal }))
 
     expect(onSuccess).toBeCalledTimes(1)
     expect(onSuccess).toHaveBeenCalledWith(expect.any(Object), expect.any(Object), expect.objectContaining({ signal }))
@@ -311,7 +311,7 @@ it('still work without middleware', async () => {
   await expect(client({ val: '123' })).resolves.toEqual({ val: 123 })
 
   expect(handler).toBeCalledTimes(1)
-  expect(handler).toHaveBeenCalledWith({ val: 123 }, undefined, { path: [], procedure })
+  expect(handler).toHaveBeenCalledWith({ input: { val: 123 }, context: undefined, path: [], procedure })
 })
 
 it('still work without InputSchema', async () => {
@@ -330,7 +330,7 @@ it('still work without InputSchema', async () => {
   await expect(client('anything')).resolves.toEqual({ val: 123 })
 
   expect(handler).toBeCalledTimes(1)
-  expect(handler).toHaveBeenCalledWith('anything', undefined, { path: [], procedure })
+  expect(handler).toHaveBeenCalledWith({ input: 'anything', context: undefined, path: [], procedure })
 })
 
 it('still work without OutputSchema', async () => {
@@ -352,7 +352,7 @@ it('still work without OutputSchema', async () => {
   await expect(client({ val: '123' })).resolves.toEqual('anything')
 
   expect(handler).toBeCalledTimes(1)
-  expect(handler).toHaveBeenCalledWith({ val: 123 }, undefined, { path: [], procedure })
+  expect(handler).toHaveBeenCalledWith({ input: { val: 123 }, context: undefined, path: [], procedure })
 })
 
 it('has helper `output` in meta', async () => {

--- a/packages/server/src/procedure-client.ts
+++ b/packages/server/src/procedure-client.ts
@@ -2,7 +2,7 @@ import type { Schema, SchemaInput, SchemaOutput } from '@orpc/contract'
 import type { Hooks, Value } from '@orpc/shared'
 import type { Lazyable } from './lazy'
 import type { MiddlewareMeta } from './middleware'
-import type { ANY_PROCEDURE, Procedure } from './procedure'
+import type { ANY_PROCEDURE, Procedure, ProcedureHandlerOptions } from './procedure'
 import type { Context, Meta, WELL_CONTEXT, WithSignal } from './types'
 import { executeWithHooks, value } from '@orpc/shared'
 import { ORPCError } from '@orpc/shared/error'
@@ -71,12 +71,13 @@ export function createProcedureClient<
     const executeWithValidation = async () => {
       const validInput = await validateInput(procedure, input)
 
-      const output = await executeMiddlewareChain(
-        procedure,
-        validInput,
+      const output = await executeMiddlewareChain({
         context,
-        meta,
-      )
+        input: validInput,
+        path,
+        procedure,
+        signal: callerOptions?.signal,
+      })
 
       return validateOutput(procedure, output) as SchemaOutput<TOutputSchema, THandlerOutput>
     }
@@ -125,15 +126,10 @@ async function validateOutput(procedure: ANY_PROCEDURE, output: unknown) {
   return result.value
 }
 
-async function executeMiddlewareChain(
-  procedure: ANY_PROCEDURE,
-  input: unknown,
-  context: Context,
-  meta: Meta,
-) {
-  const middlewares = procedure['~orpc'].middlewares ?? []
+async function executeMiddlewareChain(opt: ProcedureHandlerOptions<any, any>) {
+  const middlewares = opt.procedure['~orpc'].middlewares ?? []
   let currentMidIndex = 0
-  let currentContext = context
+  let currentContext = opt.context
 
   const next: MiddlewareMeta<unknown>['next'] = async (nextOptions) => {
     const mid = middlewares[currentMidIndex]
@@ -141,15 +137,15 @@ async function executeMiddlewareChain(
     currentContext = mergeContext(currentContext, nextOptions.context)
 
     if (mid) {
-      return await mid(input, currentContext, {
-        ...meta,
+      return await mid(opt.input, currentContext, {
+        ...opt,
         next,
         output: output => ({ output, context: undefined }),
       })
     }
 
     const result = {
-      output: await procedure['~orpc'].handler(input, currentContext, meta),
+      output: await opt.procedure['~orpc'].handler({ ...opt, context: currentContext }),
       context: currentContext,
     }
 

--- a/packages/server/src/procedure-decorated.test.ts
+++ b/packages/server/src/procedure-decorated.test.ts
@@ -8,7 +8,7 @@ beforeEach(() => {
 })
 
 const handler = vi.fn(() => ({ val: '123' }))
-const mid = vi.fn((_, __, meta) => meta.next({}))
+const mid = vi.fn(({ next }, _, __) => next({}))
 
 const schema = z.object({ val: z.string().transform(v => Number.parseInt(v)) })
 const procedure = new Procedure<{ auth: boolean }, { db: string }, typeof schema, typeof schema, { val: string }>({
@@ -73,13 +73,13 @@ describe('self chainable', () => {
     extraMid.mockReturnValueOnce('__extra__')
     map.mockReturnValueOnce('__map__')
 
-    expect((applied as any)['~orpc'].middlewares[1]('input')).toBe('__extra__')
+    expect((applied as any)['~orpc'].middlewares[1]({}, 'input', '__output__')).toBe('__extra__')
 
     expect(map).toBeCalledTimes(1)
     expect(map).toBeCalledWith('input')
 
     expect(extraMid).toBeCalledTimes(1)
-    expect(extraMid).toBeCalledWith('__map__')
+    expect(extraMid).toBeCalledWith({}, '__map__', '__output__')
   })
 
   it('unshiftTag', () => {

--- a/packages/server/src/procedure-implementer.test-d.ts
+++ b/packages/server/src/procedure-implementer.test-d.ts
@@ -1,6 +1,7 @@
 import type { Middleware, MiddlewareMeta } from './middleware'
+import type { ANY_PROCEDURE } from './procedure'
 import type { DecoratedProcedure } from './procedure-decorated'
-import type { Meta, WELL_CONTEXT } from './types'
+import type { WELL_CONTEXT } from './types'
 import { ContractProcedure } from '@orpc/contract'
 import { z } from 'zod'
 import { ProcedureImplementer } from './procedure-implementer'
@@ -129,10 +130,12 @@ describe('to DecoratedProcedure', () => {
   })
 
   it('handler', () => {
-    const procedure = implementer.handler((input, context, meta) => {
+    const procedure = implementer.handler(({ input, context, procedure, path, signal }) => {
       expectTypeOf(context).toEqualTypeOf<({ id?: string } & { db: string }) | { db: string }>()
       expectTypeOf(input).toEqualTypeOf<{ val: number }>()
-      expectTypeOf(meta).toEqualTypeOf<Meta>()
+      expectTypeOf(procedure).toEqualTypeOf<ANY_PROCEDURE>()
+      expectTypeOf(path).toEqualTypeOf<string[]>()
+      expectTypeOf(signal).toEqualTypeOf<undefined | InstanceType<typeof AbortSignal>>()
 
       return { val: '1' }
     })

--- a/packages/server/src/procedure-implementer.test-d.ts
+++ b/packages/server/src/procedure-implementer.test-d.ts
@@ -1,4 +1,4 @@
-import type { Middleware, MiddlewareMeta } from './middleware'
+import type { Middleware, MiddlewareOutputFn } from './middleware'
 import type { ANY_PROCEDURE } from './procedure'
 import type { DecoratedProcedure } from './procedure-decorated'
 import type { WELL_CONTEXT } from './types'
@@ -19,25 +19,29 @@ describe('self chainable', () => {
 
   it('use middleware', () => {
     const i = implementer
-      .use((input, context, meta) => {
+      .use(({ context, path, next, procedure }, input, output) => {
         expectTypeOf(input).toEqualTypeOf<{ val: number }>()
         expectTypeOf(context).toEqualTypeOf<{ id?: string }>()
-        expectTypeOf(meta).toEqualTypeOf<MiddlewareMeta<{ val: string }>>()
+        expectTypeOf(path).toEqualTypeOf<string[]>()
+        expectTypeOf(procedure).toEqualTypeOf<ANY_PROCEDURE>()
+        expectTypeOf(output).toEqualTypeOf<MiddlewareOutputFn<{ val: string }>>()
 
-        return meta.next({
+        return next({
           context: {
             auth: true,
           },
         })
       })
-      .use((input, context, meta) => {
+      .use(({ context, path, next, procedure }, input, output) => {
         expectTypeOf(input).toEqualTypeOf<{ val: number }>()
         expectTypeOf(context).toEqualTypeOf<
           { id?: string } & { auth: boolean }
         >()
-        expectTypeOf(meta).toEqualTypeOf<MiddlewareMeta<{ val: string }>>()
+        expectTypeOf(path).toEqualTypeOf<string[]>()
+        expectTypeOf(procedure).toEqualTypeOf<ANY_PROCEDURE>()
+        expectTypeOf(output).toEqualTypeOf<MiddlewareOutputFn<{ val: string }>>()
 
-        return meta.next({})
+        return next({})
       })
 
     expectTypeOf(i).toEqualTypeOf<
@@ -51,8 +55,8 @@ describe('self chainable', () => {
   })
 
   it('use middleware with map input', () => {
-    const mid: Middleware<WELL_CONTEXT, { id: string, extra: boolean }, number, any> = (input, context, meta) => {
-      return meta.next({
+    const mid: Middleware<WELL_CONTEXT, { id: string, extra: boolean }, number, any> = ({ next }) => {
+      return next({
         context: { id: 'string', extra: true },
       })
     }
@@ -79,27 +83,27 @@ describe('self chainable', () => {
   })
 
   it('prevent conflict on context', () => {
-    implementer.use((input, context, meta) => meta.next({}))
-    implementer.use((input, context, meta) => meta.next({ context: { id: '1' } }))
-    implementer.use((input, context, meta) => meta.next({ context: { id: '1', extra: true } }))
-    implementer.use((input, context, meta) => meta.next({ context: { auth: true } }))
+    implementer.use(({ context, path, next }, input) => next({}))
+    implementer.use(({ context, path, next }, input) => next({ context: { id: '1' } }))
+    implementer.use(({ context, path, next }, input) => next({ context: { id: '1', extra: true } }))
+    implementer.use(({ context, path, next }, input) => next({ context: { auth: true } }))
 
-    implementer.use((input, context, meta) => meta.next({}), () => 'anything')
-    implementer.use((input, context, meta) => meta.next({ context: { id: '1' } }), () => 'anything')
-    implementer.use((input, context, meta) => meta.next({ context: { id: '1', extra: true } }), () => 'anything')
-    implementer.use((input, context, meta) => meta.next({ context: { auth: true } }), () => 'anything')
-
-    // @ts-expect-error - conflict with context
-    implementer.use((input, context, meta) => meta.next({ context: { id: 1 } }))
+    implementer.use(({ context, path, next }, input) => next({}), () => 'anything')
+    implementer.use(({ context, path, next }, input) => next({ context: { id: '1' } }), () => 'anything')
+    implementer.use(({ context, path, next }, input) => next({ context: { id: '1', extra: true } }), () => 'anything')
+    implementer.use(({ context, path, next }, input) => next({ context: { auth: true } }), () => 'anything')
 
     // @ts-expect-error - conflict with context
-    implementer.use((input, context, meta) => meta.next({ context: { id: 1, extra: true } }))
+    implementer.use(({ context, path, next }, input) => next({ context: { id: 1 } }))
 
     // @ts-expect-error - conflict with context
-    implementer.use((input, context, meta) => meta.next({ context: { id: 1 } }), () => 'anything')
+    implementer.use(({ context, path, next }, input) => next({ context: { id: 1, extra: true } }))
 
     // @ts-expect-error - conflict with context
-    implementer.use((input, context, meta) => meta.next({ context: { id: 1, extra: true } }), () => 'anything')
+    implementer.use(({ context, path, next }, input) => next({ context: { id: 1 } }), () => 'anything')
+
+    // @ts-expect-error - conflict with context
+    implementer.use(({ context, path, next }, input) => next({ context: { id: 1, extra: true } }), () => 'anything')
   })
 
   it('handle middleware with output is typed', () => {

--- a/packages/server/src/procedure-implementer.test.ts
+++ b/packages/server/src/procedure-implementer.test.ts
@@ -35,13 +35,13 @@ describe('self chainable', () => {
     map.mockReturnValueOnce('__input__')
     mid.mockReturnValueOnce('__mid__')
 
-    expect((i as any)['~orpc'].middlewares[0]('input')).toBe('__mid__')
+    expect((i as any)['~orpc'].middlewares[0]({}, 'input', '__output__')).toBe('__mid__')
 
     expect(map).toBeCalledTimes(1)
     expect(map).toBeCalledWith('input')
 
     expect(mid).toBeCalledTimes(1)
-    expect(mid).toBeCalledWith('__input__')
+    expect(mid).toBeCalledWith({}, '__input__', '__output__')
   })
 })
 

--- a/packages/server/src/procedure-implementer.ts
+++ b/packages/server/src/procedure-implementer.ts
@@ -1,6 +1,6 @@
 import type { ContractProcedure, Schema, SchemaInput, SchemaOutput } from '@orpc/contract'
 import type { ANY_MAP_INPUT_MIDDLEWARE, ANY_MIDDLEWARE, MapInputMiddleware, Middleware } from './middleware'
-import type { ProcedureFunc } from './procedure'
+import type { ProcedureHandler } from './procedure'
 import type { DecoratedProcedure } from './procedure-decorated'
 import type { Context, MergeContext } from './types'
 import { decorateMiddleware } from './middleware-decorated'
@@ -77,7 +77,7 @@ export class ProcedureImplementer<
   }
 
   handler<UFuncOutput extends SchemaInput<TOutputSchema>>(
-    handler: ProcedureFunc<TContext, TExtraContext, TInputSchema, TOutputSchema, UFuncOutput>,
+    handler: ProcedureHandler<TContext, TExtraContext, TInputSchema, TOutputSchema, UFuncOutput>,
   ): DecoratedProcedure<TContext, TExtraContext, TInputSchema, TOutputSchema, UFuncOutput > {
     return decorateProcedure(new Procedure({
       middlewares: this['~orpc'].middlewares,

--- a/packages/server/src/procedure.ts
+++ b/packages/server/src/procedure.ts
@@ -4,7 +4,7 @@ import type { Middleware } from './middleware'
 import type { Context, MergeContext, Meta } from './types'
 import { type ContractProcedure, isContractProcedure, type Schema, type SchemaInput, type SchemaOutput } from '@orpc/contract'
 
-export interface ProcedureFunc<
+export interface ProcedureHandler<
   TContext extends Context,
   TExtraContext extends Context,
   TInputSchema extends Schema,
@@ -27,7 +27,7 @@ export interface ProcedureDef<
 > {
   middlewares?: Middleware<MergeContext<TContext, TExtraContext>, Partial<TExtraContext> | undefined, SchemaOutput<TInputSchema>, any>[]
   contract: ContractProcedure<TInputSchema, TOutputSchema>
-  handler: ProcedureFunc<TContext, TExtraContext, TInputSchema, TOutputSchema, THandlerOutput>
+  handler: ProcedureHandler<TContext, TExtraContext, TInputSchema, TOutputSchema, THandlerOutput>
 }
 
 export class Procedure<

--- a/packages/server/src/procedure.ts
+++ b/packages/server/src/procedure.ts
@@ -1,8 +1,16 @@
 import type { Promisable } from '@orpc/shared'
 import type { Lazy } from './lazy'
 import type { Middleware } from './middleware'
-import type { Context, MergeContext, Meta } from './types'
+import type { AbortSignal, Context, MergeContext } from './types'
 import { type ContractProcedure, isContractProcedure, type Schema, type SchemaInput, type SchemaOutput } from '@orpc/contract'
+
+export interface ProcedureHandlerOptions<TContext extends Context, TInput> {
+  context: TContext
+  input: TInput
+  path: string[]
+  procedure: ANY_PROCEDURE
+  signal?: AbortSignal
+}
 
 export interface ProcedureHandler<
   TContext extends Context,
@@ -12,9 +20,7 @@ export interface ProcedureHandler<
   THandlerOutput extends SchemaInput<TOutputSchema>,
 > {
   (
-    input: SchemaOutput<TInputSchema>,
-    context: MergeContext<TContext, TExtraContext>,
-    meta: Meta,
+    opt: ProcedureHandlerOptions<MergeContext<TContext, TExtraContext>, SchemaOutput<TInputSchema>>
   ): Promisable<SchemaInput<TOutputSchema, THandlerOutput>>
 }
 

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -1,3 +1,4 @@
+import type { FindGlobalInstanceType } from '@orpc/shared'
 import type { ANY_PROCEDURE } from './procedure'
 
 export type Context = Record<string, any> | undefined
@@ -7,6 +8,8 @@ export type MergeContext<
   TA extends Context,
   TB extends Context,
 > = TA extends undefined ? TB : TB extends undefined ? TA : TA & TB
+
+export type AbortSignal = FindGlobalInstanceType<'AbortSignal'>
 
 export interface WithSignal {
   signal?: AbortSignal

--- a/packages/vue-colada/src/utils-router.test-d.ts
+++ b/packages/vue-colada/src/utils-router.test-d.ts
@@ -15,7 +15,7 @@ const contractRouter = oc.router({
   pong: pongContract,
 })
 
-const ping = os.contract(pingContract).handler(({ name }) => `ping ${name}`)
+const ping = os.contract(pingContract).handler(({ input }) => `ping ${input.name}`)
 const pong = os.contract(pongContract).handler(num => `pong ${num}`)
 
 const router = os.contract(contractRouter).router({

--- a/packages/vue-colada/tests/helpers.ts
+++ b/packages/vue-colada/tests/helpers.ts
@@ -22,7 +22,7 @@ export const UserFindInputSchema = z
 export const userFind = orpcServer
   .input(UserFindInputSchema)
   .output(UserSchema)
-  .handler((input) => {
+  .handler(({ input }) => {
     return {
       data: {
         id: input.data.id,
@@ -48,7 +48,7 @@ export const UserListOutputSchema = z
 export const userList = orpcServer
   .input(UserListInputSchema)
   .output(UserListOutputSchema)
-  .handler((input) => {
+  .handler(({ input }) => {
     return {
       data: {
         nextCursor: input.data.cursor + 2,
@@ -70,7 +70,7 @@ export const UserCreateInputSchema = z
 export const userCreate = orpcServer
   .input(UserCreateInputSchema)
   .output(UserSchema)
-  .handler((input) => {
+  .handler(({ input }) => {
     return {
       data: {
         id: '28aa6286-48e9-4f23-adea-3486c86acd55',

--- a/packages/vue-query/src/utils-router.test-d.ts
+++ b/packages/vue-query/src/utils-router.test-d.ts
@@ -15,7 +15,7 @@ const contractRouter = oc.router({
   pong: pongContract,
 })
 
-const ping = os.contract(pingContract).handler(({ name }) => `ping ${name}`)
+const ping = os.contract(pingContract).handler(({ input }) => `ping ${input.name}`)
 const pong = os.contract(pongContract).handler(num => `pong ${num}`)
 
 const router = os.contract(contractRouter).router({

--- a/packages/vue-query/tests/helpers.ts
+++ b/packages/vue-query/tests/helpers.ts
@@ -20,7 +20,7 @@ export const UserFindInputSchema = z
 export const userFind = orpcServer
   .input(UserFindInputSchema)
   .output(UserSchema)
-  .handler((input) => {
+  .handler(({ input }) => {
     return {
       data: {
         id: input.data.id,
@@ -46,7 +46,7 @@ export const UserListOutputSchema = z
 export const userList = orpcServer
   .input(UserListInputSchema)
   .output(UserListOutputSchema)
-  .handler((input) => {
+  .handler(({ input }) => {
     return {
       data: {
         nextCursor: input.data.cursor + 2,
@@ -68,7 +68,7 @@ export const UserCreateInputSchema = z
 export const userCreate = orpcServer
   .input(UserCreateInputSchema)
   .output(UserSchema)
-  .handler((input) => {
+  .handler(({ input }) => {
     return {
       data: {
         id: '28aa6286-48e9-4f23-adea-3486c86acd55',

--- a/packages/zod/tests/coercer.test.ts
+++ b/packages/zod/tests/coercer.test.ts
@@ -33,6 +33,6 @@ describe('zodCoercer', () => {
     }))
 
     expect(res.status).toBe(200)
-    expect(fn).toHaveBeenCalledWith({ val: 123n }, undefined, expect.any(Object))
+    expect(fn).toHaveBeenCalledWith(expect.objectContaining({ input: { val: 123n } }))
   })
 })

--- a/playgrounds/contract-openapi/src/orpc.ts
+++ b/playgrounds/contract-openapi/src/orpc.ts
@@ -8,26 +8,26 @@ export interface ORPCContext {
   db?: any
 }
 
-const base = os.context<ORPCContext>().use(async (input, context, meta) => {
+const base = os.context<ORPCContext>().use(async ({ context, path, next }, input) => {
   const start = Date.now()
 
   try {
-    return await meta.next({})
+    return await next({})
   }
   finally {
     // eslint-disable-next-line no-console
-    console.log(`[${meta.path.join('/')}] ${Date.now() - start}ms`)
+    console.log(`[${path.join('/')}] ${Date.now() - start}ms`)
   }
 })
 
-const authMid = base.middleware((input, context, meta) => {
+const authMid = base.middleware(({ context, next, path }, input) => {
   if (!context.user) {
     throw new ORPCError({
       code: 'UNAUTHORIZED',
     })
   }
 
-  return meta.next({
+  return next({
     context: {
       user: context.user,
     },

--- a/playgrounds/contract-openapi/src/router/auth.ts
+++ b/playgrounds/contract-openapi/src/router/auth.ts
@@ -1,6 +1,6 @@
 import { authed, pub } from '../orpc'
 
-export const signup = pub.auth.signup.handler(async (input, context, meta) => {
+export const signup = pub.auth.signup.handler(async ({ input, context }) => {
   return {
     id: '28aa6286-48e9-4f23-adea-3486c86acd55',
     email: input.email,
@@ -8,14 +8,14 @@ export const signup = pub.auth.signup.handler(async (input, context, meta) => {
   }
 })
 
-export const signin = pub.auth.signin.handler(async (input, context, meta) => {
+export const signin = pub.auth.signin.handler(async ({ input, context }) => {
   return {
     token: 'token',
   }
 })
 
 export const refresh = authed.auth.refresh.handler(
-  async (input, context, meta) => {
+  async ({ input, context }) => {
     return {
       token: 'new-token',
     }
@@ -23,11 +23,11 @@ export const refresh = authed.auth.refresh.handler(
 )
 
 export const revoke = authed.auth.revoke.handler(
-  async (input, context, meta) => {
+  async ({ input, context }) => {
     // Do something
   },
 )
 
-export const me = authed.auth.me.handler(async (input, context, meta) => {
+export const me = authed.auth.me.handler(async ({ input, context }) => {
   return context.user
 })

--- a/playgrounds/contract-openapi/src/router/planet.ts
+++ b/playgrounds/contract-openapi/src/router/planet.ts
@@ -3,13 +3,13 @@ import { planets } from '../data/planet'
 import { authed, pub } from '../orpc'
 
 export const listPlanets = pub.planet.list.handler(
-  async (input, context, meta) => {
+  async ({ input, context }) => {
     return planets
   },
 )
 
 export const createPlanet = authed.planet.create.handler(
-  async (input, context, meta) => {
+  async ({ input, context }) => {
     const id = planets.length + 1
 
     const planet = {
@@ -27,7 +27,7 @@ export const createPlanet = authed.planet.create.handler(
 )
 
 export const findPlanet = pub.planet.find.handler(
-  async (input, context, meta) => {
+  async ({ input, context }) => {
     const planet = planets.find(planet => planet.id === input.id)
 
     if (!planet) {
@@ -42,7 +42,7 @@ export const findPlanet = pub.planet.find.handler(
 )
 
 export const updatePlanet = authed.planet.update.handler(
-  async (input, context, meta) => {
+  async ({ input, context }) => {
     const planet = planets.find(planet => planet.id === input.id)
 
     if (!planet) {
@@ -61,7 +61,7 @@ export const updatePlanet = authed.planet.update.handler(
 )
 
 export const updatePlanetImage = authed.planet.updateImage.handler(
-  async (input, context, meta) => {
+  async ({ input, context }) => {
     const planet = planets.find(planet => planet.id === input.id)
 
     if (!planet) {
@@ -78,7 +78,7 @@ export const updatePlanetImage = authed.planet.updateImage.handler(
 )
 
 export const deletePlanet = authed.planet.delete.handler(
-  async (input, context, meta) => {
+  async ({ input, context }) => {
     const planet = planets.find(planet => planet.id === input.id)
 
     if (!planet) {

--- a/playgrounds/expressjs/src/orpc.ts
+++ b/playgrounds/expressjs/src/orpc.ts
@@ -7,26 +7,26 @@ export interface ORPCContext {
   db?: any
 }
 
-export const pub = os.context<ORPCContext>().use(async (input, context, meta) => {
+export const pub = os.context<ORPCContext>().use(async ({ context, path, next }, input) => {
   const start = Date.now()
 
   try {
-    return await meta.next({})
+    return await next({})
   }
   finally {
     // eslint-disable-next-line no-console
-    console.log(`[${meta.path.join('/')}] ${Date.now() - start}ms`)
+    console.log(`[${path.join('/')}] ${Date.now() - start}ms`)
   }
 })
 
-export const authed = pub.use((input, context, meta) => {
+export const authed = pub.use(({ context, path, next }, input) => {
   if (!context.user) {
     throw new ORPCError({
       code: 'UNAUTHORIZED',
     })
   }
 
-  return meta.next({
+  return next({
     context: {
       user: context.user,
     },

--- a/playgrounds/expressjs/src/router/auth.ts
+++ b/playgrounds/expressjs/src/router/auth.ts
@@ -10,7 +10,7 @@ export const signup = pub
   })
   .input(NewUserSchema)
   .output(UserSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     return {
       id: '28aa6286-48e9-4f23-adea-3486c86acd55',
       email: input.email,
@@ -26,7 +26,7 @@ export const signin = pub
   })
   .input(CredentialSchema)
   .output(TokenSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     return {
       token: 'token',
     }
@@ -39,7 +39,7 @@ export const refresh = authed
     summary: 'Refresh a token',
   })
   .output(TokenSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     return {
       token: 'new-token',
     }
@@ -52,7 +52,7 @@ export const revoke = authed
     summary: 'Revoke a token',
   })
   .input(TokenSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     // Do something
   })
 
@@ -63,6 +63,6 @@ export const me = authed
     summary: 'Get the current user',
   })
   .output(UserSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     return context.user
   })

--- a/playgrounds/expressjs/src/router/planet.ts
+++ b/playgrounds/expressjs/src/router/planet.ts
@@ -22,7 +22,7 @@ export const listPlanets = pub
     }),
   )
   .output(oz.openapi(z.array(PlanetSchema), { examples: [planets] }))
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     return planets
   })
 
@@ -34,7 +34,7 @@ export const createPlanet = authed
   })
   .input(NewPlanetSchema)
   .output(PlanetSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     const id = planets.length + 1
 
     const planet = {
@@ -62,7 +62,7 @@ export const findPlanet = pub
     }),
   )
   .output(PlanetSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     const planet = planets.find(planet => planet.id === input.id)
 
     if (!planet) {
@@ -83,7 +83,7 @@ export const updatePlanet = authed
   })
   .input(UpdatePlanetSchema)
   .output(PlanetSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     const planet = planets.find(planet => planet.id === input.id)
 
     if (!planet) {
@@ -113,7 +113,7 @@ export const updatePlanetImage = authed
     }),
   )
   .output(PlanetSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     const planet = planets.find(planet => planet.id === input.id)
 
     if (!planet) {
@@ -140,7 +140,7 @@ export const deletePlanet = authed
       id: z.number().int().min(1),
     }),
   )
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     const planet = planets.find(planet => planet.id === input.id)
 
     if (!planet) {

--- a/playgrounds/nextjs/src/actions/auth.ts
+++ b/playgrounds/nextjs/src/actions/auth.ts
@@ -7,7 +7,7 @@ import { NewUserSchema, UserSchema } from '../schemas/user'
 export const signup = pub
   .input(NewUserSchema)
   .output(UserSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     return {
       id: '28aa6286-48e9-4f23-adea-3486c86acd55',
       email: input.email,
@@ -18,7 +18,7 @@ export const signup = pub
 export const signin = pub
   .input(CredentialSchema)
   .output(TokenSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     return {
       token: 'token',
     }
@@ -26,7 +26,7 @@ export const signin = pub
 
 export const refresh = authed
   .output(TokenSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     return {
       token: 'new-token',
     }
@@ -34,12 +34,12 @@ export const refresh = authed
 
 export const revoke = authed
   .input(TokenSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     // Do something
   })
 
 export const me = authed
   .output(UserSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     return context.user
   })

--- a/playgrounds/nextjs/src/actions/planet.ts
+++ b/playgrounds/nextjs/src/actions/planet.ts
@@ -20,14 +20,14 @@ export const listPlanets = pub
     }),
   )
   .output(z.array(PlanetSchema))
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     return planets
   })
 
 export const createPlanet = authed
   .input(NewPlanetSchema)
   .output(PlanetSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     const id = planets.length + 1
 
     const planet = {
@@ -58,7 +58,7 @@ export const findPlanet = pub
     }),
   )
   .output(PlanetSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     const planet = planets.find(planet => planet.id === input.id)
 
     if (!planet) {
@@ -74,7 +74,7 @@ export const findPlanet = pub
 export const updatePlanet = authed
   .input(UpdatePlanetSchema)
   .output(PlanetSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     const planet = planets.find(planet => planet.id === input.id)
 
     if (!planet) {
@@ -99,7 +99,7 @@ export const updatePlanetImage = authed
     }),
   )
   .output(PlanetSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     const planet = planets.find(planet => planet.id === input.id)
 
     if (!planet) {
@@ -120,7 +120,7 @@ export const deletePlanet = authed
       id: z.number().int().min(1),
     }),
   )
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     const planet = planets.find(planet => planet.id === input.id)
 
     if (!planet) {

--- a/playgrounds/nextjs/src/orpc.ts
+++ b/playgrounds/nextjs/src/orpc.ts
@@ -3,11 +3,11 @@ import type { UserSchema } from './schemas/user'
 import { ORPCError, os } from '@orpc/server'
 
 const base = os
-  .use(async (input, context, meta) => {
+  .use(async ({ context, path, next }, input) => {
     const start = Date.now()
 
     try {
-      return await meta.next({})
+      return await next({})
     }
     catch (e) {
       console.error(e)
@@ -15,10 +15,10 @@ const base = os
     }
     finally {
       // eslint-disable-next-line no-console
-      console.log(`[${meta.path.join('/')}] ${Date.now() - start}ms`)
+      console.log(`[${path.join('/')}] ${Date.now() - start}ms`)
     }
   })
-  .use(async (input, context, meta) => {
+  .use(async ({ context, path, next }, input) => {
     // You can use headers or cookies here to create the user object:
     // import { cookies, headers } from 'next/headers'
     // const headerList = await headers();
@@ -29,7 +29,7 @@ const base = os
 
     const user = { id: 'test', name: 'John Doe', email: 'john@doe.com' } satisfies z.infer<typeof UserSchema>
 
-    return meta.next({
+    return next({
       context: {
         db: 'dummy:postgres',
         user,
@@ -39,14 +39,14 @@ const base = os
 
 export const pub = base
 
-export const authed = pub.use(async (input, context, meta) => {
+export const authed = pub.use(async ({ context, path, next }, input) => {
   if (!context.user) {
     throw new ORPCError({
       code: 'UNAUTHORIZED',
     })
   }
 
-  return meta.next({
+  return next({
     context: {
       user: context.user,
     },

--- a/playgrounds/nuxt/server/orpc.ts
+++ b/playgrounds/nuxt/server/orpc.ts
@@ -7,26 +7,26 @@ export interface ORPCContext {
   db?: any
 }
 
-export const pub = os.context<ORPCContext>().use(async (input, context, meta) => {
+export const pub = os.context<ORPCContext>().use(async ({ context, path, next }, input) => {
   const start = Date.now()
 
   try {
-    return await meta.next({})
+    return await next({})
   }
   finally {
     // eslint-disable-next-line no-console
-    console.log(`[${meta.path.join('/')}] ${Date.now() - start}ms`)
+    console.log(`[${path.join('/')}] ${Date.now() - start}ms`)
   }
 })
 
-export const authed = pub.use((input, context, meta) => {
+export const authed = pub.use(({ context, path, next }, input) => {
   if (!context.user) {
     throw new ORPCError({
       code: 'UNAUTHORIZED',
     })
   }
 
-  return meta.next({
+  return next({
     context: {
       user: context.user,
     },

--- a/playgrounds/nuxt/server/router/auth.ts
+++ b/playgrounds/nuxt/server/router/auth.ts
@@ -10,7 +10,7 @@ export const signup = pub
   })
   .input(NewUserSchema)
   .output(UserSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     return {
       id: '28aa6286-48e9-4f23-adea-3486c86acd55',
       email: input.email,
@@ -26,7 +26,7 @@ export const signin = pub
   })
   .input(CredentialSchema)
   .output(TokenSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     return {
       token: 'token',
     }
@@ -39,7 +39,7 @@ export const refresh = authed
     summary: 'Refresh a token',
   })
   .output(TokenSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     return {
       token: 'new-token',
     }
@@ -52,7 +52,7 @@ export const revoke = authed
     summary: 'Revoke a token',
   })
   .input(TokenSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     // Do something
   })
 
@@ -63,6 +63,6 @@ export const me = authed
     summary: 'Get the current user',
   })
   .output(UserSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     return context.user
   })

--- a/playgrounds/nuxt/server/router/planet.ts
+++ b/playgrounds/nuxt/server/router/planet.ts
@@ -22,7 +22,7 @@ export const listPlanets = pub
     }),
   )
   .output(oz.openapi(z.array(PlanetSchema), { examples: [planets] }))
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     return planets
   })
 
@@ -34,7 +34,7 @@ export const createPlanet = authed
   })
   .input(NewPlanetSchema)
   .output(PlanetSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     const id = planets.length + 1
 
     const planet = {
@@ -62,7 +62,7 @@ export const findPlanet = pub
     }),
   )
   .output(PlanetSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     const planet = planets.find(planet => planet.id === input.id)
 
     if (!planet) {
@@ -83,7 +83,7 @@ export const updatePlanet = authed
   })
   .input(UpdatePlanetSchema)
   .output(PlanetSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     const planet = planets.find(planet => planet.id === input.id)
 
     if (!planet) {
@@ -113,7 +113,7 @@ export const updatePlanetImage = authed
     }),
   )
   .output(PlanetSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     const planet = planets.find(planet => planet.id === input.id)
 
     if (!planet) {
@@ -140,7 +140,7 @@ export const deletePlanet = authed
       id: z.number().int().min(1),
     }),
   )
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     const planet = planets.find(planet => planet.id === input.id)
 
     if (!planet) {

--- a/playgrounds/openapi/src/orpc.ts
+++ b/playgrounds/openapi/src/orpc.ts
@@ -7,26 +7,26 @@ export interface ORPCContext {
   db?: any
 }
 
-export const pub = os.context<ORPCContext>().use(async (input, context, meta) => {
+export const pub = os.context<ORPCContext>().use(async ({ context, path, next }, input) => {
   const start = Date.now()
 
   try {
-    return await meta.next({})
+    return await next({})
   }
   finally {
     // eslint-disable-next-line no-console
-    console.log(`[${meta.path.join('/')}] ${Date.now() - start}ms`)
+    console.log(`[${path.join('/')}] ${Date.now() - start}ms`)
   }
 })
 
-export const authed = pub.use((input, context, meta) => {
+export const authed = pub.use(({ context, path, next }, input) => {
   if (!context.user) {
     throw new ORPCError({
       code: 'UNAUTHORIZED',
     })
   }
 
-  return meta.next({
+  return next({
     context: {
       user: context.user,
     },

--- a/playgrounds/openapi/src/router/auth.ts
+++ b/playgrounds/openapi/src/router/auth.ts
@@ -10,7 +10,7 @@ export const signup = pub
   })
   .input(NewUserSchema)
   .output(UserSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     return {
       id: '28aa6286-48e9-4f23-adea-3486c86acd55',
       email: input.email,
@@ -26,7 +26,7 @@ export const signin = pub
   })
   .input(CredentialSchema)
   .output(TokenSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     return {
       token: 'token',
     }
@@ -39,7 +39,7 @@ export const refresh = authed
     summary: 'Refresh a token',
   })
   .output(TokenSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     return {
       token: 'new-token',
     }
@@ -52,7 +52,7 @@ export const revoke = authed
     summary: 'Revoke a token',
   })
   .input(TokenSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     // Do something
   })
 
@@ -63,6 +63,6 @@ export const me = authed
     summary: 'Get the current user',
   })
   .output(UserSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     return context.user
   })

--- a/playgrounds/openapi/src/router/planet.ts
+++ b/playgrounds/openapi/src/router/planet.ts
@@ -22,7 +22,7 @@ export const listPlanets = pub
     }),
   )
   .output(oz.openapi(z.array(PlanetSchema), { examples: [planets] }))
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     return planets
   })
 
@@ -34,7 +34,7 @@ export const createPlanet = authed
   })
   .input(NewPlanetSchema)
   .output(PlanetSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     const id = planets.length + 1
 
     const planet = {
@@ -62,7 +62,7 @@ export const findPlanet = pub
     }),
   )
   .output(PlanetSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     const planet = planets.find(planet => planet.id === input.id)
 
     if (!planet) {
@@ -83,7 +83,7 @@ export const updatePlanet = authed
   })
   .input(UpdatePlanetSchema)
   .output(PlanetSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     const planet = planets.find(planet => planet.id === input.id)
 
     if (!planet) {
@@ -113,7 +113,7 @@ export const updatePlanetImage = authed
     }),
   )
   .output(PlanetSchema)
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     const planet = planets.find(planet => planet.id === input.id)
 
     if (!planet) {
@@ -140,7 +140,7 @@ export const deletePlanet = authed
       id: z.number().int().min(1),
     }),
   )
-  .handler(async (input, context, meta) => {
+  .handler(async ({ input, context }) => {
     const planet = planets.find(planet => planet.id === input.id)
 
     if (!planet) {


### PR DESCRIPTION
```ts
os.handler((input, context, meta) => { }) // 🛑 old
os.handler(({ context, input }) => { }) // ✅ new

os.middleware((input, context, meta) => meta.next({})) // 🛑 old
os.middleware(({ context, next }, input) => next({})) // ✅ new

os.use((input, context, meta) => meta.next({})) // 🛑 old
os.use(({ context, next }, input) => next({})) // ✅ new
```
