### PR TITLE
fix(zod): apply` propertyNames` to string schemas in JSON Schema gen

### DIFF
--- a/packages/zod/src/converter.test.ts
+++ b/packages/zod/src/converter.test.ts
@@ -405,6 +405,11 @@ const edgeCases: SchemaTestCase[] = [
     input: [true, { type: 'object', additionalProperties: { type: 'string' }, propertyNames: { type: 'number' } }],
     ignoreZodToJsonSchema: true,
   },
+  {
+    schema: z.record(z.string().date(), z.string()),
+    input: [true, { type: 'object', additionalProperties: { type: 'string' }, propertyNames: { type: 'string', format: 'date' } }],
+    ignoreZodToJsonSchema: true,
+  },
 ]
 
 describe.each([

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -413,10 +413,9 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
 
         const json: JSONSchema = { type: 'object' }
 
-        const keyTypeName = this.#getZodTypeName(schema_._def.keyType._def)
+        const [__, keyJson] = this.convert(schema_._def.keyType, options, lazyDepth, false, false)
 
-        if (keyTypeName !== ZodFirstPartyTypeKind.ZodString) {
-          const [_, keyJson] = this.convert(schema_._def.keyType, options, lazyDepth, false, false)
+        if (Object.entries(keyJson).some(([k, v]) => k !== 'type' || v !== 'string')) {
           json.propertyNames = keyJson
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Introduced an edge-case test to verify proper handling of schemas with date-formatted keys.
- **Refactor**
	- Streamlined the logic for processing record key types, simplifying the conversion of schema definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->