### PR TITLE
fix(server): reflect middleware initial context in procedure when use

### DIFF
--- a/packages/server/src/builder-variants.test-d.ts
+++ b/packages/server/src/builder-variants.test-d.ts
@@ -231,7 +231,7 @@ describe('BuilderWithMiddlewares', () => {
 
   it('.router', () => {
     expectTypeOf(builder.router(router)).toEqualTypeOf<
-      EnhancedRouter<typeof router, InitialContext, typeof baseErrorMap>
+      EnhancedRouter<typeof router, InitialContext, CurrentContext, typeof baseErrorMap>
     >()
 
     builder.router({
@@ -255,7 +255,7 @@ describe('BuilderWithMiddlewares', () => {
 
   it('.lazy', () => {
     expectTypeOf(builder.lazy(() => Promise.resolve({ default: router }))).toEqualTypeOf<
-      EnhancedRouter<Lazy<typeof router>, InitialContext, typeof baseErrorMap>
+      EnhancedRouter<Lazy<typeof router>, InitialContext, CurrentContext, typeof baseErrorMap>
     >()
 
     // @ts-expect-error - initial context is not match
@@ -1203,7 +1203,7 @@ describe('RouterBuilder', () => {
 
   it('.router', () => {
     expectTypeOf(builder.router(router)).toEqualTypeOf<
-      EnhancedRouter<typeof router, InitialContext, typeof baseErrorMap>
+      EnhancedRouter<typeof router, InitialContext, CurrentContext, typeof baseErrorMap>
     >()
 
     builder.router({
@@ -1227,7 +1227,7 @@ describe('RouterBuilder', () => {
 
   it('.lazy', () => {
     expectTypeOf(builder.lazy(() => Promise.resolve({ default: router }))).toEqualTypeOf<
-      EnhancedRouter<Lazy<typeof router>, InitialContext, typeof baseErrorMap>
+      EnhancedRouter<Lazy<typeof router>, InitialContext, CurrentContext, typeof baseErrorMap>
     >()
 
     // @ts-expect-error - initial context is not match

--- a/packages/server/src/builder-variants.ts
+++ b/packages/server/src/builder-variants.ts
@@ -105,7 +105,7 @@ export interface ProcedureBuilder<
 
   'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      TCurrentContext,
+      UInContext,
       UOutContext,
       unknown,
       unknown,
@@ -159,7 +159,7 @@ export interface ProcedureBuilderWithInput<
 
   'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      TCurrentContext,
+      UInContext,
       UOutContext,
       InferSchemaOutput<TInputSchema>,
       unknown,
@@ -178,7 +178,7 @@ export interface ProcedureBuilderWithInput<
 
   'use'<UOutContext extends Context, UInput, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      TCurrentContext,
+      UInContext,
       UOutContext,
       UInput,
       unknown,
@@ -236,7 +236,7 @@ export interface ProcedureBuilderWithOutput<
 
   'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      TCurrentContext,
+      UInContext,
       UOutContext,
       unknown,
       InferSchemaInput<TOutputSchema>,
@@ -286,7 +286,7 @@ export interface ProcedureBuilderWithInputOutput<
 
   'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      TCurrentContext,
+      UInContext,
       UOutContext,
       InferSchemaOutput<TInputSchema>,
       InferSchemaInput<TOutputSchema>,
@@ -305,7 +305,7 @@ export interface ProcedureBuilderWithInputOutput<
 
   'use'<UOutContext extends Context, UInput, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      TCurrentContext,
+      UInContext,
       UOutContext,
       UInput,
       InferSchemaInput<TOutputSchema>,
@@ -350,7 +350,7 @@ export interface RouterBuilder<
 
   'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      TCurrentContext,
+      UInContext,
       UOutContext,
       unknown,
       unknown,

--- a/packages/server/src/builder-variants.ts
+++ b/packages/server/src/builder-variants.ts
@@ -75,11 +75,11 @@ export interface BuilderWithMiddlewares<
 
   'router'<U extends Router<ContractRouter<TMeta>, TCurrentContext>>(
     router: U
-  ): EnhancedRouter<U, TInitialContext, TErrorMap>
+  ): EnhancedRouter<U, TInitialContext, TCurrentContext, TErrorMap>
 
   'lazy'<U extends Router<ContractRouter<TMeta>, TCurrentContext>>(
     loader: () => Promise<{ default: U }>,
-  ): EnhancedRouter<Lazy<U>, TInitialContext, TErrorMap>
+  ): EnhancedRouter<Lazy<U>, TInitialContext, TCurrentContext, TErrorMap>
 }
 
 export interface ProcedureBuilder<
@@ -371,9 +371,9 @@ export interface RouterBuilder<
 
   'router'<U extends Router<ContractRouter<TMeta>, TCurrentContext>>(
     router: U
-  ): EnhancedRouter<U, TInitialContext, TErrorMap>
+  ): EnhancedRouter<U, TInitialContext, TCurrentContext, TErrorMap>
 
   'lazy'<U extends Router<ContractRouter<TMeta>, TCurrentContext>>(
     loader: () => Promise<{ default: U }>,
-  ): EnhancedRouter<Lazy<U>, TInitialContext, TErrorMap>
+  ): EnhancedRouter<Lazy<U>, TInitialContext, TCurrentContext, TErrorMap>
 }

--- a/packages/server/src/builder-variants.ts
+++ b/packages/server/src/builder-variants.ts
@@ -1,6 +1,6 @@
 import type { AnySchema, ContractRouter, ErrorMap, HTTPPath, InferSchemaInput, InferSchemaOutput, MergedErrorMap, Meta, Route, Schema } from '@orpc/contract'
 import type { BuilderDef } from './builder'
-import type { ConflictContextGuard, Context, MergedContext } from './context'
+import type { Context, ContextExtendsGuard, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
 import type { Lazy } from './lazy'
 import type { MapInputMiddleware, Middleware } from './middleware'
@@ -30,19 +30,19 @@ export interface BuilderWithMiddlewares<
     TMeta
   >
 
-  'use'<UOutContext extends Context>(
+  'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      TCurrentContext,
+      UInContext,
       UOutContext,
       unknown,
       unknown,
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>> &
-    BuilderWithMiddlewares<
-      TInitialContext,
-      MergedContext<TCurrentContext, UOutContext>,
+  ): ContextExtendsGuard<UInContext, TCurrentContext>
+    & BuilderWithMiddlewares<
+      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+      MergedCurrentContext<TCurrentContext, UOutContext>,
       TInputSchema,
       TOutputSchema,
       TErrorMap,
@@ -103,7 +103,7 @@ export interface ProcedureBuilder<
     TMeta
   >
 
-  'use'<UOutContext extends Context>(
+  'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
       TCurrentContext,
       UOutContext,
@@ -112,10 +112,10 @@ export interface ProcedureBuilder<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>> &
-    ProcedureBuilder<
-      TInitialContext,
-      MergedContext<TCurrentContext, UOutContext>,
+  ): ContextExtendsGuard<UInContext, TCurrentContext>
+    & ProcedureBuilder<
+      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+      MergedCurrentContext<TCurrentContext, UOutContext>,
       TInputSchema,
       TOutputSchema,
       TErrorMap,
@@ -157,7 +157,7 @@ export interface ProcedureBuilderWithInput<
     errors: U,
   ): ProcedureBuilderWithInput<TInitialContext, TCurrentContext, TInputSchema, TOutputSchema, MergedErrorMap<TErrorMap, U>, TMeta>
 
-  'use'<UOutContext extends Context>(
+  'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
       TCurrentContext,
       UOutContext,
@@ -166,17 +166,17 @@ export interface ProcedureBuilderWithInput<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>> &
-    ProcedureBuilderWithInput<
-      TInitialContext,
-      MergedContext<TCurrentContext, UOutContext>,
+  ): ContextExtendsGuard<UInContext, TCurrentContext>
+    & ProcedureBuilderWithInput<
+      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+      MergedCurrentContext<TCurrentContext, UOutContext>,
       TInputSchema,
       TOutputSchema,
       TErrorMap,
       TMeta
     >
 
-  'use'<UOutContext extends Context, UInput>(
+  'use'<UOutContext extends Context, UInput, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
       TCurrentContext,
       UOutContext,
@@ -186,10 +186,10 @@ export interface ProcedureBuilderWithInput<
       TMeta
     >,
     mapInput: MapInputMiddleware<InferSchemaOutput<TInputSchema>, UInput>,
-  ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>> &
-    ProcedureBuilderWithInput<
-      TInitialContext,
-      MergedContext<TCurrentContext, UOutContext>,
+  ): ContextExtendsGuard<UInContext, TCurrentContext>
+    & ProcedureBuilderWithInput<
+      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+      MergedCurrentContext<TCurrentContext, UOutContext>,
       TInputSchema,
       TOutputSchema,
       TErrorMap,
@@ -234,7 +234,7 @@ export interface ProcedureBuilderWithOutput<
     TMeta
   >
 
-  'use'<UOutContext extends Context>(
+  'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
       TCurrentContext,
       UOutContext,
@@ -243,10 +243,10 @@ export interface ProcedureBuilderWithOutput<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>> &
-    ProcedureBuilderWithOutput<
-      TInitialContext,
-      MergedContext<TCurrentContext, UOutContext>,
+  ): ContextExtendsGuard<UInContext, TCurrentContext>
+    & ProcedureBuilderWithOutput<
+      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+      MergedCurrentContext<TCurrentContext, UOutContext>,
       TInputSchema,
       TOutputSchema,
       TErrorMap,
@@ -284,7 +284,7 @@ export interface ProcedureBuilderWithInputOutput<
     errors: U,
   ): ProcedureBuilderWithInputOutput<TInitialContext, TCurrentContext, TInputSchema, TOutputSchema, MergedErrorMap<TErrorMap, U>, TMeta>
 
-  'use'<UOutContext extends Context>(
+  'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
       TCurrentContext,
       UOutContext,
@@ -293,17 +293,17 @@ export interface ProcedureBuilderWithInputOutput<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>> &
-    ProcedureBuilderWithInputOutput<
-      TInitialContext,
-      MergedContext<TCurrentContext, UOutContext>,
+  ): ContextExtendsGuard<UInContext, TCurrentContext>
+    & ProcedureBuilderWithInputOutput<
+      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+      MergedCurrentContext<TCurrentContext, UOutContext>,
       TInputSchema,
       TOutputSchema,
       TErrorMap,
       TMeta
     >
 
-  'use'<UOutContext extends Context, UInput>(
+  'use'<UOutContext extends Context, UInput, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
       TCurrentContext,
       UOutContext,
@@ -313,10 +313,10 @@ export interface ProcedureBuilderWithInputOutput<
       TMeta
     >,
     mapInput: MapInputMiddleware<InferSchemaOutput<TInputSchema>, UInput>,
-  ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>> &
-    ProcedureBuilderWithInputOutput<
-      TInitialContext,
-      MergedContext<TCurrentContext, UOutContext>,
+  ): ContextExtendsGuard<UInContext, TCurrentContext>
+    & ProcedureBuilderWithInputOutput<
+      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+      MergedCurrentContext<TCurrentContext, UOutContext>,
       TInputSchema,
       TOutputSchema,
       TErrorMap,
@@ -348,7 +348,7 @@ export interface RouterBuilder<
     errors: U,
   ): RouterBuilder<TInitialContext, TCurrentContext, MergedErrorMap<TErrorMap, U>, TMeta>
 
-  'use'<UOutContext extends Context>(
+  'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
       TCurrentContext,
       UOutContext,
@@ -357,8 +357,13 @@ export interface RouterBuilder<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>> &
-    RouterBuilder<TInitialContext, MergedContext<TCurrentContext, UOutContext>, TErrorMap, TMeta>
+  ): ContextExtendsGuard<UInContext, TCurrentContext>
+    & RouterBuilder<
+      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+      MergedCurrentContext<TCurrentContext, UOutContext>,
+      TErrorMap,
+      TMeta
+    >
 
   'prefix'(prefix: HTTPPath): RouterBuilder<TInitialContext, TCurrentContext, TErrorMap, TMeta>
 

--- a/packages/server/src/builder-variants.ts
+++ b/packages/server/src/builder-variants.ts
@@ -39,7 +39,7 @@ export interface BuilderWithMiddlewares<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<UInContext, TCurrentContext>
+  ): ContextExtendsGuard<TCurrentContext, UInContext>
     & BuilderWithMiddlewares<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,
@@ -112,7 +112,7 @@ export interface ProcedureBuilder<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<UInContext, TCurrentContext>
+  ): ContextExtendsGuard<TCurrentContext, UInContext>
     & ProcedureBuilder<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,
@@ -166,7 +166,7 @@ export interface ProcedureBuilderWithInput<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<UInContext, TCurrentContext>
+  ): ContextExtendsGuard<TCurrentContext, UInContext>
     & ProcedureBuilderWithInput<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,
@@ -186,7 +186,7 @@ export interface ProcedureBuilderWithInput<
       TMeta
     >,
     mapInput: MapInputMiddleware<InferSchemaOutput<TInputSchema>, UInput>,
-  ): ContextExtendsGuard<UInContext, TCurrentContext>
+  ): ContextExtendsGuard<TCurrentContext, UInContext>
     & ProcedureBuilderWithInput<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,
@@ -243,7 +243,7 @@ export interface ProcedureBuilderWithOutput<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<UInContext, TCurrentContext>
+  ): ContextExtendsGuard<TCurrentContext, UInContext>
     & ProcedureBuilderWithOutput<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,
@@ -293,7 +293,7 @@ export interface ProcedureBuilderWithInputOutput<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<UInContext, TCurrentContext>
+  ): ContextExtendsGuard<TCurrentContext, UInContext>
     & ProcedureBuilderWithInputOutput<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,
@@ -313,7 +313,7 @@ export interface ProcedureBuilderWithInputOutput<
       TMeta
     >,
     mapInput: MapInputMiddleware<InferSchemaOutput<TInputSchema>, UInput>,
-  ): ContextExtendsGuard<UInContext, TCurrentContext>
+  ): ContextExtendsGuard<TCurrentContext, UInContext>
     & ProcedureBuilderWithInputOutput<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,
@@ -357,7 +357,7 @@ export interface RouterBuilder<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<UInContext, TCurrentContext>
+  ): ContextExtendsGuard<TCurrentContext, UInContext>
     & RouterBuilder<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,

--- a/packages/server/src/builder.test-d.ts
+++ b/packages/server/src/builder.test-d.ts
@@ -432,7 +432,7 @@ describe('Builder', () => {
 
   it('.router', () => {
     expectTypeOf(builder.router(router)).toEqualTypeOf<
-      EnhancedRouter<typeof router, InitialContext, typeof baseErrorMap>
+      EnhancedRouter<typeof router, InitialContext, CurrentContext, typeof baseErrorMap>
     >()
 
     builder.router({
@@ -456,7 +456,7 @@ describe('Builder', () => {
 
   it('.lazy', () => {
     expectTypeOf(builder.lazy(() => Promise.resolve({ default: router }))).toEqualTypeOf<
-      EnhancedRouter<Lazy<typeof router>, InitialContext, typeof baseErrorMap>
+      EnhancedRouter<Lazy<typeof router>, InitialContext, CurrentContext, typeof baseErrorMap>
     >()
 
     // @ts-expect-error - initial context is not match

--- a/packages/server/src/builder.ts
+++ b/packages/server/src/builder.ts
@@ -240,14 +240,14 @@ export class Builder<
 
   router<U extends Router<ContractRouter<TMeta>, TCurrentContext>>(
     router: U,
-  ): EnhancedRouter<U, TInitialContext, TErrorMap> {
+  ): EnhancedRouter<U, TInitialContext, TCurrentContext, TErrorMap> {
     return enhanceRouter(router, this['~orpc'])
   }
 
   lazy<U extends Router<ContractRouter<TMeta>, TCurrentContext>>(
     loader: () => Promise<{ default: U }>,
-  ): EnhancedRouter<Lazy<U>, TInitialContext, TErrorMap> {
-    return enhanceRouter(lazy(loader), this['~orpc'])
+  ): EnhancedRouter<Lazy<U>, TInitialContext, TCurrentContext, TErrorMap> {
+    return enhanceRouter(lazy(loader), this['~orpc']) as any
   }
 }
 

--- a/packages/server/src/builder.ts
+++ b/packages/server/src/builder.ts
@@ -143,7 +143,7 @@ export class Builder<
 
   use<UOutContext extends Context, UInput, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      TCurrentContext,
+      UInContext,
       UOutContext,
       UInput,
       unknown,

--- a/packages/server/src/builder.ts
+++ b/packages/server/src/builder.ts
@@ -131,7 +131,7 @@ export class Builder<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<UInContext, TCurrentContext>
+  ): ContextExtendsGuard<TCurrentContext, UInContext>
     & BuilderWithMiddlewares<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,
@@ -151,7 +151,7 @@ export class Builder<
       TMeta
     >,
     mapInput: MapInputMiddleware<unknown, UInput>,
-  ): ContextExtendsGuard<UInContext, TCurrentContext>
+  ): ContextExtendsGuard<TCurrentContext, UInContext>
     & BuilderWithMiddlewares<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,

--- a/packages/server/src/builder.ts
+++ b/packages/server/src/builder.ts
@@ -1,6 +1,6 @@
 import type { AnySchema, ContractProcedureDef, ContractRouter, ErrorMap, HTTPPath, MergedErrorMap, Meta, Route, Schema } from '@orpc/contract'
 import type { BuilderWithMiddlewares, ProcedureBuilder, ProcedureBuilderWithInput, ProcedureBuilderWithOutput, RouterBuilder } from './builder-variants'
-import type { ConflictContextGuard, Context, MergedContext } from './context'
+import type { Context, ContextExtendsGuard, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
 import type { Lazy } from './lazy'
 import type { AnyMiddleware, MapInputMiddleware, Middleware } from './middleware'
@@ -122,26 +122,26 @@ export class Builder<
     })
   }
 
-  use<UOutContext extends Context>(
+  use<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      TCurrentContext,
+      UInContext,
       UOutContext,
       unknown,
       unknown,
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>> &
-    BuilderWithMiddlewares<
-      TInitialContext,
-      MergedContext<TCurrentContext, UOutContext>,
+  ): ContextExtendsGuard<UInContext, TCurrentContext>
+    & BuilderWithMiddlewares<
+      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+      MergedCurrentContext<TCurrentContext, UOutContext>,
       TInputSchema,
       TOutputSchema,
       TErrorMap,
       TMeta
     >
 
-  use<UOutContext extends Context, UInput>(
+  use<UOutContext extends Context, UInput, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
       TCurrentContext,
       UOutContext,
@@ -151,10 +151,10 @@ export class Builder<
       TMeta
     >,
     mapInput: MapInputMiddleware<unknown, UInput>,
-  ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>> &
-    BuilderWithMiddlewares<
-      TInitialContext,
-      MergedContext<TCurrentContext, UOutContext>,
+  ): ContextExtendsGuard<UInContext, TCurrentContext>
+    & BuilderWithMiddlewares<
+      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+      MergedCurrentContext<TCurrentContext, UOutContext>,
       TInputSchema,
       TOutputSchema,
       TErrorMap,

--- a/packages/server/src/context.test-d.ts
+++ b/packages/server/src/context.test-d.ts
@@ -16,13 +16,16 @@ interface Empty {
 }
 
 it('ContextExtendsGuard', () => {
-  expectTypeOf<ContextExtendsGuard<{ a: string }, { a: string, b: string }>>().toEqualTypeOf<unknown>()
+  expectTypeOf < ContextExtendsGuard< { a: string, b: string }, { a: string }>>().toEqualTypeOf<unknown>()
   expectTypeOf<ContextExtendsGuard<{ a: string }, { a: string }>>().toEqualTypeOf<unknown>()
-  expectTypeOf<ContextExtendsGuard<Empty, { a: string, b: string }>>().toEqualTypeOf<unknown>()
-  expectTypeOf<ContextExtendsGuard<Record<never, never>, { a: string, b: string }>>().toEqualTypeOf<unknown>()
-  expectTypeOf<ContextExtendsGuard<{ g?: string }, { a: string, b: string }>>().toEqualTypeOf<unknown>()
+  expectTypeOf < ContextExtendsGuard< { a: string, b: string }, Empty>>().toEqualTypeOf<unknown>()
+  expectTypeOf < ContextExtendsGuard< { a: string, b: string }, Record<never, never>>>().toEqualTypeOf<unknown>()
+  expectTypeOf < ContextExtendsGuard< { a: string, b: string }, { g?: string }>>().toEqualTypeOf<unknown>()
+  expectTypeOf<ContextExtendsGuard<Empty, { a?: string }>>().toEqualTypeOf<unknown>()
+  expectTypeOf<ContextExtendsGuard<{ b: string }, { a?: string }>>().toEqualTypeOf<unknown>()
+  expectTypeOf<ContextExtendsGuard<{ b?: string }, { a?: string }>>().toEqualTypeOf<unknown>()
 
-  expectTypeOf<ContextExtendsGuard<{ a: string, b: string }, { a: string }>>().toEqualTypeOf<never>()
-  expectTypeOf<ContextExtendsGuard<{ a: string }, { a: number }>>().toEqualTypeOf<never>()
-  expectTypeOf<ContextExtendsGuard<{ a: string }, Empty>>().toEqualTypeOf<never>()
+  expectTypeOf < ContextExtendsGuard < { a: string }, { a: string, b: string }>>().toEqualTypeOf<never>()
+  expectTypeOf < ContextExtendsGuard < { a: number }, { a: string }>>().toEqualTypeOf<never>()
+  expectTypeOf<ContextExtendsGuard<Empty, { a: string }>>().toEqualTypeOf<never>()
 })

--- a/packages/server/src/context.test-d.ts
+++ b/packages/server/src/context.test-d.ts
@@ -1,12 +1,28 @@
-import type { ConflictContextGuard, MergedContext } from './context'
+import type { ContextExtendsGuard, MergedCurrentContext, MergedInitialContext } from './context'
 
-it('MergedContext', () => {
-  expectTypeOf<MergedContext<{ a: string }, { b: number }>>().toMatchTypeOf<{ a: string, b: number }>()
-  expectTypeOf<MergedContext<{ a: string }, { a: number }>>().toMatchTypeOf<{ a: never }>()
+it('MergedInitialContext', () => {
+  expectTypeOf<MergedInitialContext<{ a: string }, { b: number }, { c: string }>>().toMatchTypeOf<{ a: string, b: number }>()
+  expectTypeOf<MergedInitialContext<{ a: string }, { a: number }, { c: string }>>().toMatchTypeOf<{ a: never }>()
+  expectTypeOf<MergedInitialContext<{ a: string }, { c: number }, { c: string }>>().toMatchTypeOf<{ a: string }>()
 })
 
-it('ConflictContextGuard', () => {
-  expectTypeOf<ConflictContextGuard<MergedContext<{ a: string }, { b: number }>>>().toEqualTypeOf<unknown>()
-  expectTypeOf<ConflictContextGuard<MergedContext<{ a: string }, { a: number }>>>().toEqualTypeOf<never>()
-  expectTypeOf<ConflictContextGuard<never>>().toEqualTypeOf<never>()
+it('MergedCurrentContext', () => {
+  expectTypeOf<MergedCurrentContext<{ a: string }, { b: number }>>().toMatchTypeOf<{ a: string, b: number }>()
+  expectTypeOf<MergedCurrentContext<{ a: string }, { a: number }>>().toMatchTypeOf<{ a: number }>()
+})
+
+interface Empty {
+
+}
+
+it('ContextExtendsGuard', () => {
+  expectTypeOf<ContextExtendsGuard<{ a: string }, { a: string, b: string }>>().toEqualTypeOf<unknown>()
+  expectTypeOf<ContextExtendsGuard<{ a: string }, { a: string }>>().toEqualTypeOf<unknown>()
+  expectTypeOf<ContextExtendsGuard<Empty, { a: string, b: string }>>().toEqualTypeOf<unknown>()
+  expectTypeOf<ContextExtendsGuard<Record<never, never>, { a: string, b: string }>>().toEqualTypeOf<unknown>()
+  expectTypeOf<ContextExtendsGuard<{ g?: string }, { a: string, b: string }>>().toEqualTypeOf<unknown>()
+
+  expectTypeOf<ContextExtendsGuard<{ a: string, b: string }, { a: string }>>().toEqualTypeOf<never>()
+  expectTypeOf<ContextExtendsGuard<{ a: string }, { a: number }>>().toEqualTypeOf<never>()
+  expectTypeOf<ContextExtendsGuard<{ a: string }, Empty>>().toEqualTypeOf<never>()
 })

--- a/packages/server/src/context.test.ts
+++ b/packages/server/src/context.test.ts
@@ -1,6 +1,6 @@
-import { mergeContext } from './context'
+import { mergeCurrentContext } from './context'
 
-it('mergeContext', () => {
-  expect(mergeContext({ a: 1 }, { b: 2 })).toEqual({ a: 1, b: 2 })
-  expect(mergeContext({ a: 1 }, { a: 2 })).toEqual({ a: 2 })
+it('mergeCurrentContext', () => {
+  expect(mergeCurrentContext({ a: 1 }, { b: 2 })).toEqual({ a: 1, b: 2 })
+  expect(mergeCurrentContext({ a: 1 }, { a: 2 })).toEqual({ a: 2 })
 })

--- a/packages/server/src/context.ts
+++ b/packages/server/src/context.ts
@@ -15,5 +15,4 @@ export function mergeCurrentContext<T extends Context, U extends Context>(
   return { ...context, ...other }
 }
 
-export type ContextExtendsGuard<T extends Context, U extends Context> =
-  ((c: T & U) => any) extends ((c: U) => any) ? unknown : never
+export type ContextExtendsGuard<T extends Context, U extends Context> = T extends T & U ? unknown : never

--- a/packages/server/src/context.ts
+++ b/packages/server/src/context.ts
@@ -1,17 +1,19 @@
-import type { IsNever } from '@orpc/shared'
-
 export type Context = Record<string, any>
 
-export type MergedContext<T extends Context, U extends Context> = T & U
+export type MergedInitialContext<
+  TInitial extends Context,
+  TAdditional extends Context,
+  TCurrent extends Context,
+> = TInitial & Omit<TAdditional, keyof TCurrent>
 
-export function mergeContext<T extends Context, U extends Context>(
+export type MergedCurrentContext<T extends Context, U extends Context> = Omit<T, keyof U> & U
+
+export function mergeCurrentContext<T extends Context, U extends Context>(
   context: T,
   other: U,
-): MergedContext<T, U> {
+): MergedCurrentContext<T, U> {
   return { ...context, ...other }
 }
 
-export type ConflictContextGuard<T extends Context> =
-    true extends IsNever<T> | { [K in keyof T]: IsNever<T[K]> }[keyof T]
-      ? never // 'Conflict context detected: Please ensure your middlewares do not return conflicting context'
-      : unknown
+export type ContextExtendsGuard<T extends Context, U extends Context> =
+  ((c: T & U) => any) extends ((c: U) => any) ? unknown : never

--- a/packages/server/src/implementer-procedure.ts
+++ b/packages/server/src/implementer-procedure.ts
@@ -2,7 +2,7 @@ import type { ClientContext, ClientRest } from '@orpc/client'
 import type { AnySchema, ErrorMap, InferSchemaInput, InferSchemaOutput, Meta } from '@orpc/contract'
 import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { BuilderDef } from './builder'
-import type { ConflictContextGuard, Context, MergedContext } from './context'
+import type { Context, ContextExtendsGuard, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
 import type { MapInputMiddleware, Middleware } from './middleware'
 import type { Procedure, ProcedureHandler } from './procedure'
@@ -20,28 +20,29 @@ export interface ImplementedProcedure<
   TErrorMap extends ErrorMap,
   TMeta extends Meta,
 > extends Procedure<TInitialContext, TCurrentContext, TInputSchema, TOutputSchema, TErrorMap, TMeta> {
-  use<U extends Context>(
+  use<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      TCurrentContext,
-      U,
+      UInContext,
+      UOutContext,
       InferSchemaOutput<TInputSchema>,
       InferSchemaInput<TOutputSchema>,
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ConflictContextGuard<MergedContext<TCurrentContext, U>>
+  ): ContextExtendsGuard<UInContext, TCurrentContext>
+    & ContextExtendsGuard<TCurrentContext, MergedCurrentContext<TCurrentContext, UOutContext>>
     & DecoratedProcedure<
-      TInitialContext,
-      MergedContext<TCurrentContext, U>,
+      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+      MergedCurrentContext<TCurrentContext, UOutContext>,
       TInputSchema,
       TOutputSchema,
       TErrorMap,
       TMeta
     >
 
-  use<UOutContext extends Context, UInput>(
+  use<UOutContext extends Context, UInput, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      TCurrentContext,
+      UInContext,
       UOutContext,
       UInput,
       InferSchemaInput<TOutputSchema>,
@@ -49,10 +50,11 @@ export interface ImplementedProcedure<
       TMeta
     >,
     mapInput: MapInputMiddleware<InferSchemaOutput<TInputSchema>, UInput>,
-  ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>>
+  ): ContextExtendsGuard<UInContext, TCurrentContext>
+    & ContextExtendsGuard<TCurrentContext, MergedCurrentContext<TCurrentContext, UOutContext>>
     & DecoratedProcedure<
-      TInitialContext,
-      MergedContext<TCurrentContext, UOutContext>,
+      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+      MergedCurrentContext<TCurrentContext, UOutContext>,
       TInputSchema,
       TOutputSchema,
       TErrorMap,
@@ -107,28 +109,28 @@ export interface ProcedureImplementer<
 > {
   '~orpc': BuilderDef<TInputSchema, TOutputSchema, TErrorMap, TMeta>
 
-  'use'<U extends Context>(
+  'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      TCurrentContext,
-      U,
+      UInContext,
+      UOutContext,
       InferSchemaOutput<TInputSchema>,
       InferSchemaInput<TOutputSchema>,
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ConflictContextGuard<MergedContext<TCurrentContext, U>>
+  ): ContextExtendsGuard<UInContext, TCurrentContext>
     & ProcedureImplementer<
-      TInitialContext,
-      MergedContext<TCurrentContext, U>,
+      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+      MergedCurrentContext<TCurrentContext, UOutContext>,
       TInputSchema,
       TOutputSchema,
       TErrorMap,
       TMeta
     >
 
-  'use'<UOutContext extends Context, UInput>(
+  'use'<UOutContext extends Context, UInput, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      TCurrentContext,
+      UInContext,
       UOutContext,
       UInput,
       InferSchemaInput<TOutputSchema>,
@@ -136,10 +138,10 @@ export interface ProcedureImplementer<
       TMeta
     >,
     mapInput: MapInputMiddleware<InferSchemaOutput<TInputSchema>, UInput>,
-  ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>>
+  ): ContextExtendsGuard<UInContext, TCurrentContext>
     & ProcedureImplementer<
-      TInitialContext,
-      MergedContext<TCurrentContext, UOutContext>,
+      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+      MergedCurrentContext<TCurrentContext, UOutContext>,
       TInputSchema,
       TOutputSchema,
       TErrorMap,

--- a/packages/server/src/implementer-procedure.ts
+++ b/packages/server/src/implementer-procedure.ts
@@ -7,7 +7,6 @@ import type { ORPCErrorConstructorMap } from './error'
 import type { MapInputMiddleware, Middleware } from './middleware'
 import type { Procedure, ProcedureHandler } from './procedure'
 import type { CreateProcedureClientOptions, ProcedureClient } from './procedure-client'
-import type { DecoratedProcedure } from './procedure-decorated'
 
 /**
  * Like `DecoratedProcedure`, but removed all method that can change the contract.
@@ -31,7 +30,7 @@ export interface ImplementedProcedure<
     >,
   ): ContextExtendsGuard<UInContext, TCurrentContext>
     & ContextExtendsGuard<TCurrentContext, MergedCurrentContext<TCurrentContext, UOutContext>>
-    & DecoratedProcedure<
+    & ImplementedProcedure<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,
       TInputSchema,
@@ -52,7 +51,7 @@ export interface ImplementedProcedure<
     mapInput: MapInputMiddleware<InferSchemaOutput<TInputSchema>, UInput>,
   ): ContextExtendsGuard<UInContext, TCurrentContext>
     & ContextExtendsGuard<TCurrentContext, MergedCurrentContext<TCurrentContext, UOutContext>>
-    & DecoratedProcedure<
+    & ImplementedProcedure<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,
       TInputSchema,

--- a/packages/server/src/implementer-procedure.ts
+++ b/packages/server/src/implementer-procedure.ts
@@ -28,8 +28,8 @@ export interface ImplementedProcedure<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<UInContext, TCurrentContext>
-    & ContextExtendsGuard<TCurrentContext, MergedCurrentContext<TCurrentContext, UOutContext>>
+  ): ContextExtendsGuard<TCurrentContext, UInContext>
+    & ContextExtendsGuard<MergedCurrentContext<TCurrentContext, UOutContext>, TCurrentContext>
     & ImplementedProcedure<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,
@@ -49,8 +49,8 @@ export interface ImplementedProcedure<
       TMeta
     >,
     mapInput: MapInputMiddleware<InferSchemaOutput<TInputSchema>, UInput>,
-  ): ContextExtendsGuard<UInContext, TCurrentContext>
-    & ContextExtendsGuard<TCurrentContext, MergedCurrentContext<TCurrentContext, UOutContext>>
+  ): ContextExtendsGuard<TCurrentContext, UInContext>
+    & ContextExtendsGuard<MergedCurrentContext<TCurrentContext, UOutContext>, TCurrentContext>
     & ImplementedProcedure<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,
@@ -117,7 +117,7 @@ export interface ProcedureImplementer<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<UInContext, TCurrentContext>
+  ): ContextExtendsGuard<TCurrentContext, UInContext>
     & ProcedureImplementer<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,
@@ -137,7 +137,7 @@ export interface ProcedureImplementer<
       TMeta
     >,
     mapInput: MapInputMiddleware<InferSchemaOutput<TInputSchema>, UInput>,
-  ): ContextExtendsGuard<UInContext, TCurrentContext>
+  ): ContextExtendsGuard<TCurrentContext, UInContext>
     & ProcedureImplementer<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,

--- a/packages/server/src/implementer-variants.test-d.ts
+++ b/packages/server/src/implementer-variants.test-d.ts
@@ -1,13 +1,13 @@
 import type { AnySchema, ErrorMap, Meta, Schema } from '@orpc/contract'
 import type { baseErrorMap, BaseMeta, inputSchema, outputSchema, router } from '../../contract/tests/shared'
 import type { CurrentContext, InitialContext } from '../tests/shared'
-import type { Context, MergedContext } from './context'
+import type { Context, MergedCurrentContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
 import type { ImplementerInternal } from './implementer'
 import type { ProcedureImplementer } from './implementer-procedure'
 import type { ImplementerInternalWithMiddlewares } from './implementer-variants'
 import type { Lazy } from './lazy'
-import type { MiddlewareOutputFn } from './middleware'
+import type { Middleware, MiddlewareOutputFn } from './middleware'
 import type { Procedure } from './procedure'
 import type { EnhancedRouter } from './router-utils'
 import { router as implRouter } from '../tests/shared'
@@ -19,41 +19,53 @@ describe('ImplementerWithMiddlewares', () => {
   })
 
   describe('router level', () => {
-    it('.use', () => {
-      const applied = implementer.nested.use(({ context, next, path, procedure, errors, signal }, input, output) => {
-        expectTypeOf(input).toEqualTypeOf<unknown>()
-        expectTypeOf(context).toEqualTypeOf<CurrentContext>()
-        expectTypeOf(path).toEqualTypeOf<readonly string[]>()
-        expectTypeOf(procedure).toEqualTypeOf<
-          Procedure<Context, Context, AnySchema, AnySchema, ErrorMap, BaseMeta | Meta>
-        >()
-        expectTypeOf(output).toEqualTypeOf<MiddlewareOutputFn<unknown>>()
-        expectTypeOf(errors).toEqualTypeOf<ORPCErrorConstructorMap<typeof baseErrorMap | Record<never, never>>>()
-        expectTypeOf(signal).toEqualTypeOf<undefined | InstanceType<typeof AbortSignal>>()
+    describe('.use', () => {
+      it('without map input', () => {
+        const applied = implementer.nested.use(({ context, next, path, procedure, errors, signal }, input, output) => {
+          expectTypeOf(input).toEqualTypeOf<unknown>()
+          expectTypeOf(context).toEqualTypeOf<CurrentContext>()
+          expectTypeOf(path).toEqualTypeOf<readonly string[]>()
+          expectTypeOf(procedure).toEqualTypeOf<
+            Procedure<Context, Context, AnySchema, AnySchema, ErrorMap, BaseMeta | Meta>
+          >()
+          expectTypeOf(output).toEqualTypeOf<MiddlewareOutputFn<unknown>>()
+          expectTypeOf(errors).toEqualTypeOf<ORPCErrorConstructorMap<typeof baseErrorMap | Record<never, never>>>()
+          expectTypeOf(signal).toEqualTypeOf<undefined | InstanceType<typeof AbortSignal>>()
 
-        return next({
-          context: {
-            extra: true,
-          },
+          return next({
+            context: {
+              extra: true,
+            },
+          })
         })
+
+        expectTypeOf(applied).toEqualTypeOf<
+          ImplementerInternalWithMiddlewares<
+          typeof router['nested'],
+          InitialContext & Record<never, never>,
+          MergedCurrentContext<CurrentContext, { extra: boolean }>
+          >
+        >()
+
+        // invalid TInContext
+        expectTypeOf(implementer.nested.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)).toEqualTypeOf<never>()
+        // @ts-expect-error --- input is not match
+        implementer.use(({ next }, input: 'invalid') => next({}))
+        // @ts-expect-error --- output is not match
+        implementer.use(({ next }, input, output: MiddlewareOutputFn<'invalid'>) => next({}))
       })
 
-      expectTypeOf(applied).toMatchTypeOf<
-        ImplementerInternalWithMiddlewares<
-          typeof router['nested'],
-          InitialContext,
-          MergedContext<CurrentContext, { extra: boolean }>
-        >
-      >()
+      it('with TInContext', () => {
+        const mid = {} as Middleware<{ cacheable?: boolean }, Record<never, never>, unknown, unknown, ORPCErrorConstructorMap<any>, BaseMeta>
 
-      // @ts-expect-error --- conflict context
-      implementer.use(({ next }) => next({ context: { db: 123 } }))
-      // conflict but not detected
-      expectTypeOf(implementer.use(({ next }) => next({ context: { db: undefined } }))).toMatchTypeOf<never>()
-      // @ts-expect-error --- input is not match
-      implementer.use(({ next }, input: 'invalid') => next({}))
-      // @ts-expect-error --- output is not match
-      implementer.use(({ next }, input, output: MiddlewareOutputFn<'invalid'>) => next({}))
+        expectTypeOf(implementer.use(mid)).toEqualTypeOf<
+          ImplementerInternalWithMiddlewares<
+              typeof router,
+              InitialContext & { cacheable?: boolean },
+              Omit<CurrentContext, never> & Record<never, never>
+          >
+        >()
+      })
     })
 
     it('.router', () => {

--- a/packages/server/src/implementer-variants.test-d.ts
+++ b/packages/server/src/implementer-variants.test-d.ts
@@ -70,7 +70,7 @@ describe('ImplementerWithMiddlewares', () => {
 
     it('.router', () => {
       expectTypeOf(implementer.router(implRouter)).toEqualTypeOf<
-        EnhancedRouter<typeof implRouter, InitialContext, Record<never, never>>
+        EnhancedRouter < typeof implRouter, InitialContext, CurrentContext, Record<never, never>>
       >()
 
       implementer.router({
@@ -105,7 +105,7 @@ describe('ImplementerWithMiddlewares', () => {
 
     it('.lazy', () => {
       expectTypeOf(implementer.lazy(() => Promise.resolve({ default: implRouter }))).toEqualTypeOf<
-        EnhancedRouter<Lazy<typeof implRouter>, InitialContext, Record<never, never>>
+        EnhancedRouter<Lazy<typeof implRouter>, InitialContext, CurrentContext, Record<never, never>>
       >()
 
       // @ts-expect-error - initial context is not match

--- a/packages/server/src/implementer-variants.ts
+++ b/packages/server/src/implementer-variants.ts
@@ -29,11 +29,11 @@ export interface RouterImplementerWithMiddlewares<
     >
 
   router<U extends Router<T, TCurrentContext>>(
-    router: U): EnhancedRouter<U, TInitialContext, Record<never, never>>
+    router: U): EnhancedRouter<U, TInitialContext, TCurrentContext, Record<never, never>>
 
   lazy<U extends Router<T, TInitialContext>>(
     loader: () => Promise<{ default: U }>
-  ): EnhancedRouter<Lazy<U>, TInitialContext, Record<never, never>>
+  ): EnhancedRouter<Lazy<U>, TInitialContext, TCurrentContext, Record<never, never>>
 }
 
 export type ImplementerInternalWithMiddlewares<

--- a/packages/server/src/implementer-variants.ts
+++ b/packages/server/src/implementer-variants.ts
@@ -21,7 +21,7 @@ export interface RouterImplementerWithMiddlewares<
       ORPCErrorConstructorMap<InferContractRouterErrorMap<T>>,
       InferContractRouterMeta<T>
     >,
-  ): ContextExtendsGuard<UInContext, TCurrentContext>
+  ): ContextExtendsGuard<TCurrentContext, UInContext>
     & ImplementerInternalWithMiddlewares<
       T,
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,

--- a/packages/server/src/implementer-variants.ts
+++ b/packages/server/src/implementer-variants.ts
@@ -1,5 +1,5 @@
 import type { AnyContractRouter, ContractProcedure, InferContractRouterErrorMap, InferContractRouterMeta } from '@orpc/contract'
-import type { ConflictContextGuard, Context, MergedContext } from './context'
+import type { Context, ContextExtendsGuard, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
 import type { ProcedureImplementer } from './implementer-procedure'
 import type { Lazy } from './lazy'
@@ -12,17 +12,21 @@ export interface RouterImplementerWithMiddlewares<
   TInitialContext extends Context,
   TCurrentContext extends Context,
 > {
-  use<U extends Context>(
+  use<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      TCurrentContext,
-      U,
+      UInContext,
+      UOutContext,
       unknown,
       unknown,
       ORPCErrorConstructorMap<InferContractRouterErrorMap<T>>,
       InferContractRouterMeta<T>
     >,
-  ): ConflictContextGuard<MergedContext<TCurrentContext, U>>
-    & ImplementerInternalWithMiddlewares<T, TInitialContext, MergedContext<TCurrentContext, U>>
+  ): ContextExtendsGuard<UInContext, TCurrentContext>
+    & ImplementerInternalWithMiddlewares<
+      T,
+      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+      MergedCurrentContext<TCurrentContext, UOutContext>
+    >
 
   router<U extends Router<T, TCurrentContext>>(
     router: U): EnhancedRouter<U, TInitialContext, Record<never, never>>

--- a/packages/server/src/implementer.test-d.ts
+++ b/packages/server/src/implementer.test-d.ts
@@ -139,7 +139,7 @@ describe('Implementer', () => {
 
     it('.router', () => {
       expectTypeOf(implementer.router(implRouter)).toEqualTypeOf<
-        EnhancedRouter<typeof implRouter, InitialContext, Record<never, never>>
+        EnhancedRouter < typeof implRouter, InitialContext, CurrentContext, Record<never, never>>
       >()
 
       implementer.router({
@@ -174,7 +174,7 @@ describe('Implementer', () => {
 
     it('.lazy', () => {
       expectTypeOf(implementer.lazy(() => Promise.resolve({ default: implRouter }))).toEqualTypeOf<
-        EnhancedRouter<Lazy<typeof implRouter>, InitialContext, Record<never, never>>
+        EnhancedRouter<Lazy<typeof implRouter>, InitialContext, CurrentContext, Record<never, never>>
       >()
 
       // @ts-expect-error - initial context is not match

--- a/packages/server/src/implementer.ts
+++ b/packages/server/src/implementer.ts
@@ -1,6 +1,6 @@
 import type { AnyContractRouter, ContractProcedure, InferContractRouterErrorMap, InferContractRouterMeta } from '@orpc/contract'
 import type { AnyFunction } from '@orpc/shared'
-import type { ConflictContextGuard, Context, MergedContext } from './context'
+import type { Context, ContextExtendsGuard, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
 import type { ProcedureImplementer } from './implementer-procedure'
 import type { ImplementerInternalWithMiddlewares } from './implementer-variants'
@@ -32,17 +32,21 @@ export interface RouterImplementer<
     >,
   ): DecoratedMiddleware<TCurrentContext, UOutContext, TInput, TOutput, ORPCErrorConstructorMap<any>, InferContractRouterMeta<T>> // ORPCErrorConstructorMap<any> ensures middleware can used in any procedure
 
-  use<U extends Context>(
+  use<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      TCurrentContext,
-      U,
+      UInContext,
+      UOutContext,
       unknown,
       unknown,
       ORPCErrorConstructorMap<InferContractRouterErrorMap<T>>,
       InferContractRouterMeta<T>
     >,
-  ): ConflictContextGuard<MergedContext<TCurrentContext, U>>
-    & ImplementerInternalWithMiddlewares<T, TInitialContext, MergedContext<TCurrentContext, U>>
+  ): ContextExtendsGuard<UInContext, TCurrentContext>
+    & ImplementerInternalWithMiddlewares<
+      T,
+      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+      MergedCurrentContext<TCurrentContext, UOutContext>
+    >
 
   router<U extends Router<T, TCurrentContext>>(
     router: U): EnhancedRouter<U, TInitialContext, Record<never, never>>

--- a/packages/server/src/implementer.ts
+++ b/packages/server/src/implementer.ts
@@ -49,11 +49,11 @@ export interface RouterImplementer<
     >
 
   router<U extends Router<T, TCurrentContext>>(
-    router: U): EnhancedRouter<U, TInitialContext, Record<never, never>>
+    router: U): EnhancedRouter<U, TInitialContext, TCurrentContext, Record<never, never>>
 
   lazy<U extends Router<T, TCurrentContext>>(
     loader: () => Promise<{ default: U }>
-  ): EnhancedRouter<Lazy<U>, TInitialContext, Record<never, never>>
+  ): EnhancedRouter<Lazy<U>, TInitialContext, TCurrentContext, Record<never, never>>
 }
 
 export type ImplementerInternal<

--- a/packages/server/src/implementer.ts
+++ b/packages/server/src/implementer.ts
@@ -41,7 +41,7 @@ export interface RouterImplementer<
       ORPCErrorConstructorMap<InferContractRouterErrorMap<T>>,
       InferContractRouterMeta<T>
     >,
-  ): ContextExtendsGuard<UInContext, TCurrentContext>
+  ): ContextExtendsGuard<TCurrentContext, UInContext>
     & ImplementerInternalWithMiddlewares<
       T,
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,

--- a/packages/server/src/middleware-decorated.ts
+++ b/packages/server/src/middleware-decorated.ts
@@ -50,7 +50,7 @@ export interface DecoratedMiddleware<
     mapInput: MapInputMiddleware<TInput, UMappedInput>,
   ): ContextExtendsGuard<UInContext, MergedCurrentContext<TInContext, TOutContext>>
     & DecoratedMiddleware<
-      MergedInitialContext<TInContext, UInContext, TOutContext>,
+      MergedInitialContext<TInContext, UInContext, MergedCurrentContext<TInContext, TOutContext>>,
       MergedCurrentContext<TOutContext, UOutContext>,
       TInput,
       TOutput,

--- a/packages/server/src/middleware-decorated.ts
+++ b/packages/server/src/middleware-decorated.ts
@@ -24,7 +24,7 @@ export interface DecoratedMiddleware<
       TErrorConstructorMap,
       TMeta
     >,
-  ): ContextExtendsGuard<UInContext, MergedCurrentContext<TInContext, TOutContext>>
+  ): ContextExtendsGuard<MergedCurrentContext<TInContext, TOutContext>, UInContext>
     & DecoratedMiddleware<
       MergedInitialContext<TInContext, UInContext, MergedCurrentContext<TInContext, TOutContext>>,
       MergedCurrentContext<TOutContext, UOutContext>,
@@ -48,7 +48,7 @@ export interface DecoratedMiddleware<
       TMeta
     >,
     mapInput: MapInputMiddleware<TInput, UMappedInput>,
-  ): ContextExtendsGuard<UInContext, MergedCurrentContext<TInContext, TOutContext>>
+  ): ContextExtendsGuard<MergedCurrentContext<TInContext, TOutContext>, UInContext>
     & DecoratedMiddleware<
       MergedInitialContext<TInContext, UInContext, MergedCurrentContext<TInContext, TOutContext>>,
       MergedCurrentContext<TOutContext, UOutContext>,

--- a/packages/server/src/middleware-decorated.ts
+++ b/packages/server/src/middleware-decorated.ts
@@ -1,5 +1,5 @@
 import type { Meta } from '@orpc/contract'
-import type { Context, MergedContext } from './context'
+import type { Context, ContextExtendsGuard, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
 import type { AnyMiddleware, MapInputMiddleware, Middleware } from './middleware'
 
@@ -15,30 +15,32 @@ export interface DecoratedMiddleware<
     map: MapInputMiddleware<UInput, TInput>,
   ): DecoratedMiddleware<TInContext, TOutContext, UInput, TOutput, TErrorConstructorMap, TMeta>
 
-  concat<UOutContext extends Context>(
+  concat<UOutContext extends Context, UInContext extends Context = MergedCurrentContext<TInContext, TOutContext>>(
     middleware: Middleware<
-      TInContext & TOutContext,
+      UInContext,
       UOutContext,
       TInput,
       TOutput,
       TErrorConstructorMap,
       TMeta
     >,
-  ): DecoratedMiddleware<
-    TInContext,
-    MergedContext<TOutContext, UOutContext>,
-    TInput,
-    TOutput,
-    TErrorConstructorMap,
-    TMeta
-  >
+  ): ContextExtendsGuard<UInContext, MergedCurrentContext<TInContext, TOutContext>>
+    & DecoratedMiddleware<
+      MergedInitialContext<TInContext, UInContext, MergedCurrentContext<TInContext, TOutContext>>,
+      MergedCurrentContext<TOutContext, UOutContext>,
+      TInput,
+      TOutput,
+      TErrorConstructorMap,
+      TMeta
+    >
 
   concat<
     UOutContext extends Context,
     UMappedInput,
+    UInContext extends Context = MergedCurrentContext<TInContext, TOutContext>,
   >(
     middleware: Middleware<
-      TInContext & TOutContext,
+      UInContext,
       UOutContext,
       UMappedInput,
       TOutput,
@@ -46,14 +48,15 @@ export interface DecoratedMiddleware<
       TMeta
     >,
     mapInput: MapInputMiddleware<TInput, UMappedInput>,
-  ): DecoratedMiddleware<
-    TInContext,
-    MergedContext<TOutContext, UOutContext>,
-    TInput,
-    TOutput,
-    TErrorConstructorMap,
-    TMeta
-  >
+  ): ContextExtendsGuard<UInContext, MergedCurrentContext<TInContext, TOutContext>>
+    & DecoratedMiddleware<
+      MergedInitialContext<TInContext, UInContext, TOutContext>,
+      MergedCurrentContext<TOutContext, UOutContext>,
+      TInput,
+      TOutput,
+      TErrorConstructorMap,
+      TMeta
+    >
 }
 
 export function decorateMiddleware<

--- a/packages/server/src/middleware.test-d.ts
+++ b/packages/server/src/middleware.test-d.ts
@@ -23,7 +23,7 @@ describe('middleware', () => {
       >()
       expectTypeOf(signal).toEqualTypeOf<undefined | InstanceType<typeof AbortSignal>>()
       expectTypeOf(output).toEqualTypeOf<MiddlewareOutputFn<{ output: string }>>()
-      expectTypeOf(next).toEqualTypeOf<MiddlewareNextFn<{ auth: boolean }, { output: string }>>()
+      expectTypeOf(next).toEqualTypeOf<MiddlewareNextFn<{ output: string }>>()
       expectTypeOf(errors).toEqualTypeOf<ORPCErrorConstructorMap<typeof baseErrorMap>>()
 
       return next()

--- a/packages/server/src/middleware.ts
+++ b/packages/server/src/middleware.ts
@@ -13,8 +13,8 @@ export type MiddlewareNextFnOptions<TOutContext extends Context> = Record<never,
   ? { context?: TOutContext }
   : { context: TOutContext }
 
-export interface MiddlewareNextFn<TInContext extends Context, TOutput> {
-  <U extends Context & Partial<TInContext> = Record<never, never>>(
+export interface MiddlewareNextFn<TOutput> {
+  <U extends Context = Record<never, never>>(
     ...rest: MaybeOptionalOptions<MiddlewareNextFnOptions<U>>
   ): MiddlewareResult<U, TOutput>
 }
@@ -34,7 +34,7 @@ export interface MiddlewareOptions<
   procedure: Procedure<Context, Context, AnySchema, AnySchema, ErrorMap, TMeta>
   signal?: AbortSignal
   lastEventId: string | undefined
-  next: MiddlewareNextFn<TInContext, TOutput>
+  next: MiddlewareNextFn<TOutput>
   errors: TErrorConstructorMap
 }
 

--- a/packages/server/src/procedure-client.ts
+++ b/packages/server/src/procedure-client.ts
@@ -169,7 +169,7 @@ async function executeProcedureInternal(procedure: AnyProcedure, options: Proced
   let currentContext = options.context
   let currentInput = options.input
 
-  const next: MiddlewareNextFn<any, any> = async (...[nextOptions]) => {
+  const next: MiddlewareNextFn<any> = async (...[nextOptions]) => {
     const index = currentIndex
     currentIndex += 1
     currentContext = { ...currentContext, ...nextOptions?.context }

--- a/packages/server/src/procedure-decorated.ts
+++ b/packages/server/src/procedure-decorated.ts
@@ -62,8 +62,8 @@ export class DecoratedProcedure<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<UInContext, TCurrentContext>
-    & ContextExtendsGuard<TCurrentContext, MergedCurrentContext<TCurrentContext, UOutContext>>
+  ): ContextExtendsGuard<TCurrentContext, UInContext>
+    & ContextExtendsGuard<MergedCurrentContext<TCurrentContext, UOutContext>, TCurrentContext>
     & DecoratedProcedure<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,
@@ -83,8 +83,8 @@ export class DecoratedProcedure<
       TMeta
     >,
     mapInput: MapInputMiddleware<InferSchemaOutput<TInputSchema>, UInput>,
-  ): ContextExtendsGuard<UInContext, TCurrentContext>
-    & ContextExtendsGuard<TCurrentContext, MergedCurrentContext<TCurrentContext, UOutContext>>
+  ): ContextExtendsGuard<TCurrentContext, UInContext>
+    & ContextExtendsGuard<MergedCurrentContext<TCurrentContext, UOutContext>, TCurrentContext>
     & DecoratedProcedure<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,

--- a/packages/server/src/procedure-decorated.ts
+++ b/packages/server/src/procedure-decorated.ts
@@ -1,7 +1,7 @@
 import type { ClientContext, ClientRest } from '@orpc/client'
 import type { AnySchema, ErrorMap, InferSchemaInput, InferSchemaOutput, MergedErrorMap, Meta, Route } from '@orpc/contract'
 import type { MaybeOptionalOptions } from '@orpc/shared'
-import type { ConflictContextGuard, Context, MergedContext } from './context'
+import type { Context, ContextExtendsGuard, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
 import type { AnyMiddleware, MapInputMiddleware, Middleware } from './middleware'
 import type { CreateProcedureClientOptions, ProcedureClient } from './procedure-client'
@@ -53,28 +53,29 @@ export class DecoratedProcedure<
     })
   }
 
-  use<U extends Context>(
+  use<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      TCurrentContext,
-      U,
+      UInContext,
+      UOutContext,
       InferSchemaOutput<TInputSchema>,
       InferSchemaInput<TOutputSchema>,
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ConflictContextGuard<MergedContext<TCurrentContext, U>>
+  ): ContextExtendsGuard<UInContext, TCurrentContext>
+    & ContextExtendsGuard<TCurrentContext, MergedCurrentContext<TCurrentContext, UOutContext>>
     & DecoratedProcedure<
-      TInitialContext,
-      MergedContext<TCurrentContext, U>,
+      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+      MergedCurrentContext<TCurrentContext, UOutContext>,
       TInputSchema,
       TOutputSchema,
       TErrorMap,
       TMeta
     >
 
-  use<UOutContext extends Context, UInput>(
+  use<UOutContext extends Context, UInput, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      TCurrentContext,
+      UInContext,
       UOutContext,
       UInput,
       InferSchemaInput<TOutputSchema>,
@@ -82,10 +83,11 @@ export class DecoratedProcedure<
       TMeta
     >,
     mapInput: MapInputMiddleware<InferSchemaOutput<TInputSchema>, UInput>,
-  ): ConflictContextGuard<MergedContext<TCurrentContext, UOutContext>>
+  ): ContextExtendsGuard<UInContext, TCurrentContext>
+    & ContextExtendsGuard<TCurrentContext, MergedCurrentContext<TCurrentContext, UOutContext>>
     & DecoratedProcedure<
-      TInitialContext,
-      MergedContext<TCurrentContext, UOutContext>,
+      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+      MergedCurrentContext<TCurrentContext, UOutContext>,
       TInputSchema,
       TOutputSchema,
       TErrorMap,

--- a/packages/server/src/router-utils.test-d.ts
+++ b/packages/server/src/router-utils.test-d.ts
@@ -1,7 +1,7 @@
 import type { MergedErrorMap, Meta, Schema } from '@orpc/contract'
 import type { baseErrorMap, BaseMeta, inputSchema, outputSchema } from '../../contract/tests/shared'
 import type { CurrentContext, InitialContext, router } from '../tests/shared'
-import type { Context } from './context'
+import type { Context, MergedInitialContext } from './context'
 import type { Lazy } from './lazy'
 import type { Procedure } from './procedure'
 import type { AccessibleLazyRouter, EnhancedRouter, UnlaziedRouter } from './router-utils'
@@ -18,58 +18,60 @@ it('AccessibleLazyRouter', () => {
 })
 
 it('EnhancedRouter', () => {
-    type TErrorMap = { INVALID: { message: string }, OVERRIDE: { message: string } }
-    type Enhanced = EnhancedRouter<typeof router, InitialContext, TErrorMap>
+  type TErrorMap = { INVALID: { message: string }, OVERRIDE: { message: string } }
+  type InitialContext2 = { auth?: boolean, user?: string }
+  type CurrentContext2 = { auth?: boolean, user?: string, db?: string, extra?: string }
+  type Enhanced = EnhancedRouter<typeof router, InitialContext2, CurrentContext2, TErrorMap>
 
-    expectTypeOf<Enhanced['ping']>().toEqualTypeOf<
-      Lazy<
-        Procedure<
-          InitialContext,
-          CurrentContext,
-            typeof inputSchema,
-            typeof outputSchema,
-            MergedErrorMap<TErrorMap, typeof baseErrorMap>,
-            BaseMeta
-        >
-      >
-    >()
-
-    expectTypeOf<Enhanced['nested']['ping']>().toEqualTypeOf<
-      Lazy<
-        Procedure<
-          InitialContext,
-          CurrentContext,
-            typeof inputSchema,
-            typeof outputSchema,
-            MergedErrorMap<TErrorMap, typeof baseErrorMap>,
-            BaseMeta
-        >
-      >
-    >()
-
-    expectTypeOf<Enhanced['pong']>().toEqualTypeOf<
+  expectTypeOf<Enhanced['ping']>().toEqualTypeOf<
+    Lazy<
       Procedure<
-        InitialContext,
+        MergedInitialContext<InitialContext2, InitialContext, CurrentContext2>,
+        CurrentContext,
+        typeof inputSchema,
+        typeof outputSchema,
+        MergedErrorMap<TErrorMap, typeof baseErrorMap>,
+        BaseMeta
+      >
+    >
+  >()
+
+  expectTypeOf<Enhanced['nested']['ping']>().toEqualTypeOf<
+    Lazy<
+      Procedure<
+        MergedInitialContext<InitialContext2, InitialContext, CurrentContext2>,
+        CurrentContext,
+        typeof inputSchema,
+        typeof outputSchema,
+        MergedErrorMap<TErrorMap, typeof baseErrorMap>,
+        BaseMeta
+      >
+    >
+  >()
+
+  expectTypeOf<Enhanced['pong']>().toEqualTypeOf<
+    Procedure<
+      MergedInitialContext<InitialContext2, Context, CurrentContext2>,
+      Context,
+      Schema<unknown, unknown>,
+      Schema<unknown, unknown>,
+      MergedErrorMap<TErrorMap, Record<never, never>>,
+      Meta
+    >
+  >()
+
+  expectTypeOf<Enhanced['nested']['pong']>().toEqualTypeOf<
+    Lazy<
+      Procedure<
+        MergedInitialContext<InitialContext2, Context, CurrentContext2>,
         Context,
         Schema<unknown, unknown>,
         Schema<unknown, unknown>,
         MergedErrorMap<TErrorMap, Record<never, never>>,
         Meta
       >
-    >()
-
-    expectTypeOf<Enhanced['nested']['pong']>().toEqualTypeOf<
-      Lazy<
-        Procedure<
-          InitialContext,
-          Context,
-          Schema<unknown, unknown>,
-          Schema<unknown, unknown>,
-          MergedErrorMap<TErrorMap, Record<never, never>>,
-          Meta
-        >
-      >
-    >()
+    >
+  >()
 })
 
 it('UnlaziedRouter', () => {


### PR DESCRIPTION
**Bug Description:**

The procedure ignores the middleware's initial context type. It only checks that the current context meets the expected type when calling `.use`. As a result, you can accidentally pass extra or invalid context values that the middleware doesn't expect, potentially causing it to break.

**Example:**

```ts
const mid = os.$context<{ retryable?: boolean }>().middleware(({ context, next }) => {
  // Use context.retryable here
  return next();
});

const procedure = os.use(mid).handler(() => 'Hello world');
```

In this example, `procedure` does not reflect the initial context type `{ retryable?: boolean }`. It only verifies that the current context satisfies the `{ retryable?: boolean }`.

```ts
const handler = new RPCHandler(procedure);

handler.handle(request, {
  context: {
    retryable: 'any-value-can-provide' // Invalid value that may break the middleware
  }
});
```

Now, the middleware `mid` can break when it encounters unexpected context values.

---

This PR also removes the unnecessary current context check after `.use`, as we had already removed the `dedupe-middleware` logic earlier. Therefore, it is safe to remove this check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced middleware and context management for more flexible and robust API behavior.
	- Updated builder, procedure, and router interfaces to offer clearer configuration and improved type safety.
	- Simplified type definitions for middleware functions, focusing on output types and removing unnecessary constraints.

- **Tests**
	- Expanded test coverage to rigorously validate context merging and middleware configurations, ensuring accurate error handling and robust type checking.
	- Added new tests for invalid context types and refined existing tests for better clarity and type safety.
	- Restructured tests for better organization and readability, focusing on specific context handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->