### PR TITLE
feat(zod): support `readOnly`, `propertyNames` in JSON schema

### DIFF
--- a/packages/zod/src/converter.test.ts
+++ b/packages/zod/src/converter.test.ts
@@ -400,6 +400,11 @@ const edgeCases: SchemaTestCase[] = [
     schema: z.object({ value: z.string() }).catchall(z.number()),
     input: [true, { type: 'object', properties: { value: { type: 'string' } }, required: ['value'], additionalProperties: { type: 'number' } }],
   },
+  {
+    schema: z.record(z.number(), z.string()),
+    input: [true, { type: 'object', additionalProperties: { type: 'string' }, propertyNames: { type: 'number' } }],
+    ignoreZodToJsonSchema: true,
+  },
 ]
 
 describe.each([

--- a/packages/zod/src/converter.test.ts
+++ b/packages/zod/src/converter.test.ts
@@ -296,7 +296,8 @@ const processedCases: SchemaTestCase[] = [
   },
   {
     schema: z.number().readonly(),
-    input: [true, { type: 'number' }],
+    input: [true, { type: 'number', readOnly: true }],
+    ignoreZodToJsonSchema: true,
   },
 ]
 

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -524,7 +524,9 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
 
       case ZodFirstPartyTypeKind.ZodReadonly: {
         const schema_ = schema as ZodReadonly<ZodTypeAny>
-        return this.convert(schema_._def.innerType, options, lazyDepth, false, false)
+        const [required, json] = this.convert(schema_._def.innerType, options, lazyDepth, false, false)
+
+        return [required, { ...json, readOnly: true }]
       }
 
       case ZodFirstPartyTypeKind.ZodDefault: {

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -413,7 +413,12 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
 
         const json: JSONSchema = { type: 'object' }
 
-        // WARN: ignore keyType
+        const keyTypeName = this.#getZodTypeName(schema_._def.keyType._def)
+
+        if (keyTypeName !== ZodFirstPartyTypeKind.ZodString) {
+          const [_, keyJson] = this.convert(schema_._def.keyType, options, lazyDepth, false, false)
+          json.propertyNames = keyJson
+        }
 
         const [_, itemJson] = this.convert(schema_._def.valueType, options, lazyDepth, false, false)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced JSON Schema generation now clearly marks read-only fields, ensuring that schemas accurately reflect their immutable status.
  - Improved conversion of record types delivers more precise JSON definitions by better handling key types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->