### PR TITLE
fix(openapi-client): empty object in bracket-notation

### DIFF
--- a/packages/openapi-client/src/adapters/standard/bracket-notation.test.ts
+++ b/packages/openapi-client/src/adapters/standard/bracket-notation.test.ts
@@ -87,6 +87,10 @@ describe('bracketNotation', () => {
   })
 
   describe('.deserialize', () => {
+    it('can deserialize empty objects', () => {
+      expect(serializer.deserialize([])).toEqual({})
+    })
+
     it('can deserialize arrays', () => {
       expect(serializer.deserialize([
         ['', 1],
@@ -181,6 +185,7 @@ describe('bracketNotation', () => {
   })
 
   it.each([
+    [{ }],
     [{ a: 1, b: 2, c: [1, 2, { a: 1, b: 2 }, new Date(), new Blob([]), new Set([1, 2]), new Map([[1, 2]])] }],
   ])('.serialize + .deserialize', (value) => {
     expect(serializer.deserialize(serializer.serialize(value))).toEqual(value)

--- a/packages/openapi-client/src/adapters/standard/bracket-notation.ts
+++ b/packages/openapi-client/src/adapters/standard/bracket-notation.ts
@@ -23,9 +23,13 @@ export class BracketNotationSerializer {
     return result
   }
 
-  deserialize(serialized: BracketNotationSerialized): unknown {
+  deserialize(serialized: BracketNotationSerialized): Record<string, unknown> | unknown[] {
+    if (serialized.length === 0) {
+      return {}
+    }
+
     const arrayPushStyles = new WeakSet()
-    const ref = { value: [] }
+    const ref: { value: Record<string, unknown> | unknown[] } = { value: [] }
 
     for (const [path, value] of serialized) {
       const segments = this.parsePath(path)


### PR DESCRIPTION
closes: https://github.com/unnoq/orpc/issues/195

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of empty inputs so that providing no data now returns a consistent empty structure.
  
- **Refactor**
	- Improved internal processing for data conversion, ensuring more predictable and precise outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->