### PR TITLE
fix(query): unable to infer mutation context when onMutate has args

### DIFF
--- a/packages/react-query/src/procedure-utils.test-d.ts
+++ b/packages/react-query/src/procedure-utils.test-d.ts
@@ -290,7 +290,7 @@ describe('ProcedureUtils', () => {
     it('infer correct mutation context type', () => {
       useMutation({
         ...utils.mutationOptions({
-          onMutate: () => ({ mutationContext: true }),
+          onMutate: v => ({ mutationContext: true }),
           onError: (e, v, context) => {
             expectTypeOf(context?.mutationContext).toEqualTypeOf<undefined | boolean>()
           },

--- a/packages/react-query/src/procedure-utils.ts
+++ b/packages/react-query/src/procedure-utils.ts
@@ -1,7 +1,7 @@
 import type { Client, ClientContext } from '@orpc/client'
 import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { InfiniteData } from '@tanstack/react-query'
-import type { InfiniteOptionsBase, InfiniteOptionsIn, MutationOptionsBase, MutationOptionsIn, QueryOptionsBase, QueryOptionsIn } from './types'
+import type { InfiniteOptionsBase, InfiniteOptionsIn, MutationOptionsBase, MutationOptionsIn, MutationOptionsRest, QueryOptionsBase, QueryOptionsIn } from './types'
 import { buildKey } from './key'
 
 export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TOutput, TError extends Error> {
@@ -18,9 +18,11 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
   ): NoInfer<U & Omit<InfiniteOptionsBase<TOutput, TError, UPageParam>, keyof U>>
 
   mutationOptions<U, UMutationContext>(
-    ...rest: MaybeOptionalOptions<
-      U & MutationOptionsIn<TClientContext, TInput, TOutput, TError, UMutationContext>
-    >
+    ...rest: MutationOptionsRest<U & MutationOptionsIn<TClientContext, TInput, TOutput, TError, UMutationContext>>
+  ): NoInfer<U & Omit<MutationOptionsBase<TInput, TOutput, TError>, keyof U>>
+
+  mutationOptions<U, UMutationContext>(
+    options: U & MutationOptionsIn<TClientContext, TInput, TOutput, TError, UMutationContext>
   ): NoInfer<U & Omit<MutationOptionsBase<TInput, TOutput, TError>, keyof U>>
 }
 

--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -26,12 +26,6 @@ export interface InfiniteOptionsBase<TOutput, TError extends Error, TPageParam> 
 
 export type MutationOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError extends Error, TMutationContext> =
   & (Record<never, never> extends TClientContext ? { context?: TClientContext } : { context: TClientContext })
-  & UseMutationOptions<TOutput, TError, TInput, TMutationContext>
+  & MutationOptions<TInput, TOutput, TError, TMutationContext>
 
-export interface MutationOptionsBase<TInput, TOutput, TError extends Error> {
-  mutationKey: QueryKey
-  mutationFn(input: TInput): Promise<TOutput>
-  retry?(failureCount: number, error: TError): boolean // this make tanstack can infer the TError type
-}
-
-export type MutationOptionsRest<T> = Record<never, never> extends T ? [] : [options: T]
+export type MutationOptions<TInput, TOutput, TError extends Error, TMutationContext> = UseMutationOptions<TOutput, TError, TInput, TMutationContext>

--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -33,3 +33,5 @@ export interface MutationOptionsBase<TInput, TOutput, TError extends Error> {
   mutationFn(input: TInput): Promise<TOutput>
   retry?(failureCount: number, error: TError): boolean // this make tanstack can infer the TError type
 }
+
+export type MutationOptionsRest<T> = Record<never, never> extends T ? [] : [options: T]

--- a/packages/server/src/procedure-decorated.ts
+++ b/packages/server/src/procedure-decorated.ts
@@ -124,7 +124,7 @@ export class DecoratedProcedure<
     >
   ): Procedure<TInitialContext, TCurrentContext, TInputSchema, TOutputSchema, THandlerOutput, TErrorMap, TMeta>
     & ProcedureClient<TClientContext, TInputSchema, TOutputSchema, THandlerOutput, TErrorMap> {
-    return Object.assign(createProcedureClient(this, ...rest), {
+    return Object.assign(createProcedureClient(this, ...rest as any), {
       '~type': 'Procedure' as const,
       '~orpc': this['~orpc'],
     })

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,5 +1,5 @@
-export type MaybeOptionalOptions<TOptions> =
-  | [options: TOptions]
-  | (Record<never, never> extends TOptions ? [] : never)
+export type MaybeOptionalOptions<TOptions> = Record<never, never> extends TOptions
+  ? [options?: TOptions]
+  : [options: TOptions]
 
 export type SetOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>

--- a/packages/vue-colada/tests/e2e.test-d.ts
+++ b/packages/vue-colada/tests/e2e.test-d.ts
@@ -72,9 +72,9 @@ describe('.mutationOptions', () => {
       input: 'INVALID',
     })
 
-    // @ts-expect-error --- cache is invalid
     useMutation(orpc.ping.mutationOptions({
       context: {
+        // @ts-expect-error --- cache is invalid
         cache: 123,
       },
     }))

--- a/packages/vue-query/src/procedure-utils.test-d.ts
+++ b/packages/vue-query/src/procedure-utils.test-d.ts
@@ -277,7 +277,7 @@ describe('ProcedureUtils', () => {
     it('infer correct mutation context type', () => {
       useMutation({
         ...utils.mutationOptions({
-          onMutate: () => ({ mutationContext: true }),
+          onMutate: v => ({ mutationContext: true }),
           onError: (e, v, context) => {
             expectTypeOf(context?.mutationContext).toEqualTypeOf<undefined | boolean>()
           },

--- a/packages/vue-query/src/procedure-utils.test.ts
+++ b/packages/vue-query/src/procedure-utils.test.ts
@@ -61,7 +61,7 @@ describe('createProcedureUtils', () => {
     expect(buildKeySpy).toHaveBeenCalledTimes(1)
     expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { type: 'mutation' })
 
-    await expect(options.mutationFn!('__input__')).resolves.toEqual('__output__')
+    await expect((options as any).mutationFn('__input__')).resolves.toEqual('__output__')
     expect(client).toHaveBeenCalledTimes(1)
     expect(client).toBeCalledWith('__input__', { context: { batch: '__batch__' } })
   })

--- a/packages/vue-query/src/procedure-utils.ts
+++ b/packages/vue-query/src/procedure-utils.ts
@@ -1,7 +1,7 @@
 import type { Client, ClientContext } from '@orpc/client'
 import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { InfiniteData } from '@tanstack/vue-query'
-import type { InfiniteOptionsBase, InfiniteOptionsIn, MutationOptionsBase, MutationOptionsIn, QueryOptionsBase, QueryOptionsIn } from './types'
+import type { InfiniteOptionsBase, InfiniteOptionsIn, MutationOptionsBase, MutationOptionsIn, MutationOptionsRest, QueryOptionsBase, QueryOptionsIn } from './types'
 import { computed } from 'vue'
 import { buildKey } from './key'
 import { unrefDeep } from './utils'
@@ -20,9 +20,11 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
   ): NoInfer<U & Omit<InfiniteOptionsBase<TOutput, TError, UPageParam>, keyof U>>
 
   mutationOptions<U, UMutationContext>(
-    ...rest: MaybeOptionalOptions<
-      U & MutationOptionsIn<TClientContext, TInput, TOutput, TError, UMutationContext>
-    >
+    ...rest: MutationOptionsRest<U & MutationOptionsIn<TClientContext, TInput, TOutput, TError, UMutationContext>>
+  ): NoInfer<U & Omit<MutationOptionsBase<TInput, TOutput, TError>, keyof U>>
+
+  mutationOptions<U, UMutationContext>(
+    options: U & MutationOptionsIn<TClientContext, TInput, TOutput, TError, UMutationContext>
   ): NoInfer<U & Omit<MutationOptionsBase<TInput, TOutput, TError>, keyof U>>
 }
 

--- a/packages/vue-query/src/types.ts
+++ b/packages/vue-query/src/types.ts
@@ -47,17 +47,11 @@ export interface InfiniteOptionsBase<TOutput, TError extends Error, TPageParam> 
 
 export type MutationOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError extends Error, TMutationContext> =
   & (Record<never, never> extends TClientContext ? { context?: TClientContext } : { context: TClientContext })
-  & {
+  & MutationOptions<TInput, TOutput, TError, TMutationContext>
+
+export type MutationOptions<TInput, TOutput, TError extends Error, TMutationContext> =
+  {
     [P in keyof MutationObserverOptions<TOutput, TError, TInput, TMutationContext>]: MaybeRefDeep<MutationObserverOptions<TOutput, TError, TInput, TMutationContext>[P]>
-  }
-  & {
+  } & {
     shallow?: MaybeRef<boolean>
   }
-
-export interface MutationOptionsBase<TInput, TOutput, TError extends Error> {
-  mutationKey: QueryKey
-  mutationFn(input: TInput): Promise<TOutput>
-  retry?(failureCount: number, error: TError): boolean // this help tanstack can infer TError
-}
-
-export type MutationOptionsRest<T> = Record<never, never> extends T ? [] : [options: T]

--- a/packages/vue-query/src/types.ts
+++ b/packages/vue-query/src/types.ts
@@ -59,3 +59,5 @@ export interface MutationOptionsBase<TInput, TOutput, TError extends Error> {
   mutationFn(input: TInput): Promise<TOutput>
   retry?(failureCount: number, error: TError): boolean // this help tanstack can infer TError
 }
+
+export type MutationOptionsRest<T> = Record<never, never> extends T ? [] : [options: T]


### PR DESCRIPTION

Related: https://discord.com/channels/1308966753044398161/1316404696830836816/1346472892547727414

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced mutation option configuration by introducing a new overload, allowing for a more straightforward specification of mutation settings.
  - Added improved type safeguards for mutation options, increasing flexibility and reliability.

- **Refactor**
  - Updated mutation callbacks to accept parameters, enabling potential future enhancements in mutation handling.
  - Simplified method signatures for `mutationOptions`, `queryOptions`, and `infiniteOptions`, streamlining option handling across the interface.
  - Modified error handling comments in tests for better clarity and context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->