### PR TITLE
feat(server)!: remove dedupe middleware logic

### DIFF
--- a/packages/server/src/middleware-utils.test.ts
+++ b/packages/server/src/middleware-utils.test.ts
@@ -1,25 +1,14 @@
-import { addMiddleware, dedupeMiddlewares, mergeMiddlewares } from './middleware-utils'
+import { addMiddleware, mergeMiddlewares } from './middleware-utils'
 
 const mid1 = vi.fn()
 const mid2 = vi.fn()
 const mid3 = vi.fn()
 
-it('dedupeMiddlewares', () => {
-  expect(dedupeMiddlewares([mid1, mid2], [])).toEqual([])
-  expect(dedupeMiddlewares([], [mid1, mid2])).toEqual([mid1, mid2])
-  expect(dedupeMiddlewares([mid1], [mid2])).toEqual([mid2])
-  expect(dedupeMiddlewares([mid1], [mid1, mid2])).toEqual([mid2])
-  expect(dedupeMiddlewares([mid1, mid3], [mid1, mid2])).toEqual([mid2])
-  expect(dedupeMiddlewares([mid1, mid3], [mid1, mid2, mid3])).toEqual([mid2, mid3])
-})
-
 it('mergeMiddlewares', () => {
   expect(mergeMiddlewares([mid1, mid2], [])).toEqual([mid1, mid2])
   expect(mergeMiddlewares([], [mid1, mid2])).toEqual([mid1, mid2])
   expect(mergeMiddlewares([mid1], [mid2])).toEqual([mid1, mid2])
-  expect(mergeMiddlewares([mid1], [mid1, mid2])).toEqual([mid1, mid2])
-  expect(mergeMiddlewares([mid1, mid3], [mid1, mid2])).toEqual([mid1, mid3, mid2])
-  expect(mergeMiddlewares([mid1, mid3], [mid1, mid2, mid3])).toEqual([mid1, mid3, mid2, mid3])
+  expect(mergeMiddlewares([mid1], [mid1, mid2])).toEqual([mid1, mid1, mid2])
 })
 
 it('addMiddleware', () => {

--- a/packages/server/src/middleware-utils.ts
+++ b/packages/server/src/middleware-utils.ts
@@ -1,23 +1,7 @@
 import type { AnyMiddleware } from './middleware'
 
-export function dedupeMiddlewares(compare: readonly AnyMiddleware[], middlewares: readonly AnyMiddleware[]): AnyMiddleware[] {
-  let min = 0
-
-  for (let i = 0; i < middlewares.length; i++) {
-    const index = compare.indexOf(middlewares[i]!, min)
-
-    if (index === -1) {
-      return middlewares.slice(i)
-    }
-
-    min = index + 1
-  }
-
-  return []
-}
-
 export function mergeMiddlewares(first: readonly AnyMiddleware[], second: readonly AnyMiddleware[]): AnyMiddleware[] {
-  return [...first, ...dedupeMiddlewares(first, second)]
+  return [...first, ...second]
 }
 
 export function addMiddleware(middlewares: readonly AnyMiddleware[], addition: AnyMiddleware): AnyMiddleware[] {

--- a/packages/server/src/router-utils.test.ts
+++ b/packages/server/src/router-utils.test.ts
@@ -33,10 +33,10 @@ describe('enhanceRouter', () => {
     const enhanced = enhanceRouter(router, options)
 
     expect(enhanced.ping).toSatisfy(isLazy)
-    expect((await unlazy(enhanced.ping)).default['~orpc'].middlewares).toEqual([mid, ...ping['~orpc'].middlewares])
+    expect((await unlazy(enhanced.ping)).default['~orpc'].middlewares).toEqual([mid, pingMiddleware, ...ping['~orpc'].middlewares])
     expect((await unlazy(enhanced.ping)).default['~orpc'].route).toEqual(enhanceRoute(ping['~orpc'].route, options))
-    expect((await unlazy(enhanced.ping)).default['~orpc'].inputValidationIndex).toEqual(2)
-    expect((await unlazy(enhanced.ping)).default['~orpc'].outputValidationIndex).toEqual(2)
+    expect((await unlazy(enhanced.ping)).default['~orpc'].inputValidationIndex).toEqual(3)
+    expect((await unlazy(enhanced.ping)).default['~orpc'].outputValidationIndex).toEqual(3)
     expect(getLazyMeta(enhanced.ping)).toEqual({ prefix: '/adapt' })
 
     expect(enhanced.pong['~orpc'].middlewares).toEqual([mid, pingMiddleware, ...pong['~orpc'].middlewares])
@@ -48,10 +48,10 @@ describe('enhanceRouter', () => {
     expect(getLazyMeta(enhanced.nested)).toEqual({ prefix: '/adapt' })
 
     expect(enhanced.nested.ping).toSatisfy(isLazy)
-    expect((await unlazy(enhanced.nested.ping)).default['~orpc'].middlewares).toEqual([mid, ...ping['~orpc'].middlewares])
+    expect((await unlazy(enhanced.nested.ping)).default['~orpc'].middlewares).toEqual([mid, pingMiddleware, ...ping['~orpc'].middlewares])
     expect((await unlazy(enhanced.nested.ping)).default['~orpc'].route).toEqual(enhanceRoute(ping['~orpc'].route, options))
-    expect((await unlazy(enhanced.nested.ping)).default['~orpc'].inputValidationIndex).toEqual(2)
-    expect((await unlazy(enhanced.nested.ping)).default['~orpc'].outputValidationIndex).toEqual(2)
+    expect((await unlazy(enhanced.nested.ping)).default['~orpc'].inputValidationIndex).toEqual(3)
+    expect((await unlazy(enhanced.nested.ping)).default['~orpc'].outputValidationIndex).toEqual(3)
     expect(getLazyMeta(enhanced.nested.ping)).toEqual({ prefix: '/adapt' })
 
     expect(enhanced.nested.pong).toSatisfy(isLazy)


### PR DESCRIPTION
Previously, router-level middlewares were designed to deduplicate calls with those at the procedure level. However, this approach did not fully guarantee safe execution in all cases. In this PR, we remove the router-level deduplication mechanism. We now recommend refactoring your middlewares so they can safely run multiple times without adverse effects.