### PR TITLE
feat(contract): new  `type` util for custom schema

### DIFF
--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -18,6 +18,7 @@ export * from './procedure-decorated'
 export * from './router'
 export * from './router-builder'
 export * from './router-client'
+export * from './schema-utils'
 export * from './types'
 
 export const oc = new ContractBuilder<Record<never, never>>({

--- a/packages/contract/src/schema-utils.test-d.ts
+++ b/packages/contract/src/schema-utils.test-d.ts
@@ -1,0 +1,13 @@
+import type { SchemaInput, SchemaOutput } from './types'
+import { type } from './schema-utils'
+
+it('type', () => {
+  const schema = type<string>()
+
+  expectTypeOf<SchemaInput<typeof schema>>().toEqualTypeOf<string>()
+  expectTypeOf<SchemaOutput<typeof schema>>().toEqualTypeOf<string>()
+
+  const schema2 = type<string, number>()
+  expectTypeOf<SchemaInput<typeof schema2>>().toEqualTypeOf<string>()
+  expectTypeOf<SchemaOutput<typeof schema2>>().toEqualTypeOf<number>()
+})

--- a/packages/contract/src/schema-utils.test-d.ts
+++ b/packages/contract/src/schema-utils.test-d.ts
@@ -1,13 +1,28 @@
 import type { SchemaInput, SchemaOutput } from './types'
 import { type } from './schema-utils'
 
-it('type', () => {
-  const schema = type<string>()
+describe('type', () => {
+  it('without map', () => {
+    const schema = type<string>()
 
-  expectTypeOf<SchemaInput<typeof schema>>().toEqualTypeOf<string>()
-  expectTypeOf<SchemaOutput<typeof schema>>().toEqualTypeOf<string>()
+    expectTypeOf<SchemaInput<typeof schema>>().toEqualTypeOf<string>()
+    expectTypeOf<SchemaOutput<typeof schema>>().toEqualTypeOf<string>()
+  })
 
-  const schema2 = type<string, number>()
-  expectTypeOf<SchemaInput<typeof schema2>>().toEqualTypeOf<string>()
-  expectTypeOf<SchemaOutput<typeof schema2>>().toEqualTypeOf<number>()
+  it('with map', () => {
+    const schema2 = type<string, number>((val) => {
+      expectTypeOf(val).toEqualTypeOf<string>()
+
+      return Number(val)
+    })
+
+    expectTypeOf<SchemaInput<typeof schema2>>().toEqualTypeOf<string>()
+    expectTypeOf<SchemaOutput<typeof schema2>>().toEqualTypeOf<number>()
+
+    // @ts-expect-error - map is required when TInput !== TOutput
+    type<string, number>()
+
+    // @ts-expect-error - output not match number
+    type<string, number>(() => '123')
+  })
 })

--- a/packages/contract/src/schema-utils.test.ts
+++ b/packages/contract/src/schema-utils.test.ts
@@ -1,0 +1,17 @@
+import { type } from './schema-utils'
+
+describe('type', async () => {
+  it('without check', async () => {
+    const schema = type()
+    const val = {}
+    expect((await schema['~standard'].validate(val) as any).value).toBe(val)
+  })
+
+  it('with check', async () => {
+    const val = {}
+    const check = vi.fn().mockReturnValueOnce({ value: val })
+    const schema = type(check)
+    expect((await schema['~standard'].validate(val) as any).value).toBe(val)
+    expect(check).toHaveBeenCalledWith(val)
+  })
+})

--- a/packages/contract/src/schema-utils.test.ts
+++ b/packages/contract/src/schema-utils.test.ts
@@ -1,17 +1,17 @@
 import { type } from './schema-utils'
 
 describe('type', async () => {
-  it('without check', async () => {
+  it('without map', async () => {
     const schema = type()
     const val = {}
     expect((await schema['~standard'].validate(val) as any).value).toBe(val)
   })
 
-  it('with check', async () => {
+  it('with map', async () => {
     const val = {}
-    const check = vi.fn().mockReturnValueOnce({ value: val })
+    const check = vi.fn().mockReturnValueOnce('__mapped__')
     const schema = type(check)
-    expect((await schema['~standard'].validate(val) as any).value).toBe(val)
+    expect((await schema['~standard'].validate(val) as any).value).toBe('__mapped__')
     expect(check).toHaveBeenCalledWith(val)
   })
 })

--- a/packages/contract/src/schema-utils.ts
+++ b/packages/contract/src/schema-utils.ts
@@ -1,14 +1,21 @@
+import type { IsEqual, Promisable } from '@orpc/shared'
 import type { StandardSchemaV1 } from '@standard-schema/spec'
 
-export function type<TInput, TOutput = TInput>(
-  check?: (val: unknown) => StandardSchemaV1.Result<TOutput> | Promise<StandardSchemaV1.Result<TOutput>>,
-): StandardSchemaV1<TInput, TOutput> {
+export type TypeRest<TInput, TOutput> =
+  | [map: (input: TInput) => Promisable<TOutput>]
+  | (IsEqual<TInput, TOutput> extends true ? [] : never)
+
+export function type<TInput, TOutput = TInput>(...[map]: TypeRest<TInput, TOutput>): StandardSchemaV1<TInput, TOutput> {
   return {
     '~standard': {
       vendor: 'custom',
       version: 1,
-      validate(value) {
-        return check ? check(value) : { value: value as any }
+      async validate(value) {
+        if (map) {
+          return { value: await map(value as TInput) as TOutput }
+        }
+
+        return { value: value as TOutput }
       },
     },
   }

--- a/packages/contract/src/schema-utils.ts
+++ b/packages/contract/src/schema-utils.ts
@@ -1,0 +1,15 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec'
+
+export function type<TInput, TOutput = TInput>(
+  check?: (val: unknown) => StandardSchemaV1.Result<TOutput> | Promise<StandardSchemaV1.Result<TOutput>>,
+): StandardSchemaV1<TInput, TOutput> {
+  return {
+    '~standard': {
+      vendor: 'custom',
+      version: 1,
+      validate(value) {
+        return check ? check(value) : { value: value as any }
+      },
+    },
+  }
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -21,6 +21,7 @@ export * from './router-client'
 export * from './router-implementer'
 export * from './types'
 export * from './utils'
-export { configGlobal, fallbackToGlobalConfig, isDefinedError, ORPCError, safe } from '@orpc/contract'
+
+export { configGlobal, fallbackToGlobalConfig, isDefinedError, ORPCError, safe, type } from '@orpc/contract'
 
 export const os = new Builder<WELL_CONTEXT>({})


### PR DESCRIPTION
```ts
export const getting = oc.input(type<{ id: string }>());
```

`type` can be used to create a custom schema, which helps reduce bundle size when extensive validation logic isn't required.

Closes: https://github.com/unnoq/orpc/issues/89