### PR TITLE
feat(client, server): Event-Source Ping Interval

### DIFF
--- a/apps/content/docs/client/rpc-link.md
+++ b/apps/content/docs/client/rpc-link.md
@@ -89,7 +89,7 @@ const link = new RPCLink({
 
 ## Event Source Configuration
 
-Customize the retry logic for event sources using these options:
+Customize the retry logic for event sources (the mechanism behind [Event Iterator](/docs/event-iterator)) using these options:
 
 - **eventSourceMaxNumberOfRetries:** Maximum retry attempts.
 - **eventSourceRetryDelay:** Delay between retries.
@@ -114,4 +114,24 @@ const link = new RPCLink<ClientContext>({
 
 :::tip
 You should disable event source retries when streaming results from a chatbot AI.
+:::
+
+## Event-Source Ping Interval
+
+To keep EventSource connections alive (the mechanism behind [Event Iterator](/docs/event-iterator)), `RPCLink` periodically sends a ping comment to the server. You can configure this behavior using the following options:
+
+- `eventSourcePingEnabled` (default: `true`) – Enables or disables pings.
+- `eventSourcePingInterval` (default: `5000`) – Time between pings (in milliseconds).
+- `eventSourcePingContent` (default: `''`) – Custom content for ping messages.
+
+```ts
+const link = new RPCLink({
+  eventSourcePingEnabled: true,
+  eventSourcePingInterval: 5000, // 5 seconds
+  eventSourcePingContent: '',
+})
+```
+
+:::warning
+These options for sending [Event Iterator](/docs/event-iterator) from client to the server, not from the server to client as used in [RPCHandler](/docs/rpc-handler#event-source-ping-interval) or [OpenAPIHandler](/docs/openapi/openapi-handler#event-source-ping-interval).
 :::

--- a/apps/content/docs/openapi/openapi-handler.md
+++ b/apps/content/docs/openapi/openapi-handler.md
@@ -86,3 +86,19 @@ export default async function fetch(request: Request) {
   return new Response('Not Found', { status: 404 })
 }
 ```
+
+## Event-Source Ping Interval
+
+To keep EventSource connections alive (the mechanism behind [Event Iterator](/docs/event-iterator)), `OpenAPIHandler` periodically sends a ping comment to the client. You can configure this behavior using the following options:
+
+- `eventSourcePingEnabled` (default: `true`) – Enables or disables pings.
+- `eventSourcePingInterval` (default: `5000`) – Time between pings (in milliseconds).
+- `eventSourcePingContent` (default: `''`) – Custom content for ping messages.
+
+```ts
+const result = await handler.handle(request, {
+  eventSourcePingEnabled: true,
+  eventSourcePingInterval: 5000, // 5 seconds
+  eventSourcePingContent: '',
+})
+```

--- a/apps/content/docs/rpc-handler.md
+++ b/apps/content/docs/rpc-handler.md
@@ -65,3 +65,19 @@ export default async function fetch(request: Request) {
   return new Response('Not Found', { status: 404 })
 }
 ```
+
+## Event-Source Ping Interval
+
+To keep EventSource connections alive (the mechanism behind [Event Iterator](/docs/event-iterator)), `RPCHandler` periodically sends a ping comment to the client. You can configure this behavior using the following options:
+
+- `eventSourcePingEnabled` (default: `true`) – Enables or disables pings.
+- `eventSourcePingInterval` (default: `5000`) – Time between pings (in milliseconds).
+- `eventSourcePingContent` (default: `''`) – Custom content for ping messages.
+
+```ts
+const result = await handler.handle(request, {
+  eventSourcePingEnabled: true,
+  eventSourcePingInterval: 5000, // 5 seconds
+  eventSourcePingContent: '',
+})
+```

--- a/packages/client/src/adapters/fetch/rpc-link.ts
+++ b/packages/client/src/adapters/fetch/rpc-link.ts
@@ -1,5 +1,5 @@
 import type { Value } from '@orpc/shared'
-import type { StandardBody, StandardEventSourceOptions } from '@orpc/standard-server'
+import type { StandardBody, StandardServerEventSourceOptions } from '@orpc/standard-server'
 import type { ClientContext, ClientLink, ClientOptionsOut } from '../../types'
 import type { FetchWithContext } from './types'
 import { isAsyncIteratorObject, stringifyJSON, trim, value } from '@orpc/shared'
@@ -12,7 +12,7 @@ type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
 
 export class InvalidEventSourceRetryResponse extends Error { }
 
-export interface RPCLinkOptions<TClientContext extends ClientContext> extends StandardEventSourceOptions {
+export interface RPCLinkOptions<TClientContext extends ClientContext> extends StandardServerEventSourceOptions {
   /**
    * Base url for all requests.
    */
@@ -105,7 +105,7 @@ export class RPCLink<TClientContext extends ClientContext> implements ClientLink
   private readonly eventSourceMaxNumberOfRetries: Exclude<RPCLinkOptions<TClientContext>['eventSourceMaxNumberOfRetries'], undefined>
   private readonly eventSourceRetryDelay: Exclude<RPCLinkOptions<TClientContext>['eventSourceRetryDelay'], undefined>
   private readonly eventSourceRetry: Exclude<RPCLinkOptions<TClientContext>['eventSourceRetry'], undefined>
-  private readonly standardEventSourceOptions: StandardEventSourceOptions
+  private readonly standardEventSourceOptions: StandardServerEventSourceOptions
 
   constructor(options: RPCLinkOptions<TClientContext>) {
     this.fetch = options.fetch ?? globalThis.fetch.bind(globalThis)

--- a/packages/client/src/adapters/fetch/rpc-link.ts
+++ b/packages/client/src/adapters/fetch/rpc-link.ts
@@ -1,5 +1,6 @@
 import type { Value } from '@orpc/shared'
-import type { StandardBody, StandardServerEventSourceOptions } from '@orpc/standard-server'
+import type { StandardBody } from '@orpc/standard-server'
+import type { ToFetchBodyOptions } from '@orpc/standard-server-fetch'
 import type { ClientContext, ClientLink, ClientOptionsOut } from '../../types'
 import type { FetchWithContext } from './types'
 import { isAsyncIteratorObject, stringifyJSON, trim, value } from '@orpc/shared'
@@ -12,7 +13,7 @@ type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
 
 export class InvalidEventSourceRetryResponse extends Error { }
 
-export interface RPCLinkOptions<TClientContext extends ClientContext> extends StandardServerEventSourceOptions {
+export interface RPCLinkOptions<TClientContext extends ClientContext> extends ToFetchBodyOptions {
   /**
    * Base url for all requests.
    */
@@ -105,7 +106,7 @@ export class RPCLink<TClientContext extends ClientContext> implements ClientLink
   private readonly eventSourceMaxNumberOfRetries: Exclude<RPCLinkOptions<TClientContext>['eventSourceMaxNumberOfRetries'], undefined>
   private readonly eventSourceRetryDelay: Exclude<RPCLinkOptions<TClientContext>['eventSourceRetryDelay'], undefined>
   private readonly eventSourceRetry: Exclude<RPCLinkOptions<TClientContext>['eventSourceRetry'], undefined>
-  private readonly standardEventSourceOptions: StandardServerEventSourceOptions
+  private readonly toFetchBodyOptions: ToFetchBodyOptions
 
   constructor(options: RPCLinkOptions<TClientContext>) {
     this.fetch = options.fetch ?? globalThis.fetch.bind(globalThis)
@@ -122,7 +123,7 @@ export class RPCLink<TClientContext extends ClientContext> implements ClientLink
     this.eventSourceRetryDelay = options.eventSourceRetryDelay
       ?? (({ retryTimes, lastRetry }) => lastRetry ?? (1000 * 2 ** retryTimes))
 
-    this.standardEventSourceOptions = options
+    this.toFetchBodyOptions = options
   }
 
   async call(path: readonly string[], input: unknown, options: ClientOptionsOut<TClientContext>): Promise<unknown> {
@@ -163,7 +164,7 @@ export class RPCLink<TClientContext extends ClientContext> implements ClientLink
   ): Promise<unknown> {
     const encoded = await this.encodeRequest(path, input, options)
 
-    const fetchBody = toFetchBody(encoded.body, encoded.headers, this.standardEventSourceOptions)
+    const fetchBody = toFetchBody(encoded.body, encoded.headers, this.toFetchBodyOptions)
 
     if (options.lastEventId !== undefined) {
       encoded.headers.set('last-event-id', options.lastEventId)

--- a/packages/openapi/src/adapters/fetch/openapi-handler.test.ts
+++ b/packages/openapi/src/adapters/fetch/openapi-handler.test.ts
@@ -44,7 +44,8 @@ describe('openAPIHandler', () => {
       },
     })
 
-    const result = await handler.handle(request, { prefix: '/api/v1', context: { db: 'postgres' } })
+    const options = { prefix: '/api/v1', context: { db: 'postgres' } } as const
+    const result = await handler.handle(request, options)
 
     expect(result).toEqual({
       matched: true,
@@ -54,7 +55,7 @@ describe('openAPIHandler', () => {
     expect(handle).toHaveBeenCalledOnce()
     expect(handle).toHaveBeenCalledWith(
       vi.mocked(toStandardRequest).mock.results[0]!.value,
-      { prefix: '/api/v1', context: { db: 'postgres' } },
+      options,
     )
 
     expect(vi.mocked(toStandardRequest)).toHaveBeenCalledOnce()
@@ -65,7 +66,7 @@ describe('openAPIHandler', () => {
       status: 200,
       headers: {},
       body: '__body__',
-    })
+    }, options)
   })
 
   it('on mismatch', async () => {

--- a/packages/openapi/src/adapters/fetch/openapi-handler.ts
+++ b/packages/openapi/src/adapters/fetch/openapi-handler.ts
@@ -28,7 +28,7 @@ export class OpenAPIHandler<T extends Context> implements FetchHandler<T> {
 
     return {
       matched: true,
-      response: toFetchResponse(result.response),
+      response: toFetchResponse(result.response, rest[0] ?? {}),
     }
   }
 }

--- a/packages/openapi/src/adapters/fetch/openapi-handler.ts
+++ b/packages/openapi/src/adapters/fetch/openapi-handler.ts
@@ -2,6 +2,7 @@ import type { Context, Router } from '@orpc/server'
 import type { FetchHandler, FetchHandleResult } from '@orpc/server/fetch'
 import type { StandardHandleOptions } from '@orpc/server/standard'
 import type { MaybeOptionalOptions } from '@orpc/shared'
+import type { ToFetchResponseOptions } from '@orpc/standard-server-fetch'
 import type { OpenAPIHandlerOptions } from '../standard'
 import { StandardHandler } from '@orpc/server/standard'
 import { toFetchResponse, toStandardRequest } from '@orpc/standard-server-fetch'
@@ -17,10 +18,13 @@ export class OpenAPIHandler<T extends Context> implements FetchHandler<T> {
     this.standardHandler = new StandardHandler(router, matcher, codec, options)
   }
 
-  async handle(request: Request, ...rest: MaybeOptionalOptions<StandardHandleOptions<T>>): Promise<FetchHandleResult> {
+  async handle(
+    request: Request,
+    ...[options]: MaybeOptionalOptions<StandardHandleOptions<T> & ToFetchResponseOptions>
+  ): Promise<FetchHandleResult> {
     const standardRequest = toStandardRequest(request)
 
-    const result = await this.standardHandler.handle(standardRequest, ...rest)
+    const result = await this.standardHandler.handle(standardRequest, options as any)
 
     if (!result.matched) {
       return result
@@ -28,7 +32,7 @@ export class OpenAPIHandler<T extends Context> implements FetchHandler<T> {
 
     return {
       matched: true,
-      response: toFetchResponse(result.response, rest[0] ?? {}),
+      response: toFetchResponse(result.response, options),
     }
   }
 }

--- a/packages/openapi/src/adapters/node/openapi-handler.test.ts
+++ b/packages/openapi/src/adapters/node/openapi-handler.test.ts
@@ -61,7 +61,8 @@ describe('openapiHandler', async () => {
       },
     })
 
-    const result = await handler.handle(req, res, { prefix: '/api/v1', context: { db: 'postgres' } })
+    const options = { prefix: '/api/v1', context: { db: 'postgres' } } as const
+    const result = await handler.handle(req, res, options)
 
     expect(result).toEqual({
       matched: true,
@@ -70,7 +71,7 @@ describe('openapiHandler', async () => {
     expect(handle).toHaveBeenCalledOnce()
     expect(handle).toHaveBeenCalledWith(
       standardRequest,
-      { prefix: '/api/v1', context: { db: 'postgres' } },
+      options,
     )
 
     expect(toStandardRequest).toHaveBeenCalledOnce()
@@ -81,7 +82,7 @@ describe('openapiHandler', async () => {
       status: 200,
       headers: {},
       body: '__body__',
-    })
+    }, options)
   })
 
   it('on mismatch', async () => {

--- a/packages/openapi/src/adapters/node/openapi-handler.ts
+++ b/packages/openapi/src/adapters/node/openapi-handler.ts
@@ -30,7 +30,7 @@ export class OpenAPIHandler<T extends Context> implements NodeHttpHandler<T> {
       return { matched: false }
     }
 
-    await sendStandardResponse(res, result.response)
+    await sendStandardResponse(res, result.response, rest[0] ?? {})
 
     return { matched: true }
   }

--- a/packages/openapi/src/adapters/node/openapi-handler.ts
+++ b/packages/openapi/src/adapters/node/openapi-handler.ts
@@ -2,6 +2,7 @@ import type { Context, Router } from '@orpc/server'
 import type { NodeHttpHandler, NodeHttpHandleResult, NodeHttpRequest, NodeHttpResponse } from '@orpc/server/node'
 import type { StandardHandleOptions } from '@orpc/server/standard'
 import type { MaybeOptionalOptions } from '@orpc/shared'
+import type { SendStandardResponseOptions } from '@orpc/standard-server-node'
 import type { OpenAPIHandlerOptions } from '../standard'
 import { StandardHandler } from '@orpc/server/standard'
 import { sendStandardResponse, toStandardRequest } from '@orpc/standard-server-node'
@@ -20,17 +21,17 @@ export class OpenAPIHandler<T extends Context> implements NodeHttpHandler<T> {
   async handle(
     req: NodeHttpRequest,
     res: NodeHttpResponse,
-    ...rest: MaybeOptionalOptions<StandardHandleOptions<T>>
+    ...[options]: MaybeOptionalOptions<StandardHandleOptions<T> & SendStandardResponseOptions>
   ): Promise<NodeHttpHandleResult> {
     const standardRequest = toStandardRequest(req, res)
 
-    const result = await this.standardHandler.handle(standardRequest, ...rest)
+    const result = await this.standardHandler.handle(standardRequest, options as any)
 
     if (!result.matched) {
       return { matched: false }
     }
 
-    await sendStandardResponse(res, result.response, rest[0] ?? {})
+    await sendStandardResponse(res, result.response, options)
 
     return { matched: true }
   }

--- a/packages/server/src/adapters/fetch/rpc-handler.test.ts
+++ b/packages/server/src/adapters/fetch/rpc-handler.test.ts
@@ -39,7 +39,8 @@ describe('rpcHandler', () => {
       body: '__body__',
     } })
 
-    const result = await handler.handle(request, { prefix: '/api/v1', context: { db: 'postgres' } })
+    const options = { prefix: '/api/v1', context: { db: 'postgres' } } as const
+    const result = await handler.handle(request, options)
 
     expect(result).toEqual({
       matched: true,
@@ -49,7 +50,7 @@ describe('rpcHandler', () => {
     expect(handle).toHaveBeenCalledOnce()
     expect(handle).toHaveBeenCalledWith(
       vi.mocked(toStandardRequest).mock.results[0]!.value,
-      { prefix: '/api/v1', context: { db: 'postgres' } },
+      options,
     )
 
     expect(vi.mocked(toStandardRequest)).toHaveBeenCalledOnce()
@@ -60,7 +61,7 @@ describe('rpcHandler', () => {
       status: 200,
       headers: {},
       body: '__body__',
-    })
+    }, options)
   })
 
   it('on mismatch', async () => {

--- a/packages/server/src/adapters/fetch/rpc-handler.ts
+++ b/packages/server/src/adapters/fetch/rpc-handler.ts
@@ -26,7 +26,7 @@ export class RPCHandler<T extends Context> implements FetchHandler<T> {
 
     return {
       matched: true,
-      response: toFetchResponse(result.response),
+      response: toFetchResponse(result.response, rest[0] ?? {}),
     }
   }
 }

--- a/packages/server/src/adapters/fetch/rpc-handler.ts
+++ b/packages/server/src/adapters/fetch/rpc-handler.ts
@@ -1,4 +1,5 @@
 import type { MaybeOptionalOptions } from '@orpc/shared'
+import type { ToFetchResponseOptions } from '@orpc/standard-server-fetch'
 import type { Context } from '../../context'
 import type { Router } from '../../router'
 import type { RPCHandlerOptions, StandardHandleOptions } from '../standard'
@@ -15,10 +16,13 @@ export class RPCHandler<T extends Context> implements FetchHandler<T> {
     this.standardHandler = new StandardHandler(router, matcher, codec, options)
   }
 
-  async handle(request: Request, ...rest: MaybeOptionalOptions<StandardHandleOptions<T>>): Promise<FetchHandleResult> {
+  async handle(
+    request: Request,
+    ...[options]: MaybeOptionalOptions<StandardHandleOptions<T> & ToFetchResponseOptions>
+  ): Promise<FetchHandleResult> {
     const standardRequest = toStandardRequest(request)
 
-    const result = await this.standardHandler.handle(standardRequest, ...rest)
+    const result = await this.standardHandler.handle(standardRequest, options as any)
 
     if (!result.matched) {
       return result
@@ -26,7 +30,7 @@ export class RPCHandler<T extends Context> implements FetchHandler<T> {
 
     return {
       matched: true,
-      response: toFetchResponse(result.response, rest[0] ?? {}),
+      response: toFetchResponse(result.response, options),
     }
   }
 }

--- a/packages/server/src/adapters/fetch/types.ts
+++ b/packages/server/src/adapters/fetch/types.ts
@@ -1,9 +1,13 @@
 import type { MaybeOptionalOptions } from '@orpc/shared'
+import type { ToFetchResponseOptions } from '@orpc/standard-server-fetch'
 import type { Context } from '../../context'
 import type { StandardHandleOptions } from '../standard'
 
 export type FetchHandleResult = { matched: true, response: Response } | { matched: false, response: undefined }
 
 export interface FetchHandler<T extends Context> {
-  handle(request: Request, ...rest: MaybeOptionalOptions<StandardHandleOptions<T>>): Promise<FetchHandleResult>
+  handle(
+    request: Request,
+    ...rest: MaybeOptionalOptions<StandardHandleOptions<T> & ToFetchResponseOptions>
+  ): Promise<FetchHandleResult>
 }

--- a/packages/server/src/adapters/node/rpc-handler.test.ts
+++ b/packages/server/src/adapters/node/rpc-handler.test.ts
@@ -60,7 +60,8 @@ describe('rpcHandler', async () => {
       },
     })
 
-    const result = await handler.handle(req, res, { prefix: '/api/v1', context: { db: 'postgres' } })
+    const options = { prefix: '/api/v1', context: { db: 'postgres' } } as const
+    const result = await handler.handle(req, res, options)
 
     expect(result).toEqual({
       matched: true,
@@ -80,7 +81,7 @@ describe('rpcHandler', async () => {
       status: 200,
       headers: {},
       body: '__body__',
-    })
+    }, options)
   })
 
   it('on mismatch', async () => {

--- a/packages/server/src/adapters/node/rpc-handler.ts
+++ b/packages/server/src/adapters/node/rpc-handler.ts
@@ -29,7 +29,7 @@ export class RPCHandler<T extends Context> implements NodeHttpHandler<T> {
       return { matched: false }
     }
 
-    await sendStandardResponse(res, result.response)
+    await sendStandardResponse(res, result.response, rest[0] ?? {})
 
     return { matched: true }
   }

--- a/packages/server/src/adapters/node/rpc-handler.ts
+++ b/packages/server/src/adapters/node/rpc-handler.ts
@@ -1,4 +1,5 @@
 import type { MaybeOptionalOptions } from '@orpc/shared'
+import type { SendStandardResponseOptions } from '@orpc/standard-server-node'
 import type { Context } from '../../context'
 import type { Router } from '../../router'
 import type { RPCHandlerOptions, StandardHandleOptions } from '../standard'
@@ -19,17 +20,17 @@ export class RPCHandler<T extends Context> implements NodeHttpHandler<T> {
   async handle(
     req: NodeHttpRequest,
     res: NodeHttpResponse,
-    ...rest: MaybeOptionalOptions<StandardHandleOptions<T>>
+    ...[options]: MaybeOptionalOptions<StandardHandleOptions<T> & SendStandardResponseOptions>
   ): Promise<NodeHttpHandleResult> {
     const standardRequest = toStandardRequest(req, res)
 
-    const result = await this.standardHandler.handle(standardRequest, ...rest)
+    const result = await this.standardHandler.handle(standardRequest, options as any)
 
     if (!result.matched) {
       return { matched: false }
     }
 
-    await sendStandardResponse(res, result.response, rest[0] ?? {})
+    await sendStandardResponse(res, result.response, options)
 
     return { matched: true }
   }

--- a/packages/server/src/adapters/node/types.ts
+++ b/packages/server/src/adapters/node/types.ts
@@ -1,6 +1,7 @@
 /// <reference types="node" />
 
 import type { MaybeOptionalOptions } from '@orpc/shared'
+import type { SendStandardResponseOptions } from '@orpc/standard-server-node'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { Http2ServerRequest, Http2ServerResponse } from 'node:http2'
 import type { Context } from '../../context'
@@ -22,6 +23,6 @@ export interface NodeHttpHandler<T extends Context> {
   handle(
     req: NodeHttpRequest,
     res: NodeHttpResponse,
-    ...rest: MaybeOptionalOptions<StandardHandleOptions<T>>
+    ...rest: MaybeOptionalOptions<StandardHandleOptions<T> & SendStandardResponseOptions>
   ): Promise<NodeHttpHandleResult>
 }

--- a/packages/server/src/adapters/standard/handler.ts
+++ b/packages/server/src/adapters/standard/handler.ts
@@ -1,6 +1,6 @@
 import type { ErrorFromErrorMap, HTTPPath, Meta, Schema, SchemaOutput } from '@orpc/contract'
 import type { Interceptor, MaybeOptionalOptions } from '@orpc/shared'
-import type { StandardRequest, StandardResponse, StandardServerEventSourceOptions } from '@orpc/standard-server'
+import type { StandardRequest, StandardResponse } from '@orpc/standard-server'
 import type { Context } from '../../context'
 import type { Plugin } from '../../plugins'
 import type { ProcedureClientInterceptorOptions } from '../../procedure-client'
@@ -12,7 +12,6 @@ import { CompositePlugin } from '../../plugins'
 import { createProcedureClient } from '../../procedure-client'
 
 export type StandardHandleOptions<T extends Context> =
-  & StandardServerEventSourceOptions
   & { prefix?: HTTPPath }
   & (Record<never, never> extends T ? { context?: T } : { context: T })
 

--- a/packages/server/src/adapters/standard/handler.ts
+++ b/packages/server/src/adapters/standard/handler.ts
@@ -1,6 +1,6 @@
 import type { ErrorFromErrorMap, HTTPPath, Meta, Schema, SchemaOutput } from '@orpc/contract'
 import type { Interceptor, MaybeOptionalOptions } from '@orpc/shared'
-import type { StandardRequest, StandardResponse } from '@orpc/standard-server'
+import type { StandardEventSourceOptions, StandardRequest, StandardResponse } from '@orpc/standard-server'
 import type { Context } from '../../context'
 import type { Plugin } from '../../plugins'
 import type { ProcedureClientInterceptorOptions } from '../../procedure-client'
@@ -12,6 +12,7 @@ import { CompositePlugin } from '../../plugins'
 import { createProcedureClient } from '../../procedure-client'
 
 export type StandardHandleOptions<T extends Context> =
+  & StandardEventSourceOptions
   & { prefix?: HTTPPath }
   & (Record<never, never> extends T ? { context?: T } : { context: T })
 

--- a/packages/server/src/adapters/standard/handler.ts
+++ b/packages/server/src/adapters/standard/handler.ts
@@ -1,6 +1,6 @@
 import type { ErrorFromErrorMap, HTTPPath, Meta, Schema, SchemaOutput } from '@orpc/contract'
 import type { Interceptor, MaybeOptionalOptions } from '@orpc/shared'
-import type { StandardEventSourceOptions, StandardRequest, StandardResponse } from '@orpc/standard-server'
+import type { StandardRequest, StandardResponse, StandardServerEventSourceOptions } from '@orpc/standard-server'
 import type { Context } from '../../context'
 import type { Plugin } from '../../plugins'
 import type { ProcedureClientInterceptorOptions } from '../../procedure-client'
@@ -12,7 +12,7 @@ import { CompositePlugin } from '../../plugins'
 import { createProcedureClient } from '../../procedure-client'
 
 export type StandardHandleOptions<T extends Context> =
-  & StandardEventSourceOptions
+  & StandardServerEventSourceOptions
   & { prefix?: HTTPPath }
   & (Record<never, never> extends T ? { context?: T } : { context: T })
 

--- a/packages/standard-server-fetch/playground/event-source.ts
+++ b/packages/standard-server-fetch/playground/event-source.ts
@@ -39,7 +39,7 @@ serve({
       headers: {},
       status: 200,
       body: gen(),
-    })
+    }, {})
   },
   port: 3000,
 })

--- a/packages/standard-server-fetch/src/body.ts
+++ b/packages/standard-server-fetch/src/body.ts
@@ -1,4 +1,4 @@
-import type { StandardBody, StandardEventSourceOptions } from '@orpc/standard-server'
+import type { StandardBody, StandardServerEventSourceOptions } from '@orpc/standard-server'
 import { isAsyncIteratorObject, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
 import { contentDisposition, parseContentDisposition } from '@orpc/standard-server'
 import { toEventIterator, toEventStream } from './event-source'
@@ -58,7 +58,7 @@ export async function toStandardBody(re: Request | Response): Promise<StandardBo
 export function toFetchBody(
   body: StandardBody,
   headers: Headers,
-  options: StandardEventSourceOptions,
+  options: StandardServerEventSourceOptions,
 ): string | Blob | FormData | URLSearchParams | undefined | ReadableStream<Uint8Array> {
   headers.delete('content-type')
   headers.delete('content-disposition')

--- a/packages/standard-server-fetch/src/body.ts
+++ b/packages/standard-server-fetch/src/body.ts
@@ -1,5 +1,4 @@
-import type { StandardBody } from '@orpc/standard-server'
-import type { ToEventStreamOptions } from './event-source'
+import type { StandardBody, StandardEventSourceOptions } from '@orpc/standard-server'
 import { isAsyncIteratorObject, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
 import { contentDisposition, parseContentDisposition } from '@orpc/standard-server'
 import { toEventIterator, toEventStream } from './event-source'
@@ -52,8 +51,6 @@ export async function toStandardBody(re: Request | Response): Promise<StandardBo
   })
 }
 
-export interface ToFetchBodyOptions extends ToEventStreamOptions {}
-
 /**
  * @param body
  * @param headers - The headers can be changed by the function and effects on the original headers.
@@ -61,7 +58,7 @@ export interface ToFetchBodyOptions extends ToEventStreamOptions {}
 export function toFetchBody(
   body: StandardBody,
   headers: Headers,
-  options: ToFetchBodyOptions,
+  options: StandardEventSourceOptions,
 ): string | Blob | FormData | URLSearchParams | undefined | ReadableStream<Uint8Array> {
   headers.delete('content-type')
   headers.delete('content-disposition')

--- a/packages/standard-server-fetch/src/body.ts
+++ b/packages/standard-server-fetch/src/body.ts
@@ -1,4 +1,5 @@
 import type { StandardBody } from '@orpc/standard-server'
+import type { ToEventStreamOptions } from './event-source'
 import { isAsyncIteratorObject, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
 import { contentDisposition, parseContentDisposition } from '@orpc/standard-server'
 import { toEventIterator, toEventStream } from './event-source'
@@ -51,6 +52,8 @@ export async function toStandardBody(re: Request | Response): Promise<StandardBo
   })
 }
 
+export interface ToFetchBodyOptions extends ToEventStreamOptions {}
+
 /**
  * @param body
  * @param headers - The headers can be changed by the function and effects on the original headers.
@@ -58,6 +61,7 @@ export async function toStandardBody(re: Request | Response): Promise<StandardBo
 export function toFetchBody(
   body: StandardBody,
   headers: Headers,
+  options: ToFetchBodyOptions,
 ): string | Blob | FormData | URLSearchParams | undefined | ReadableStream<Uint8Array> {
   headers.delete('content-type')
   headers.delete('content-disposition')
@@ -90,7 +94,7 @@ export function toFetchBody(
     headers.set('cache-control', 'no-cache')
     headers.set('connection', 'keep-alive')
 
-    return toEventStream(body)
+    return toEventStream(body, options)
   }
 
   headers.set('content-type', 'application/json')

--- a/packages/standard-server-fetch/src/body.ts
+++ b/packages/standard-server-fetch/src/body.ts
@@ -1,4 +1,5 @@
-import type { StandardBody, StandardServerEventSourceOptions } from '@orpc/standard-server'
+import type { StandardBody } from '@orpc/standard-server'
+import type { ToEventStreamOptions } from './event-source'
 import { isAsyncIteratorObject, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
 import { contentDisposition, parseContentDisposition } from '@orpc/standard-server'
 import { toEventIterator, toEventStream } from './event-source'
@@ -51,6 +52,8 @@ export async function toStandardBody(re: Request | Response): Promise<StandardBo
   })
 }
 
+export interface ToFetchBodyOptions extends ToEventStreamOptions {}
+
 /**
  * @param body
  * @param headers - The headers can be changed by the function and effects on the original headers.
@@ -58,7 +61,7 @@ export async function toStandardBody(re: Request | Response): Promise<StandardBo
 export function toFetchBody(
   body: StandardBody,
   headers: Headers,
-  options: StandardServerEventSourceOptions,
+  options: ToFetchBodyOptions = {},
 ): string | Blob | FormData | URLSearchParams | undefined | ReadableStream<Uint8Array> {
   headers.delete('content-type')
   headers.delete('content-disposition')

--- a/packages/standard-server-fetch/src/event-source.test.ts
+++ b/packages/standard-server-fetch/src/event-source.test.ts
@@ -8,6 +8,7 @@ describe('toEventIterator', () => {
       async pull(controller) {
         controller.enqueue('event: message\ndata: {"order": 1}\nid: id-1\nretry: 10000\n\n')
         controller.enqueue('event: message\ndata: {"order": 2}\nid: id-2\n\n')
+        controller.enqueue(': ping\n\n')
         controller.enqueue('event: done\ndata: {"order": 3}\nid: id-3\nretry: 30000\n\n')
         controller.close()
       },
@@ -44,6 +45,7 @@ describe('toEventIterator', () => {
   it('without dont event', async () => {
     const stream = new ReadableStream<string>({
       async pull(controller) {
+        controller.enqueue(': ping\n\n')
         controller.enqueue('event: message\ndata: {"order": 1}\nid: id-1\nretry: 10000\n\n')
         controller.enqueue('event: message\ndata: {"order": 2}\nid: id-2\n\n')
         controller.close()
@@ -86,6 +88,7 @@ describe('toEventIterator', () => {
         controller.enqueue('event: message\ndata: {"order": 1}\nid: id-1\nretry: 10000\n\n')
         controller.enqueue('event: message\ndata: {"order": 2}\nid: id-2\n\n')
         controller.enqueue('event: error\ndata: {"order": 3}\nid: id-3\nretry: 30000\n\n')
+        controller.enqueue(': ping\n\n')
         controller.close()
       },
     }).pipeThrough(new TextEncoderStream())
@@ -125,6 +128,7 @@ describe('toEventIterator', () => {
       async pull(controller) {
         controller.enqueue('event: message\ndata: {"order": 1}\nid: id-1\nretry: 10000\n\n')
         controller.enqueue('event: message\ndata: {"order": 2}\nid: id-2\n\n')
+        controller.enqueue(': ping\n\n')
         controller.enqueue('event: unknown\ndata: {"order": 3}\nid: id-3\nretry: 30000')
         controller.close()
       },
@@ -157,7 +161,7 @@ describe('toEventStream', () => {
       return withEventMeta({ order: 4 }, { id: 'id-4', retry: 40000 })
     }
 
-    const reader = toEventStream(gen())
+    const reader = toEventStream(gen(), {})
       .pipeThrough(new TextDecoderStream())
       .getReader()
 
@@ -176,7 +180,7 @@ describe('toEventStream', () => {
       throw withEventMeta(new Error('order-4'), { id: 'id-4', retry: 40000 })
     }
 
-    const reader = toEventStream(gen())
+    const reader = toEventStream(gen(), {})
       .pipeThrough(new TextDecoderStream())
       .getReader()
 
@@ -195,7 +199,7 @@ describe('toEventStream', () => {
       throw withEventMeta(new ErrorEvent({ data: { order: 4 } }), { id: 'id-4', retry: 40000 })
     }
 
-    const reader = toEventStream(gen())
+    const reader = toEventStream(gen(), {})
       .pipeThrough(new TextDecoderStream())
       .getReader()
 
@@ -224,7 +228,7 @@ describe('toEventStream', () => {
       }
     }
 
-    const stream = toEventStream(gen())
+    const stream = toEventStream(gen(), {})
 
     const reader = stream.getReader()
     await reader.read()
@@ -254,7 +258,7 @@ describe('toEventStream', () => {
       }
     }
 
-    const stream = toEventStream(gen())
+    const stream = toEventStream(gen(), {})
 
     const reason = new Error('reason')
     const reader = stream.getReader()
@@ -266,4 +270,52 @@ describe('toEventStream', () => {
       expect(hasFinally).toBe(true)
     })
   })
+
+  it('ping internal', async () => {
+    async function* gen() {
+      while (true) {
+        await new Promise(resolve => setTimeout(resolve, 100))
+        yield 'hello'
+      }
+    }
+
+    const stream = toEventStream(gen(), {
+      eventSourcePingEnabled: true,
+      eventSourcePingInterval: 40,
+      eventSourcePingContent: 'ping',
+    })
+
+    const reader = stream
+      .pipeThrough(new TextDecoderStream())
+      .getReader()
+
+    let now = Date.now()
+    await expect(reader.read()).resolves.toEqual({ done: false, value: ': ping\n\n' })
+    await expect(reader.read()).resolves.toEqual({ done: false, value: ': ping\n\n' })
+    await expect(reader.read()).resolves.toEqual({ done: false, value: 'event: message\ndata: "hello"\n\n' })
+    expect(Date.now() - now).toBeGreaterThanOrEqual(80)
+    expect(Date.now() - now).toBeLessThan(120)
+
+    now = Date.now()
+    await expect(reader.read()).resolves.toEqual({ done: false, value: ': ping\n\n' })
+    await expect(reader.read()).resolves.toEqual({ done: false, value: ': ping\n\n' })
+    await expect(reader.read()).resolves.toEqual({ done: false, value: 'event: message\ndata: "hello"\n\n' })
+    expect(Date.now() - now).toBeGreaterThanOrEqual(80)
+    expect(Date.now() - now).toBeLessThan(120)
+  })
+})
+
+it.each([
+  [[1, 2, 3, 4, 5, 6]],
+  [[{ a: 1 }, { b: 2 }, { c: 3 }, { d: 4 }, { e: 5 }, { f: 6 }]],
+])('toEventStream + toEventIterator: %#', async (...values) => {
+  const iterator = toEventIterator(toEventStream((async function*() {
+    for (const value of values) {
+      yield value
+    }
+  })(), { eventSourcePingInterval: 0 }))
+
+  for await (const value of iterator) {
+    expect(value).toEqual(values.shift())
+  }
 })

--- a/packages/standard-server-fetch/src/event-source.ts
+++ b/packages/standard-server-fetch/src/event-source.ts
@@ -1,3 +1,6 @@
+import type {
+  StandardEventSourceOptions,
+} from '@orpc/standard-server'
 import { isTypescriptObject, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
 import {
   encodeEventMessage,
@@ -67,38 +70,15 @@ export function toEventIterator(
   return gen()
 }
 
-export interface ToEventStreamOptions {
-  /**
-   * If true, a ping comment is sent periodically to keep the connection alive.
-   *
-   * @default true
-   */
-  eventSourcePingEnabled?: boolean
-
-  /**
-   * Interval (in milliseconds) between ping comments sent after the last event.
-   *
-   * @default 5000
-   */
-  eventSourcePingInterval?: number
-
-  /**
-   * The content of the ping comment. Must not include newline characters.
-   *
-   * @default ''
-   */
-  eventSourcePingContent?: string
-}
-
 export function toEventStream(
   iterator: AsyncIterator<unknown | void, unknown | void, void>,
-  options: ToEventStreamOptions,
+  options: StandardEventSourceOptions,
 ): ReadableStream<Uint8Array> {
   const pingEnabled = options.eventSourcePingEnabled ?? true
   const pingInterval = options.eventSourcePingInterval ?? 5_000
   const pingContent = options.eventSourcePingContent ?? ''
 
-  let timeout: number | undefined
+  let timeout: ReturnType<typeof setInterval> | undefined
 
   const stream = new ReadableStream<string>({
     async pull(controller) {

--- a/packages/standard-server-fetch/src/event-source.ts
+++ b/packages/standard-server-fetch/src/event-source.ts
@@ -106,6 +106,8 @@ export function toEventStream(
         }
       }
       catch (err) {
+        clearInterval(timeout)
+
         controller.enqueue(encodeEventMessage({
           ...getEventMeta(err),
           event: 'error',

--- a/packages/standard-server-fetch/src/event-source.ts
+++ b/packages/standard-server-fetch/src/event-source.ts
@@ -1,6 +1,3 @@
-import type {
-  StandardServerEventSourceOptions,
-} from '@orpc/standard-server'
 import { isTypescriptObject, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
 import {
   encodeEventMessage,
@@ -70,9 +67,32 @@ export function toEventIterator(
   return gen()
 }
 
+export interface ToEventStreamOptions {
+  /**
+   * If true, a ping comment is sent periodically to keep the connection alive.
+   *
+   * @default true
+   */
+  eventSourcePingEnabled?: boolean
+
+  /**
+   * Interval (in milliseconds) between ping comments sent after the last event.
+   *
+   * @default 5000
+   */
+  eventSourcePingInterval?: number
+
+  /**
+   * The content of the ping comment. Must not include newline characters.
+   *
+   * @default ''
+   */
+  eventSourcePingContent?: string
+}
+
 export function toEventStream(
   iterator: AsyncIterator<unknown | void, unknown | void, void>,
-  options: StandardServerEventSourceOptions,
+  options: ToEventStreamOptions = {},
 ): ReadableStream<Uint8Array> {
   const pingEnabled = options.eventSourcePingEnabled ?? true
   const pingInterval = options.eventSourcePingInterval ?? 5_000

--- a/packages/standard-server-fetch/src/event-source.ts
+++ b/packages/standard-server-fetch/src/event-source.ts
@@ -1,5 +1,5 @@
 import type {
-  StandardEventSourceOptions,
+  StandardServerEventSourceOptions,
 } from '@orpc/standard-server'
 import { isTypescriptObject, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
 import {
@@ -72,7 +72,7 @@ export function toEventIterator(
 
 export function toEventStream(
   iterator: AsyncIterator<unknown | void, unknown | void, void>,
-  options: StandardEventSourceOptions,
+  options: StandardServerEventSourceOptions,
 ): ReadableStream<Uint8Array> {
   const pingEnabled = options.eventSourcePingEnabled ?? true
   const pingInterval = options.eventSourcePingInterval ?? 5_000

--- a/packages/standard-server-fetch/src/event-source.ts
+++ b/packages/standard-server-fetch/src/event-source.ts
@@ -67,13 +67,53 @@ export function toEventIterator(
   return gen()
 }
 
+export interface ToEventStreamOptions {
+  /**
+   * If true, a ping comment is sent periodically to keep the connection alive.
+   *
+   * @default true
+   */
+  eventSourcePingEnabled?: boolean
+
+  /**
+   * Interval (in milliseconds) between ping comments sent after the last event.
+   *
+   * @default 5000
+   */
+  eventSourcePingInterval?: number
+
+  /**
+   * The content of the ping comment. Must not include newline characters.
+   *
+   * @default ''
+   */
+  eventSourcePingContent?: string
+}
+
 export function toEventStream(
   iterator: AsyncIterator<unknown | void, unknown | void, void>,
+  options: ToEventStreamOptions,
 ): ReadableStream<Uint8Array> {
+  const pingEnabled = options.eventSourcePingEnabled ?? true
+  const pingInterval = options.eventSourcePingInterval ?? 5_000
+  const pingContent = options.eventSourcePingContent ?? ''
+
+  let timeout: number | undefined
+
   const stream = new ReadableStream<string>({
     async pull(controller) {
       try {
+        if (pingEnabled) {
+          timeout = setInterval(() => {
+            controller.enqueue(encodeEventMessage({
+              comments: [pingContent],
+            }))
+          }, pingInterval)
+        }
+
         const value = await iterator.next()
+
+        clearInterval(timeout)
 
         controller.enqueue(encodeEventMessage({
           ...getEventMeta(value.value),

--- a/packages/standard-server-fetch/src/response.test.ts
+++ b/packages/standard-server-fetch/src/response.test.ts
@@ -20,7 +20,9 @@ describe('toFetchResponse', () => {
       status: 206,
     }
 
-    const fetchResponse = toFetchResponse(standardResponse)
+    const options = { eventSourcePingEnabled: true }
+
+    const fetchResponse = toFetchResponse(standardResponse, options)
 
     expect(fetchResponse.status).toBe(206)
     expect([...fetchResponse.headers]).toEqual([
@@ -34,7 +36,7 @@ describe('toFetchResponse', () => {
     expect(toFetchHeadersSpy).toBeCalledWith(standardResponse.headers)
 
     expect(toFetchBodySpy).toBeCalledTimes(1)
-    expect(toFetchBodySpy).toBeCalledWith(standardResponse.body, fetchResponse.headers)
+    expect(toFetchBodySpy).toBeCalledWith(standardResponse.body, fetchResponse.headers, options)
   })
 
   it('cancel async generator when client cancels', async () => {
@@ -56,7 +58,7 @@ describe('toFetchResponse', () => {
       body: gen(),
       headers: {},
       status: 209,
-    })
+    }, {})
 
     const reader = response.body!.pipeThrough(new TextDecoderStream()).getReader()
 

--- a/packages/standard-server-fetch/src/response.ts
+++ b/packages/standard-server-fetch/src/response.ts
@@ -1,9 +1,12 @@
 import type { StandardResponse } from '@orpc/standard-server'
+import type { ToFetchBodyOptions } from './body'
 import { toFetchBody } from './body'
 import { toFetchHeaders } from './headers'
 
-export function toFetchResponse(response: StandardResponse): Response {
+export interface ToFetchResponseOptions extends ToFetchBodyOptions {}
+
+export function toFetchResponse(response: StandardResponse, options: ToFetchResponseOptions): Response {
   const headers = toFetchHeaders(response.headers)
-  const body = toFetchBody(response.body, headers)
+  const body = toFetchBody(response.body, headers, options)
   return new Response(body, { headers, status: response.status })
 }

--- a/packages/standard-server-fetch/src/response.ts
+++ b/packages/standard-server-fetch/src/response.ts
@@ -1,8 +1,14 @@
-import type { StandardResponse, StandardServerEventSourceOptions } from '@orpc/standard-server'
+import type { StandardResponse } from '@orpc/standard-server'
+import type { ToFetchBodyOptions } from './body'
 import { toFetchBody } from './body'
 import { toFetchHeaders } from './headers'
 
-export function toFetchResponse(response: StandardResponse, options: StandardServerEventSourceOptions): Response {
+export interface ToFetchResponseOptions extends ToFetchBodyOptions {}
+
+export function toFetchResponse(
+  response: StandardResponse,
+  options: ToFetchResponseOptions = {},
+): Response {
   const headers = toFetchHeaders(response.headers)
   const body = toFetchBody(response.body, headers, options)
   return new Response(body, { headers, status: response.status })

--- a/packages/standard-server-fetch/src/response.ts
+++ b/packages/standard-server-fetch/src/response.ts
@@ -1,8 +1,8 @@
-import type { StandardEventSourceOptions, StandardResponse } from '@orpc/standard-server'
+import type { StandardResponse, StandardServerEventSourceOptions } from '@orpc/standard-server'
 import { toFetchBody } from './body'
 import { toFetchHeaders } from './headers'
 
-export function toFetchResponse(response: StandardResponse, options: StandardEventSourceOptions): Response {
+export function toFetchResponse(response: StandardResponse, options: StandardServerEventSourceOptions): Response {
   const headers = toFetchHeaders(response.headers)
   const body = toFetchBody(response.body, headers, options)
   return new Response(body, { headers, status: response.status })

--- a/packages/standard-server-fetch/src/response.ts
+++ b/packages/standard-server-fetch/src/response.ts
@@ -1,11 +1,8 @@
-import type { StandardResponse } from '@orpc/standard-server'
-import type { ToFetchBodyOptions } from './body'
+import type { StandardEventSourceOptions, StandardResponse } from '@orpc/standard-server'
 import { toFetchBody } from './body'
 import { toFetchHeaders } from './headers'
 
-export interface ToFetchResponseOptions extends ToFetchBodyOptions {}
-
-export function toFetchResponse(response: StandardResponse, options: ToFetchResponseOptions): Response {
+export function toFetchResponse(response: StandardResponse, options: StandardEventSourceOptions): Response {
   const headers = toFetchHeaders(response.headers)
   const body = toFetchBody(response.body, headers, options)
   return new Response(body, { headers, status: response.status })

--- a/packages/standard-server-node/playground/event-source.ts
+++ b/packages/standard-server-node/playground/event-source.ts
@@ -39,7 +39,7 @@ const server = createServer(async (req, res) => {
     headers: {},
     status: 200,
     body: gen(),
-  })
+  }, {})
 })
 
 server.listen(3000, '127.0.0.1', () => {

--- a/packages/standard-server-node/src/body.ts
+++ b/packages/standard-server-node/src/body.ts
@@ -1,6 +1,5 @@
-import type { StandardBody, StandardHeaders } from '@orpc/standard-server'
+import type { StandardBody, StandardEventSourceOptions, StandardHeaders } from '@orpc/standard-server'
 import type { Buffer } from 'node:buffer'
-import type { ToEventStreamOptions } from './event-source'
 import type { NodeHttpRequest } from './types'
 import { Readable } from 'node:stream'
 import { isAsyncIteratorObject, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
@@ -49,10 +48,6 @@ export async function toStandardBody(req: NodeHttpRequest): Promise<StandardBody
   return _streamToFile(req, 'blob', contentType)
 }
 
-export interface ToNodeHttpBodyOptions extends ToEventStreamOptions {
-
-}
-
 /**
  * @param body
  * @param headers - WARNING: The headers can be changed by the function and effects on the original headers.
@@ -61,7 +56,7 @@ export interface ToNodeHttpBodyOptions extends ToEventStreamOptions {
 export function toNodeHttpBody(
   body: StandardBody,
   headers: StandardHeaders,
-  options: ToNodeHttpBodyOptions,
+  options: StandardEventSourceOptions,
 ): Readable | undefined | string {
   delete headers['content-type']
   delete headers['content-disposition']

--- a/packages/standard-server-node/src/body.ts
+++ b/packages/standard-server-node/src/body.ts
@@ -1,4 +1,4 @@
-import type { StandardBody, StandardEventSourceOptions, StandardHeaders } from '@orpc/standard-server'
+import type { StandardBody, StandardHeaders, StandardServerEventSourceOptions } from '@orpc/standard-server'
 import type { Buffer } from 'node:buffer'
 import type { NodeHttpRequest } from './types'
 import { Readable } from 'node:stream'
@@ -56,7 +56,7 @@ export async function toStandardBody(req: NodeHttpRequest): Promise<StandardBody
 export function toNodeHttpBody(
   body: StandardBody,
   headers: StandardHeaders,
-  options: StandardEventSourceOptions,
+  options: StandardServerEventSourceOptions,
 ): Readable | undefined | string {
   delete headers['content-type']
   delete headers['content-disposition']

--- a/packages/standard-server-node/src/body.ts
+++ b/packages/standard-server-node/src/body.ts
@@ -1,5 +1,6 @@
 import type { StandardBody, StandardHeaders } from '@orpc/standard-server'
 import type { Buffer } from 'node:buffer'
+import type { ToEventStreamOptions } from './event-source'
 import type { NodeHttpRequest } from './types'
 import { Readable } from 'node:stream'
 import { isAsyncIteratorObject, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
@@ -48,11 +49,20 @@ export async function toStandardBody(req: NodeHttpRequest): Promise<StandardBody
   return _streamToFile(req, 'blob', contentType)
 }
 
+export interface ToNodeHttpBodyOptions extends ToEventStreamOptions {
+
+}
+
 /**
  * @param body
- * @param headers - The headers can be changed by the function and effects on the original headers.
+ * @param headers - WARNING: The headers can be changed by the function and effects on the original headers.
+ * @param options
  */
-export function toNodeHttpBody(body: StandardBody, headers: StandardHeaders): Readable | undefined | string {
+export function toNodeHttpBody(
+  body: StandardBody,
+  headers: StandardHeaders,
+  options: ToNodeHttpBodyOptions,
+): Readable | undefined | string {
   delete headers['content-type']
   delete headers['content-disposition']
 
@@ -89,7 +99,7 @@ export function toNodeHttpBody(body: StandardBody, headers: StandardHeaders): Re
     headers['cache-control'] = 'no-cache'
     headers.connection = 'keep-alive'
 
-    return toEventStream(body)
+    return toEventStream(body, options)
   }
 
   headers['content-type'] = 'application/json'

--- a/packages/standard-server-node/src/body.ts
+++ b/packages/standard-server-node/src/body.ts
@@ -1,5 +1,6 @@
-import type { StandardBody, StandardHeaders, StandardServerEventSourceOptions } from '@orpc/standard-server'
+import type { StandardBody, StandardHeaders } from '@orpc/standard-server'
 import type { Buffer } from 'node:buffer'
+import type { ToEventStreamOptions } from './event-source'
 import type { NodeHttpRequest } from './types'
 import { Readable } from 'node:stream'
 import { isAsyncIteratorObject, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
@@ -48,6 +49,8 @@ export async function toStandardBody(req: NodeHttpRequest): Promise<StandardBody
   return _streamToFile(req, 'blob', contentType)
 }
 
+export interface ToNodeHttpBodyOptions extends ToEventStreamOptions {}
+
 /**
  * @param body
  * @param headers - WARNING: The headers can be changed by the function and effects on the original headers.
@@ -56,7 +59,7 @@ export async function toStandardBody(req: NodeHttpRequest): Promise<StandardBody
 export function toNodeHttpBody(
   body: StandardBody,
   headers: StandardHeaders,
-  options: StandardServerEventSourceOptions,
+  options: ToNodeHttpBodyOptions = {},
 ): Readable | undefined | string {
   delete headers['content-type']
   delete headers['content-disposition']

--- a/packages/standard-server-node/src/event-source.ts
+++ b/packages/standard-server-node/src/event-source.ts
@@ -1,6 +1,3 @@
-import type {
-  StandardServerEventSourceOptions,
-} from '@orpc/standard-server'
 import { Readable } from 'node:stream'
 import { isTypescriptObject, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
 import {
@@ -71,9 +68,32 @@ export function toEventIterator(
   return gen()
 }
 
+export interface ToEventStreamOptions {
+  /**
+   * If true, a ping comment is sent periodically to keep the connection alive.
+   *
+   * @default true
+   */
+  eventSourcePingEnabled?: boolean
+
+  /**
+   * Interval (in milliseconds) between ping comments sent after the last event.
+   *
+   * @default 5000
+   */
+  eventSourcePingInterval?: number
+
+  /**
+   * The content of the ping comment. Must not include newline characters.
+   *
+   * @default ''
+   */
+  eventSourcePingContent?: string
+}
+
 export function toEventStream(
   iterator: AsyncIterator<unknown | void, unknown | void, void>,
-  options: StandardServerEventSourceOptions,
+  options: ToEventStreamOptions = {},
 ): Readable {
   const pingEnabled = options.eventSourcePingEnabled ?? true
   const pingInterval = options.eventSourcePingInterval ?? 5_000

--- a/packages/standard-server-node/src/event-source.ts
+++ b/packages/standard-server-node/src/event-source.ts
@@ -1,3 +1,6 @@
+import type {
+  StandardEventSourceOptions,
+} from '@orpc/standard-server'
 import { Readable } from 'node:stream'
 import { isTypescriptObject, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
 import {
@@ -68,38 +71,15 @@ export function toEventIterator(
   return gen()
 }
 
-export interface ToEventStreamOptions {
-  /**
-   * If true, a ping comment is sent periodically to keep the connection alive.
-   *
-   * @default true
-   */
-  eventSourcePingEnabled?: boolean
-
-  /**
-   * Interval (in milliseconds) between ping comments sent after the last event.
-   *
-   * @default 5000
-   */
-  eventSourcePingInterval?: number
-
-  /**
-   * The content of the ping comment. Must not include newline characters.
-   *
-   * @default ''
-   */
-  eventSourcePingContent?: string
-}
-
 export function toEventStream(
   iterator: AsyncIterator<unknown | void, unknown | void, void>,
-  options: ToEventStreamOptions,
+  options: StandardEventSourceOptions,
 ): Readable {
   const pingEnabled = options.eventSourcePingEnabled ?? true
   const pingInterval = options.eventSourcePingInterval ?? 5_000
   const pingContent = options.eventSourcePingContent ?? ''
 
-  let timeout: NodeJS.Timeout | undefined
+  let timeout: ReturnType<typeof setInterval> | undefined
 
   const stream = new ReadableStream<string>({
     async pull(controller) {

--- a/packages/standard-server-node/src/event-source.ts
+++ b/packages/standard-server-node/src/event-source.ts
@@ -1,5 +1,5 @@
 import type {
-  StandardEventSourceOptions,
+  StandardServerEventSourceOptions,
 } from '@orpc/standard-server'
 import { Readable } from 'node:stream'
 import { isTypescriptObject, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
@@ -73,7 +73,7 @@ export function toEventIterator(
 
 export function toEventStream(
   iterator: AsyncIterator<unknown | void, unknown | void, void>,
-  options: StandardEventSourceOptions,
+  options: StandardServerEventSourceOptions,
 ): Readable {
   const pingEnabled = options.eventSourcePingEnabled ?? true
   const pingInterval = options.eventSourcePingInterval ?? 5_000

--- a/packages/standard-server-node/src/event-source.ts
+++ b/packages/standard-server-node/src/event-source.ts
@@ -107,6 +107,8 @@ export function toEventStream(
         }
       }
       catch (err) {
+        clearInterval(timeout)
+
         controller.enqueue(encodeEventMessage({
           ...getEventMeta(err),
           event: 'error',

--- a/packages/standard-server-node/src/response.test.ts
+++ b/packages/standard-server-node/src/response.test.ts
@@ -22,7 +22,7 @@ describe('sendStandardResponse', () => {
           'x-custom-header': 'custom-value',
         },
         body: undefined,
-      })
+      }, {})
     }).get('/')
 
     expect(toNodeHttpBodySpy).toBeCalledTimes(1)
@@ -53,7 +53,7 @@ describe('sendStandardResponse', () => {
           'x-custom-header': 'custom-value',
         },
         body: { foo: 'bar' },
-      })
+      }, {})
     }).get('/')
 
     expect(toNodeHttpBodySpy).toBeCalledTimes(1)
@@ -87,7 +87,7 @@ describe('sendStandardResponse', () => {
           'x-custom-header': 'custom-value',
         },
         body: blob,
-      })
+      }, {})
     }).get('/')
 
     expect(toNodeHttpBodySpy).toBeCalledTimes(1)
@@ -123,6 +123,8 @@ describe('sendStandardResponse', () => {
 
     let endSpy: any
 
+    const options = { eventSourcePingEnabled: true }
+
     const res = await request(async (req: IncomingMessage, res: ServerResponse) => {
       endSpy = vi.spyOn(res, 'end')
 
@@ -132,7 +134,7 @@ describe('sendStandardResponse', () => {
           'x-custom-header': 'custom-value',
         },
         body: generator,
-      })
+      }, options)
     }).get('/')
 
     expect(toNodeHttpBodySpy).toBeCalledTimes(1)
@@ -141,7 +143,7 @@ describe('sendStandardResponse', () => {
       'cache-control': 'no-cache',
       'content-type': 'text/event-stream',
       'x-custom-header': 'custom-value',
-    })
+    }, options)
 
     expect(endSpy).toBeCalledTimes(1)
     expect(endSpy).toBeCalledWith()

--- a/packages/standard-server-node/src/response.test.ts
+++ b/packages/standard-server-node/src/response.test.ts
@@ -13,6 +13,7 @@ describe('sendStandardResponse', () => {
   it('works with undefined', async () => {
     let endSpy: any
 
+    const options = { eventSourcePingEnabled: true }
     const res = await request(async (req: IncomingMessage, res: ServerResponse) => {
       endSpy = vi.spyOn(res, 'end')
 
@@ -22,13 +23,13 @@ describe('sendStandardResponse', () => {
           'x-custom-header': 'custom-value',
         },
         body: undefined,
-      }, {})
+      }, options)
     }).get('/')
 
     expect(toNodeHttpBodySpy).toBeCalledTimes(1)
     expect(toNodeHttpBodySpy).toBeCalledWith(undefined, {
       'x-custom-header': 'custom-value',
-    })
+    }, options)
 
     expect(endSpy).toBeCalledTimes(1)
     expect(endSpy).toBeCalledWith(toNodeHttpBodySpy.mock.results[0]!.value)
@@ -44,6 +45,7 @@ describe('sendStandardResponse', () => {
   it('works with json', async () => {
     let endSpy: any
 
+    const options = { eventSourcePingEnabled: true }
     const res = await request(async (req: IncomingMessage, res: ServerResponse) => {
       endSpy = vi.spyOn(res, 'end')
 
@@ -53,14 +55,14 @@ describe('sendStandardResponse', () => {
           'x-custom-header': 'custom-value',
         },
         body: { foo: 'bar' },
-      }, {})
+      }, options)
     }).get('/')
 
     expect(toNodeHttpBodySpy).toBeCalledTimes(1)
     expect(toNodeHttpBodySpy).toBeCalledWith({ foo: 'bar' }, {
       'content-type': 'application/json',
       'x-custom-header': 'custom-value',
-    })
+    }, options)
 
     expect(endSpy).toBeCalledTimes(1)
     expect(endSpy).toBeCalledWith(toNodeHttpBodySpy.mock.results[0]!.value)
@@ -78,6 +80,7 @@ describe('sendStandardResponse', () => {
     const blob = new Blob(['foo'], { type: 'text/plain' })
     let endSpy: any
 
+    const options = { eventSourcePingEnabled: true }
     const res = await request(async (req: IncomingMessage, res: ServerResponse) => {
       endSpy = vi.spyOn(res, 'end')
 
@@ -87,7 +90,7 @@ describe('sendStandardResponse', () => {
           'x-custom-header': 'custom-value',
         },
         body: blob,
-      }, {})
+      }, options)
     }).get('/')
 
     expect(toNodeHttpBodySpy).toBeCalledTimes(1)
@@ -96,7 +99,7 @@ describe('sendStandardResponse', () => {
       'content-length': '3',
       'content-type': 'text/plain',
       'x-custom-header': 'custom-value',
-    })
+    }, options)
 
     expect(endSpy).toBeCalledTimes(1)
     expect(endSpy).toBeCalledWith()

--- a/packages/standard-server-node/src/response.ts
+++ b/packages/standard-server-node/src/response.ts
@@ -1,11 +1,11 @@
-import type { StandardEventSourceOptions, StandardHeaders, StandardResponse } from '@orpc/standard-server'
+import type { StandardHeaders, StandardResponse, StandardServerEventSourceOptions } from '@orpc/standard-server'
 import type { NodeHttpResponse } from './types'
 import { toNodeHttpBody } from './body'
 
 export function sendStandardResponse(
   res: NodeHttpResponse,
   standardResponse: StandardResponse,
-  options: StandardEventSourceOptions,
+  options: StandardServerEventSourceOptions,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     res.on('error', reject)

--- a/packages/standard-server-node/src/response.ts
+++ b/packages/standard-server-node/src/response.ts
@@ -1,10 +1,14 @@
 import type { StandardHeaders, StandardResponse } from '@orpc/standard-server'
+import type { ToNodeHttpBodyOptions } from './body'
 import type { NodeHttpResponse } from './types'
 import { toNodeHttpBody } from './body'
+
+export interface SendStandardResponseOptions extends ToNodeHttpBodyOptions {}
 
 export function sendStandardResponse(
   res: NodeHttpResponse,
   standardResponse: StandardResponse,
+  options: SendStandardResponseOptions,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     res.on('error', reject)
@@ -12,7 +16,7 @@ export function sendStandardResponse(
 
     const resHeaders: StandardHeaders = standardResponse.headers
 
-    const resBody = toNodeHttpBody(standardResponse.body, resHeaders)
+    const resBody = toNodeHttpBody(standardResponse.body, resHeaders, options)
 
     res.writeHead(standardResponse.status, resHeaders)
 

--- a/packages/standard-server-node/src/response.ts
+++ b/packages/standard-server-node/src/response.ts
@@ -1,11 +1,14 @@
-import type { StandardHeaders, StandardResponse, StandardServerEventSourceOptions } from '@orpc/standard-server'
+import type { StandardHeaders, StandardResponse } from '@orpc/standard-server'
+import type { ToNodeHttpBodyOptions } from './body'
 import type { NodeHttpResponse } from './types'
 import { toNodeHttpBody } from './body'
+
+export interface SendStandardResponseOptions extends ToNodeHttpBodyOptions {}
 
 export function sendStandardResponse(
   res: NodeHttpResponse,
   standardResponse: StandardResponse,
-  options: StandardServerEventSourceOptions,
+  options: SendStandardResponseOptions = {},
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     res.on('error', reject)

--- a/packages/standard-server-node/src/response.ts
+++ b/packages/standard-server-node/src/response.ts
@@ -1,14 +1,11 @@
-import type { StandardHeaders, StandardResponse } from '@orpc/standard-server'
-import type { ToNodeHttpBodyOptions } from './body'
+import type { StandardEventSourceOptions, StandardHeaders, StandardResponse } from '@orpc/standard-server'
 import type { NodeHttpResponse } from './types'
 import { toNodeHttpBody } from './body'
-
-export interface SendStandardResponseOptions extends ToNodeHttpBodyOptions {}
 
 export function sendStandardResponse(
   res: NodeHttpResponse,
   standardResponse: StandardResponse,
-  options: SendStandardResponseOptions,
+  options: StandardEventSourceOptions,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     res.on('error', reject)

--- a/packages/standard-server/src/event-source/encoder.test.ts
+++ b/packages/standard-server/src/event-source/encoder.test.ts
@@ -12,6 +12,8 @@ describe('encodeEventMessage', () => {
     expect(encodeEventMessage({ event: 'message', data: 'hello\nworld' })).toEqual('event: message\ndata: hello\ndata: world\n\n')
     expect(encodeEventMessage({ event: 'message', id: '123', retry: 10000 }))
       .toEqual('event: message\nretry: 10000\nid: 123\n\n')
+    expect(encodeEventMessage({ event: 'message', id: '123', retry: 10000, comments: ['hello', 'world'] }))
+      .toEqual(': hello\n: world\nevent: message\nretry: 10000\nid: 123\n\n')
   })
 
   it('invalid event', () => {
@@ -33,5 +35,10 @@ describe('encodeEventMessage', () => {
 
     expect(() => encodeEventMessage({ event: 'message', retry: 1.5 }))
       .toThrowError('Event-source retry must be a integer and >= 0')
+  })
+
+  it('invalid comment', () => {
+    expect(() => encodeEventMessage({ event: 'message', comments: ['hi\n'] }))
+      .toThrowError('Event-source comment must not contain a newline character')
   })
 })

--- a/packages/standard-server/src/event-source/encoder.ts
+++ b/packages/standard-server/src/event-source/encoder.ts
@@ -19,6 +19,12 @@ export function assertEventRetry(retry: number): void {
   }
 }
 
+export function assertEventComment(comment: string): void {
+  if (comment.includes('\n')) {
+    throw new EventEncoderError('Event-source comment must not contain a newline character')
+  }
+}
+
 export function encodeEventData(data: string | undefined): string {
   const lines = data?.split(/\n/) ?? []
 
@@ -31,8 +37,22 @@ export function encodeEventData(data: string | undefined): string {
   return output
 }
 
+export function encodeEventComments(comments: string[] | undefined): string {
+  let output = ''
+
+  for (const comment of comments ?? []) {
+    assertEventComment(comment)
+
+    output += `: ${comment}\n`
+  }
+
+  return output
+}
+
 export function encodeEventMessage(message: Partial<EventMessage>): string {
   let output = ''
+
+  output += encodeEventComments(message.comments)
 
   if (message.event !== undefined) {
     assertEventName(message.event)

--- a/packages/standard-server/src/event-source/meta.test.ts
+++ b/packages/standard-server/src/event-source/meta.test.ts
@@ -2,10 +2,10 @@ import { getEventMeta, withEventMeta } from './meta'
 
 it('get/withEventMeta', () => {
   const data = { value: 123, meta: undefined }
-  const applied = withEventMeta(data, { id: '123', retry: 10000 })
+  const applied = withEventMeta(data, { id: '123', retry: 10000, comments: ['hello', 'world'] })
   expect(applied).toEqual(data)
   expect(applied).not.toBe(data)
-  expect(getEventMeta(applied)).toEqual({ id: '123', retry: 10000 })
+  expect(getEventMeta(applied)).toEqual({ id: '123', retry: 10000, comments: ['hello', 'world'] })
   expect(getEventMeta(data)).toEqual(undefined)
   expect(getEventMeta(1)).toEqual(undefined)
 
@@ -13,4 +13,5 @@ it('get/withEventMeta', () => {
   expect(() => withEventMeta(data, { retry: Number.NaN })).toThrow('Event-source retry must be a integer and >= 0')
   expect(() => withEventMeta(data, { retry: 1.1 })).toThrow('Event-source retry must be a integer and >= 0')
   expect(() => withEventMeta(data, { retry: -1 })).toThrow('Event-source retry must be a integer and >= 0')
+  expect(() => withEventMeta(data, { comments: ['hi\n'] })).toThrow('Event-source comment must not contain a newline character')
 })

--- a/packages/standard-server/src/event-source/meta.ts
+++ b/packages/standard-server/src/event-source/meta.ts
@@ -1,10 +1,10 @@
 import type { EventMessage } from './types'
 import { isTypescriptObject } from '@orpc/shared'
-import { assertEventId, assertEventRetry } from './encoder'
+import { assertEventComment, assertEventId, assertEventRetry } from './encoder'
 
 const EVENT_SOURCE_META_SYMBOL = Symbol('ORPC_EVENT_SOURCE_META')
 
-export type EventMeta = Partial<Pick<EventMessage, 'retry' | 'id'>>
+export type EventMeta = Partial<Pick<EventMessage, 'retry' | 'id' | 'comments'>>
 
 export function withEventMeta<T extends object>(container: T, meta: EventMeta): T {
   if (meta.id !== undefined) {
@@ -13,6 +13,12 @@ export function withEventMeta<T extends object>(container: T, meta: EventMeta): 
 
   if (meta.retry !== undefined) {
     assertEventRetry(meta.retry)
+  }
+
+  if (meta.comments !== undefined) {
+    for (const comment of meta.comments) {
+      assertEventComment(comment)
+    }
   }
 
   return new Proxy(container, {

--- a/packages/standard-server/src/types.ts
+++ b/packages/standard-server/src/types.ts
@@ -35,7 +35,7 @@ export interface StandardResponse {
   body: StandardBody
 }
 
-export interface StandardEventSourceOptions {
+export interface StandardServerEventSourceOptions {
   /**
    * If true, a ping comment is sent periodically to keep the connection alive.
    *

--- a/packages/standard-server/src/types.ts
+++ b/packages/standard-server/src/types.ts
@@ -34,3 +34,26 @@ export interface StandardResponse {
   headers: StandardHeaders
   body: StandardBody
 }
+
+export interface StandardEventSourceOptions {
+  /**
+   * If true, a ping comment is sent periodically to keep the connection alive.
+   *
+   * @default true
+   */
+  eventSourcePingEnabled?: boolean
+
+  /**
+   * Interval (in milliseconds) between ping comments sent after the last event.
+   *
+   * @default 5000
+   */
+  eventSourcePingInterval?: number
+
+  /**
+   * The content of the ping comment. Must not include newline characters.
+   *
+   * @default ''
+   */
+  eventSourcePingContent?: string
+}

--- a/packages/standard-server/src/types.ts
+++ b/packages/standard-server/src/types.ts
@@ -34,26 +34,3 @@ export interface StandardResponse {
   headers: StandardHeaders
   body: StandardBody
 }
-
-export interface StandardServerEventSourceOptions {
-  /**
-   * If true, a ping comment is sent periodically to keep the connection alive.
-   *
-   * @default true
-   */
-  eventSourcePingEnabled?: boolean
-
-  /**
-   * Interval (in milliseconds) between ping comments sent after the last event.
-   *
-   * @default 5000
-   */
-  eventSourcePingInterval?: number
-
-  /**
-   * The content of the ping comment. Must not include newline characters.
-   *
-   * @default ''
-   */
-  eventSourcePingContent?: string
-}


### PR DESCRIPTION
## Event-Source Ping Interval

To keep EventSource connections alive (the mechanism behind [Event Iterator](https://orpc.unnoq.com/docs/event-iterator)), `RPCHandler` periodically sends a ping comment to the client. You can configure this behavior using the following options:

- `eventSourcePingEnabled` (default: `true`) – Enables or disables pings.
- `eventSourcePingInterval` (default: `5000`) – Time between pings (in milliseconds).
- `eventSourcePingContent` (default: `''`) – Custom content for ping messages.

```ts
const result = await handler.handle(request, {
  eventSourcePingEnabled: true,
  eventSourcePingInterval: 5000, // 5 seconds
  eventSourcePingContent: '',
})
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated guides now explain how to configure periodic ping settings to keep event connections active.
- **New Features**
  - Introduced customizable options to control keep-alive behavior, including enabling pings, adjusting intervals, and setting ping content.
- **Enhancements**
  - Standardized the handling of request and response configurations across services for a more consistent and reliable connection experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->