### PR TITLE
feat(server)!: improve default options for CORSPlugin

### DIFF
--- a/packages/server/src/plugins/cors.ts
+++ b/packages/server/src/plugins/cors.ts
@@ -18,12 +18,8 @@ export class CORSPlugin<TContext extends Context> implements Plugin<TContext> {
 
   constructor(options?: Partial<CORSOptions<TContext>>) {
     const defaults: CORSOptions<TContext> = {
-      origin: '*',
+      origin: origin => origin,
       allowMethods: ['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH'],
-    }
-
-    if (options?.credentials) {
-      defaults.origin = origin => origin
     }
 
     this.options = {


### PR DESCRIPTION
Use default * for allow origin can security risk in some cases