### PR TITLE
refactor(contract, server, client): improve client types

### DIFF
--- a/packages/client/src/client.test-d.ts
+++ b/packages/client/src/client.test-d.ts
@@ -30,15 +30,15 @@ describe('createORPCClient', () => {
   it('build correct types with contract router', () => {
     const client = createORPCClient<typeof contractRouter>({} as any)
 
-    expectTypeOf(client.ping).toMatchTypeOf<Client<unknown, { in: string }, { out: string }, Error>>()
-    expectTypeOf(client.nested.pong).toMatchTypeOf<Client<unknown, number, unknown, Error>>()
+    expectTypeOf(client.ping).toEqualTypeOf<Client<unknown, { in: string }, { out: string }, Error>>()
+    expectTypeOf(client.nested.pong).toEqualTypeOf<Client<unknown, number, unknown, Error>>()
   })
 
   it('build correct types with router', () => {
     const client = createORPCClient<typeof router>({} as any)
 
-    expectTypeOf(client.ping).toMatchTypeOf<Client<unknown, { in: string }, { out: string }, Error>>()
-    expectTypeOf(client.nested.pong).toMatchTypeOf<Client<unknown, number, string, Error>>()
+    expectTypeOf(client.ping).toEqualTypeOf<Client<unknown, { in: string }, { out: string }, Error>>()
+    expectTypeOf(client.nested.pong).toEqualTypeOf<Client<unknown, number, string, Error>>()
   })
 
   it('pass correct context', () => {

--- a/packages/client/src/client.test-d.ts
+++ b/packages/client/src/client.test-d.ts
@@ -1,4 +1,4 @@
-import type { ProcedureClient } from '@orpc/server'
+import type { Client } from '@orpc/contract'
 import { oc } from '@orpc/contract'
 import { os } from '@orpc/server'
 import { z } from 'zod'
@@ -30,22 +30,22 @@ describe('createORPCClient', () => {
   it('build correct types with contract router', () => {
     const client = createORPCClient<typeof contractRouter>({} as any)
 
-    expectTypeOf(client.ping).toMatchTypeOf<ProcedureClient<unknown, { in: string }, { out: string }, Error>>()
-    expectTypeOf(client.nested.pong).toMatchTypeOf<ProcedureClient<unknown, number, unknown, Error>>()
+    expectTypeOf(client.ping).toMatchTypeOf<Client<unknown, { in: string }, { out: string }, Error>>()
+    expectTypeOf(client.nested.pong).toMatchTypeOf<Client<unknown, number, unknown, Error>>()
   })
 
   it('build correct types with router', () => {
     const client = createORPCClient<typeof router>({} as any)
 
-    expectTypeOf(client.ping).toMatchTypeOf<ProcedureClient<unknown, { in: string }, { out: string }, Error>>()
-    expectTypeOf(client.nested.pong).toMatchTypeOf<ProcedureClient<unknown, number, string, Error>>()
+    expectTypeOf(client.ping).toMatchTypeOf<Client<unknown, { in: string }, { out: string }, Error>>()
+    expectTypeOf(client.nested.pong).toMatchTypeOf<Client<unknown, number, string, Error>>()
   })
 
   it('pass correct context', () => {
     type Context = { a: number }
     const client = createORPCClient<typeof router, Context>({} as any)
 
-    expectTypeOf(client.ping).toEqualTypeOf<ProcedureClient<{ a: number }, { in: string }, { out: string }, Error>>()
-    expectTypeOf(client.nested.pong).toEqualTypeOf < ProcedureClient < { a: number }, number, string, Error>>()
+    expectTypeOf(client.ping).toEqualTypeOf<Client<{ a: number }, { in: string }, { out: string }, Error>>()
+    expectTypeOf(client.nested.pong).toEqualTypeOf < Client < { a: number }, number, string, Error>>()
   })
 })

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,5 +1,5 @@
-import type { ContractRouter } from '@orpc/contract'
-import type { ANY_ROUTER, ProcedureClient, RouterClient } from '@orpc/server'
+import type { Client, ContractRouter, ContractRouterClient } from '@orpc/contract'
+import type { ANY_ROUTER, RouterClient } from '@orpc/server'
 import type { ClientLink } from './types'
 
 export interface createORPCClientOptions {
@@ -12,10 +12,14 @@ export interface createORPCClientOptions {
 export function createORPCClient<TRouter extends ANY_ROUTER | ContractRouter, TClientContext = unknown>(
   link: ClientLink<TClientContext>,
   options?: createORPCClientOptions,
-): RouterClient<TRouter, TClientContext> {
+): TRouter extends ContractRouter
+    ? ContractRouterClient<TRouter, TClientContext>
+    : TRouter extends ANY_ROUTER
+      ? RouterClient<TRouter, TClientContext>
+      : never {
   const path = options?.path ?? []
 
-  const procedureClient: ProcedureClient<TClientContext, unknown, unknown, Error> = async (...[input, options]) => {
+  const procedureClient: Client<TClientContext, unknown, unknown, Error> = async (...[input, options]) => {
     return await link.call(path, input, (options ?? {}) as Exclude<typeof options, undefined>)
   }
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -14,7 +14,7 @@ export function createORPCClient<TRouter extends ANY_ROUTER | ContractRouter, TC
   options?: createORPCClientOptions,
 ): TRouter extends ContractRouter
     ? ContractRouterClient<TRouter, TClientContext>
-    : TRouter extends ANY_ROUTER
+    : TRouter extends ANY_ROUTER // put this in lower priority than ContractRouter, will make createORPCClient can work without @orpc/server
       ? RouterClient<TRouter, TClientContext>
       : never {
   const path = options?.path ?? []

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -10,9 +10,11 @@ export * from './error'
 export * from './error-map'
 export * from './error-orpc'
 export * from './procedure'
+export * from './procedure-client'
 export * from './procedure-decorated'
 export * from './router'
 export * from './router-builder'
+export * from './router-client'
 export * from './types'
 
 export const oc = new ContractBuilder()

--- a/packages/contract/src/procedure-client.test-d.ts
+++ b/packages/contract/src/procedure-client.test-d.ts
@@ -1,0 +1,31 @@
+import type { Client } from './client'
+import type { ORPCError } from './error-orpc'
+import type { ContractProcedureClient } from './procedure-client'
+import { z } from 'zod'
+
+const schema = z.object({
+  value: z.string().transform(() => 1),
+})
+const baseErrors = {
+  CODE: {
+    data: z.object({
+      why: z.string(),
+    }),
+  },
+}
+
+describe('ContractProcedureClient', () => {
+  it('compatible with Client', () => {
+    expectTypeOf<
+      ContractProcedureClient<'context', typeof schema, typeof schema, typeof baseErrors>
+    >().toEqualTypeOf<Client<'context', { value: string }, { value: number }, Error | ORPCError<'CODE', { why: string }>>>()
+
+    expectTypeOf<
+      ContractProcedureClient<'context', typeof schema, typeof schema, typeof baseErrors>
+    >().not.toEqualTypeOf<Client<'diff', { value: string }, { value: number }, Error | ORPCError<'CODE', { why: string }>>>()
+
+    expectTypeOf<
+      ContractProcedureClient<'context', typeof schema, typeof schema, typeof baseErrors>
+    >().not.toEqualTypeOf<Client<'context', { value: number }, { value: number }, Error | ORPCError<'CODE', { why: string }>>>()
+  })
+})

--- a/packages/contract/src/procedure-client.ts
+++ b/packages/contract/src/procedure-client.ts
@@ -1,0 +1,11 @@
+import type { Client } from './client'
+import type { ErrorFromErrorMap } from './error'
+import type { ErrorMap } from './error-map'
+import type { Schema, SchemaInput, SchemaOutput } from './types'
+
+export type ContractProcedureClient<
+  TClientContext,
+  TInputSchema extends Schema,
+  TOutputSchema extends Schema,
+  TErrorMap extends ErrorMap,
+> = Client<TClientContext, SchemaInput<TInputSchema>, SchemaOutput<TOutputSchema>, ErrorFromErrorMap<TErrorMap>>

--- a/packages/contract/src/router-client.test-d.ts
+++ b/packages/contract/src/router-client.test-d.ts
@@ -1,0 +1,35 @@
+import type { NestedClient } from './client'
+import type { ContractRouterClient } from './router-client'
+import { z } from 'zod'
+import { ContractProcedure } from './procedure'
+import { DecoratedContractProcedure } from './procedure-decorated'
+
+const schema = z.object({
+  value: z.string().transform(() => 1),
+})
+
+const ping = new ContractProcedure({ InputSchema: schema, OutputSchema: undefined, route: { path: '/procedure' }, errorMap: undefined })
+const pinged = DecoratedContractProcedure.decorate(ping)
+
+const pong = new ContractProcedure({ InputSchema: undefined, OutputSchema: schema, errorMap: undefined })
+const ponged = DecoratedContractProcedure.decorate(pong)
+
+const router = {
+  ping,
+  pinged,
+  pong,
+  ponged,
+  nested: {
+    ping,
+    pinged,
+    pong,
+    ponged,
+  },
+}
+
+describe('ContractRouterClient', () => {
+  it('compatible with NestedClient', () => {
+    expectTypeOf<ContractRouterClient<typeof router, unknown>>().toMatchTypeOf<NestedClient<unknown>>()
+    expectTypeOf<ContractRouterClient<typeof router, 'invalid'>>().not.toMatchTypeOf<NestedClient<unknown>>()
+  })
+})

--- a/packages/contract/src/router-client.ts
+++ b/packages/contract/src/router-client.ts
@@ -1,0 +1,10 @@
+import type { ContractProcedure } from './procedure'
+import type { ContractProcedureClient } from './procedure-client'
+import type { ContractRouter } from './router'
+
+export type ContractRouterClient<TRouter extends ContractRouter, TClientContext> =
+  TRouter extends ContractProcedure<infer UInputSchema, infer UOutputSchema, infer UErrorMap>
+    ? ContractProcedureClient<TClientContext, UInputSchema, UOutputSchema, UErrorMap>
+    : {
+        [K in keyof TRouter]: TRouter[K] extends ContractRouter ? ContractRouterClient<TRouter[K], TClientContext> : never
+      }

--- a/packages/react-query/package.json
+++ b/packages/react-query/package.json
@@ -47,7 +47,6 @@
   "peerDependencies": {
     "@orpc/client": "workspace:*",
     "@orpc/contract": "workspace:*",
-    "@orpc/server": "workspace:*",
     "@tanstack/react-query": ">=5.59.0",
     "react": ">=18.3.0"
   },

--- a/packages/react-query/src/utils-procedure.test-d.ts
+++ b/packages/react-query/src/utils-procedure.test-d.ts
@@ -1,16 +1,17 @@
-import type { ORPCError, ProcedureClient } from '@orpc/server'
+import type { Client } from '@orpc/contract'
+import type { ORPCError } from '@orpc/server'
 import type { InfiniteData, QueryFunctionContext, QueryKey } from '@tanstack/react-query'
 import type { ProcedureUtils } from './utils-procedure'
 import { useInfiniteQuery, useMutation, useQuery } from '@tanstack/react-query'
 import { createProcedureUtils } from './utils-procedure'
 
 describe('queryOptions', () => {
-  const client = vi.fn<ProcedureClient<unknown, number | undefined, string | undefined, Error>>(
+  const client = vi.fn<Client<unknown, number | undefined, string | undefined, Error>>(
     (...[input]) => Promise.resolve(input?.toString()),
   )
   const utils = createProcedureUtils(client, [])
 
-  const client2 = {} as ProcedureClient<unknown, number, string, Error>
+  const client2 = {} as Client<unknown, number, string, Error>
   const utils2 = createProcedureUtils(client2, [])
 
   it('infer correct input type', () => {
@@ -77,7 +78,7 @@ describe('queryOptions', () => {
   })
 
   it('can infer errors', () => {
-    const utils = createProcedureUtils({} as ProcedureClient<unknown, unknown, string, Error | ORPCError<'CODE', 'data'>>, [])
+    const utils = createProcedureUtils({} as Client<unknown, unknown, string, Error | ORPCError<'CODE', 'data'>>, [])
     expectTypeOf(useQuery(utils.queryOptions()).error).toEqualTypeOf<Error | ORPCError<'CODE', 'data'> | null>()
     expectTypeOf(useQuery(utils.queryOptions({})).error).toEqualTypeOf<Error | ORPCError<'CODE', 'data'> | null>()
   })
@@ -87,7 +88,7 @@ describe('infiniteOptions', () => {
   const getNextPageParam = vi.fn()
 
   it('cannot use on procedure without input object-able', () => {
-    const utils = createProcedureUtils({} as ProcedureClient<unknown, number, string, Error>, [])
+    const utils = createProcedureUtils({} as Client<unknown, number, string, Error>, [])
 
     // @ts-expect-error missing initialPageParam
     utils.infiniteOptions({
@@ -110,7 +111,7 @@ describe('infiniteOptions', () => {
   })
 
   it('infer correct queryFn type', () => {
-    const utils = createProcedureUtils({} as ProcedureClient<unknown, { limit?: number, cursor: number }, string, Error>, [])
+    const utils = createProcedureUtils({} as Client<unknown, { limit?: number, cursor: number }, string, Error>, [])
     const options = utils.infiniteOptions({
       input: {},
       getNextPageParam,
@@ -121,7 +122,7 @@ describe('infiniteOptions', () => {
   })
 
   it('infer correct input type', () => {
-    const utils = createProcedureUtils({} as ProcedureClient<unknown, { limit?: number, cursor: number }, string, Error>, [])
+    const utils = createProcedureUtils({} as Client<unknown, { limit?: number, cursor: number }, string, Error>, [])
 
     utils.infiniteOptions({
       input: {
@@ -152,7 +153,7 @@ describe('infiniteOptions', () => {
   })
 
   it('infer correct initialPageParam type', () => {
-    const utils = createProcedureUtils({} as ProcedureClient<unknown, { limit?: number, cursor: number }, string, Error>, [])
+    const utils = createProcedureUtils({} as Client<unknown, { limit?: number, cursor: number }, string, Error>, [])
 
     utils.infiniteOptions({
       input: {},
@@ -175,14 +176,14 @@ describe('infiniteOptions', () => {
   })
 
   it('initialPageParam can be optional', () => {
-    const utils = createProcedureUtils({} as ProcedureClient<unknown, { limit?: number, cursor?: number }, string, Error>, [])
+    const utils = createProcedureUtils({} as Client<unknown, { limit?: number, cursor?: number }, string, Error>, [])
 
     utils.infiniteOptions({
       input: {},
       getNextPageParam,
     })
 
-    const utils2 = createProcedureUtils({} as ProcedureClient<unknown, { limit?: number, cursor: number }, string, Error>, [])
+    const utils2 = createProcedureUtils({} as Client<unknown, { limit?: number, cursor: number }, string, Error>, [])
 
     // @ts-expect-error initialPageParam is required
     utils2.infiniteOptions({
@@ -192,13 +193,13 @@ describe('infiniteOptions', () => {
   })
 
   it('input can be optional', () => {
-    const utils = createProcedureUtils({} as ProcedureClient<unknown, { limit?: number, cursor?: number } | undefined, string, Error>, [])
+    const utils = createProcedureUtils({} as Client<unknown, { limit?: number, cursor?: number } | undefined, string, Error>, [])
 
     utils.infiniteOptions({
       getNextPageParam,
     })
 
-    const utils2 = createProcedureUtils({} as ProcedureClient<unknown, { limit?: number, cursor?: number }, string, Error>, [])
+    const utils2 = createProcedureUtils({} as Client<unknown, { limit?: number, cursor?: number }, string, Error>, [])
 
     // @ts-expect-error input is required
     utils2.infiniteOptions({
@@ -207,7 +208,7 @@ describe('infiniteOptions', () => {
   })
 
   it('infer correct output type', () => {
-    const utils = createProcedureUtils({} as ProcedureClient<unknown, { limit?: number, cursor: number }, string, Error>, [])
+    const utils = createProcedureUtils({} as Client<unknown, { limit?: number, cursor: number }, string, Error>, [])
     const query = useInfiniteQuery(utils.infiniteOptions({
       input: {
         limit: 1,
@@ -222,7 +223,7 @@ describe('infiniteOptions', () => {
   })
 
   it('work with select options', () => {
-    const utils = createProcedureUtils({} as ProcedureClient<unknown, { limit?: number, cursor: number }, string, Error>, [])
+    const utils = createProcedureUtils({} as Client<unknown, { limit?: number, cursor: number }, string, Error>, [])
     const query = useInfiniteQuery(utils.infiniteOptions({
       input: {
         limit: 1,
@@ -270,7 +271,7 @@ describe('infiniteOptions', () => {
   })
 
   it('can infer errors', () => {
-    const utils = createProcedureUtils({} as ProcedureClient<unknown, { cursor?: number } | undefined, string, Error | ORPCError<'CODE', 'data'>>, [])
+    const utils = createProcedureUtils({} as Client<unknown, { cursor?: number } | undefined, string, Error | ORPCError<'CODE', 'data'>>, [])
     expectTypeOf(
       useInfiniteQuery(utils.infiniteOptions({
         getNextPageParam: () => 2,
@@ -280,7 +281,7 @@ describe('infiniteOptions', () => {
 })
 
 describe('mutationOptions', () => {
-  const client = {} as ProcedureClient<unknown, number, string, Error>
+  const client = {} as Client<unknown, number, string, Error>
   const utils = createProcedureUtils(client, [])
 
   it('infer correct input type', () => {
@@ -340,7 +341,7 @@ describe('mutationOptions', () => {
   })
 
   it('can infer errors', () => {
-    const utils = createProcedureUtils({} as ProcedureClient<unknown, unknown, string, Error | ORPCError<'CODE', 'data'>>, [])
+    const utils = createProcedureUtils({} as Client<unknown, unknown, string, Error | ORPCError<'CODE', 'data'>>, [])
     expectTypeOf(useMutation(utils.mutationOptions()).error).toEqualTypeOf<Error | ORPCError<'CODE', 'data'> | null>()
     expectTypeOf(useMutation(utils.mutationOptions({})).error).toEqualTypeOf<Error | ORPCError<'CODE', 'data'> | null>()
   })

--- a/packages/react-query/src/utils-procedure.ts
+++ b/packages/react-query/src/utils-procedure.ts
@@ -1,4 +1,4 @@
-import type { ProcedureClient } from '@orpc/server'
+import type { Client } from '@orpc/contract'
 import type { IsEqual } from '@orpc/shared'
 import type { InfiniteOptionsBase, InfiniteOptionsExtra, MutationOptionsBase, MutationOptionsExtra, QueryOptionsBase, QueryOptionsExtra } from './types'
 import { buildKey } from './key'
@@ -25,7 +25,7 @@ export interface ProcedureUtils<TClientContext, TInput, TOutput, TError extends 
 }
 
 export function createProcedureUtils<TClientContext, TInput, TOutput, TError extends Error>(
-  client: ProcedureClient<TClientContext, TInput, TOutput, TError>,
+  client: Client<TClientContext, TInput, TOutput, TError>,
   path: string[],
 ): ProcedureUtils<TClientContext, TInput, TOutput, TError> {
   return {

--- a/packages/react-query/src/utils-router.test-d.ts
+++ b/packages/react-query/src/utils-router.test-d.ts
@@ -1,3 +1,4 @@
+import type { ContractRouterClient } from '@orpc/contract'
 import type { RouterClient } from '@orpc/server'
 import type { GeneralUtils } from './utils-general'
 import type { ProcedureUtils } from './utils-procedure'
@@ -25,7 +26,7 @@ const router = os.contract(contractRouter).router({
 
 describe('with contract router', () => {
   it('build correct types', () => {
-    const utils = createRouterUtils({} as RouterClient<typeof contractRouter, unknown>)
+    const utils = createRouterUtils({} as ContractRouterClient<typeof contractRouter, unknown>)
 
     const generalUtils = createGeneralUtils([])
     const pingUtils = createProcedureUtils(ping, [])

--- a/packages/react-query/src/utils-router.ts
+++ b/packages/react-query/src/utils-router.ts
@@ -1,19 +1,19 @@
-import type { ProcedureClient, RouterClient } from '@orpc/server'
+import type { Client, NestedClient } from '@orpc/contract'
 import { createGeneralUtils, type GeneralUtils } from './utils-general'
 import { createProcedureUtils, type ProcedureUtils } from './utils-procedure'
 
-export type RouterUtils<T extends RouterClient<any, any>> =
-  T extends ProcedureClient<infer UClientContext, infer UInput, infer UOutput, infer UError>
+export type RouterUtils<T extends NestedClient<any>> =
+  T extends Client<infer UClientContext, infer UInput, infer UOutput, infer UError>
     ? ProcedureUtils<UClientContext, UInput, UOutput, UError> & GeneralUtils<UInput>
     : {
-      [K in keyof T]: T[K] extends RouterClient<any, any> ? RouterUtils<T[K]> : never
+      [K in keyof T]: T[K] extends NestedClient<any> ? RouterUtils<T[K]> : never
     } & GeneralUtils<unknown>
 
 /**
  * @param client - The client create form `@orpc/client`
  * @param path - The base path for query key
  */
-export function createRouterUtils<T extends RouterClient<any, any>>(
+export function createRouterUtils<T extends NestedClient<any>>(
   client: T,
   path: string[] = [],
 ): RouterUtils<T> {

--- a/packages/server/src/procedure-client.ts
+++ b/packages/server/src/procedure-client.ts
@@ -10,7 +10,13 @@ import { createORPCErrorConstructorMap } from './error'
 import { unlazy } from './lazy'
 import { mergeContext } from './utils'
 
-export type ProcedureClient<TClientContext, TInput, TOutput, TError extends Error> = Client<TClientContext, TInput, TOutput, TError>
+export type ProcedureClient<
+  TClientContext,
+  TInputSchema extends Schema,
+  TOutputSchema extends Schema,
+  THandlerOutput extends SchemaInput<TOutputSchema>,
+  TErrorMap extends ErrorMap,
+> = Client<TClientContext, SchemaInput<TInputSchema>, SchemaOutput<TOutputSchema, THandlerOutput>, ErrorFromErrorMap<TErrorMap>>
 
 /**
  * Options for creating a procedure caller with comprehensive type safety
@@ -52,7 +58,7 @@ export function createProcedureClient<
 >(
   lazyableProcedure: Lazyable<Procedure<TContext, any, TInputSchema, TOutputSchema, THandlerOutput, TErrorMap>>,
   ...[options]: CreateProcedureClientRest<TContext, TOutputSchema, THandlerOutput, TClientContext>
-): ProcedureClient<TClientContext, SchemaInput<TInputSchema>, SchemaOutput<TOutputSchema, THandlerOutput>, ErrorFromErrorMap<TErrorMap>> {
+): ProcedureClient<TClientContext, TInputSchema, TOutputSchema, THandlerOutput, TErrorMap> {
   return async (...[input, callerOptions]) => {
     const path = options?.path ?? []
     const { default: procedure } = await unlazy(lazyableProcedure)

--- a/packages/server/src/procedure-decorated.ts
+++ b/packages/server/src/procedure-decorated.ts
@@ -1,7 +1,7 @@
-import type { Client, ClientRest, ErrorFromErrorMap, ErrorMap, HTTPPath, RouteOptions, Schema, SchemaInput, SchemaOutput } from '@orpc/contract'
+import type { ClientRest, ErrorMap, HTTPPath, RouteOptions, Schema, SchemaInput, SchemaOutput } from '@orpc/contract'
 import type { ORPCErrorConstructorMap } from './error'
 import type { ANY_MIDDLEWARE, MapInputMiddleware, Middleware } from './middleware'
-import type { CreateProcedureClientRest } from './procedure-client'
+import type { CreateProcedureClientRest, ProcedureClient } from './procedure-client'
 import type { Context, MergeContext } from './types'
 import { DecoratedContractProcedure } from '@orpc/contract'
 import { createCallableObject } from '@orpc/shared'
@@ -147,7 +147,7 @@ export class DecoratedProcedure<
    */
   callable<TClientContext>(...rest: CreateProcedureClientRest<TContext, TOutputSchema, THandlerOutput, TClientContext>):
     & DecoratedProcedure<TContext, TExtraContext, TInputSchema, TOutputSchema, THandlerOutput, TErrorMap>
-    & (Client<TClientContext, SchemaInput<TInputSchema>, SchemaOutput<TOutputSchema, THandlerOutput>, ErrorFromErrorMap<TErrorMap>>) {
+    & ProcedureClient<TClientContext, TInputSchema, TOutputSchema, THandlerOutput, TErrorMap> {
     return createCallableObject(this, createProcedureClient(this, ...rest))
   }
 

--- a/packages/server/src/router-client.test-d.ts
+++ b/packages/server/src/router-client.test-d.ts
@@ -1,6 +1,5 @@
-import type { ORPCError } from '@orpc/contract'
+import type { Client, NestedClient, ORPCError } from '@orpc/contract'
 import type { Procedure } from './procedure'
-import type { ProcedureClient } from './procedure-client'
 import type { Meta, WELL_CONTEXT } from './types'
 import { z } from 'zod'
 import { lazy } from './lazy'
@@ -35,21 +34,26 @@ const routerWithLazy = {
 }
 
 describe('RouterClient', () => {
+  it('compatible with NestedClient', () => {
+    expectTypeOf<RouterClient<typeof router, unknown>>().toMatchTypeOf<NestedClient<unknown>>()
+    expectTypeOf<RouterClient<typeof router, 'invalid'>>().not.toMatchTypeOf<NestedClient<unknown>>()
+  })
+
   it('router without lazy', () => {
     const client = {} as RouterClient<typeof router, unknown>
 
     expectTypeOf(client.ping).toEqualTypeOf<
-      ProcedureClient<unknown, { val: string }, { val: number }, Error | ORPCError<'CODE', { why: number }>>
+      Client<unknown, { val: string }, { val: number }, Error | ORPCError<'CODE', { why: number }>>
     >()
     expectTypeOf(client.pong).toEqualTypeOf<
-      ProcedureClient<unknown, unknown, unknown, Error>
+      Client<unknown, unknown, unknown, Error>
     >()
 
     expectTypeOf(client.nested.ping).toEqualTypeOf<
-      ProcedureClient<unknown, { val: string }, { val: number }, Error | ORPCError<'CODE', { why: number }>>
+      Client<unknown, { val: string }, { val: number }, Error | ORPCError<'CODE', { why: number }>>
     >()
     expectTypeOf(client.nested.pong).toEqualTypeOf<
-      ProcedureClient<unknown, unknown, unknown, Error>
+      Client<unknown, unknown, unknown, Error>
     >()
   })
 
@@ -58,7 +62,7 @@ describe('RouterClient', () => {
   })
 
   it('support procedure as router', () => {
-    expectTypeOf<RouterClient<typeof ping, unknown>>().toEqualTypeOf<ProcedureClient<unknown, { val: string }, { val: number }, Error | ORPCError<'CODE', { why: number }>>>()
+    expectTypeOf<RouterClient<typeof ping, unknown>>().toEqualTypeOf<Client<unknown, { val: string }, { val: number }, Error | ORPCError<'CODE', { why: number }>>>()
   })
 })
 

--- a/packages/server/src/router-client.ts
+++ b/packages/server/src/router-client.ts
@@ -1,4 +1,3 @@
-import type { ContractProcedure, ContractRouter, ErrorFromErrorMap, SchemaInput, SchemaOutput } from '@orpc/contract'
 import type { Hooks, Value } from '@orpc/shared'
 import type { Lazy } from './lazy'
 import type { Procedure } from './procedure'
@@ -13,20 +12,15 @@ import { type ANY_ROUTER, getRouterChild, type Router } from './router'
 /**
  * FIXME: separate RouterClient and ContractRouterClient, don't mix them
  */
-export type RouterClient<TRouter extends ANY_ROUTER | ContractRouter, TClientContext> =
-  TRouter extends Lazy<infer U extends ANY_ROUTER | ContractRouter>
-    ? RouterClient<U, TClientContext>
-    : TRouter extends
-    | ContractProcedure<infer UInputSchema, infer UOutputSchema, infer UErrorMap>
-    | Procedure<any, any, infer UInputSchema, infer UOutputSchema, infer UFuncOutput, infer UErrorMap>
-      ? ProcedureClient<TClientContext, SchemaInput<UInputSchema>, SchemaOutput<UOutputSchema, UFuncOutput>, ErrorFromErrorMap<UErrorMap>>
-      : {
-          [K in keyof TRouter]: TRouter[K] extends ANY_ROUTER | ContractRouter ? RouterClient<TRouter[K], TClientContext> : never
-        }
+export type RouterClient<TRouter extends ANY_ROUTER, TClientContext> = TRouter extends Lazy<infer U extends ANY_ROUTER>
+  ? RouterClient<U, TClientContext>
+  : TRouter extends Procedure<any, any, infer UInputSchema, infer UOutputSchema, infer UFuncOutput, infer UErrorMap>
+    ? ProcedureClient<TClientContext, UInputSchema, UOutputSchema, UFuncOutput, UErrorMap>
+    : {
+        [K in keyof TRouter]: TRouter[K] extends ANY_ROUTER ? RouterClient<TRouter[K], TClientContext> : never
+      }
 
-export type CreateRouterClientOptions<
-  TRouter extends ANY_ROUTER,
-> =
+export type CreateRouterClientOptions<TRouter extends ANY_ROUTER> =
   & {
     /**
      * This is helpful for logging and analytics.

--- a/packages/vue-colada/package.json
+++ b/packages/vue-colada/package.json
@@ -48,7 +48,6 @@
   "peerDependencies": {
     "@orpc/client": "workspace:*",
     "@orpc/contract": "workspace:*",
-    "@orpc/server": "workspace:*",
     "@pinia/colada": ">=0.13.1",
     "vue": ">=3.3.0"
   },

--- a/packages/vue-colada/src/utils-procedure.test-d.ts
+++ b/packages/vue-colada/src/utils-procedure.test-d.ts
@@ -1,4 +1,5 @@
-import type { ORPCError, ProcedureClient } from '@orpc/server'
+import type { Client } from '@orpc/contract'
+import type { ORPCError } from '@orpc/server'
 import type { QueryOptions } from './types'
 import type { ProcedureUtils } from './utils-procedure'
 import { useMutation, useQuery } from '@pinia/colada'
@@ -6,10 +7,10 @@ import { ref } from 'vue'
 import { createProcedureUtils } from './utils-procedure'
 
 describe('queryOptions', () => {
-  const client = {} as ProcedureClient<undefined, number | undefined, string | undefined, Error>
+  const client = {} as Client<undefined, number | undefined, string | undefined, Error>
   const utils = createProcedureUtils(client, [])
 
-  const client2 = {} as ProcedureClient<undefined, number, string, Error>
+  const client2 = {} as Client<undefined, number, string, Error>
   const utils2 = createProcedureUtils(client2, [])
 
   it('infer correct input type', () => {
@@ -75,7 +76,7 @@ describe('queryOptions', () => {
 })
 
 describe('mutationOptions', () => {
-  const client = {} as ProcedureClient<undefined, number, string, Error>
+  const client = {} as Client<undefined, number, string, Error>
   const utils = createProcedureUtils(client, [])
 
   it('infer correct input type', () => {

--- a/packages/vue-colada/src/utils-procedure.ts
+++ b/packages/vue-colada/src/utils-procedure.ts
@@ -1,4 +1,4 @@
-import type { ProcedureClient } from '@orpc/server'
+import type { Client } from '@orpc/contract'
 import type { MutationOptions, MutationOptionsExtra, QueryOptions, QueryOptionsExtra } from './types'
 import { computed } from 'vue'
 import { buildKey } from './key'
@@ -18,7 +18,7 @@ export interface ProcedureUtils<TClientContext, TInput, TOutput, TError extends 
 }
 
 export function createProcedureUtils<TClientContext, TInput, TOutput, TError extends Error>(
-  client: ProcedureClient<TClientContext, TInput, TOutput, TError>,
+  client: Client<TClientContext, TInput, TOutput, TError>,
   path: string[],
 ): ProcedureUtils<TClientContext, TInput, TOutput, TError> {
   return {

--- a/packages/vue-colada/src/utils-router.test-d.ts
+++ b/packages/vue-colada/src/utils-router.test-d.ts
@@ -1,3 +1,4 @@
+import type { ContractRouterClient } from '@orpc/contract'
 import type { RouterClient } from '@orpc/server'
 import type { GeneralUtils } from './utils-general'
 import type { ProcedureUtils } from './utils-procedure'
@@ -25,7 +26,7 @@ const router = os.contract(contractRouter).router({
 
 describe('with contract router', () => {
   it('build correct types', () => {
-    const utils = createRouterUtils({} as RouterClient<typeof contractRouter, unknown>)
+    const utils = createRouterUtils({} as ContractRouterClient<typeof contractRouter, unknown>)
 
     const generalUtils = createGeneralUtils([])
     const pingUtils = createProcedureUtils(ping, [])

--- a/packages/vue-colada/src/utils-router.ts
+++ b/packages/vue-colada/src/utils-router.ts
@@ -1,19 +1,19 @@
-import type { ProcedureClient, RouterClient } from '@orpc/server'
+import type { Client, NestedClient } from '@orpc/contract'
 import { createGeneralUtils, type GeneralUtils } from './utils-general'
 import { createProcedureUtils, type ProcedureUtils } from './utils-procedure'
 
-export type RouterUtils<T extends RouterClient<any, any>> =
-  T extends ProcedureClient<infer UClientContext, infer UInput, infer UOutput, infer UError>
+export type RouterUtils<T extends NestedClient<any>> =
+  T extends Client<infer UClientContext, infer UInput, infer UOutput, infer UError>
     ? ProcedureUtils<UClientContext, UInput, UOutput, UError> & GeneralUtils<UInput>
     : {
-      [K in keyof T]: T[K] extends RouterClient<any, any> ? RouterUtils<T[K]> : never
+      [K in keyof T]: T[K] extends NestedClient<any> ? RouterUtils<T[K]> : never
     } & GeneralUtils<unknown>
 
 /**
  * @param client - The client create form `@orpc/client`
  * @param path - The base path for query key
  */
-export function createRouterUtils<T extends RouterClient<any, any>>(
+export function createRouterUtils<T extends NestedClient<any>>(
   client: T,
   path: string[] = [],
 ): RouterUtils<T> {

--- a/packages/vue-query/package.json
+++ b/packages/vue-query/package.json
@@ -47,7 +47,6 @@
   "peerDependencies": {
     "@orpc/client": "workspace:*",
     "@orpc/contract": "workspace:*",
-    "@orpc/server": "workspace:*",
     "@tanstack/vue-query": ">=5.50.0",
     "vue": ">=3.3.0"
   }

--- a/packages/vue-query/src/utils-procedure.test-d.ts
+++ b/packages/vue-query/src/utils-procedure.test-d.ts
@@ -1,4 +1,5 @@
-import type { ORPCError, ProcedureClient } from '@orpc/server'
+import type { Client } from '@orpc/contract'
+import type { ORPCError } from '@orpc/server'
 import type { InfiniteData, QueryFunctionContext, QueryKey } from '@tanstack/vue-query'
 import type { ComputedRef } from 'vue'
 import type { ProcedureUtils } from './utils-procedure'
@@ -7,10 +8,10 @@ import { ref } from 'vue'
 import { createProcedureUtils } from './utils-procedure'
 
 describe('queryOptions', () => {
-  const client = {} as ProcedureClient<undefined, number | undefined, string | undefined, Error>
+  const client = {} as Client<undefined, number | undefined, string | undefined, Error>
   const utils = createProcedureUtils(client, [])
 
-  const client2 = {} as ProcedureClient<undefined, number, string, Error>
+  const client2 = {} as Client<undefined, number, string, Error>
   const utils2 = createProcedureUtils(client2, [])
 
   it('infer correct input type', () => {
@@ -98,7 +99,7 @@ describe('infiniteOptions', () => {
   const getNextPageParam = vi.fn()
 
   it('cannot use on procedure without input object-able', () => {
-    const utils = createProcedureUtils({} as ProcedureClient<undefined, number, string, Error>, [])
+    const utils = createProcedureUtils({} as Client<undefined, number, string, Error>, [])
 
     // @ts-expect-error missing initialPageParam
     utils.infiniteOptions({
@@ -121,7 +122,7 @@ describe('infiniteOptions', () => {
   })
 
   it('infer correct queryFn type', () => {
-    const utils = createProcedureUtils({} as ProcedureClient<undefined, { limit?: number, cursor: number }, string, Error>, [])
+    const utils = createProcedureUtils({} as Client<undefined, { limit?: number, cursor: number }, string, Error>, [])
     const options = utils.infiniteOptions({
       input: {},
       getNextPageParam,
@@ -132,7 +133,7 @@ describe('infiniteOptions', () => {
   })
 
   it('infer correct input type', () => {
-    const utils = createProcedureUtils({} as ProcedureClient<undefined, { limit?: number, cursor: number }, string, Error>, [])
+    const utils = createProcedureUtils({} as Client<undefined, { limit?: number, cursor: number }, string, Error>, [])
 
     utils.infiniteOptions({
       input: {
@@ -177,7 +178,7 @@ describe('infiniteOptions', () => {
   })
 
   it('infer correct initialPageParam type', () => {
-    const utils = createProcedureUtils({} as ProcedureClient<undefined, { limit?: number, cursor: number }, string, Error>, [])
+    const utils = createProcedureUtils({} as Client<undefined, { limit?: number, cursor: number }, string, Error>, [])
 
     utils.infiniteOptions({
       input: {},
@@ -213,14 +214,14 @@ describe('infiniteOptions', () => {
   })
 
   it('initialPageParam can be optional', () => {
-    const utils = createProcedureUtils({} as ProcedureClient<undefined, { limit?: number, cursor?: number }, string, Error>, [])
+    const utils = createProcedureUtils({} as Client<undefined, { limit?: number, cursor?: number }, string, Error>, [])
 
     utils.infiniteOptions({
       input: {},
       getNextPageParam,
     })
 
-    const utils2 = createProcedureUtils({} as ProcedureClient<undefined, { limit?: number, cursor: number }, string, Error>, [])
+    const utils2 = createProcedureUtils({} as Client<undefined, { limit?: number, cursor: number }, string, Error>, [])
 
     // @ts-expect-error initialPageParam is required
     utils2.infiniteOptions({
@@ -230,13 +231,13 @@ describe('infiniteOptions', () => {
   })
 
   it('input can be optional', () => {
-    const utils = createProcedureUtils({} as ProcedureClient<undefined, { limit?: number, cursor?: number } | undefined, string, Error>, [])
+    const utils = createProcedureUtils({} as Client<undefined, { limit?: number, cursor?: number } | undefined, string, Error>, [])
 
     utils.infiniteOptions({
       getNextPageParam,
     })
 
-    const utils2 = createProcedureUtils({} as ProcedureClient<undefined, { limit?: number, cursor?: number }, string, Error>, [])
+    const utils2 = createProcedureUtils({} as Client<undefined, { limit?: number, cursor?: number }, string, Error>, [])
 
     // @ts-expect-error input is required
     utils2.infiniteOptions({
@@ -245,7 +246,7 @@ describe('infiniteOptions', () => {
   })
 
   it('infer correct output type', () => {
-    const utils = createProcedureUtils({} as ProcedureClient<undefined, { limit?: number, cursor: number }, string, Error>, [])
+    const utils = createProcedureUtils({} as Client<undefined, { limit?: number, cursor: number }, string, Error>, [])
     const query = useInfiniteQuery(utils.infiniteOptions({
       input: {
         limit: 1,
@@ -258,7 +259,7 @@ describe('infiniteOptions', () => {
   })
 
   it('work with select options', () => {
-    const utils = createProcedureUtils({} as ProcedureClient<undefined, { limit?: number, cursor: number }, string, Error>, [])
+    const utils = createProcedureUtils({} as Client<undefined, { limit?: number, cursor: number }, string, Error>, [])
     const query = useInfiniteQuery(utils.infiniteOptions({
       input: {
         limit: ref(1),
@@ -323,7 +324,7 @@ describe('infiniteOptions', () => {
 })
 
 describe('mutationOptions', () => {
-  const client = {} as ProcedureClient<undefined, number, string, Error>
+  const client = {} as Client<undefined, number, string, Error>
   const utils = createProcedureUtils(client, [])
 
   it('infer correct input type', () => {

--- a/packages/vue-query/src/utils-procedure.ts
+++ b/packages/vue-query/src/utils-procedure.ts
@@ -1,4 +1,4 @@
-import type { ProcedureClient } from '@orpc/server'
+import type { Client } from '@orpc/contract'
 import type { IsEqual } from '@orpc/shared'
 import type { InfiniteOptionsBase, InfiniteOptionsExtra, MutationOptionsBase, MutationOptionsExtra, QueryOptionsBase, QueryOptionsExtra } from './types'
 import { computed } from 'vue'
@@ -27,7 +27,7 @@ export interface ProcedureUtils<TClientContext, TInput, TOutput, TError extends 
 }
 
 export function createProcedureUtils<TClientContext, TInput, TOutput, TError extends Error>(
-  client: ProcedureClient<TClientContext, TInput, TOutput, TError>,
+  client: Client<TClientContext, TInput, TOutput, TError>,
   path: string[],
 ): ProcedureUtils<TClientContext, TInput, TOutput, TError> {
   return {

--- a/packages/vue-query/src/utils-router.test-d.ts
+++ b/packages/vue-query/src/utils-router.test-d.ts
@@ -1,3 +1,4 @@
+import type { ContractRouterClient } from '@orpc/contract'
 import type { RouterClient } from '@orpc/server'
 import type { GeneralUtils } from './utils-general'
 import type { ProcedureUtils } from './utils-procedure'
@@ -25,7 +26,7 @@ const router = os.contract(contractRouter).router({
 
 describe('with contract router', () => {
   it('build correct types', () => {
-    const utils = createRouterUtils({} as RouterClient<typeof contractRouter, unknown>)
+    const utils = createRouterUtils({} as ContractRouterClient<typeof contractRouter, unknown>)
 
     const generalUtils = createGeneralUtils([])
     const pingUtils = createProcedureUtils(ping, [])

--- a/packages/vue-query/src/utils-router.ts
+++ b/packages/vue-query/src/utils-router.ts
@@ -1,19 +1,19 @@
-import type { ProcedureClient, RouterClient } from '@orpc/server'
+import type { Client, NestedClient } from '@orpc/contract'
 import { createGeneralUtils, type GeneralUtils } from './utils-general'
 import { createProcedureUtils, type ProcedureUtils } from './utils-procedure'
 
-export type RouterUtils<T extends RouterClient<any, any>> =
-  T extends ProcedureClient<infer TClientContext, infer UInput, infer UOutput, infer UError>
+export type RouterUtils<T extends NestedClient<any>> =
+  T extends Client<infer TClientContext, infer UInput, infer UOutput, infer UError>
     ? ProcedureUtils<TClientContext, UInput, UOutput, UError> & GeneralUtils<UInput>
     : {
-      [K in keyof T]: T[K] extends RouterClient<any, any> ? RouterUtils<T[K]> : never
+      [K in keyof T]: T[K] extends NestedClient<any> ? RouterUtils<T[K]> : never
     } & GeneralUtils<unknown>
 
 /**
  * @param client - The client create form `@orpc/client`
  * @param path - The base path for query key
  */
-export function createRouterUtils<T extends RouterClient<any, any>>(
+export function createRouterUtils<T extends NestedClient<any>>(
   client: T,
   path: string[] = [],
 ): RouterUtils<T> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,9 +243,6 @@ importers:
       '@orpc/contract':
         specifier: workspace:*
         version: link:../contract
-      '@orpc/server':
-        specifier: workspace:*
-        version: link:../server
       '@orpc/shared':
         specifier: workspace:*
         version: link:../shared
@@ -323,9 +320,6 @@ importers:
       '@orpc/contract':
         specifier: workspace:*
         version: link:../contract
-      '@orpc/server':
-        specifier: workspace:*
-        version: link:../server
       '@tanstack/vue-query':
         specifier: '>=5.50.0'
         version: 5.62.9(vue@3.5.13(typescript@5.7.2))


### PR DESCRIPTION
It can make @orpc/client and related packages can work without `@orpc/server`