### PR TITLE
feat(server, openapi): returnFalseOnNoMatch option for handler

### DIFF
--- a/packages/openapi/src/adapters/fetch/openapi-handler.test.ts
+++ b/packages/openapi/src/adapters/fetch/openapi-handler.test.ts
@@ -440,4 +440,14 @@ describe.each(hono)('openAPIHandler: %s', (_, HonoConstructor) => {
       expect(response.status).toBe(500)
     })
   })
+
+  it('returnFalseOnNoMatch option', async () => {
+    const handler = new OpenAPIHandler(hono, router)
+
+    expect(await handler.fetch(new Request('https://example.com/not_found')))
+      .toBeInstanceOf(Response)
+
+    expect(await handler.fetch(new Request('https://example.com/not_found'), { returnFalseOnNoMatch: true }))
+      .toBe(false)
+  })
 })

--- a/packages/openapi/src/adapters/node/openapi-handler.test.ts
+++ b/packages/openapi/src/adapters/node/openapi-handler.test.ts
@@ -585,4 +585,14 @@ describe.each(hono)('openAPIHandler: %s', (_, HonoConstructor) => {
     expect(mockBeforeSend).toHaveBeenCalledTimes(1)
     expect(mockBeforeSend).toHaveBeenCalledWith(expect.any(Response), { __context: true })
   })
+
+  it('returnFalseOnNoMatch option', async () => {
+    const handler = new OpenAPIHandler(hono, router)
+
+    vi.mocked(createRequest).mockReturnValue(new Request('https://example.com/not_found'))
+
+    expect(await handler.handle(req, res)).toBe(undefined)
+
+    expect(await handler.handle(req, res, { returnFalseOnNoMatch: true })).toBe(false)
+  })
 })

--- a/packages/openapi/src/adapters/node/openapi-handler.ts
+++ b/packages/openapi/src/adapters/node/openapi-handler.ts
@@ -18,12 +18,20 @@ export class OpenAPIHandler<T extends Context> implements ConditionalRequestHand
     return request.headers[ORPC_HANDLER_HEADER] === undefined
   }
 
-  async handle(req: IncomingMessage, res: ServerResponse, ...[options]: [options: RequestOptions<T>] | (undefined extends T ? [] : never)): Promise<void> {
+  async handle<UReturnFalseOnNoMatch extends boolean = false>(
+    req: IncomingMessage,
+    res: ServerResponse,
+    ...[options]: [options: RequestOptions<T, UReturnFalseOnNoMatch>] | (undefined extends T ? [] : never)
+  ): Promise<void | (true extends UReturnFalseOnNoMatch ? false : never)> {
     const request = createRequest(req, res, options)
 
     const castedOptions = (options ?? {}) as Exclude<typeof options, undefined>
 
     const response = await this.openapiFetchHandler.fetch(request, castedOptions)
+
+    if (response === false) {
+      return false as any
+    }
 
     await options?.beforeSend?.(response, castedOptions.context as T)
 

--- a/packages/server/src/adapters/fetch/composite-handler.test.ts
+++ b/packages/server/src/adapters/fetch/composite-handler.test.ts
@@ -53,7 +53,7 @@ describe('compositeHandler', () => {
     expect(mockHandler1.fetch).toHaveBeenCalledTimes(0)
     expect(mockHandler2.fetch).toHaveBeenCalledTimes(0)
     expect(response.status).toBe(404)
-    expect(await response.text()).toBe('None of the handlers can handle the request.')
+    expect(await response.text()).toBe('No handler found for the request.')
   })
 
   it('should handle an empty handlers array', async () => {
@@ -63,7 +63,7 @@ describe('compositeHandler', () => {
     const response = await compositeHandler.fetch(request)
 
     expect(response.status).toBe(404)
-    expect(await response.text()).toBe('None of the handlers can handle the request.')
+    expect(await response.text()).toBe('No handler found for the request.')
   })
 
   it('should handle multiple handlers, but only call the first matching handler', async () => {
@@ -85,5 +85,17 @@ describe('compositeHandler', () => {
     expect(mockHandler1.fetch).toHaveBeenCalledTimes(1)
     expect(mockHandler2.fetch).toHaveBeenCalledTimes(0)
     expect(await response.text()).toBe('Handler 1 response')
+  })
+
+  it('returnFalseOnNoMatch option', async () => {
+    const compositeHandler = new CompositeHandler([])
+
+    const request = new Request('https://example.com/unknown')
+
+    const r1 = await compositeHandler.fetch(request)
+    expect(r1).toBeInstanceOf(Response)
+
+    const r2 = await compositeHandler.fetch(request, { returnFalseOnNoMatch: true })
+    expect(r2).toBe(false)
   })
 })

--- a/packages/server/src/adapters/fetch/composite-handler.test.ts
+++ b/packages/server/src/adapters/fetch/composite-handler.test.ts
@@ -4,7 +4,7 @@ import { CompositeHandler } from './composite-handler'
 // Mock a basic handler implementation
 function createMockHandler(
   condition: (request: Request) => boolean,
-  fetch: (request: Request, options?: FetchOptions<any>) => Promise<Response>,
+  fetch: (request: Request, options?: FetchOptions<any, any>) => Promise<Response>,
 ): ConditionalFetchHandler<any> {
   return {
     condition,

--- a/packages/server/src/adapters/fetch/composite-handler.ts
+++ b/packages/server/src/adapters/fetch/composite-handler.ts
@@ -16,7 +16,11 @@ export class CompositeHandler<T extends Context> implements FetchHandler<T> {
       }
     }
 
-    return new Response('None of the handlers can handle the request.', {
+    if (opt[0]?.returnFalseOnNoMatch) {
+      return false as any
+    }
+
+    return new Response('No handler found for the request.', {
       status: 404,
     })
   }

--- a/packages/server/src/adapters/fetch/composite-handler.ts
+++ b/packages/server/src/adapters/fetch/composite-handler.ts
@@ -6,10 +6,10 @@ export class CompositeHandler<T extends Context> implements FetchHandler<T> {
     private readonly handlers: ConditionalFetchHandler<T>[],
   ) {}
 
-  async fetch(
+  async fetch<UReturnFalseOnNoMatch extends boolean = false>(
     request: Request,
-    ...opt: [options: FetchOptions<T>] | (undefined extends T ? [] : never)
-  ): Promise<Response> {
+    ...opt: [options: FetchOptions<T, UReturnFalseOnNoMatch>] | (undefined extends T ? [] : never)
+  ): Promise<Response | (true extends UReturnFalseOnNoMatch ? false : never)> {
     for (const handler of this.handlers) {
       if (handler.condition(request)) {
         return handler.fetch(request, ...opt)

--- a/packages/server/src/adapters/fetch/orpc-handler.test-d.ts
+++ b/packages/server/src/adapters/fetch/orpc-handler.test-d.ts
@@ -11,7 +11,7 @@ describe('oRPCHandler', () => {
     const handler = new ORPCHandler(router, {
       onSuccess(state, context, meta) {
         expectTypeOf(state.input).toEqualTypeOf<Request>()
-        expectTypeOf(state.output).toEqualTypeOf<Response>()
+        expectTypeOf(state.output).toEqualTypeOf<Response | false>()
         expectTypeOf(context).toEqualTypeOf<{ userId?: string }>()
         expectTypeOf(meta).toEqualTypeOf<WithSignal>()
       },

--- a/packages/server/src/adapters/fetch/orpc-handler.test.ts
+++ b/packages/server/src/adapters/fetch/orpc-handler.test.ts
@@ -173,4 +173,14 @@ describe('oRPCHandler', () => {
       headers: new Headers({ [ORPC_HANDLER_HEADER]: ORPC_HANDLER_VALUE }),
     }))).toBe(true)
   })
+
+  it('returnFalseOnNoMatch option', async () => {
+    const handler = new ORPCHandler(router)
+
+    expect(await handler.fetch(new Request('https://example.com/not_found')))
+      .toBeInstanceOf(Response)
+
+    expect(await handler.fetch(new Request('https://example.com/not_found'), { returnFalseOnNoMatch: true }))
+      .toBe(false)
+  })
 })

--- a/packages/server/src/adapters/fetch/types.test-d.ts
+++ b/packages/server/src/adapters/fetch/types.test-d.ts
@@ -13,4 +13,16 @@ describe('FetchHandler', () => {
     handler2.fetch(new Request('https://example.com'))
     handler2.fetch(new Request('https://example.com'), { context: { auth: true } })
   })
+
+  it('returnFalseOnNoMatch option', () => {
+    const handler = {} as FetchHandler<undefined>
+
+    expectTypeOf(
+      handler.fetch(new Request('https://example.com')),
+    ).toEqualTypeOf<Promise<Response>>()
+
+    expectTypeOf(
+      handler.fetch(new Request('https://example.com'), { returnFalseOnNoMatch: true }),
+    ).toEqualTypeOf<Promise<false | Response>>()
+  })
 })

--- a/packages/server/src/adapters/fetch/types.ts
+++ b/packages/server/src/adapters/fetch/types.ts
@@ -1,16 +1,16 @@
 import type { HTTPPath } from '@orpc/contract'
 import type { Context, WithSignal } from '../../types'
 
-export type FetchOptions<T extends Context> =
+export type FetchOptions<TContext extends Context, TReturnFalseOnNoMatch extends boolean> =
   & WithSignal
-  & { prefix?: HTTPPath }
-  & (undefined extends T ? { context?: T } : { context: T })
+  & { prefix?: HTTPPath, returnFalseOnNoMatch?: TReturnFalseOnNoMatch }
+  & (undefined extends TContext ? { context?: TContext } : { context: TContext })
 
 export interface FetchHandler<T extends Context> {
-  fetch: (
+  fetch: <UReturnFalseOnNoMatch extends boolean = false>(
     request: Request,
-    ...opt: [options: FetchOptions<T>] | (undefined extends T ? [] : never)
-  ) => Promise<Response>
+    ...opt: [options: FetchOptions<T, UReturnFalseOnNoMatch>] | (undefined extends T ? [] : never)
+  ) => Promise<Response | (true extends UReturnFalseOnNoMatch ? false : never)>
 }
 
 export interface ConditionalFetchHandler<T extends Context> extends FetchHandler<T> {

--- a/packages/server/src/adapters/node/orpc-handler.test.ts
+++ b/packages/server/src/adapters/node/orpc-handler.test.ts
@@ -241,4 +241,15 @@ describe('oRPCHandler', () => {
     expect(mockBeforeSend).toHaveBeenCalledTimes(1)
     expect(mockBeforeSend).toHaveBeenCalledWith(expect.any(Response), { __context: true })
   })
+
+  it('returnFalseOnNoMatch option', async () => {
+    const handler = new ORPCHandler(router)
+
+    vi.mocked(createRequest).mockReturnValue(new Request('https://example.com/not_found'))
+
+    expect(await handler.handle(req, res)).toBe(undefined)
+
+    expect(await handler.handle(req, res, { returnFalseOnNoMatch: true }))
+      .toBe(false)
+  })
 })

--- a/packages/server/src/adapters/node/types.test-d.ts
+++ b/packages/server/src/adapters/node/types.test-d.ts
@@ -1,0 +1,32 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { RequestHandler } from './types'
+
+describe('RequestHandler', () => {
+  const req = {} as IncomingMessage
+  const res = {} as ServerResponse
+
+  it('optional second argument when context is not required', () => {
+    const handler = {} as RequestHandler<{ auth: boolean } | undefined>
+
+    handler.handle(req, res)
+    handler.handle(req, res, { context: { auth: true } })
+
+    const handler2 = {} as RequestHandler<{ auth: boolean }>
+
+    // @ts-expect-error -- context is required
+    handler2.handle(req, res)
+    handler2.handle(req, res, { context: { auth: true } })
+  })
+
+  it('returnFalseOnNoMatch option', () => {
+    const handler = {} as RequestHandler<undefined>
+
+    expectTypeOf(
+      handler.handle(req, res),
+    ).toEqualTypeOf<Promise<void>>()
+
+    expectTypeOf(
+      handler.handle(req, res, { returnFalseOnNoMatch: true }),
+    ).toEqualTypeOf<Promise<false | void>>()
+  })
+})

--- a/packages/server/src/adapters/node/types.ts
+++ b/packages/server/src/adapters/node/types.ts
@@ -6,17 +6,22 @@ import type { Promisable } from '@orpc/shared'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { Context, WithSignal } from '../../types'
 
-export type RequestOptions<T extends Context> =
+export type RequestOptions<T extends Context, TReturnFalseOnNoMatch extends boolean> =
   & BaseRequestOptions
   & WithSignal
-  & { prefix?: HTTPPath }
-  & (undefined extends T ? { context?: T } : { context: T })
   & {
+    prefix?: HTTPPath
+    returnFalseOnNoMatch?: TReturnFalseOnNoMatch
     beforeSend?: (response: Response, context: T) => Promisable<void>
   }
+  & (undefined extends T ? { context?: T } : { context: T })
 
 export interface RequestHandler<T extends Context> {
-  handle: (req: IncomingMessage, res: ServerResponse, ...opt: [options: RequestOptions<T>] | (undefined extends T ? [] : never)) => void
+  handle: <UReturnFalseOnNoMatch extends boolean = false>(
+    req: IncomingMessage,
+    res: ServerResponse,
+    ...opt: [options: RequestOptions<T, UReturnFalseOnNoMatch>] | (undefined extends T ? [] : never)
+  ) => Promise<void | (true extends UReturnFalseOnNoMatch ? false : never)>
 }
 
 export interface ConditionalRequestHandler<T extends Context> extends RequestHandler<T> {


### PR DESCRIPTION
```ts
const result = await openAPIHandler.handle(req, res, { returnFalseOnNoMatch: true })

if (result === false) {
  // your custom logic here like call next() from hono.js or express.js
}
```