### PR TITLE
feat(contract, client)!: enforce stricter client context

### DIFF
--- a/apps/content/content/docs/client/vanilla.mdx
+++ b/apps/content/content/docs/client/vanilla.mdx
@@ -47,8 +47,7 @@ import type { router } from 'examples/server'
 import { createORPCClient, ORPCError } from '@orpc/client'
 import { RPCLink } from '@orpc/client/fetch'
 
-type ClientContext = { cache?: RequestCache } | undefined
-// if context is not undefinable, it will require you pass context in every call
+type ClientContext = { cache?: RequestCache }
 
 const rpcLink = new RPCLink<ClientContext>({
   url: 'http://localhost:3000/rpc',

--- a/apps/content/examples/react-query.ts
+++ b/apps/content/examples/react-query.ts
@@ -2,4 +2,4 @@ import type { RouterClient } from '@orpc/server'
 import type { router } from 'examples/server'
 import { createORPCReactQueryUtils } from '@orpc/react-query'
 
-export const orpc = createORPCReactQueryUtils({} as RouterClient<typeof router /** or contract router */, unknown>)
+export const orpc = createORPCReactQueryUtils({} as RouterClient<typeof router /** or contract router */, Record<never, never>>)

--- a/apps/content/examples/vue-colada.ts
+++ b/apps/content/examples/vue-colada.ts
@@ -2,4 +2,4 @@ import type { RouterClient } from '@orpc/server'
 import type { router } from 'examples/server'
 import { createORPCVueColadaUtils } from '@orpc/vue-colada'
 
-export const orpc = createORPCVueColadaUtils({} as RouterClient<typeof router /** or contract router */, unknown>)
+export const orpc = createORPCVueColadaUtils({} as RouterClient<typeof router /** or contract router */, Record<never, never>>)

--- a/apps/content/examples/vue-query.ts
+++ b/apps/content/examples/vue-query.ts
@@ -2,4 +2,4 @@ import type { RouterClient } from '@orpc/server'
 import type { router } from 'examples/server'
 import { createORPCVueQueryUtils } from '@orpc/vue-query'
 
-export const orpc = createORPCVueQueryUtils({} as RouterClient<typeof router /** or contract router */, unknown>)
+export const orpc = createORPCVueQueryUtils({} as RouterClient<typeof router /** or contract router */, Record<never, never>>)

--- a/packages/client/src/adapters/fetch/types.ts
+++ b/packages/client/src/adapters/fetch/types.ts
@@ -1,3 +1,5 @@
-export interface FetchWithContext<TClientContext> {
+import type { ClientContext } from '@orpc/contract'
+
+export interface FetchWithContext<TClientContext extends ClientContext> {
   (url: Request | string | URL, init: RequestInit | undefined, context: TClientContext): Promise<Response>
 }

--- a/packages/client/src/client.test-d.ts
+++ b/packages/client/src/client.test-d.ts
@@ -1,4 +1,4 @@
-import type { Client } from '@orpc/contract'
+import type { Client, ClientContext } from '@orpc/contract'
 import { oc } from '@orpc/contract'
 import { implement, os } from '@orpc/server'
 import { z } from 'zod'
@@ -30,15 +30,15 @@ describe('createORPCClient', () => {
   it('build correct types with contract router', () => {
     const client = createORPCClient<typeof contractRouter>({} as any)
 
-    expectTypeOf(client.ping).toEqualTypeOf<Client<unknown, { in: string }, { out: string }, Error>>()
-    expectTypeOf(client.nested.pong).toEqualTypeOf<Client<unknown, number, unknown, Error>>()
+    expectTypeOf(client.ping).toEqualTypeOf<Client<ClientContext, { in: string }, { out: string }, Error>>()
+    expectTypeOf(client.nested.pong).toEqualTypeOf<Client<ClientContext, number, unknown, Error>>()
   })
 
   it('build correct types with router', () => {
     const client = createORPCClient<typeof router>({} as any)
 
-    expectTypeOf(client.ping).toEqualTypeOf<Client<unknown, { in: string }, { out: string }, Error>>()
-    expectTypeOf(client.nested.pong).toEqualTypeOf<Client<unknown, number, string, Error>>()
+    expectTypeOf(client.ping).toEqualTypeOf<Client<ClientContext, { in: string }, { out: string }, Error>>()
+    expectTypeOf(client.nested.pong).toEqualTypeOf<Client<ClientContext, number, string, Error>>()
   })
 
   it('pass correct context', () => {

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -1,3 +1,4 @@
+import type { ClientContext } from '@orpc/contract'
 import type { ClientLink } from './types'
 import { createORPCClient } from './client'
 
@@ -6,7 +7,7 @@ beforeEach(() => {
 })
 
 describe('createORPCClient', () => {
-  const mockedLink: ClientLink<unknown> = {
+  const mockedLink: ClientLink<ClientContext> = {
     call: vi.fn().mockReturnValue('__mocked__'),
   }
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,4 +1,4 @@
-import type { AnyContractRouter, Client, ContractRouterClient } from '@orpc/contract'
+import type { AnyContractRouter, Client, ClientContext, ContractRouterClient } from '@orpc/contract'
 import type { AnyRouter, RouterClient } from '@orpc/server'
 import type { ClientLink } from './types'
 
@@ -9,7 +9,7 @@ export interface createORPCClientOptions {
   path?: string[]
 }
 
-export function createORPCClient<TRouter extends AnyRouter | AnyContractRouter, TClientContext = unknown>(
+export function createORPCClient<TRouter extends AnyRouter | AnyContractRouter, TClientContext extends ClientContext = Record<never, never>>(
   link: ClientLink<TClientContext>,
   options?: createORPCClientOptions,
 ): TRouter extends AnyRouter // TODO: move this bellow `TRouter extends AnyContractRouter` can help me remove @orpc/server in dependencies

--- a/packages/client/src/dynamic-link.test.ts
+++ b/packages/client/src/dynamic-link.test.ts
@@ -23,4 +23,22 @@ describe('dynamicLink', () => {
     expect(mockedLink.call).toHaveBeenCalledTimes(1)
     expect(mockedLink.call).toHaveBeenCalledWith(path, input, options)
   })
+
+  it('works with undefined context', async () => {
+    const mockedLink = { call: vi.fn().mockResolvedValue('__mocked__') }
+    const mockLinkResolver = vi.fn().mockResolvedValue(mockedLink)
+    const link = new DynamicLink(mockLinkResolver)
+
+    const path = ['users', 'getProfile']
+    const input = { id: 123 }
+    const options: ClientOptions<any> = {
+    }
+
+    expect(await link.call(path, input, options)).toEqual('__mocked__')
+
+    expect(mockLinkResolver).toHaveBeenCalledTimes(1)
+    expect(mockLinkResolver).toHaveBeenCalledWith(path, input, {})
+    expect(mockedLink.call).toHaveBeenCalledTimes(1)
+    expect(mockedLink.call).toHaveBeenCalledWith(path, input, { ...options, context: {} })
+  })
 })

--- a/packages/client/src/dynamic-link.ts
+++ b/packages/client/src/dynamic-link.ts
@@ -17,10 +17,11 @@ export class DynamicLink<TClientContext extends ClientContext> implements Client
   }
 
   async call(path: readonly string[], input: unknown, options: ClientOptions<TClientContext>): Promise<unknown> {
-    // Since the context is only optional when the context is undefinable, we can safely cast it
-    const resolvedLink = await this.linkResolver(path, input, options.context as TClientContext)
+    const clientContext = options.context ?? {} as TClientContext // options.context can be undefined when all field is optional
 
-    const output = await resolvedLink.call(path, input, options)
+    const resolvedLink = await this.linkResolver(path, input, clientContext)
+
+    const output = await resolvedLink.call(path, input, { ...options, context: clientContext })
 
     return output
   }

--- a/packages/client/src/dynamic-link.ts
+++ b/packages/client/src/dynamic-link.ts
@@ -1,4 +1,4 @@
-import type { ClientOptions } from '@orpc/contract'
+import type { ClientContext, ClientOptions } from '@orpc/contract'
 import type { Promisable } from '@orpc/shared'
 import type { ClientLink } from './types'
 
@@ -6,7 +6,7 @@ import type { ClientLink } from './types'
  * DynamicLink provides a way to dynamically resolve and delegate calls to other ClientLinks
  * based on the request path, input, and context.
  */
-export class DynamicLink<TClientContext> implements ClientLink<TClientContext> {
+export class DynamicLink<TClientContext extends ClientContext> implements ClientLink<TClientContext> {
   constructor(
     private readonly linkResolver: (
       path: readonly string[],

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -1,5 +1,5 @@
-import type { ClientOptions } from '@orpc/contract'
+import type { ClientContext, ClientOptions } from '@orpc/contract'
 
-export interface ClientLink<TClientContext> {
+export interface ClientLink<TClientContext extends ClientContext> {
   call(path: readonly string[], input: unknown, options: ClientOptions<TClientContext>): Promise<unknown>
 }

--- a/packages/client/tests/helpers.ts
+++ b/packages/client/tests/helpers.ts
@@ -126,7 +126,7 @@ export const router = implement(contract).router({
 
 const rpcHandler = new RPCHandler(router)
 
-export type ClientContext = { cache?: string } | undefined
+export type ClientContext = { cache?: string }
 
 const rpcLink = new RPCLink<ClientContext>({
   url: 'http://localhost:3000',

--- a/packages/client/tests/shared.ts
+++ b/packages/client/tests/shared.ts
@@ -5,7 +5,7 @@ import { RPCLink } from '../src/adapters/fetch'
 
 const rpcHandler = new RPCHandler(router)
 
-export type ClientContext = { cache?: string } | undefined
+export type ClientContext = { cache?: string }
 
 const rpcLink = new RPCLink<ClientContext>({
   url: 'http://localhost:3000',

--- a/packages/contract/src/client-utils.test-d.ts
+++ b/packages/contract/src/client-utils.test-d.ts
@@ -1,10 +1,10 @@
-import type { Client } from './client'
+import type { Client, ClientContext } from './client'
 import type { ORPCError } from './error-orpc'
 import { safe } from './client-utils'
 import { isDefinedError } from './error-utils'
 
 it('safe', async () => {
-  const client = {} as Client<unknown, string, number, Error | ORPCError<'BAD_GATEWAY', { val: string }>>
+  const client = {} as Client<ClientContext, string, number, Error | ORPCError<'BAD_GATEWAY', { val: string }>>
 
   const [output, error, isDefined] = await safe(client('123'))
 

--- a/packages/contract/src/client.test-d.ts
+++ b/packages/contract/src/client.test-d.ts
@@ -1,13 +1,13 @@
-import type { Client } from './client'
+import type { Client, ClientContext } from './client'
 
 describe('client', () => {
-  const fn: Client<unknown, string, number, Error> = async (...[input, options]) => {
+  const fn: Client<ClientContext, string, number, Error> = async (...[input, options]) => {
     expectTypeOf(input).toEqualTypeOf<string>()
     expectTypeOf(options).toMatchTypeOf<({ context?: unknown, signal?: AbortSignal }) | undefined>()
     return 123
   }
 
-  const fnWithOptionalInput: Client<unknown, string | undefined, number, Error> = async (...args) => {
+  const fnWithOptionalInput: Client<ClientContext, string | undefined, number, Error> = async (...args) => {
     const [input, options] = args
 
     expectTypeOf(input).toEqualTypeOf<string | undefined>()
@@ -16,8 +16,8 @@ describe('client', () => {
   }
 
   it('just a function', () => {
-    expectTypeOf(fn).toMatchTypeOf<(input: string, options: { context?: unknown, signal?: AbortSignal }) => Promise<number>>()
-    expectTypeOf(fnWithOptionalInput).toMatchTypeOf<(input: string | undefined, options: { context?: unknown, signal?: AbortSignal }) => Promise<number>>()
+    expectTypeOf(fn).toMatchTypeOf<(input: string, options: { context?: ClientContext, signal?: AbortSignal }) => Promise<number>>()
+    expectTypeOf(fnWithOptionalInput).toMatchTypeOf<(input: string | undefined, options: { context?: ClientContext, signal?: AbortSignal }) => Promise<number>>()
   })
 
   it('infer correct input', () => {
@@ -63,16 +63,17 @@ describe('client', () => {
     })
 
     it('optional options when context is optional', () => {
-      const client = {} as Client<undefined | { userId: string }, { val: string }, { val: number }, Error>
+      const client = {} as Client<{ userId?: string }, { val: string }, { val: number }, Error>
 
       client({ val: '123' })
       client({ val: '123' }, { context: { userId: '123' } })
     })
 
     it('can call without args when both input and context are optional', () => {
-      const client = {} as Client<undefined | { userId: string }, undefined | { val: string }, { val: number }, Error>
+      const client = {} as Client<{ userId?: string }, undefined | { val: string }, { val: number }, Error>
 
       client()
+      client({ val: 'string' })
       client({ val: 'string' }, { context: { userId: '123' } })
       // @ts-expect-error - input is invalid
       client({ val: 123 }, { context: { userId: '123' } })

--- a/packages/contract/src/client.ts
+++ b/packages/contract/src/client.ts
@@ -1,18 +1,19 @@
-export type ClientOptions<TClientContext> =
-  & { signal?: AbortSignal }
-  & (undefined extends TClientContext ? { context?: TClientContext } : { context: TClientContext })
+export type ClientContext = Record<string, any>
 
-export type ClientRest<TClientContext, TInput> =
+export type ClientOptions<TClientContext extends ClientContext> =
+  & { signal?: AbortSignal }
+  & (Record<never, never> extends TClientContext ? { context?: TClientContext } : { context: TClientContext })
+
+export type ClientRest<TClientContext extends ClientContext, TInput> =
   | [input: TInput, options: ClientOptions<TClientContext>]
-  | (undefined extends TInput & TClientContext ? [] : never)
-  | (undefined extends TClientContext ? [input: TInput] : never)
+  | (Record<never, never> extends TClientContext ? (undefined extends TInput ? [input?: TInput] : [input: TInput]) : never)
 
 export type ClientPromiseResult<TOutput, TError extends Error> = Promise<TOutput> & { __error?: { type: TError } }
 
-export interface Client<TClientContext, TInput, TOutput, TError extends Error> {
+export interface Client<TClientContext extends ClientContext, TInput, TOutput, TError extends Error> {
   (...rest: ClientRest<TClientContext, TInput>): ClientPromiseResult<TOutput, TError>
 }
 
-export type NestedClient<TClientContext> = Client<TClientContext, any, any, any> | {
+export type NestedClient<TClientContext extends ClientContext> = Client<TClientContext, any, any, any> | {
   [k: string]: NestedClient<TClientContext>
 }

--- a/packages/contract/src/procedure-client.test-d.ts
+++ b/packages/contract/src/procedure-client.test-d.ts
@@ -6,10 +6,10 @@ import type { ContractProcedureClient } from './procedure-client'
 describe('ContractProcedureClient', () => {
   it('is a client', () => {
     expectTypeOf<
-      ContractProcedureClient<'context', typeof inputSchema, typeof outputSchema, typeof baseErrorMap>
+      ContractProcedureClient<{ cache?: boolean }, typeof inputSchema, typeof outputSchema, typeof baseErrorMap>
     >().toEqualTypeOf<
       Client<
-        'context',
+        { cache?: boolean },
         { input: number },
         { output: string },
         Error | ORPCError<'BASE', { output: string }> | ORPCError<'OVERRIDE', unknown>

--- a/packages/contract/src/procedure-client.ts
+++ b/packages/contract/src/procedure-client.ts
@@ -1,10 +1,10 @@
-import type { Client } from './client'
+import type { Client, ClientContext } from './client'
 import type { ErrorFromErrorMap } from './error'
 import type { ErrorMap } from './error-map'
 import type { Schema, SchemaInput, SchemaOutput } from './schema'
 
 export type ContractProcedureClient<
-  TClientContext,
+  TClientContext extends ClientContext,
   TInputSchema extends Schema,
   TOutputSchema extends Schema,
   TErrorMap extends ErrorMap,

--- a/packages/contract/src/router-client.test-d.ts
+++ b/packages/contract/src/router-client.test-d.ts
@@ -1,4 +1,4 @@
-import type { NestedClient } from './client'
+import type { ClientContext, NestedClient } from './client'
 import type { ContractRouterClient } from './router-client'
 import { ping, pong } from '../tests/shared'
 
@@ -13,7 +13,7 @@ const router = {
 
 describe('ContractRouterClient', () => {
   it('is a NestedClient', () => {
-    expectTypeOf<ContractRouterClient<typeof router, unknown>>().toMatchTypeOf<NestedClient<unknown>>()
-    expectTypeOf<ContractRouterClient<typeof router, 'invalid'>>().not.toMatchTypeOf<NestedClient<unknown>>()
+    expectTypeOf<ContractRouterClient<typeof router, ClientContext>>().toMatchTypeOf<NestedClient<ClientContext>>()
+    expectTypeOf<ContractRouterClient<typeof router, { cache?: boolean }>>().not.toMatchTypeOf<NestedClient<{ cache?: string }>>()
   })
 })

--- a/packages/contract/src/router-client.ts
+++ b/packages/contract/src/router-client.ts
@@ -1,8 +1,9 @@
+import type { ClientContext } from './client'
 import type { ContractProcedure } from './procedure'
 import type { ContractProcedureClient } from './procedure-client'
 import type { AnyContractRouter } from './router'
 
-export type ContractRouterClient<TRouter extends AnyContractRouter, TClientContext> =
+export type ContractRouterClient<TRouter extends AnyContractRouter, TClientContext extends ClientContext> =
   TRouter extends ContractProcedure<infer UInputSchema, infer UOutputSchema, infer UErrorMap, any>
     ? ContractProcedureClient<TClientContext, UInputSchema, UOutputSchema, UErrorMap>
     : {

--- a/packages/react-query/src/procedure-utils.test-d.ts
+++ b/packages/react-query/src/procedure-utils.test-d.ts
@@ -10,7 +10,7 @@ describe('ProcedureUtils', () => {
   type UtilsOutput = { title: string }[]
 
   const utils = {} as ProcedureUtils<
-    { batch?: boolean } | undefined,
+    { batch?: boolean },
     UtilsInput,
     UtilsOutput,
     ErrorFromErrorMap<typeof baseErrorMap>
@@ -19,7 +19,7 @@ describe('ProcedureUtils', () => {
   it('.call', () => {
     expectTypeOf(utils.call).toEqualTypeOf<
       Client<
-        { batch?: boolean } | undefined,
+        { batch?: boolean },
         UtilsInput,
         UtilsOutput,
         ErrorFromErrorMap<typeof baseErrorMap>
@@ -122,7 +122,7 @@ describe('ProcedureUtils', () => {
     const initialPageParam = 1
 
     it('can optional context', () => {
-      const requiredUtils = {} as ProcedureUtils<{ batch?: boolean }, 'input' | undefined, UtilsOutput, Error>
+      const requiredUtils = {} as ProcedureUtils<{ batch: boolean }, 'input' | undefined, UtilsOutput, Error>
 
       utils.infiniteOptions({
         input: () => ({}),
@@ -251,7 +251,7 @@ describe('ProcedureUtils', () => {
 
   describe('.mutationOptions', () => {
     it('can optional options', () => {
-      const requiredUtils = {} as ProcedureUtils<{ batch?: boolean }, 'input', UtilsOutput, Error>
+      const requiredUtils = {} as ProcedureUtils<{ batch: boolean }, 'input', UtilsOutput, Error>
 
       utils.mutationOptions()
       utils.mutationOptions({})

--- a/packages/react-query/src/procedure-utils.ts
+++ b/packages/react-query/src/procedure-utils.ts
@@ -1,10 +1,10 @@
-import type { Client } from '@orpc/contract'
+import type { Client, ClientContext } from '@orpc/contract'
 import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { InfiniteData } from '@tanstack/react-query'
 import type { InfiniteOptionsBase, InfiniteOptionsIn, MutationOptionsBase, MutationOptionsIn, QueryOptionsBase, QueryOptionsIn } from './types'
 import { buildKey } from './key'
 
-export interface ProcedureUtils<TClientContext, TInput, TOutput, TError extends Error> {
+export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TOutput, TError extends Error> {
   call: Client<TClientContext, TInput, TOutput, TError>
 
   queryOptions<U, USelectData = TOutput>(
@@ -24,7 +24,7 @@ export interface ProcedureUtils<TClientContext, TInput, TOutput, TError extends 
   ): NoInfer<U & MutationOptionsBase<TInput, TOutput, TError>>
 }
 
-export function createProcedureUtils<TClientContext, TInput, TOutput, TError extends Error>(
+export function createProcedureUtils<TClientContext extends ClientContext, TInput, TOutput, TError extends Error>(
   client: Client<TClientContext, TInput, TOutput, TError>,
   path: string[],
 ): ProcedureUtils<TClientContext, TInput, TOutput, TError> {

--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -1,9 +1,10 @@
+import type { ClientContext } from '@orpc/contract'
 import type { SetOptional } from '@orpc/shared'
 import type { QueryFunctionContext, QueryKey, UseInfiniteQueryOptions, UseMutationOptions, UseQueryOptions } from '@tanstack/react-query'
 
-export type QueryOptionsIn<TClientContext, TInput, TOutput, TError extends Error, TSelectData> =
+export type QueryOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError extends Error, TSelectData> =
   & (undefined extends TInput ? { input?: TInput } : { input: TInput })
-  & (undefined extends TClientContext ? { context?: TClientContext } : { context: TClientContext })
+  & (Record<never, never> extends TClientContext ? { context?: TClientContext } : { context: TClientContext })
   & SetOptional<UseQueryOptions<TOutput, TError, TSelectData>, 'queryKey'>
 
 export interface QueryOptionsBase<TOutput, TError extends Error> {
@@ -12,9 +13,9 @@ export interface QueryOptionsBase<TOutput, TError extends Error> {
   retry?(failureCount: number, error: TError): boolean // this make tanstack can infer the TError type
 }
 
-export type InfiniteOptionsIn<TClientContext, TInput, TOutput, TError extends Error, TSelectData, TPageParam> =
+export type InfiniteOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError extends Error, TSelectData, TPageParam> =
   & { input: (pageParam: TPageParam) => TInput }
-  & (undefined extends TClientContext ? { context?: TClientContext } : { context: TClientContext })
+  & (Record<never, never> extends TClientContext ? { context?: TClientContext } : { context: TClientContext })
   & SetOptional<UseInfiniteQueryOptions<TOutput, TError, TSelectData, TOutput, QueryKey, TPageParam>, 'queryKey'>
 
 export interface InfiniteOptionsBase<TOutput, TError extends Error, TPageParam> {
@@ -23,8 +24,8 @@ export interface InfiniteOptionsBase<TOutput, TError extends Error, TPageParam> 
   retry?(failureCount: number, error: TError): boolean // this make tanstack can infer the TError type
 }
 
-export type MutationOptionsIn<TClientContext, TInput, TOutput, TError extends Error> =
-  & (undefined extends TClientContext ? { context?: TClientContext } : { context: TClientContext })
+export type MutationOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError extends Error> =
+  & (Record<never, never> extends TClientContext ? { context?: TClientContext } : { context: TClientContext })
   & UseMutationOptions<TOutput, TError, TInput>
 
 export interface MutationOptionsBase<TInput, TOutput, TError extends Error> {

--- a/packages/server/src/adapters/standard/handler.ts
+++ b/packages/server/src/adapters/standard/handler.ts
@@ -21,7 +21,7 @@ export type StandardHandleResult = { matched: true, response: StandardResponse }
 export type StandardHandlerInterceptorOptions<TContext extends Context> = WellStandardHandleOptions<TContext> & { request: StandardRequest }
 
 export type WellCreateProcedureClientOptions<TContext extends Context> =
-  CreateProcedureClientOptions<TContext, Schema, Schema, unknown, ErrorMap, Meta, unknown> & {
+  CreateProcedureClientOptions<TContext, Schema, Schema, unknown, ErrorMap, Meta, Record<never, never>> & {
     context: TContext
   }
 

--- a/packages/server/src/implementer-procedure.test-d.ts
+++ b/packages/server/src/implementer-procedure.test-d.ts
@@ -145,7 +145,7 @@ describe('ImplementedProcedure', () => {
 
   it('.callable', () => {
     const applied = implemented.callable({
-      context: async (clientContext: 'client-context') => ({ db: 'postgres' }),
+      context: async (clientContext: { batch?: boolean }) => ({ db: 'postgres' }),
     })
 
     expectTypeOf(applied).toEqualTypeOf<
@@ -158,13 +158,13 @@ describe('ImplementedProcedure', () => {
           typeof baseErrorMap,
           BaseMeta
       >
-      & Client<'client-context', { input: number }, { output: string }, ErrorFromErrorMap<typeof baseErrorMap>>
+      & Client<{ batch?: boolean }, { input: number }, { output: string }, ErrorFromErrorMap<typeof baseErrorMap>>
     >()
   })
 
   it('.actionable', () => {
     const applied = implemented.actionable({
-      context: async (clientContext: 'client-context') => ({ db: 'postgres' }),
+      context: async (clientContext: { batch?: boolean }) => ({ db: 'postgres' }),
     })
 
     expectTypeOf(applied).toEqualTypeOf<
@@ -177,7 +177,7 @@ describe('ImplementedProcedure', () => {
           typeof baseErrorMap,
           BaseMeta
       >
-      & ((...rest: ClientRest<'client-context', { input: number }>) => Promise<{ output: string }>)
+      & ((...rest: ClientRest<{ batch?: boolean }, { input: number }>) => Promise<{ output: string }>)
     >()
   })
 })

--- a/packages/server/src/implementer-procedure.ts
+++ b/packages/server/src/implementer-procedure.ts
@@ -1,4 +1,4 @@
-import type { ClientRest, ErrorMap, Meta, ORPCErrorConstructorMap, Schema, SchemaInput, SchemaOutput } from '@orpc/contract'
+import type { ClientContext, ClientRest, ErrorMap, Meta, ORPCErrorConstructorMap, Schema, SchemaInput, SchemaOutput } from '@orpc/contract'
 import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { BuilderDef } from './builder'
 import type { ConflictContextGuard, Context, MergedContext } from './context'
@@ -45,7 +45,7 @@ export interface ImplementedProcedure<
   /**
    * Make this procedure callable (works like a function while still being a procedure).
    */
-  callable<TClientContext>(
+  callable<TClientContext extends ClientContext>(
     ...rest: MaybeOptionalOptions<
       CreateProcedureClientOptions<
         TInitialContext,
@@ -58,12 +58,12 @@ export interface ImplementedProcedure<
       >
     >
   ): Procedure<TInitialContext, TCurrentContext, TInputSchema, TOutputSchema, THandlerOutput, TErrorMap, TMeta>
-    & ProcedureClient < TClientContext, TInputSchema, TOutputSchema, THandlerOutput, TErrorMap >
+    & ProcedureClient<TClientContext, TInputSchema, TOutputSchema, THandlerOutput, TErrorMap >
 
   /**
    * Make this procedure compatible with server action (the same as .callable, but the type is compatible with server action).
    */
-  actionable<TClientContext>(
+  actionable<TClientContext extends ClientContext>(
     ...rest: MaybeOptionalOptions<
       CreateProcedureClientOptions<
         TInitialContext,

--- a/packages/server/src/procedure-client.test-d.ts
+++ b/packages/server/src/procedure-client.test-d.ts
@@ -1,4 +1,4 @@
-import type { Client, ErrorMap, ORPCError, ORPCErrorConstructorMap, Schema } from '@orpc/contract'
+import type { Client, ClientContext, ErrorMap, ORPCError, ORPCErrorConstructorMap, Schema } from '@orpc/contract'
 import type { baseErrorMap, BaseMeta, inputSchema, outputSchema } from '../../contract/tests/shared'
 import type { Context } from './context'
 import type { Procedure } from './procedure'
@@ -8,7 +8,7 @@ import { createProcedureClient, type ProcedureClient } from './procedure-client'
 
 describe('ProcedureClient', () => {
   const client = {} as ProcedureClient<
-    'client-context',
+    { cache: boolean },
     typeof inputSchema,
     typeof outputSchema,
     { output: number },
@@ -18,7 +18,7 @@ describe('ProcedureClient', () => {
   it('is a client', () => {
     expectTypeOf(client).toMatchTypeOf<
       Client<
-        'client-context',
+        { cache: boolean },
         { input: number },
         { output: string },
         Error | ORPCError<'BASE', { output: string }>
@@ -27,7 +27,7 @@ describe('ProcedureClient', () => {
   })
 
   it('works', async () => {
-    const [output, error, isDefined] = await safe(client({ input: 123 }, { context: 'client-context' }))
+    const [output, error, isDefined] = await safe(client({ input: 123 }, { context: { cache: true } }))
 
     if (!error) {
       expectTypeOf(output).toEqualTypeOf<{ output: string }>()
@@ -38,7 +38,7 @@ describe('ProcedureClient', () => {
     }
 
     // @ts-expect-error - invalid input
-    client({ input: 'INVALID' }, { context: 'client-context' })
+    client({ input: 'INVALID' }, { context: { cache: true } })
     // @ts-expect-error - invalid client context
     client({ input: 123 }, { context: 'INVALID' })
     // @ts-expect-error - client context is required
@@ -46,7 +46,7 @@ describe('ProcedureClient', () => {
   })
 
   it('can fallback to handler output', async () => {
-    const client = {} as ProcedureClient<unknown, typeof inputSchema, undefined, { handler: number }, typeof baseErrorMap>
+    const client = {} as ProcedureClient<ClientContext, typeof inputSchema, undefined, { handler: number }, typeof baseErrorMap>
 
     const output = await client({ input: 123 })
 
@@ -68,11 +68,11 @@ describe('createProcedureClient', () => {
   })
 
   it('can type client context', () => {
-    const client = createProcedureClient(ping, { context: (clientContext: 'client-context') => ({ db: 'postgres' }) })
+    const client = createProcedureClient(ping, { context: (clientContext: { cache?: boolean }) => ({ db: 'postgres' }) })
 
     expectTypeOf(client).toEqualTypeOf<
       ProcedureClient<
-        'client-context',
+        { cache?: boolean },
         typeof inputSchema,
         typeof outputSchema,
         { output: number },

--- a/packages/server/src/procedure-client.test.ts
+++ b/packages/server/src/procedure-client.test.ts
@@ -451,7 +451,7 @@ describe.each(procedureCases)('createProcedureClient - case %s', async (_, proce
 
     await client({ val: '123' })
     expect(context).toBeCalledTimes(1)
-    expect(context).toBeCalledWith(undefined)
+    expect(context).toBeCalledWith({})
 
     context.mockClear()
     await client({ val: '123' }, { context: { cache: true } })

--- a/packages/server/src/procedure-decorated.test-d.ts
+++ b/packages/server/src/procedure-decorated.test-d.ts
@@ -175,7 +175,7 @@ describe('DecoratedProcedure', () => {
 
   it('.callable', () => {
     const applied = builder.callable({
-      context: async (clientContext: 'client-context') => ({ db: 'postgres' }),
+      context: async (clientContext: { batch?: boolean }) => ({ db: 'postgres' }),
     })
 
     expectTypeOf(applied).toEqualTypeOf<
@@ -188,13 +188,13 @@ describe('DecoratedProcedure', () => {
         typeof baseErrorMap,
         BaseMeta
       >
-      & Client<'client-context', { input: number }, { output: string }, ErrorFromErrorMap<typeof baseErrorMap>>
+      & Client<{ batch?: boolean }, { input: number }, { output: string }, ErrorFromErrorMap<typeof baseErrorMap>>
     >()
   })
 
   it('.actionable', () => {
     const applied = builder.actionable({
-      context: async (clientContext: 'client-context') => ({ db: 'postgres' }),
+      context: async (clientContext: { batch?: boolean }) => ({ db: 'postgres' }),
     })
 
     expectTypeOf(applied).toEqualTypeOf<
@@ -207,7 +207,7 @@ describe('DecoratedProcedure', () => {
         typeof baseErrorMap,
         BaseMeta
       >
-      & ((...rest: ClientRest<'client-context', { input: number }>) => Promise<{ output: string }>)
+      & ((...rest: ClientRest<{ batch?: boolean }, { input: number }>) => Promise<{ output: string }>)
     >()
   })
 })

--- a/packages/server/src/procedure-decorated.ts
+++ b/packages/server/src/procedure-decorated.ts
@@ -1,4 +1,4 @@
-import type { ClientRest, ErrorMap, MergedErrorMap, Meta, ORPCErrorConstructorMap, Route, Schema, SchemaInput, SchemaOutput } from '@orpc/contract'
+import type { ClientContext, ClientRest, ErrorMap, MergedErrorMap, Meta, ORPCErrorConstructorMap, Route, Schema, SchemaInput, SchemaOutput } from '@orpc/contract'
 import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { ConflictContextGuard, Context, MergedContext } from './context'
 import type { AnyMiddleware, MapInputMiddleware, Middleware } from './middleware'
@@ -92,7 +92,7 @@ export class DecoratedProcedure<
   /**
    * Make this procedure callable (works like a function while still being a procedure).
    */
-  callable<TClientContext>(
+  callable<TClientContext extends ClientContext>(
     ...rest: MaybeOptionalOptions<
       CreateProcedureClientOptions<
         TInitialContext,
@@ -115,7 +115,7 @@ export class DecoratedProcedure<
   /**
    * Make this procedure compatible with server action (the same as .callable, but the type is compatible with server action).
    */
-  actionable<TClientContext>(
+  actionable<TClientContext extends ClientContext>(
     ...rest: MaybeOptionalOptions<
       CreateProcedureClientOptions<
         TInitialContext,

--- a/packages/server/src/procedure-utils.ts
+++ b/packages/server/src/procedure-utils.ts
@@ -34,7 +34,7 @@ export function call<
       THandlerOutput,
       TErrorMap,
       TMeta,
-      unknown
+      Record<never, never>
     >
   >
 ): ClientPromiseResult<SchemaOutput<TOutputSchema, THandlerOutput>, ErrorFromErrorMap<TErrorMap>> {

--- a/packages/server/src/router-client.test-d.ts
+++ b/packages/server/src/router-client.test-d.ts
@@ -3,28 +3,28 @@ import type { baseErrorMap } from '../../contract/tests/shared'
 import type { router } from '../tests/shared'
 import type { RouterClient } from './router-client'
 
-const routerClient = {} as RouterClient<typeof router, 'client-context'>
+const routerClient = {} as RouterClient<typeof router, { cache: boolean }>
 
 describe('RouterClient', () => {
   it('is a nested client', () => {
-    expectTypeOf(routerClient).toMatchTypeOf<NestedClient<'client-context'>>()
+    expectTypeOf(routerClient).toMatchTypeOf<NestedClient<{ cache: boolean }>>()
   })
 
   it('works', () => {
     expectTypeOf(routerClient.ping).toEqualTypeOf<
-      Client<'client-context', { input: number }, { output: string }, ErrorFromErrorMap<typeof baseErrorMap>>
+      Client<{ cache: boolean }, { input: number }, { output: string }, ErrorFromErrorMap<typeof baseErrorMap>>
     >()
 
     expectTypeOf(routerClient.nested.ping).toEqualTypeOf<
-      Client<'client-context', { input: number }, { output: string }, ErrorFromErrorMap<typeof baseErrorMap>>
+      Client<{ cache: boolean }, { input: number }, { output: string }, ErrorFromErrorMap<typeof baseErrorMap>>
     >()
 
     expectTypeOf(routerClient.pong).toEqualTypeOf<
-      Client<'client-context', unknown, unknown, Error>
+      Client<{ cache: boolean }, unknown, unknown, Error>
     >()
 
     expectTypeOf(routerClient.nested.pong).toEqualTypeOf<
-      Client<'client-context', unknown, unknown, Error>
+      Client<{ cache: boolean }, unknown, unknown, Error>
     >()
   })
 })

--- a/packages/server/src/router-client.ts
+++ b/packages/server/src/router-client.ts
@@ -1,36 +1,25 @@
-import type { ErrorMap, Meta } from '@orpc/contract'
+import type { ClientContext, ErrorMap, Meta } from '@orpc/contract'
 import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { Lazy } from './lazy'
 import type { Procedure } from './procedure'
 import type { CreateProcedureClientOptions, ProcedureClient } from './procedure-client'
-import type { AnyRouter, InferRouterInitialContext, Router } from './router'
+import type { AnyRouter, InferRouterInitialContext } from './router'
 import { isLazy } from './lazy'
 import { createLazyProcedureFormAnyLazy } from './lazy-utils'
 import { isProcedure } from './procedure'
 import { createProcedureClient } from './procedure-client'
 import { getRouterChild } from './router'
 
-export type RouterClient<TRouter extends AnyRouter, TClientContext> = TRouter extends Lazy<infer U extends AnyRouter>
-  ? RouterClient<U, TClientContext>
-  : TRouter extends Procedure<any, any, infer UInputSchema, infer UOutputSchema, infer UFuncOutput, infer UErrorMap, any>
-    ? ProcedureClient<TClientContext, UInputSchema, UOutputSchema, UFuncOutput, UErrorMap>
-    : {
-        [K in keyof TRouter]: TRouter[K] extends AnyRouter ? RouterClient<TRouter[K], TClientContext> : never
-      }
+export type RouterClient<TRouter extends AnyRouter, TClientContext extends ClientContext> =
+  TRouter extends Lazy<infer U extends AnyRouter>
+    ? RouterClient<U, TClientContext>
+    : TRouter extends Procedure<any, any, infer UInputSchema, infer UOutputSchema, infer UFuncOutput, infer UErrorMap, any>
+      ? ProcedureClient<TClientContext, UInputSchema, UOutputSchema, UFuncOutput, UErrorMap>
+      : {
+          [K in keyof TRouter]: TRouter[K] extends AnyRouter ? RouterClient<TRouter[K], TClientContext> : never
+        }
 
-export type CreateRouterClientRest<TRouter extends AnyRouter, TClientContext> = MaybeOptionalOptions<
-  CreateProcedureClientOptions<
-    TRouter extends Router<infer UContext, any> ? UContext : never,
-    undefined,
-    undefined,
-    unknown,
-    ErrorMap,
-    Meta,
-    TClientContext
-  >
->
-
-export function createRouterClient<TRouter extends AnyRouter, TClientContext>(
+export function createRouterClient<TRouter extends AnyRouter, TClientContext extends ClientContext>(
   router: TRouter | Lazy<undefined>,
   ...rest: MaybeOptionalOptions<
     CreateProcedureClientOptions<

--- a/packages/vue-colada/src/procedure-utils.test-d.ts
+++ b/packages/vue-colada/src/procedure-utils.test-d.ts
@@ -9,7 +9,7 @@ describe('ProcedureUtils', () => {
   type UtilsOutput = { title: string }[]
 
   const utils = {} as ProcedureUtils<
-    { batch?: boolean } | undefined,
+    { batch?: boolean },
     UtilsInput,
     UtilsOutput,
     ErrorFromErrorMap<typeof baseErrorMap>
@@ -18,7 +18,7 @@ describe('ProcedureUtils', () => {
   it('.call', () => {
     expectTypeOf(utils.call).toEqualTypeOf<
       Client<
-        { batch?: boolean } | undefined,
+        { batch?: boolean },
         UtilsInput,
         UtilsOutput,
         ErrorFromErrorMap<typeof baseErrorMap>
@@ -77,7 +77,7 @@ describe('ProcedureUtils', () => {
 
   describe('.mutationOptions', () => {
     it('can optional options', () => {
-      const requiredUtils = {} as ProcedureUtils<{ batch?: boolean }, 'input', UtilsOutput, Error>
+      const requiredUtils = {} as ProcedureUtils<{ batch: boolean }, 'input', UtilsOutput, Error>
 
       utils.mutationOptions()
       utils.mutationOptions({})

--- a/packages/vue-colada/src/procedure-utils.ts
+++ b/packages/vue-colada/src/procedure-utils.ts
@@ -1,11 +1,11 @@
-import type { Client } from '@orpc/contract'
+import type { Client, ClientContext } from '@orpc/contract'
 import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { MutationOptions, MutationOptionsIn, QueryOptions, QueryOptionsIn } from './types'
 import { computed } from 'vue'
 import { buildKey } from './key'
 import { unrefDeep } from './utils'
 
-export interface ProcedureUtils<TClientContext, TInput, TOutput, TError extends Error> {
+export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TOutput, TError extends Error> {
   call: Client<TClientContext, TInput, TOutput, TError>
 
   queryOptions(
@@ -21,7 +21,7 @@ export interface ProcedureUtils<TClientContext, TInput, TOutput, TError extends 
   ): MutationOptions<TInput, TOutput, TError>
 }
 
-export function createProcedureUtils<TClientContext, TInput, TOutput, TError extends Error>(
+export function createProcedureUtils<TClientContext extends ClientContext, TInput, TOutput, TError extends Error>(
   client: Client<TClientContext, TInput, TOutput, TError>,
   path: string[],
 ): ProcedureUtils<TClientContext, TInput, TOutput, TError> {

--- a/packages/vue-colada/src/types.ts
+++ b/packages/vue-colada/src/types.ts
@@ -1,3 +1,4 @@
+import type { ClientContext } from '@orpc/contract'
 import type { AnyFunction, SetOptional } from '@orpc/shared'
 import type { UseMutationOptions, UseQueryOptions } from '@pinia/colada'
 import type { MaybeRef } from 'vue'
@@ -12,15 +13,15 @@ export type MaybeRefDeep<T> = MaybeRef<
 
 export type UseQueryFnContext = Parameters<UseQueryOptions<any>['query']>[0]
 
-export type QueryOptionsIn<TClientContext, TInput, TOutput, TError extends Error> =
+export type QueryOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError extends Error> =
   & (undefined extends TInput ? { input?: MaybeRefDeep<TInput> } : { input: MaybeRefDeep<TInput> })
-  & (undefined extends TClientContext ? { context?: MaybeRefDeep<TClientContext> } : { context: MaybeRefDeep<TClientContext> })
+  & (Record<never, never> extends TClientContext ? { context?: MaybeRefDeep<TClientContext> } : { context: MaybeRefDeep<TClientContext> })
   & SetOptional<UseQueryOptions<TOutput, TError>, 'key' | 'query'>
 
 export type QueryOptions<TOutput, TError extends Error> = UseQueryOptions<TOutput, TError>
 
-export type MutationOptionsIn<TClientContext, TInput, TOutput, TError extends Error> =
-  & (undefined extends TClientContext ? { context?: MaybeRefDeep<TClientContext> } : { context: MaybeRefDeep<TClientContext> })
+export type MutationOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError extends Error> =
+  & (Record<never, never> extends TClientContext ? { context?: MaybeRefDeep<TClientContext> } : { context: MaybeRefDeep<TClientContext> })
   & SetOptional<UseMutationOptions<TOutput, TInput, TError>, 'mutation'>
 
 export type MutationOptions<TInput, TOutput, TError extends Error> = UseMutationOptions<TOutput, TInput, TError>

--- a/packages/vue-query/src/procedure-utils.test-d.ts
+++ b/packages/vue-query/src/procedure-utils.test-d.ts
@@ -11,7 +11,7 @@ describe('ProcedureUtils', () => {
   type UtilsOutput = { title: string }[]
 
   const utils = {} as ProcedureUtils<
-    { batch?: boolean } | undefined,
+    { batch?: boolean },
     UtilsInput,
     UtilsOutput,
     ErrorFromErrorMap<typeof baseErrorMap>
@@ -20,7 +20,7 @@ describe('ProcedureUtils', () => {
   it('.call', () => {
     expectTypeOf(utils.call).toEqualTypeOf<
       Client<
-        { batch?: boolean } | undefined,
+        { batch?: boolean },
         UtilsInput,
         UtilsOutput,
         ErrorFromErrorMap<typeof baseErrorMap>
@@ -116,7 +116,7 @@ describe('ProcedureUtils', () => {
     const initialPageParam = 1
 
     it('can optional context', () => {
-      const requiredUtils = {} as ProcedureUtils<{ batch?: boolean }, 'input' | undefined, UtilsOutput, Error>
+      const requiredUtils = {} as ProcedureUtils<{ batch: boolean }, 'input' | undefined, UtilsOutput, Error>
 
       utils.infiniteOptions({
         input: () => ({}),
@@ -238,7 +238,7 @@ describe('ProcedureUtils', () => {
 
   describe('.mutationOptions', () => {
     it('can optional options', () => {
-      const requiredUtils = {} as ProcedureUtils<{ batch?: boolean }, 'input', UtilsOutput, Error>
+      const requiredUtils = {} as ProcedureUtils<{ batch: boolean }, 'input', UtilsOutput, Error>
 
       utils.mutationOptions()
       utils.mutationOptions({})

--- a/packages/vue-query/src/procedure-utils.ts
+++ b/packages/vue-query/src/procedure-utils.ts
@@ -1,4 +1,4 @@
-import type { Client } from '@orpc/contract'
+import type { Client, ClientContext } from '@orpc/contract'
 import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { InfiniteData } from '@tanstack/vue-query'
 import type { InfiniteOptionsBase, InfiniteOptionsIn, MutationOptionsBase, MutationOptionsIn, QueryOptionsBase, QueryOptionsIn } from './types'
@@ -6,7 +6,7 @@ import { computed } from 'vue'
 import { buildKey } from './key'
 import { unrefDeep } from './utils'
 
-export interface ProcedureUtils<TClientContext, TInput, TOutput, TError extends Error> {
+export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TOutput, TError extends Error> {
   call: Client<TClientContext, TInput, TOutput, TError>
 
   queryOptions<U, USelectData = TOutput>(
@@ -26,7 +26,7 @@ export interface ProcedureUtils<TClientContext, TInput, TOutput, TError extends 
   ): NoInfer<U & MutationOptionsBase<TInput, TOutput, TError>>
 }
 
-export function createProcedureUtils<TClientContext, TInput, TOutput, TError extends Error>(
+export function createProcedureUtils<TClientContext extends ClientContext, TInput, TOutput, TError extends Error>(
   client: Client<TClientContext, TInput, TOutput, TError>,
   path: string[],
 ): ProcedureUtils<TClientContext, TInput, TOutput, TError> {

--- a/packages/vue-query/src/types.ts
+++ b/packages/vue-query/src/types.ts
@@ -1,3 +1,4 @@
+import type { ClientContext } from '@orpc/contract'
 import type { AnyFunction, SetOptional } from '@orpc/shared'
 import type { Enabled, MutationObserverOptions, QueryFunctionContext, QueryKey, QueryObserverOptions, UseInfiniteQueryOptions } from '@tanstack/vue-query'
 import type { ComputedRef, MaybeRef, MaybeRefOrGetter } from 'vue'
@@ -14,9 +15,9 @@ export type MaybeRefDeep<T> = MaybeRef<
       : T
 >
 
-export type QueryOptionsIn<TClientContext, TInput, TOutput, TError extends Error, TSelectData> =
+export type QueryOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError extends Error, TSelectData> =
   & (undefined extends TInput ? { input?: MaybeRefDeep<TInput> } : { input: MaybeRefDeep<TInput> })
-  & (undefined extends TClientContext ? { context?: MaybeRefDeep<TClientContext> } : { context: MaybeRefDeep<TClientContext> })
+  & (Record<never, never> extends TClientContext ? { context?: MaybeRefDeep<TClientContext> } : { context: MaybeRefDeep<TClientContext> })
   & {
     [P in keyof Omit<QueryObserverOptions<TOutput, TError, TSelectData, TOutput>, 'queryKey' | 'enabled'>]:
     MaybeRefDeep<QueryObserverOptions<TOutput, TError, TSelectData, TOutput>[P]>
@@ -33,9 +34,9 @@ export interface QueryOptionsBase<TOutput, TError extends Error> {
   retry?(failureCount: number, error: TError): boolean // this help tanstack can infer TError
 }
 
-export type InfiniteOptionsIn<TClientContext, TInput, TOutput, TError extends Error, TSelectData, TPageParam> =
+export type InfiniteOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError extends Error, TSelectData, TPageParam> =
   & { input: (pageParam: TPageParam) => MaybeRefDeep<TInput> }
-  & (undefined extends TClientContext ? { context?: MaybeRefDeep<TClientContext> } : { context: MaybeRefDeep<TClientContext> })
+  & (Record<never, never> extends TClientContext ? { context?: MaybeRefDeep<TClientContext> } : { context: MaybeRefDeep<TClientContext> })
   & SetOptional<UseInfiniteQueryOptions<TOutput, TError, TSelectData, TOutput, QueryKey, TPageParam>, 'queryKey'>
 
 export interface InfiniteOptionsBase<TOutput, TError extends Error, TPageParam> {
@@ -44,8 +45,8 @@ export interface InfiniteOptionsBase<TOutput, TError extends Error, TPageParam> 
   retry?(failureCount: number, error: TError): boolean // this help tanstack can infer TError
 }
 
-export type MutationOptionsIn<TClientContext, TInput, TOutput, TError extends Error> =
-  & (undefined extends TClientContext ? { context?: TClientContext } : { context: TClientContext })
+export type MutationOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError extends Error> =
+  & (Record<never, never> extends TClientContext ? { context?: TClientContext } : { context: TClientContext })
   & {
     [P in keyof MutationObserverOptions<TOutput, TError, TInput>]: MaybeRefDeep<MutationObserverOptions<TOutput, TError, TInput>[P]>
   }


### PR DESCRIPTION
Previous: Client Context can be anything, and use undefined to indicate optional client context
Now: Client Context must satisfy `Record<string, any>` where optional client context can automatically detect if all field is optional.

```ts
type ClientContext = { cache?: RequestCache }
 
const rpcLink = new RPCLink<ClientContext>({
  url: 'http://localhost:3000/rpc',
  // headers: provide additional headers
  fetch: (input, init, context) => globalThis.fetch(input, {
    ...init,
    cache: context?.cache,
  }),
  method: (path, input, context) => {
    // if input contain file, and you return GET, oRPC will change it to POST automatically
 
    if (context?.cache) {
      return 'GET'
    }
 
    // or base on the path
    if (['get', 'find', 'list', 'search'].includes(path.at(-1)!)) {
      return 'GET'
    }
 
    return 'POST'
  },
})
```