### PR TITLE
[VOTE TO MERGE] feat(server): attach `.errors` into middlewares

### DIFF
--- a/packages/server/src/builder-variants.ts
+++ b/packages/server/src/builder-variants.ts
@@ -1,4 +1,4 @@
-import type { ContractRouter, ErrorMap, HTTPPath, MergedErrorMap, Meta, ORPCErrorConstructorMap, Route, Schema, SchemaInput, SchemaOutput } from '@orpc/contract'
+import type { ContractRouter, ErrorMap, HTTPPath, MergedErrorMap, Meta, Route, Schema, SchemaInput, SchemaOutput } from '@orpc/contract'
 import type { BuilderDef } from './builder'
 import type { ConflictContextGuard, Context, MergedContext } from './context'
 import type { FlattenLazy } from './lazy-utils'
@@ -21,17 +21,24 @@ export interface BuilderWithMiddlewares<
     errors: U,
   ): BuilderWithMiddlewares<TInitialContext, TCurrentContext, TInputSchema, TOutputSchema, MergedErrorMap<TErrorMap, U>, TMeta>
 
-  'use'<UOutContext extends Context>(
+  'use'<UOutContext extends Context, UErrorMap extends ErrorMap = TErrorMap>(
     middleware: Middleware<
       TCurrentContext,
       UOutContext,
       SchemaOutput<TInputSchema>,
       SchemaInput<TOutputSchema>,
-      ORPCErrorConstructorMap<TErrorMap>,
+      UErrorMap,
       TMeta
     >,
   ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>> &
-    BuilderWithMiddlewares<TInitialContext, MergedContext<TCurrentContext, UOutContext>, TInputSchema, TOutputSchema, TErrorMap, TMeta>
+    BuilderWithMiddlewares<
+      TInitialContext,
+      MergedContext<TCurrentContext, UOutContext>,
+      TInputSchema,
+      TOutputSchema,
+      MergedErrorMap<UErrorMap, TErrorMap>,
+      TMeta
+    >
 
   'meta'(
     meta: TMeta,
@@ -80,17 +87,24 @@ export interface ProcedureBuilder<
     errors: U,
   ): ProcedureBuilder<TInitialContext, TCurrentContext, TInputSchema, TOutputSchema, MergedErrorMap<TErrorMap, U>, TMeta>
 
-  'use'<UOutContext extends Context>(
+  'use'<UOutContext extends Context, UErrorMap extends ErrorMap = TErrorMap>(
     middleware: Middleware<
       TCurrentContext,
       UOutContext,
       SchemaOutput<TInputSchema>,
       SchemaInput<TOutputSchema>,
-      ORPCErrorConstructorMap<TErrorMap>,
+      UErrorMap,
       TMeta
     >,
   ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>> &
-    ProcedureBuilder<TInitialContext, MergedContext<TCurrentContext, UOutContext>, TInputSchema, TOutputSchema, TErrorMap, TMeta>
+    ProcedureBuilder<
+      TInitialContext,
+      MergedContext<TCurrentContext, UOutContext>,
+      TInputSchema,
+      TOutputSchema,
+      MergedErrorMap<UErrorMap, TErrorMap>,
+      TMeta
+    >
 
   'meta'(
     meta: TMeta,
@@ -127,30 +141,44 @@ export interface ProcedureBuilderWithInput<
     errors: U,
   ): ProcedureBuilderWithInput<TInitialContext, TCurrentContext, TInputSchema, TOutputSchema, MergedErrorMap<TErrorMap, U>, TMeta>
 
-  'use'<UOutContext extends Context>(
+  'use'<UOutContext extends Context, UErrorMap extends ErrorMap = TErrorMap>(
     middleware: Middleware<
       TCurrentContext,
       UOutContext,
       SchemaOutput<TInputSchema>,
       SchemaInput<TOutputSchema>,
-      ORPCErrorConstructorMap<TErrorMap>,
+      UErrorMap,
       TMeta
     >,
   ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>> &
-    ProcedureBuilderWithInput<TInitialContext, MergedContext<TCurrentContext, UOutContext>, TInputSchema, TOutputSchema, TErrorMap, TMeta>
+    ProcedureBuilderWithInput<
+      TInitialContext,
+      MergedContext<TCurrentContext, UOutContext>,
+      TInputSchema,
+      TOutputSchema,
+      MergedErrorMap<UErrorMap, TErrorMap>,
+      TMeta
+    >
 
-  'use'<UOutContext extends Context, UInput>(
+  'use'<UOutContext extends Context, UInput, UErrorMap extends ErrorMap = TErrorMap>(
     middleware: Middleware<
       TCurrentContext,
       UOutContext,
       UInput,
       SchemaInput<TOutputSchema>,
-      ORPCErrorConstructorMap<TErrorMap>,
+      UErrorMap,
       TMeta
     >,
     mapInput: MapInputMiddleware<SchemaOutput<TInputSchema>, UInput>,
   ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>> &
-    ProcedureBuilderWithInput<TInitialContext, MergedContext<TCurrentContext, UOutContext>, TInputSchema, TOutputSchema, TErrorMap, TMeta>
+    ProcedureBuilderWithInput<
+      TInitialContext,
+      MergedContext<TCurrentContext, UOutContext>,
+      TInputSchema,
+      TOutputSchema,
+      MergedErrorMap<UErrorMap, TErrorMap>,
+      TMeta
+    >
 
   'meta'(
     meta: TMeta,
@@ -183,17 +211,24 @@ export interface ProcedureBuilderWithOutput<
     errors: U,
   ): ProcedureBuilderWithOutput<TInitialContext, TCurrentContext, TInputSchema, TOutputSchema, MergedErrorMap<TErrorMap, U>, TMeta>
 
-  'use'<UOutContext extends Context>(
+  'use'<UOutContext extends Context, UErrorMap extends ErrorMap = TErrorMap>(
     middleware: Middleware<
       TCurrentContext,
       UOutContext,
       SchemaOutput<TInputSchema>,
       SchemaInput<TOutputSchema>,
-      ORPCErrorConstructorMap<TErrorMap>,
+      UErrorMap,
       TMeta
     >,
   ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>> &
-    ProcedureBuilderWithOutput<TInitialContext, MergedContext<TCurrentContext, UOutContext>, TInputSchema, TOutputSchema, TErrorMap, TMeta>
+    ProcedureBuilderWithOutput<
+      TInitialContext,
+      MergedContext<TCurrentContext, UOutContext>,
+      TInputSchema,
+      TOutputSchema,
+      MergedErrorMap<UErrorMap, TErrorMap>,
+      TMeta
+    >
 
   'meta'(
     meta: TMeta,
@@ -226,30 +261,44 @@ export interface ProcedureBuilderWithInputOutput<
     errors: U,
   ): ProcedureBuilderWithInputOutput<TInitialContext, TCurrentContext, TInputSchema, TOutputSchema, MergedErrorMap<TErrorMap, U>, TMeta>
 
-  'use'<UOutContext extends Context>(
+  'use'<UOutContext extends Context, UErrorMap extends ErrorMap = TErrorMap>(
     middleware: Middleware<
       TCurrentContext,
       UOutContext,
       SchemaOutput<TInputSchema>,
       SchemaInput<TOutputSchema>,
-      ORPCErrorConstructorMap<TErrorMap>,
+      UErrorMap,
       TMeta
     >,
   ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>> &
-    ProcedureBuilderWithInputOutput<TInitialContext, MergedContext<TCurrentContext, UOutContext>, TInputSchema, TOutputSchema, TErrorMap, TMeta>
+    ProcedureBuilderWithInputOutput<
+      TInitialContext,
+      MergedContext<TCurrentContext, UOutContext>,
+      TInputSchema,
+      TOutputSchema,
+      MergedErrorMap<UErrorMap, TErrorMap>,
+      TMeta
+    >
 
-  'use'<UOutContext extends Context, UInput>(
+  'use'<UOutContext extends Context, UInput, UErrorMap extends ErrorMap = TErrorMap>(
     middleware: Middleware<
       TCurrentContext,
       UOutContext,
       UInput,
       SchemaInput<TOutputSchema>,
-      ORPCErrorConstructorMap<TErrorMap>,
+      UErrorMap,
       TMeta
     >,
     mapInput: MapInputMiddleware<SchemaOutput<TInputSchema>, UInput>,
   ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>> &
-    ProcedureBuilderWithInputOutput<TInitialContext, MergedContext<TCurrentContext, UOutContext>, TInputSchema, TOutputSchema, TErrorMap, TMeta>
+    ProcedureBuilderWithInputOutput<
+      TInitialContext,
+      MergedContext<TCurrentContext, UOutContext>,
+      TInputSchema,
+      TOutputSchema,
+      MergedErrorMap<UErrorMap, TErrorMap>,
+      TMeta
+    >
 
   'meta'(
     meta: TMeta,
@@ -276,17 +325,17 @@ export interface RouterBuilder<
     errors: U,
   ): RouterBuilder<TInitialContext, TCurrentContext, MergedErrorMap<TErrorMap, U>, TMeta>
 
-  'use'<UOutContext extends Context>(
+  'use'<UOutContext extends Context, UErrorMap extends ErrorMap = TErrorMap>(
     middleware: Middleware<
       TCurrentContext,
       UOutContext,
       unknown,
       unknown,
-      ORPCErrorConstructorMap<TErrorMap>,
+      UErrorMap,
       TMeta
     >,
   ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>> &
-    RouterBuilder<TInitialContext, MergedContext<TCurrentContext, UOutContext>, TErrorMap, TMeta>
+    RouterBuilder<TInitialContext, MergedContext<TCurrentContext, UOutContext>, MergedErrorMap<UErrorMap, TErrorMap>, TMeta>
 
   'prefix'(prefix: HTTPPath): RouterBuilder<TInitialContext, TCurrentContext, TErrorMap, TMeta>
 

--- a/packages/server/src/builder.test.ts
+++ b/packages/server/src/builder.test.ts
@@ -156,7 +156,7 @@ describe('builder', () => {
         OVERRIDE: { message: 'this is low priority' },
       }
       const mid2 = vi.fn() as any
-      mid2['~attachedErrorMap'] = errorMap
+      mid2['~errorMap'] = errorMap
       const applied = builder.use(mid2)
 
       expect(applied).instanceOf(Builder)

--- a/packages/server/src/builder.ts
+++ b/packages/server/src/builder.ts
@@ -99,7 +99,9 @@ export class Builder<
 
   middleware<UOutContext extends Context, TInput, TOutput = any>( // = any here is important to make middleware can be used in any output by default
     middleware: Middleware<TCurrentContext, UOutContext, TInput, TOutput, ORPCErrorConstructorMap<TErrorMap>, TMeta>,
-  ): DecoratedMiddleware<TCurrentContext, UOutContext, TInput, TOutput, ORPCErrorConstructorMap<any>, TMeta> { // ORPCErrorConstructorMap<any> ensures middleware can used in any procedure
+  ): DecoratedMiddleware<TCurrentContext, UOutContext, TInput, TOutput, any, TMeta> { // any ensures middleware can used in any procedure without matching error requirements
+    middleware['~attachedErrorMap'] = this['~orpc'].errorMap
+
     return decorateMiddleware(middleware)
   }
 
@@ -147,6 +149,9 @@ export class Builder<
 
     return new Builder({
       ...this['~orpc'],
+      errorMap: mapped['~attachedErrorMap']
+        ? mergeErrorMap(mapped['~attachedErrorMap'], this['~orpc'].errorMap)
+        : this['~orpc'].errorMap,
       middlewares: addMiddleware(this['~orpc'].middlewares, mapped),
     })
   }

--- a/packages/server/src/builder.ts
+++ b/packages/server/src/builder.ts
@@ -100,7 +100,7 @@ export class Builder<
   middleware<UOutContext extends Context, TInput, TOutput = any>( // = any here is important to make middleware can be used in any output by default
     middleware: Middleware<TCurrentContext, UOutContext, TInput, TOutput, ORPCErrorConstructorMap<TErrorMap>, TMeta>,
   ): DecoratedMiddleware<TCurrentContext, UOutContext, TInput, TOutput, any, TMeta> { // any ensures middleware can used in any procedure without matching error requirements
-    middleware['~attachedErrorMap'] = this['~orpc'].errorMap
+    middleware['~errorMap'] = this['~orpc'].errorMap
 
     return decorateMiddleware(middleware)
   }
@@ -149,8 +149,8 @@ export class Builder<
 
     return new Builder({
       ...this['~orpc'],
-      errorMap: mapped['~attachedErrorMap']
-        ? mergeErrorMap(mapped['~attachedErrorMap'], this['~orpc'].errorMap)
+      errorMap: mapped['~errorMap']
+        ? mergeErrorMap(mapped['~errorMap'], this['~orpc'].errorMap)
         : this['~orpc'].errorMap,
       middlewares: addMiddleware(this['~orpc'].middlewares, mapped),
     })

--- a/packages/server/src/implementer-variants.ts
+++ b/packages/server/src/implementer-variants.ts
@@ -1,4 +1,4 @@
-import type { AnyContractRouter, ContractProcedure, ContractRouterToErrorMap, ContractRouterToMeta, ORPCErrorConstructorMap } from '@orpc/contract'
+import type { AnyContractRouter, ContractProcedure, ContractRouterToErrorMap, ContractRouterToMeta, ErrorMap } from '@orpc/contract'
 import type { ConflictContextGuard, Context, MergedContext } from './context'
 import type { ProcedureImplementer } from './implementer-procedure'
 import type { FlattenLazy } from './lazy-utils'
@@ -10,13 +10,13 @@ export interface RouterImplementerWithMiddlewares<
   TInitialContext extends Context,
   TCurrentContext extends Context,
 > {
-  use<U extends Context>(
+  use<U extends Context, UErrorMap extends ErrorMap = ContractRouterToErrorMap<TContract>>(
     middleware: Middleware<
       TCurrentContext,
       U,
       unknown,
       unknown,
-      ORPCErrorConstructorMap<ContractRouterToErrorMap<TContract>>,
+      UErrorMap,
       ContractRouterToMeta<TContract>
     >,
   ): ConflictContextGuard<MergedContext<TCurrentContext, U>>

--- a/packages/server/src/implementer.test-d.ts
+++ b/packages/server/src/implementer.test-d.ts
@@ -62,7 +62,7 @@ describe('Implementer', () => {
             { extra: boolean },
             unknown,
             any,
-            ORPCErrorConstructorMap<any>,
+            typeof baseErrorMap | Record<never, never>,
             Meta | BaseMeta
           >
         >()
@@ -80,7 +80,7 @@ describe('Implementer', () => {
             Record<never, never>,
             'input',
             'output',
-            ORPCErrorConstructorMap<any>,
+            typeof baseErrorMap | Record<never, never>,
             Meta | BaseMeta
           >
         >()

--- a/packages/server/src/implementer.ts
+++ b/packages/server/src/implementer.ts
@@ -1,4 +1,4 @@
-import type { AnyContractRouter, ContractProcedure, ContractRouterToErrorMap, ContractRouterToMeta, ORPCErrorConstructorMap } from '@orpc/contract'
+import type { AnyContractRouter, ContractProcedure, ContractRouterToErrorMap, ContractRouterToMeta, ErrorMap } from '@orpc/contract'
 import type { ConflictContextGuard, Context, MergedContext } from './context'
 import type { ProcedureImplementer } from './implementer-procedure'
 import type { ImplementerInternalWithMiddlewares } from './implementer-variants'
@@ -24,22 +24,29 @@ export interface RouterImplementer<
       UOutContext,
       TInput,
       TOutput,
-      ORPCErrorConstructorMap<ContractRouterToErrorMap<TContract>>,
+      ContractRouterToErrorMap<TContract>,
       ContractRouterToMeta<TContract>
     >,
-  ): DecoratedMiddleware<TCurrentContext, UOutContext, TInput, TOutput, ORPCErrorConstructorMap<any>, ContractRouterToMeta<TContract>> // ORPCErrorConstructorMap<any> ensures middleware can used in any procedure
+  ): DecoratedMiddleware<
+    TCurrentContext,
+    UOutContext,
+    TInput,
+    TOutput,
+    ContractRouterToErrorMap<TContract>,
+    ContractRouterToMeta<TContract>
+  >
 
-  use<U extends Context>(
+  use<UOutContext extends Context, UErrorMap extends ErrorMap = ContractRouterToErrorMap<TContract>>(
     middleware: Middleware<
       TCurrentContext,
-      U,
+      UOutContext,
       unknown,
       unknown,
-      ORPCErrorConstructorMap<ContractRouterToErrorMap<TContract>>,
+      UErrorMap,
       ContractRouterToMeta<TContract>
     >,
-  ): ConflictContextGuard<MergedContext<TCurrentContext, U>>
-    & ImplementerInternalWithMiddlewares<TContract, TInitialContext, MergedContext<TCurrentContext, U>>
+  ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>>
+    & ImplementerInternalWithMiddlewares<TContract, TInitialContext, MergedContext<TCurrentContext, UOutContext>>
 
   router<U extends Router<TCurrentContext, TContract>>(router: U): AdaptedRouter<U, TInitialContext, Record<never, never>>
 

--- a/packages/server/src/middleware-decorated.test-d.ts
+++ b/packages/server/src/middleware-decorated.test-d.ts
@@ -27,6 +27,27 @@ describe('DecoratedMiddleware', () => {
     >()
   })
 
+  it('.errors', () => {
+    const applied = decorated.errors({
+      BAD_GATEWAY: { message: 'BAD_GATEWAY' },
+      OVERRIDE: { message: 'OVERRIDE' },
+    })
+
+    expectTypeOf(applied).toEqualTypeOf<
+      DecoratedMiddleware<
+        CurrentContext,
+        { extra: boolean },
+        { input: string },
+        { output: number },
+        MergedErrorMap<typeof baseErrorMap, { BAD_GATEWAY: { message: string }, OVERRIDE: { message: string } }>,
+        BaseMeta
+      >
+    >()
+
+    // @ts-expect-error - invalid schema
+    decorated.errors({ BAD_GATEWAY: { data: {} } })
+  })
+
   it('.mapInput', () => {
     const mapped = decorated.mapInput((input: 'input') => ({ input }))
 

--- a/packages/server/src/middleware-decorated.test-d.ts
+++ b/packages/server/src/middleware-decorated.test-d.ts
@@ -1,4 +1,4 @@
-import type { ORPCErrorConstructorMap } from '@orpc/contract'
+import type { MergedErrorMap } from '@orpc/contract'
 import type { baseErrorMap, BaseMeta } from '../../contract/tests/shared'
 import type { CurrentContext } from '../tests/shared'
 import type { Middleware } from './middleware'
@@ -9,7 +9,7 @@ const decorated = {} as DecoratedMiddleware<
   { extra: boolean },
   { input: string },
   { output: number },
-  ORPCErrorConstructorMap<typeof baseErrorMap>,
+  typeof baseErrorMap,
   BaseMeta
 >
 
@@ -21,7 +21,7 @@ describe('DecoratedMiddleware', () => {
         { extra: boolean },
         { input: string },
         { output: number },
-        ORPCErrorConstructorMap<typeof baseErrorMap>,
+        typeof baseErrorMap,
         BaseMeta
       >
     >()
@@ -36,7 +36,7 @@ describe('DecoratedMiddleware', () => {
         { extra: boolean },
         'input',
         { output: number },
-        ORPCErrorConstructorMap<typeof baseErrorMap>,
+        typeof baseErrorMap,
         BaseMeta
       >
     >()
@@ -54,7 +54,7 @@ describe('DecoratedMiddleware', () => {
           { extra: boolean } & { extra2: boolean },
           { input: string } & { input2: string },
           { output: number },
-          ORPCErrorConstructorMap<typeof baseErrorMap>,
+          MergedErrorMap<typeof baseErrorMap, typeof baseErrorMap>,
           BaseMeta
         >
       >()
@@ -80,7 +80,7 @@ describe('DecoratedMiddleware', () => {
           { extra: boolean } & { extra2: boolean },
           { input: string } & { input2: string },
           { output: number },
-          ORPCErrorConstructorMap<typeof baseErrorMap>,
+          MergedErrorMap<typeof baseErrorMap, typeof baseErrorMap>,
           BaseMeta
         >
       >()

--- a/packages/server/src/middleware-decorated.test.ts
+++ b/packages/server/src/middleware-decorated.test.ts
@@ -13,6 +13,31 @@ describe('decorateMiddleware', () => {
     expect(fn).toHaveBeenCalledWith('input')
   })
 
+  it('.errors', () => {
+    const fn = vi.fn()
+    const decorated = decorateMiddleware(fn) as any
+
+    const applied = decorated.errors(baseErrorMap)
+    expect(applied).not.toBe(decorated)
+    expect(decorated['~errorMap']).toEqual(undefined) // ensure not changed
+    expect(applied['~errorMap']).toEqual(baseErrorMap)
+
+    const errors = {
+      BAD_GATEWAY: { message: 'BAD_GATEWAY' },
+      OVERRIDE: { message: 'OVERRIDE' },
+    }
+    const applied2 = applied.errors(errors)
+    expect(applied2).not.toBe(applied)
+    expect(applied['~errorMap']).toEqual(baseErrorMap) // ensure not changed
+    expect(applied2['~errorMap']).toEqual({ ...baseErrorMap, ...errors })
+
+    // ensure it clone correctly
+    fn.mockReturnValueOnce('__mocked__')
+    expect(applied2(1, 2, 3, 4)).toEqual('__mocked__')
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(fn).toHaveBeenCalledWith(1, 2, 3, 4)
+  })
+
   it('can map input', () => {
     const fn = vi.fn()
     const map = vi.fn()

--- a/packages/server/src/middleware-decorated.test.ts
+++ b/packages/server/src/middleware-decorated.test.ts
@@ -86,14 +86,14 @@ describe('decorateMiddleware', () => {
 
   it('can concat with attached error map', async () => {
     const mid1 = vi.fn() as any
-    mid1['~attachedErrorMap'] = baseErrorMap
+    mid1['~errorMap'] = baseErrorMap
 
     const mid2 = vi.fn() as any
     const errorMap = { BASE: { message: 'base error' }, OVERRIDE: { message: 'this has higher priority' } }
-    mid2['~attachedErrorMap'] = errorMap
+    mid2['~errorMap'] = errorMap
 
-    expect(decorateMiddleware(mid1).concat(mid2)['~attachedErrorMap']).toEqual({ ...baseErrorMap, ...errorMap })
-    expect(decorateMiddleware(mid1).concat(vi.fn())['~attachedErrorMap']).toEqual({ ...baseErrorMap })
-    expect(decorateMiddleware(vi.fn()).concat(mid2)['~attachedErrorMap']).toEqual({ ...errorMap })
+    expect(decorateMiddleware(mid1).concat(mid2)['~errorMap']).toEqual({ ...baseErrorMap, ...errorMap })
+    expect(decorateMiddleware(mid1).concat(vi.fn())['~errorMap']).toEqual({ ...baseErrorMap })
+    expect(decorateMiddleware(vi.fn()).concat(mid2)['~errorMap']).toEqual({ ...errorMap })
   })
 })

--- a/packages/server/src/middleware-decorated.test.ts
+++ b/packages/server/src/middleware-decorated.test.ts
@@ -1,3 +1,4 @@
+import { baseErrorMap } from '../../contract/tests/shared'
 import { decorateMiddleware } from './middleware-decorated'
 
 describe('decorateMiddleware', () => {
@@ -81,5 +82,18 @@ describe('decorateMiddleware', () => {
 
     expect(fn2).toHaveBeenCalledTimes(1)
     expect(fn2).toHaveBeenCalledWith({ context: { auth: true }, next }, { name: 'input' }, outputFn)
+  })
+
+  it('can concat with attached error map', async () => {
+    const mid1 = vi.fn() as any
+    mid1['~attachedErrorMap'] = baseErrorMap
+
+    const mid2 = vi.fn() as any
+    const errorMap = { BASE: { message: 'base error' }, OVERRIDE: { message: 'this has higher priority' } }
+    mid2['~attachedErrorMap'] = errorMap
+
+    expect(decorateMiddleware(mid1).concat(mid2)['~attachedErrorMap']).toEqual({ ...baseErrorMap, ...errorMap })
+    expect(decorateMiddleware(mid1).concat(vi.fn())['~attachedErrorMap']).toEqual({ ...baseErrorMap })
+    expect(decorateMiddleware(vi.fn()).concat(mid2)['~attachedErrorMap']).toEqual({ ...errorMap })
   })
 })

--- a/packages/server/src/middleware-decorated.ts
+++ b/packages/server/src/middleware-decorated.ts
@@ -91,7 +91,7 @@ export function decorateMiddleware<
       return merged
     })
 
-    concatted['~attachedErrorMap'] = mergeErrorMap(middleware['~attachedErrorMap'] ?? {}, mapped['~attachedErrorMap'] ?? {})
+    concatted['~errorMap'] = mergeErrorMap(middleware['~errorMap'] ?? {}, mapped['~errorMap'] ?? {})
 
     return concatted as any
   }

--- a/packages/server/src/middleware-decorated.ts
+++ b/packages/server/src/middleware-decorated.ts
@@ -1,22 +1,23 @@
+import type { ErrorMap, MergedErrorMap, Meta } from '@orpc/contract'
 import type { Context, MergedContext } from './context'
 import type { AnyMiddleware, MapInputMiddleware, Middleware, MiddlewareNextFn } from './middleware'
-import { mergeErrorMap, type Meta, type ORPCErrorConstructorMap } from '@orpc/contract'
+import { mergeErrorMap } from '@orpc/contract'
 
 export interface DecoratedMiddleware<
   TInContext extends Context,
   TOutContext extends Context,
   TInput,
   TOutput,
-  TErrorConstructorMap extends ORPCErrorConstructorMap<any>,
+  TErrorMap extends ErrorMap,
   TMeta extends Meta,
-> extends Middleware<TInContext, TOutContext, TInput, TOutput, TErrorConstructorMap, TMeta> {
-  concat<UOutContext extends Context, UInput>(
+> extends Middleware<TInContext, TOutContext, TInput, TOutput, TErrorMap, TMeta> {
+  concat<UOutContext extends Context, UInput, UErrorMap extends ErrorMap = TErrorMap>(
     middleware: Middleware<
       TInContext & TOutContext,
       UOutContext,
       UInput & TInput,
       TOutput,
-      TErrorConstructorMap,
+      UErrorMap,
       TMeta
     >,
   ): DecoratedMiddleware<
@@ -24,7 +25,7 @@ export interface DecoratedMiddleware<
     MergedContext<TOutContext, UOutContext>,
     UInput & TInput,
     TOutput,
-    TErrorConstructorMap,
+    MergedErrorMap<TErrorMap, UErrorMap>,
     TMeta
   >
 
@@ -32,13 +33,14 @@ export interface DecoratedMiddleware<
     UOutContext extends Context,
     UInput,
     UMappedInput,
+    UErrorMap extends ErrorMap = TErrorMap,
   >(
     middleware: Middleware<
       TInContext & TOutContext,
       UOutContext,
       UMappedInput,
       TOutput,
-      TErrorConstructorMap,
+      UErrorMap,
       TMeta
     >,
     mapInput: MapInputMiddleware<UInput & TInput, UMappedInput>,
@@ -47,13 +49,13 @@ export interface DecoratedMiddleware<
     TOutContext & UOutContext,
     UInput & TInput,
     TOutput,
-    TErrorConstructorMap,
+    MergedErrorMap<TErrorMap, UErrorMap>,
     TMeta
   >
 
   mapInput<UInput = unknown>(
     map: MapInputMiddleware<UInput, TInput>,
-  ): DecoratedMiddleware<TInContext, TOutContext, UInput, TOutput, TErrorConstructorMap, TMeta>
+  ): DecoratedMiddleware<TInContext, TOutContext, UInput, TOutput, TErrorMap, TMeta>
 }
 
 export function decorateMiddleware<
@@ -61,12 +63,12 @@ export function decorateMiddleware<
   TOutContext extends Context,
   TInput,
   TOutput,
-  TErrorConstructorMap extends ORPCErrorConstructorMap<any>,
+  TErrorMap extends ErrorMap,
   TMeta extends Meta,
 >(
-  middleware: Middleware<TInContext, TOutContext, TInput, TOutput, TErrorConstructorMap, TMeta>,
-): DecoratedMiddleware<TInContext, TOutContext, TInput, TOutput, TErrorConstructorMap, TMeta> {
-  const decorated = middleware as DecoratedMiddleware<TInContext, TOutContext, TInput, TOutput, TErrorConstructorMap, TMeta>
+  middleware: Middleware<TInContext, TOutContext, TInput, TOutput, TErrorMap, TMeta>,
+): DecoratedMiddleware<TInContext, TOutContext, TInput, TOutput, TErrorMap, TMeta> {
+  const decorated = middleware as DecoratedMiddleware<TInContext, TOutContext, TInput, TOutput, TErrorMap, TMeta>
 
   decorated.mapInput = (mapInput) => {
     const mapped = decorateMiddleware(

--- a/packages/server/src/middleware-decorated.ts
+++ b/packages/server/src/middleware-decorated.ts
@@ -1,6 +1,6 @@
-import type { Meta, ORPCErrorConstructorMap } from '@orpc/contract'
 import type { Context, MergedContext } from './context'
 import type { AnyMiddleware, MapInputMiddleware, Middleware, MiddlewareNextFn } from './middleware'
+import { mergeErrorMap, type Meta, type ORPCErrorConstructorMap } from '@orpc/contract'
 
 export interface DecoratedMiddleware<
   TInContext extends Context,
@@ -90,6 +90,8 @@ export function decorateMiddleware<
 
       return merged
     })
+
+    concatted['~attachedErrorMap'] = mergeErrorMap(middleware['~attachedErrorMap'] ?? {}, mapped['~attachedErrorMap'] ?? {})
 
     return concatted as any
   }

--- a/packages/server/src/middleware.test-d.ts
+++ b/packages/server/src/middleware.test-d.ts
@@ -11,7 +11,7 @@ describe('middleware', () => {
       Record<never, never>,
       { input: number },
       { output: string },
-      ORPCErrorConstructorMap<typeof baseErrorMap>,
+      typeof baseErrorMap,
       BaseMeta
     > = ({ context, path, procedure, signal, next, errors }, input, output) => {
       expectTypeOf(input).toEqualTypeOf<{ input: number }>()

--- a/packages/server/src/middleware.ts
+++ b/packages/server/src/middleware.ts
@@ -43,13 +43,13 @@ export interface Middleware<
   TOutContext extends Context,
   TInput,
   TOutput,
-  TErrorConstructorMap extends ORPCErrorConstructorMap<any>,
+  TErrorMap extends ErrorMap,
   TMeta extends Meta,
 > {
-  '~errorMap'?: ErrorMap
+  '~errorMap'?: TErrorMap
 
   (
-    options: MiddlewareOptions<TInContext, TOutput, TErrorConstructorMap, TMeta>,
+    options: MiddlewareOptions<TInContext, TOutput, ORPCErrorConstructorMap<TErrorMap>, TMeta>,
     input: TInput,
     output: MiddlewareOutputFn<TOutput>,
   ): Promisable<

--- a/packages/server/src/middleware.ts
+++ b/packages/server/src/middleware.ts
@@ -46,7 +46,7 @@ export interface Middleware<
   TErrorConstructorMap extends ORPCErrorConstructorMap<any>,
   TMeta extends Meta,
 > {
-  '~attachedErrorMap'?: ErrorMap
+  '~errorMap'?: ErrorMap
 
   (
     options: MiddlewareOptions<TInContext, TOutput, TErrorConstructorMap, TMeta>,

--- a/packages/server/src/middleware.ts
+++ b/packages/server/src/middleware.ts
@@ -46,6 +46,8 @@ export interface Middleware<
   TErrorConstructorMap extends ORPCErrorConstructorMap<any>,
   TMeta extends Meta,
 > {
+  '~attachedErrorMap'?: ErrorMap
+
   (
     options: MiddlewareOptions<TInContext, TOutput, TErrorConstructorMap, TMeta>,
     input: TInput,

--- a/packages/server/src/procedure-decorated.test.ts
+++ b/packages/server/src/procedure-decorated.test.ts
@@ -96,6 +96,24 @@ describe('decoratedProcedure', () => {
         middlewares: [...def.middlewares, [mid, map]],
       })
     })
+
+    it('with attached error map', () => {
+      const errorMap = {
+        ADDITION: {},
+        OVERRIDE: { message: 'this is low priority' },
+      }
+      const mid2 = vi.fn() as any
+      mid2['~attachedErrorMap'] = errorMap
+      const applied = decorated.use(mid2)
+
+      expect(applied).not.toBe(decorated)
+      expect(applied).toBeInstanceOf(DecoratedProcedure)
+      expect(applied['~orpc']).toEqual({
+        ...def,
+        errorMap: { ...errorMap, ...def.errorMap },
+        middlewares: [...def.middlewares, mid2],
+      })
+    })
   })
 
   it('.callable', () => {

--- a/packages/server/src/procedure-decorated.test.ts
+++ b/packages/server/src/procedure-decorated.test.ts
@@ -103,7 +103,7 @@ describe('decoratedProcedure', () => {
         OVERRIDE: { message: 'this is low priority' },
       }
       const mid2 = vi.fn() as any
-      mid2['~attachedErrorMap'] = errorMap
+      mid2['~errorMap'] = errorMap
       const applied = decorated.use(mid2)
 
       expect(applied).not.toBe(decorated)

--- a/packages/server/src/procedure-decorated.ts
+++ b/packages/server/src/procedure-decorated.ts
@@ -84,8 +84,8 @@ export class DecoratedProcedure<
 
     return new DecoratedProcedure({
       ...this['~orpc'],
-      errorMap: mapped['~attachedErrorMap']
-        ? mergeErrorMap(mapped['~attachedErrorMap'], this['~orpc'].errorMap)
+      errorMap: mapped['~errorMap']
+        ? mergeErrorMap(mapped['~errorMap'], this['~orpc'].errorMap)
         : this['~orpc'].errorMap,
       middlewares: addMiddleware(this['~orpc'].middlewares, mapped),
     })

--- a/packages/server/src/procedure-decorated.ts
+++ b/packages/server/src/procedure-decorated.ts
@@ -84,6 +84,9 @@ export class DecoratedProcedure<
 
     return new DecoratedProcedure({
       ...this['~orpc'],
+      errorMap: mapped['~attachedErrorMap']
+        ? mergeErrorMap(mapped['~attachedErrorMap'], this['~orpc'].errorMap)
+        : this['~orpc'].errorMap,
       middlewares: addMiddleware(this['~orpc'].middlewares, mapped),
     })
   }

--- a/packages/server/src/procedure-decorated.ts
+++ b/packages/server/src/procedure-decorated.ts
@@ -1,4 +1,4 @@
-import type { ClientRest, ErrorMap, MergedErrorMap, Meta, ORPCErrorConstructorMap, Route, Schema, SchemaInput, SchemaOutput } from '@orpc/contract'
+import type { ClientRest, ErrorMap, MergedErrorMap, Meta, Route, Schema, SchemaInput, SchemaOutput } from '@orpc/contract'
 import type { ConflictContextGuard, Context, MergedContext } from './context'
 import type { AnyMiddleware, MapInputMiddleware, Middleware } from './middleware'
 import type { CreateProcedureClientRest, ProcedureClient } from './procedure-client'
@@ -52,30 +52,46 @@ export class DecoratedProcedure<
     })
   }
 
-  use<U extends Context>(
+  use<UOutContext extends Context, UErrorMap extends ErrorMap = TErrorMap>(
     middleware: Middleware<
       TCurrentContext,
-      U,
+      UOutContext,
       SchemaOutput<TInputSchema>,
       THandlerOutput,
-      ORPCErrorConstructorMap<TErrorMap>,
+      UErrorMap,
       TMeta
     >,
-  ): ConflictContextGuard<MergedContext<TCurrentContext, U>>
-    & DecoratedProcedure<TInitialContext, MergedContext<TCurrentContext, U>, TInputSchema, TOutputSchema, THandlerOutput, TErrorMap, TMeta>
+  ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>>
+    & DecoratedProcedure<
+      TInitialContext,
+      MergedContext<TCurrentContext, UOutContext>,
+      TInputSchema,
+      TOutputSchema,
+      THandlerOutput,
+      MergedErrorMap<UErrorMap, TErrorMap>,
+      TMeta
+    >
 
-  use<UOutContext extends Context, UInput>(
+  use<UOutContext extends Context, UInput, UErrorMap extends ErrorMap = TErrorMap>(
     middleware: Middleware<
       TCurrentContext,
       UOutContext,
       UInput,
       THandlerOutput,
-      ORPCErrorConstructorMap<TErrorMap>,
+      UErrorMap,
       TMeta
     >,
     mapInput: MapInputMiddleware<SchemaOutput<TInputSchema, THandlerOutput>, UInput>,
   ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>>
-    & DecoratedProcedure<TInitialContext, MergedContext<TCurrentContext, UOutContext>, TInputSchema, TOutputSchema, THandlerOutput, TErrorMap, TMeta>
+    & DecoratedProcedure<
+      TInitialContext,
+      MergedContext<TCurrentContext, UOutContext>,
+      TInputSchema,
+      TOutputSchema,
+      THandlerOutput,
+      MergedErrorMap<UErrorMap, TErrorMap>,
+      TMeta
+    >
 
   use(middleware: AnyMiddleware, mapInput?: MapInputMiddleware<any, any>): DecoratedProcedure<any, any, any, any, any, any, any> {
     const mapped = mapInput


### PR DESCRIPTION
This PR ensures that errors defined before `.middleware` are automatically attached to the middleware. As a result, when you `.use` the middleware, those errors are seamlessly propagated into the procedure.  

#### Example:  
```ts
const auth = os
  .errors({ UNAUTHENTICATED: {} })
  .middleware(({ next }) => next())

const ping = os
  .use(auth)
  .handler(({ errors }) => {
    // errors.throw(UNAUTHENTICATED)
  })
```
  
#### Trade-off:  
This change slightly increases type-checking time for `.use`.