### PR TITLE
refactor: add standard prefix to things in standard adapter

### DIFF
--- a/packages/client/src/adapters/fetch/rpc-link.ts
+++ b/packages/client/src/adapters/fetch/rpc-link.ts
@@ -1,17 +1,18 @@
 import type { ClientContext, ClientLink, ClientOptionsOut } from '../../types'
-import type { StandardLinkOptions, StandardRPCLinkCodecOptions } from '../standard'
+import type { StandardRPCLinkOptions } from '../standard'
 import type { LinkFetchClientOptions } from './link-fetch-client'
-import { RPCSerializer, StandardLink, StandardRPCLinkCodec } from '../standard'
+import { RPCJsonSerializer, RPCSerializer, StandardLink, StandardRPCLinkCodec } from '../standard'
 import { LinkFetchClient } from './link-fetch-client'
 
 export interface RPCLinkOptions<T extends ClientContext>
-  extends StandardLinkOptions<T>, StandardRPCLinkCodecOptions<T>, LinkFetchClientOptions<T> {}
+  extends StandardRPCLinkOptions<T>, LinkFetchClientOptions<T> {}
 
 export class RPCLink<T extends ClientContext> implements ClientLink<T> {
   private readonly standardLink: StandardLink<T>
 
   constructor(options: RPCLinkOptions<T>) {
-    const serializer = new RPCSerializer()
+    const jsonSerializer = new RPCJsonSerializer(options)
+    const serializer = new RPCSerializer(jsonSerializer)
     const linkCodec = new StandardRPCLinkCodec(serializer, options)
     const linkClient = new LinkFetchClient(options)
 

--- a/packages/client/src/adapters/fetch/rpc-link.ts
+++ b/packages/client/src/adapters/fetch/rpc-link.ts
@@ -1,7 +1,7 @@
 import type { ClientContext, ClientLink, ClientOptionsOut } from '../../types'
 import type { StandardRPCLinkOptions } from '../standard'
 import type { LinkFetchClientOptions } from './link-fetch-client'
-import { RPCJsonSerializer, RPCSerializer, StandardLink, StandardRPCLinkCodec } from '../standard'
+import { StandardLink, StandardRPCJsonSerializer, StandardRPCLinkCodec, StandardRPCSerializer } from '../standard'
 import { LinkFetchClient } from './link-fetch-client'
 
 export interface RPCLinkOptions<T extends ClientContext>
@@ -11,8 +11,8 @@ export class RPCLink<T extends ClientContext> implements ClientLink<T> {
   private readonly standardLink: StandardLink<T>
 
   constructor(options: RPCLinkOptions<T>) {
-    const jsonSerializer = new RPCJsonSerializer(options)
-    const serializer = new RPCSerializer(jsonSerializer)
+    const jsonSerializer = new StandardRPCJsonSerializer(options)
+    const serializer = new StandardRPCSerializer(jsonSerializer)
     const linkCodec = new StandardRPCLinkCodec(serializer, options)
     const linkClient = new LinkFetchClient(options)
 

--- a/packages/client/src/adapters/standard/index.ts
+++ b/packages/client/src/adapters/standard/index.ts
@@ -1,5 +1,6 @@
 export * from './link'
 export * from './rpc-json-serializer'
+export * from './rpc-link'
 export * from './rpc-link-codec'
 export * from './rpc-serializer'
 export * from './types'

--- a/packages/client/src/adapters/standard/rpc-json-serializer.ts
+++ b/packages/client/src/adapters/standard/rpc-json-serializer.ts
@@ -13,7 +13,13 @@ export type RPCJsonSerializedMeta = [
 ][]
 export type RPCJsonSerialized = [json: unknown, meta: RPCJsonSerializedMeta, maps: Segment[][], blobs: Blob[]]
 
+export interface RPCJsonSerializerOptions {
+
+}
+
 export class RPCJsonSerializer {
+  constructor(options: RPCJsonSerializerOptions = {}) {}
+
   serialize(data: unknown, segments: Segment[] = [], meta: RPCJsonSerializedMeta = [], maps: Segment[][] = [], blobs: Blob[] = []): RPCJsonSerialized {
     if (data instanceof Blob) {
       maps.push(segments)

--- a/packages/client/src/adapters/standard/rpc-json-serializer.ts
+++ b/packages/client/src/adapters/standard/rpc-json-serializer.ts
@@ -13,12 +13,12 @@ export type RPCJsonSerializedMeta = [
 ][]
 export type RPCJsonSerialized = [json: unknown, meta: RPCJsonSerializedMeta, maps: Segment[][], blobs: Blob[]]
 
-export interface RPCJsonSerializerOptions {
+export interface StandardRPCJsonSerializerOptions {
 
 }
 
-export class RPCJsonSerializer {
-  constructor(options: RPCJsonSerializerOptions = {}) {}
+export class StandardRPCJsonSerializer {
+  constructor(_options: StandardRPCJsonSerializerOptions = {}) {}
 
   serialize(data: unknown, segments: Segment[] = [], meta: RPCJsonSerializedMeta = [], maps: Segment[][] = [], blobs: Blob[] = []): RPCJsonSerialized {
     if (data instanceof Blob) {

--- a/packages/client/src/adapters/standard/rpc-link-codec.test.ts
+++ b/packages/client/src/adapters/standard/rpc-link-codec.test.ts
@@ -1,14 +1,14 @@
 import { ORPCError } from '../../error'
-import { RPCJsonSerializer } from './rpc-json-serializer'
+import { StandardRPCJsonSerializer } from './rpc-json-serializer'
 import { StandardRPCLinkCodec } from './rpc-link-codec'
-import { RPCSerializer } from './rpc-serializer'
+import { StandardRPCSerializer } from './rpc-serializer'
 
 beforeEach(() => {
   vi.clearAllMocks()
 })
 
 describe('standardRPCLinkCodec', () => {
-  const serializer = new RPCSerializer(new RPCJsonSerializer())
+  const serializer = new StandardRPCSerializer(new StandardRPCJsonSerializer())
 
   const serializeSpy = vi.spyOn(serializer, 'serialize')
   const deserializeSpy = vi.spyOn(serializer, 'deserialize')

--- a/packages/client/src/adapters/standard/rpc-link-codec.test.ts
+++ b/packages/client/src/adapters/standard/rpc-link-codec.test.ts
@@ -1,4 +1,5 @@
 import { ORPCError } from '../../error'
+import { RPCJsonSerializer } from './rpc-json-serializer'
 import { StandardRPCLinkCodec } from './rpc-link-codec'
 import { RPCSerializer } from './rpc-serializer'
 
@@ -7,7 +8,7 @@ beforeEach(() => {
 })
 
 describe('standardRPCLinkCodec', () => {
-  const serializer = new RPCSerializer()
+  const serializer = new RPCSerializer(new RPCJsonSerializer())
 
   const serializeSpy = vi.spyOn(serializer, 'serialize')
   const deserializeSpy = vi.spyOn(serializer, 'deserialize')

--- a/packages/client/src/adapters/standard/rpc-link-codec.ts
+++ b/packages/client/src/adapters/standard/rpc-link-codec.ts
@@ -1,6 +1,6 @@
 import type { StandardHeaders, StandardLazyResponse, StandardRequest } from '@orpc/standard-server'
 import type { ClientContext, ClientOptionsOut } from '../../types'
-import type { RPCSerializer } from './rpc-serializer'
+import type { StandardRPCSerializer } from './rpc-serializer'
 import type { StandardLinkCodec } from './types'
 import { isAsyncIteratorObject, stringifyJSON, trim, value, type Value } from '@orpc/shared'
 import { ORPCError } from '../../error'
@@ -65,7 +65,7 @@ export class StandardRPCLinkCodec<T extends ClientContext> implements StandardLi
   private readonly headers: Exclude<StandardRPCLinkCodecOptions<T>['headers'], undefined>
 
   constructor(
-    private readonly serializer: RPCSerializer,
+    private readonly serializer: StandardRPCSerializer,
     options: StandardRPCLinkCodecOptions<T>,
   ) {
     this.baseUrl = options.url

--- a/packages/client/src/adapters/standard/rpc-link.ts
+++ b/packages/client/src/adapters/standard/rpc-link.ts
@@ -1,7 +1,7 @@
 import type { ClientContext } from '../../types'
 import type { StandardLinkOptions } from './link'
-import type { RPCJsonSerializerOptions } from './rpc-json-serializer'
+import type { StandardRPCJsonSerializerOptions } from './rpc-json-serializer'
 import type { StandardRPCLinkCodecOptions } from './rpc-link-codec'
 
 export interface StandardRPCLinkOptions<T extends ClientContext>
-  extends StandardLinkOptions<T>, StandardRPCLinkCodecOptions<T>, RPCJsonSerializerOptions {}
+  extends StandardLinkOptions<T>, StandardRPCLinkCodecOptions<T>, StandardRPCJsonSerializerOptions {}

--- a/packages/client/src/adapters/standard/rpc-link.ts
+++ b/packages/client/src/adapters/standard/rpc-link.ts
@@ -1,0 +1,7 @@
+import type { ClientContext } from '../../types'
+import type { StandardLinkOptions } from './link'
+import type { RPCJsonSerializerOptions } from './rpc-json-serializer'
+import type { StandardRPCLinkCodecOptions } from './rpc-link-codec'
+
+export interface StandardRPCLinkOptions<T extends ClientContext>
+  extends StandardLinkOptions<T>, StandardRPCLinkCodecOptions<T>, RPCJsonSerializerOptions {}

--- a/packages/client/src/adapters/standard/rpc-serializer.test.ts
+++ b/packages/client/src/adapters/standard/rpc-serializer.test.ts
@@ -2,10 +2,11 @@ import { ORPCError } from '@orpc/contract'
 import { isAsyncIteratorObject, parseEmptyableJSON } from '@orpc/shared'
 import { ErrorEvent, getEventMeta, withEventMeta } from '@orpc/standard-server'
 import { supportedDataTypes } from '../../../tests/shared'
+import { RPCJsonSerializer } from './rpc-json-serializer'
 import { RPCSerializer } from './rpc-serializer'
 
 describe.each(supportedDataTypes)('rpcSerializer: $name', ({ value, expected }) => {
-  const serializer = new RPCSerializer()
+  const serializer = new RPCSerializer(new RPCJsonSerializer())
 
   function serializeAndDeserialize(value: unknown): unknown {
     const serialized = serializer.serialize(value)
@@ -61,7 +62,7 @@ describe.each(supportedDataTypes)('rpcSerializer: $name', ({ value, expected }) 
 })
 
 describe('rpcSerializer: event iterator', async () => {
-  const serializer = new RPCSerializer()
+  const serializer = new RPCSerializer(new RPCJsonSerializer())
 
   function serializeAndDeserialize(value: unknown): unknown {
     const serialized = serializer.serialize(value)

--- a/packages/client/src/adapters/standard/rpc-serializer.test.ts
+++ b/packages/client/src/adapters/standard/rpc-serializer.test.ts
@@ -2,11 +2,11 @@ import { ORPCError } from '@orpc/contract'
 import { isAsyncIteratorObject, parseEmptyableJSON } from '@orpc/shared'
 import { ErrorEvent, getEventMeta, withEventMeta } from '@orpc/standard-server'
 import { supportedDataTypes } from '../../../tests/shared'
-import { RPCJsonSerializer } from './rpc-json-serializer'
-import { RPCSerializer } from './rpc-serializer'
+import { StandardRPCJsonSerializer } from './rpc-json-serializer'
+import { StandardRPCSerializer } from './rpc-serializer'
 
-describe.each(supportedDataTypes)('rpcSerializer: $name', ({ value, expected }) => {
-  const serializer = new RPCSerializer(new RPCJsonSerializer())
+describe.each(supportedDataTypes)('standardRPCSerializer: $name', ({ value, expected }) => {
+  const serializer = new StandardRPCSerializer(new StandardRPCJsonSerializer())
 
   function serializeAndDeserialize(value: unknown): unknown {
     const serialized = serializer.serialize(value)
@@ -61,8 +61,8 @@ describe.each(supportedDataTypes)('rpcSerializer: $name', ({ value, expected }) 
   })
 })
 
-describe('rpcSerializer: event iterator', async () => {
-  const serializer = new RPCSerializer(new RPCJsonSerializer())
+describe('standardRPCSerializer: event iterator', async () => {
+  const serializer = new StandardRPCSerializer(new StandardRPCJsonSerializer())
 
   function serializeAndDeserialize(value: unknown): unknown {
     const serialized = serializer.serialize(value)

--- a/packages/client/src/adapters/standard/rpc-serializer.ts
+++ b/packages/client/src/adapters/standard/rpc-serializer.ts
@@ -1,12 +1,12 @@
+import type { RPCJsonSerializer } from './rpc-json-serializer'
 import { isAsyncIteratorObject, stringifyJSON } from '@orpc/shared'
 import { ErrorEvent } from '@orpc/standard-server'
 import { ORPCError, toORPCError } from '../../error'
 import { mapEventIterator } from '../../event-iterator'
-import { RPCJsonSerializer } from './rpc-json-serializer'
 
 export class RPCSerializer {
   constructor(
-    private readonly jsonSerializer: RPCJsonSerializer = new RPCJsonSerializer(),
+    private readonly jsonSerializer: RPCJsonSerializer,
   ) {}
 
   serialize(data: unknown): unknown {

--- a/packages/client/src/adapters/standard/rpc-serializer.ts
+++ b/packages/client/src/adapters/standard/rpc-serializer.ts
@@ -1,12 +1,12 @@
-import type { RPCJsonSerializer } from './rpc-json-serializer'
+import type { StandardRPCJsonSerializer } from './rpc-json-serializer'
 import { isAsyncIteratorObject, stringifyJSON } from '@orpc/shared'
 import { ErrorEvent } from '@orpc/standard-server'
 import { ORPCError, toORPCError } from '../../error'
 import { mapEventIterator } from '../../event-iterator'
 
-export class RPCSerializer {
+export class StandardRPCSerializer {
   constructor(
-    private readonly jsonSerializer: RPCJsonSerializer,
+    private readonly jsonSerializer: StandardRPCJsonSerializer,
   ) {}
 
   serialize(data: unknown): unknown {

--- a/packages/openapi-client/src/adapters/standard/bracket-notation.test.ts
+++ b/packages/openapi-client/src/adapters/standard/bracket-notation.test.ts
@@ -1,7 +1,7 @@
-import { BracketNotationSerializer } from './bracket-notation'
+import { StandardBracketNotationSerializer } from './bracket-notation'
 
-describe('bracketNotation', () => {
-  const serializer = new BracketNotationSerializer()
+describe('standardBracketNotationSerializer', () => {
+  const serializer = new StandardBracketNotationSerializer()
 
   it('.stringifyPath', () => {
     expect(serializer.stringifyPath([])).toBe('')

--- a/packages/openapi-client/src/adapters/standard/bracket-notation.ts
+++ b/packages/openapi-client/src/adapters/standard/bracket-notation.ts
@@ -1,9 +1,9 @@
 import { isObject, type Segment } from '@orpc/shared'
 
-export type BracketNotationSerialized = [string, unknown][]
+export type StandardBracketNotationSerialized = [string, unknown][]
 
-export class BracketNotationSerializer {
-  serialize(data: unknown, segments: Segment[] = [], result: BracketNotationSerialized = []): BracketNotationSerialized {
+export class StandardBracketNotationSerializer {
+  serialize(data: unknown, segments: Segment[] = [], result: StandardBracketNotationSerialized = []): StandardBracketNotationSerialized {
     if (Array.isArray(data)) {
       data.forEach((item, i) => {
         this.serialize(item, [...segments, i], result)
@@ -23,7 +23,7 @@ export class BracketNotationSerializer {
     return result
   }
 
-  deserialize(serialized: BracketNotationSerialized): Record<string, unknown> | unknown[] {
+  deserialize(serialized: StandardBracketNotationSerialized): Record<string, unknown> | unknown[] {
     if (serialized.length === 0) {
       return {}
     }

--- a/packages/openapi-client/src/adapters/standard/openapi-json-serializer.ts
+++ b/packages/openapi-client/src/adapters/standard/openapi-json-serializer.ts
@@ -1,9 +1,9 @@
 import { isObject } from '@orpc/shared'
 
-export type OpenAPIJsonSerialized = [json: unknown, hasBlob: boolean]
+export type StandardOpenAPIJsonSerialized = [json: unknown, hasBlob: boolean]
 
-export class OpenAPIJsonSerializer {
-  serialize(data: unknown, hasBlobRef: { value: boolean } = { value: false }): OpenAPIJsonSerialized {
+export class StandardOpenAPIJsonSerializer {
+  serialize(data: unknown, hasBlobRef: { value: boolean } = { value: false }): StandardOpenAPIJsonSerialized {
     if (data instanceof Blob) {
       hasBlobRef.value = true
       return [data, hasBlobRef.value]

--- a/packages/openapi-client/src/adapters/standard/openapi-serializer.test.ts
+++ b/packages/openapi-client/src/adapters/standard/openapi-serializer.test.ts
@@ -1,5 +1,6 @@
 import { ORPCError } from '@orpc/contract'
 import { ErrorEvent, getEventMeta, withEventMeta } from '@orpc/standard-server'
+import { BracketNotationSerializer } from './bracket-notation'
 import { OpenAPIJsonSerializer } from './openapi-json-serializer'
 import { OpenAPISerializer } from './openapi-serializer'
 
@@ -13,7 +14,7 @@ describe('openAPISerializer', () => {
 
   const openapiSerializer = new OpenAPISerializer({
     serialize,
-  } as any)
+  } as any, new BracketNotationSerializer())
 
   describe('.serialize', () => {
     it('with undefined', () => {
@@ -344,9 +345,5 @@ describe('openAPISerializer', () => {
         })
       })
     })
-  })
-
-  it('fallback to JSONSerializer', async () => {
-    const openapiSerializer = new OpenAPISerializer()
   })
 })

--- a/packages/openapi-client/src/adapters/standard/openapi-serializer.test.ts
+++ b/packages/openapi-client/src/adapters/standard/openapi-serializer.test.ts
@@ -1,20 +1,20 @@
 import { ORPCError } from '@orpc/contract'
 import { ErrorEvent, getEventMeta, withEventMeta } from '@orpc/standard-server'
-import { BracketNotationSerializer } from './bracket-notation'
-import { OpenAPIJsonSerializer } from './openapi-json-serializer'
-import { OpenAPISerializer } from './openapi-serializer'
+import { StandardBracketNotationSerializer } from './bracket-notation'
+import { StandardOpenAPIJsonSerializer } from './openapi-json-serializer'
+import { StandardOpenAPISerializer } from './openapi-serializer'
 
 beforeEach(() => {
   vi.clearAllMocks()
 })
 
-describe('openAPISerializer', () => {
-  const jsonSerializer = new OpenAPIJsonSerializer()
+describe('standardOpenAPIJsonSerializer', () => {
+  const jsonSerializer = new StandardOpenAPIJsonSerializer()
   const serialize = vi.fn(v => jsonSerializer.serialize(v))
 
-  const openapiSerializer = new OpenAPISerializer({
+  const openapiSerializer = new StandardOpenAPISerializer({
     serialize,
-  } as any, new BracketNotationSerializer())
+  } as any, new StandardBracketNotationSerializer())
 
   describe('.serialize', () => {
     it('with undefined', () => {

--- a/packages/openapi-client/src/adapters/standard/openapi-serializer.ts
+++ b/packages/openapi-client/src/adapters/standard/openapi-serializer.ts
@@ -1,13 +1,13 @@
-import type { BracketNotationSerializer } from './bracket-notation'
-import type { OpenAPIJsonSerializer } from './openapi-json-serializer'
+import type { StandardBracketNotationSerializer } from './bracket-notation'
+import type { StandardOpenAPIJsonSerializer } from './openapi-json-serializer'
 import { mapEventIterator, ORPCError, toORPCError } from '@orpc/client'
 import { isAsyncIteratorObject } from '@orpc/shared'
 import { ErrorEvent } from '@orpc/standard-server'
 
-export class OpenAPISerializer {
+export class StandardOpenAPISerializer {
   constructor(
-    private readonly jsonSerializer: OpenAPIJsonSerializer,
-    private readonly bracketNotation: BracketNotationSerializer,
+    private readonly jsonSerializer: StandardOpenAPIJsonSerializer,
+    private readonly bracketNotation: StandardBracketNotationSerializer,
   ) {
   }
 

--- a/packages/openapi-client/src/adapters/standard/openapi-serializer.ts
+++ b/packages/openapi-client/src/adapters/standard/openapi-serializer.ts
@@ -1,13 +1,13 @@
+import type { BracketNotationSerializer } from './bracket-notation'
+import type { OpenAPIJsonSerializer } from './openapi-json-serializer'
 import { mapEventIterator, ORPCError, toORPCError } from '@orpc/client'
 import { isAsyncIteratorObject } from '@orpc/shared'
 import { ErrorEvent } from '@orpc/standard-server'
-import { BracketNotationSerializer } from './bracket-notation'
-import { OpenAPIJsonSerializer } from './openapi-json-serializer'
 
 export class OpenAPISerializer {
   constructor(
-    private readonly jsonSerializer = new OpenAPIJsonSerializer(),
-    private readonly bracketNotation = new BracketNotationSerializer(),
+    private readonly jsonSerializer: OpenAPIJsonSerializer,
+    private readonly bracketNotation: BracketNotationSerializer,
   ) {
   }
 

--- a/packages/openapi/src/adapters/fetch/openapi-handler.ts
+++ b/packages/openapi/src/adapters/fetch/openapi-handler.ts
@@ -1,20 +1,23 @@
 import type { Context, Router } from '@orpc/server'
 import type { FetchHandler, FetchHandleResult } from '@orpc/server/fetch'
-import type { StandardHandleOptions, StandardHandlerOptions } from '@orpc/server/standard'
+import type { StandardHandleOptions } from '@orpc/server/standard'
 import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { ToFetchResponseOptions } from '@orpc/standard-server-fetch'
-import { OpenAPISerializer } from '@orpc/openapi-client/standard'
+import type { StandardOpenAPIHandlerOptions } from '../standard'
+import { BracketNotationSerializer, OpenAPIJsonSerializer, OpenAPISerializer } from '@orpc/openapi-client/standard'
 import { StandardHandler } from '@orpc/server/standard'
 import { toFetchResponse, toStandardLazyRequest } from '@orpc/standard-server-fetch'
-import { OpenAPICodec, OpenAPIMatcher } from '../standard'
+import { StandardOpenAPICodec, StandardOpenAPIMatcher } from '../standard'
 
 export class OpenAPIHandler<T extends Context> implements FetchHandler<T> {
   private readonly standardHandler: StandardHandler<T>
 
-  constructor(router: Router<any, T>, options: NoInfer<StandardHandlerOptions<T>> = {}) {
-    const serializer = new OpenAPISerializer()
-    const matcher = new OpenAPIMatcher()
-    const codec = new OpenAPICodec(serializer)
+  constructor(router: Router<any, T>, options: NoInfer<StandardOpenAPIHandlerOptions<T>> = {}) {
+    const jsonSerializer = new OpenAPIJsonSerializer()
+    const bracketNotationSerializer = new BracketNotationSerializer()
+    const serializer = new OpenAPISerializer(jsonSerializer, bracketNotationSerializer)
+    const matcher = new StandardOpenAPIMatcher()
+    const codec = new StandardOpenAPICodec(serializer)
 
     this.standardHandler = new StandardHandler(router, matcher, codec, options)
   }

--- a/packages/openapi/src/adapters/fetch/openapi-handler.ts
+++ b/packages/openapi/src/adapters/fetch/openapi-handler.ts
@@ -4,7 +4,7 @@ import type { StandardHandleOptions } from '@orpc/server/standard'
 import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { ToFetchResponseOptions } from '@orpc/standard-server-fetch'
 import type { StandardOpenAPIHandlerOptions } from '../standard'
-import { BracketNotationSerializer, OpenAPIJsonSerializer, OpenAPISerializer } from '@orpc/openapi-client/standard'
+import { StandardBracketNotationSerializer, StandardOpenAPIJsonSerializer, StandardOpenAPISerializer } from '@orpc/openapi-client/standard'
 import { StandardHandler } from '@orpc/server/standard'
 import { toFetchResponse, toStandardLazyRequest } from '@orpc/standard-server-fetch'
 import { StandardOpenAPICodec, StandardOpenAPIMatcher } from '../standard'
@@ -13,9 +13,9 @@ export class OpenAPIHandler<T extends Context> implements FetchHandler<T> {
   private readonly standardHandler: StandardHandler<T>
 
   constructor(router: Router<any, T>, options: NoInfer<StandardOpenAPIHandlerOptions<T>> = {}) {
-    const jsonSerializer = new OpenAPIJsonSerializer()
-    const bracketNotationSerializer = new BracketNotationSerializer()
-    const serializer = new OpenAPISerializer(jsonSerializer, bracketNotationSerializer)
+    const jsonSerializer = new StandardOpenAPIJsonSerializer()
+    const bracketNotationSerializer = new StandardBracketNotationSerializer()
+    const serializer = new StandardOpenAPISerializer(jsonSerializer, bracketNotationSerializer)
     const matcher = new StandardOpenAPIMatcher()
     const codec = new StandardOpenAPICodec(serializer)
 

--- a/packages/openapi/src/adapters/node/openapi-handler.ts
+++ b/packages/openapi/src/adapters/node/openapi-handler.ts
@@ -1,20 +1,23 @@
 import type { Context, Router } from '@orpc/server'
 import type { NodeHttpHandler, NodeHttpHandleResult, NodeHttpRequest, NodeHttpResponse } from '@orpc/server/node'
-import type { StandardHandleOptions, StandardHandlerOptions } from '@orpc/server/standard'
+import type { StandardHandleOptions } from '@orpc/server/standard'
 import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { SendStandardResponseOptions } from '@orpc/standard-server-node'
-import { OpenAPISerializer } from '@orpc/openapi-client/standard'
+import type { StandardOpenAPIHandlerOptions } from '../standard'
+import { BracketNotationSerializer, OpenAPIJsonSerializer, OpenAPISerializer } from '@orpc/openapi-client/standard'
 import { StandardHandler } from '@orpc/server/standard'
 import { sendStandardResponse, toStandardLazyRequest } from '@orpc/standard-server-node'
-import { OpenAPICodec, OpenAPIMatcher } from '../standard'
+import { StandardOpenAPICodec, StandardOpenAPIMatcher } from '../standard'
 
 export class OpenAPIHandler<T extends Context> implements NodeHttpHandler<T> {
   private readonly standardHandler: StandardHandler<T>
 
-  constructor(router: Router<any, T>, options: NoInfer<StandardHandlerOptions<T>> = {}) {
-    const serializer = new OpenAPISerializer()
-    const matcher = new OpenAPIMatcher()
-    const codec = new OpenAPICodec(serializer)
+  constructor(router: Router<any, T>, options: NoInfer<StandardOpenAPIHandlerOptions<T>> = {}) {
+    const jsonSerializer = new OpenAPIJsonSerializer()
+    const bracketNotationSerializer = new BracketNotationSerializer()
+    const serializer = new OpenAPISerializer(jsonSerializer, bracketNotationSerializer)
+    const matcher = new StandardOpenAPIMatcher()
+    const codec = new StandardOpenAPICodec(serializer)
 
     this.standardHandler = new StandardHandler(router, matcher, codec, options)
   }

--- a/packages/openapi/src/adapters/node/openapi-handler.ts
+++ b/packages/openapi/src/adapters/node/openapi-handler.ts
@@ -4,7 +4,7 @@ import type { StandardHandleOptions } from '@orpc/server/standard'
 import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { SendStandardResponseOptions } from '@orpc/standard-server-node'
 import type { StandardOpenAPIHandlerOptions } from '../standard'
-import { BracketNotationSerializer, OpenAPIJsonSerializer, OpenAPISerializer } from '@orpc/openapi-client/standard'
+import { StandardBracketNotationSerializer, StandardOpenAPIJsonSerializer, StandardOpenAPISerializer } from '@orpc/openapi-client/standard'
 import { StandardHandler } from '@orpc/server/standard'
 import { sendStandardResponse, toStandardLazyRequest } from '@orpc/standard-server-node'
 import { StandardOpenAPICodec, StandardOpenAPIMatcher } from '../standard'
@@ -13,9 +13,9 @@ export class OpenAPIHandler<T extends Context> implements NodeHttpHandler<T> {
   private readonly standardHandler: StandardHandler<T>
 
   constructor(router: Router<any, T>, options: NoInfer<StandardOpenAPIHandlerOptions<T>> = {}) {
-    const jsonSerializer = new OpenAPIJsonSerializer()
-    const bracketNotationSerializer = new BracketNotationSerializer()
-    const serializer = new OpenAPISerializer(jsonSerializer, bracketNotationSerializer)
+    const jsonSerializer = new StandardOpenAPIJsonSerializer()
+    const bracketNotationSerializer = new StandardBracketNotationSerializer()
+    const serializer = new StandardOpenAPISerializer(jsonSerializer, bracketNotationSerializer)
     const matcher = new StandardOpenAPIMatcher()
     const codec = new StandardOpenAPICodec(serializer)
 

--- a/packages/openapi/src/adapters/standard/index.ts
+++ b/packages/openapi/src/adapters/standard/index.ts
@@ -1,3 +1,4 @@
 export * from './openapi-codec'
+export * from './openapi-handler'
 export * from './openapi-matcher'
 export * from './utils'

--- a/packages/openapi/src/adapters/standard/openapi-codec.test.ts
+++ b/packages/openapi/src/adapters/standard/openapi-codec.test.ts
@@ -1,19 +1,19 @@
 import { ORPCError } from '@orpc/contract'
 import { Procedure } from '@orpc/server'
 import { ping } from '../../../../server/tests/shared'
-import { OpenAPICodec } from './openapi-codec'
+import { StandardOpenAPICodec } from './openapi-codec'
 
 beforeEach(() => {
   vi.clearAllMocks()
 })
 
-describe('openAPICodec', () => {
+describe('standardOpenAPICodec', () => {
   const serializer = {
     serialize: vi.fn(),
     deserialize: vi.fn(),
   } as any
 
-  const codec = new OpenAPICodec(serializer)
+  const codec = new StandardOpenAPICodec(serializer)
 
   describe('.decode', () => {
     describe('with compact structure', () => {

--- a/packages/openapi/src/adapters/standard/openapi-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-codec.ts
@@ -6,7 +6,7 @@ import type { StandardBody, StandardHeaders, StandardLazyRequest, StandardRespon
 import { fallbackContractConfig } from '@orpc/contract'
 import { isObject } from '@orpc/shared'
 
-export class OpenAPICodec implements StandardCodec {
+export class StandardOpenAPICodec implements StandardCodec {
   constructor(
     private readonly serializer: OpenAPISerializer,
   ) {

--- a/packages/openapi/src/adapters/standard/openapi-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-codec.ts
@@ -1,5 +1,5 @@
 import type { ORPCError } from '@orpc/client'
-import type { OpenAPISerializer } from '@orpc/openapi-client/standard'
+import type { StandardOpenAPISerializer } from '@orpc/openapi-client/standard'
 import type { AnyProcedure } from '@orpc/server'
 import type { StandardCodec, StandardParams } from '@orpc/server/standard'
 import type { StandardBody, StandardHeaders, StandardLazyRequest, StandardResponse } from '@orpc/standard-server'
@@ -8,7 +8,7 @@ import { isObject } from '@orpc/shared'
 
 export class StandardOpenAPICodec implements StandardCodec {
   constructor(
-    private readonly serializer: OpenAPISerializer,
+    private readonly serializer: StandardOpenAPISerializer,
   ) {
   }
 

--- a/packages/openapi/src/adapters/standard/openapi-handler.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler.ts
@@ -1,0 +1,4 @@
+import type { Context } from '@orpc/server'
+import type { StandardHandlerOptions } from '@orpc/server/standard'
+
+export interface StandardOpenAPIHandlerOptions<T extends Context> extends StandardHandlerOptions<T> {}

--- a/packages/openapi/src/adapters/standard/openapi-matcher.test.ts
+++ b/packages/openapi/src/adapters/standard/openapi-matcher.test.ts
@@ -1,7 +1,7 @@
 import { implement, lazy, os, Procedure, unlazy } from '@orpc/server'
 import { router as contract } from '../../../../contract/tests/shared'
 import { ping, pong } from '../../../../server/tests/shared'
-import { OpenAPIMatcher } from './openapi-matcher'
+import { StandardOpenAPIMatcher } from './openapi-matcher'
 
 const routedPing = new Procedure({
   ...ping['~orpc'],
@@ -30,9 +30,9 @@ const router = {
   })),
 }
 
-describe('openapiMatcher', () => {
+describe('standardOpenAPIMatcher', () => {
   it('with router', async () => {
-    const rpcMatcher = new OpenAPIMatcher()
+    const rpcMatcher = new StandardOpenAPIMatcher()
     rpcMatcher.init(router)
 
     expect(await rpcMatcher.match('POST', '/base')).toEqual({
@@ -62,7 +62,7 @@ describe('openapiMatcher', () => {
   })
 
   it('with implemented router', async () => {
-    const rpcMatcher = new OpenAPIMatcher()
+    const rpcMatcher = new StandardOpenAPIMatcher()
     rpcMatcher.init(implement(contract).$context<any>().router({
       ...router,
       pong: new Procedure({
@@ -99,7 +99,7 @@ describe('openapiMatcher', () => {
   })
 
   it('with missing implementation', async () => {
-    const rpcMatcher = new OpenAPIMatcher()
+    const rpcMatcher = new StandardOpenAPIMatcher()
     rpcMatcher.init(implement(contract).$context<any>().router({
       ...router,
       pong: undefined as any, // missing here
@@ -126,7 +126,7 @@ describe('openapiMatcher', () => {
     const pingLoader = vi.fn(() => Promise.resolve({ default: ping }))
     const pongLoader = vi.fn(() => Promise.resolve({ default: pong }))
 
-    const rpcMatcher = new OpenAPIMatcher()
+    const rpcMatcher = new StandardOpenAPIMatcher()
 
     const base = os.$context<any>()
 
@@ -210,7 +210,7 @@ describe('openapiMatcher', () => {
       },
     })
 
-    const rpcMatcher = new OpenAPIMatcher()
+    const rpcMatcher = new StandardOpenAPIMatcher()
     rpcMatcher.init({ ping1, ping2, ping3 })
 
     expect(await rpcMatcher.match('GET', '/ping/unnoq%2F')).toEqual({

--- a/packages/openapi/src/adapters/standard/openapi-matcher.ts
+++ b/packages/openapi/src/adapters/standard/openapi-matcher.ts
@@ -5,7 +5,7 @@ import { createContractedProcedure, getLazyMeta, getRouter, isProcedure, toHttpP
 import { addRoute, createRouter, findRoute } from 'rou3'
 import { decodeParams, toRou3Pattern } from './utils'
 
-export class OpenAPIMatcher implements StandardMatcher {
+export class StandardOpenAPIMatcher implements StandardMatcher {
   private readonly tree = createRouter<{
     path: readonly string[]
     contract: AnyContractProcedure

--- a/packages/openapi/src/openapi-generator.ts
+++ b/packages/openapi/src/openapi-generator.ts
@@ -3,7 +3,7 @@ import type { OpenAPI } from './openapi'
 import type { JSONSchema } from './schema'
 import { fallbackORPCErrorMessage, fallbackORPCErrorStatus } from '@orpc/client'
 import { fallbackContractConfig, getEventIteratorSchemaDetails } from '@orpc/contract'
-import { OpenAPIJsonSerializer } from '@orpc/openapi-client/standard'
+import { StandardOpenAPIJsonSerializer } from '@orpc/openapi-client/standard'
 import { type AnyRouter, toHttpPath } from '@orpc/server'
 import { resolveContractProcedures } from '@orpc/server'
 import { clone } from '@orpc/shared'
@@ -19,11 +19,11 @@ export interface OpenAPIGeneratorOptions {
 }
 
 export class OpenAPIGenerator {
-  private readonly serializer: OpenAPIJsonSerializer
+  private readonly serializer: StandardOpenAPIJsonSerializer
   private readonly converter: SchemaConverter
 
   constructor(options: OpenAPIGeneratorOptions = {}) {
-    this.serializer = new OpenAPIJsonSerializer()
+    this.serializer = new StandardOpenAPIJsonSerializer()
     this.converter = new CompositeSchemaConverter(options.schemaConverters ?? [])
   }
 

--- a/packages/openapi/src/openapi-generator.ts
+++ b/packages/openapi/src/openapi-generator.ts
@@ -3,7 +3,7 @@ import type { OpenAPI } from './openapi'
 import type { JSONSchema } from './schema'
 import { fallbackORPCErrorMessage, fallbackORPCErrorStatus } from '@orpc/client'
 import { fallbackContractConfig, getEventIteratorSchemaDetails } from '@orpc/contract'
-import { OpenAPISerializer } from '@orpc/openapi-client/standard'
+import { OpenAPIJsonSerializer } from '@orpc/openapi-client/standard'
 import { type AnyRouter, toHttpPath } from '@orpc/server'
 import { resolveContractProcedures } from '@orpc/server'
 import { clone } from '@orpc/shared'
@@ -19,11 +19,11 @@ export interface OpenAPIGeneratorOptions {
 }
 
 export class OpenAPIGenerator {
-  private readonly serializer: OpenAPISerializer
+  private readonly serializer: OpenAPIJsonSerializer
   private readonly converter: SchemaConverter
 
   constructor(options: OpenAPIGeneratorOptions = {}) {
-    this.serializer = new OpenAPISerializer()
+    this.serializer = new OpenAPIJsonSerializer()
     this.converter = new CompositeSchemaConverter(options.schemaConverters ?? [])
   }
 
@@ -75,7 +75,7 @@ export class OpenAPIGenerator {
       )
     }
 
-    return this.serializer.serialize(doc) as OpenAPI.Document
+    return this.serializer.serialize(doc)[0] as OpenAPI.Document
   }
 
   #request(ref: OpenAPI.OperationObject, def: AnyContractProcedure['~orpc']): void {

--- a/packages/server/src/adapters/fetch/rpc-handler.test.ts
+++ b/packages/server/src/adapters/fetch/rpc-handler.test.ts
@@ -1,7 +1,7 @@
-import { RPCSerializer } from '@orpc/client/standard'
+import { RPCJsonSerializer, RPCSerializer } from '@orpc/client/standard'
 import { toFetchResponse, toStandardLazyRequest } from '@orpc/standard-server-fetch'
 import { router } from '../../../tests/shared'
-import { RPCCodec, RPCMatcher, StandardHandler } from '../standard'
+import { StandardHandler, StandardRPCCodec, StandardRPCMatcher } from '../standard'
 import { RPCHandler } from './rpc-handler'
 
 vi.mock('../standard', async origin => ({
@@ -92,8 +92,8 @@ describe('rpcHandler', () => {
 
   it('standardHandler constructor', async () => {
     const options = {
-      codec: new RPCCodec(new RPCSerializer()),
-      matcher: new RPCMatcher(),
+      codec: new StandardRPCCodec(new RPCSerializer(new RPCJsonSerializer())),
+      matcher: new StandardRPCMatcher(),
       interceptors: [vi.fn()],
     }
 

--- a/packages/server/src/adapters/fetch/rpc-handler.test.ts
+++ b/packages/server/src/adapters/fetch/rpc-handler.test.ts
@@ -1,4 +1,4 @@
-import { RPCJsonSerializer, RPCSerializer } from '@orpc/client/standard'
+import { StandardRPCJsonSerializer, StandardRPCSerializer } from '@orpc/client/standard'
 import { toFetchResponse, toStandardLazyRequest } from '@orpc/standard-server-fetch'
 import { router } from '../../../tests/shared'
 import { StandardHandler, StandardRPCCodec, StandardRPCMatcher } from '../standard'
@@ -92,7 +92,7 @@ describe('rpcHandler', () => {
 
   it('standardHandler constructor', async () => {
     const options = {
-      codec: new StandardRPCCodec(new RPCSerializer(new RPCJsonSerializer())),
+      codec: new StandardRPCCodec(new StandardRPCSerializer(new StandardRPCJsonSerializer())),
       matcher: new StandardRPCMatcher(),
       interceptors: [vi.fn()],
     }

--- a/packages/server/src/adapters/fetch/rpc-handler.ts
+++ b/packages/server/src/adapters/fetch/rpc-handler.ts
@@ -2,19 +2,20 @@ import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { ToFetchResponseOptions } from '@orpc/standard-server-fetch'
 import type { Context } from '../../context'
 import type { Router } from '../../router'
-import type { StandardHandleOptions, StandardHandlerOptions } from '../standard'
+import type { StandardHandleOptions, StandardRPCHandlerOptions } from '../standard'
 import type { FetchHandler, FetchHandleResult } from './types'
-import { RPCSerializer } from '@orpc/client/standard'
+import { RPCJsonSerializer, RPCSerializer } from '@orpc/client/standard'
 import { toFetchResponse, toStandardLazyRequest } from '@orpc/standard-server-fetch'
-import { RPCCodec, RPCMatcher, StandardHandler } from '../standard'
+import { StandardHandler, StandardRPCCodec, StandardRPCMatcher } from '../standard'
 
 export class RPCHandler<T extends Context> implements FetchHandler<T> {
   private readonly standardHandler: StandardHandler<T>
 
-  constructor(router: Router<any, T>, options: NoInfer<StandardHandlerOptions<T>> = {}) {
-    const serializer = new RPCSerializer()
-    const matcher = new RPCMatcher()
-    const codec = new RPCCodec(serializer)
+  constructor(router: Router<any, T>, options: NoInfer<StandardRPCHandlerOptions<T>> = {}) {
+    const jsonSerializer = new RPCJsonSerializer(options)
+    const serializer = new RPCSerializer(jsonSerializer)
+    const matcher = new StandardRPCMatcher()
+    const codec = new StandardRPCCodec(serializer)
 
     this.standardHandler = new StandardHandler(router, matcher, codec, options)
   }

--- a/packages/server/src/adapters/fetch/rpc-handler.ts
+++ b/packages/server/src/adapters/fetch/rpc-handler.ts
@@ -4,7 +4,7 @@ import type { Context } from '../../context'
 import type { Router } from '../../router'
 import type { StandardHandleOptions, StandardRPCHandlerOptions } from '../standard'
 import type { FetchHandler, FetchHandleResult } from './types'
-import { RPCJsonSerializer, RPCSerializer } from '@orpc/client/standard'
+import { StandardRPCJsonSerializer, StandardRPCSerializer } from '@orpc/client/standard'
 import { toFetchResponse, toStandardLazyRequest } from '@orpc/standard-server-fetch'
 import { StandardHandler, StandardRPCCodec, StandardRPCMatcher } from '../standard'
 
@@ -12,8 +12,8 @@ export class RPCHandler<T extends Context> implements FetchHandler<T> {
   private readonly standardHandler: StandardHandler<T>
 
   constructor(router: Router<any, T>, options: NoInfer<StandardRPCHandlerOptions<T>> = {}) {
-    const jsonSerializer = new RPCJsonSerializer(options)
-    const serializer = new RPCSerializer(jsonSerializer)
+    const jsonSerializer = new StandardRPCJsonSerializer(options)
+    const serializer = new StandardRPCSerializer(jsonSerializer)
     const matcher = new StandardRPCMatcher()
     const codec = new StandardRPCCodec(serializer)
 

--- a/packages/server/src/adapters/node/rpc-handler.test.ts
+++ b/packages/server/src/adapters/node/rpc-handler.test.ts
@@ -1,8 +1,8 @@
-import { RPCSerializer } from '@orpc/client/standard'
+import { RPCJsonSerializer, RPCSerializer } from '@orpc/client/standard'
 import { sendStandardResponse, toStandardLazyRequest } from '@orpc/standard-server-node'
 import inject from 'light-my-request'
 import { router } from '../../../tests/shared'
-import { RPCCodec, RPCMatcher, StandardHandler } from '../standard'
+import { StandardHandler, StandardRPCCodec, StandardRPCMatcher } from '../standard'
 import { RPCHandler } from './rpc-handler'
 
 vi.mock('@orpc/standard-server-node', () => ({
@@ -113,8 +113,8 @@ describe('rpcHandler', async () => {
 
   it('standardHandler constructor', async () => {
     const options = {
-      codec: new RPCCodec(new RPCSerializer()),
-      matcher: new RPCMatcher(),
+      codec: new StandardRPCCodec(new RPCSerializer(new RPCJsonSerializer())),
+      matcher: new StandardRPCMatcher(),
       interceptors: [vi.fn()],
     }
 

--- a/packages/server/src/adapters/node/rpc-handler.test.ts
+++ b/packages/server/src/adapters/node/rpc-handler.test.ts
@@ -1,4 +1,4 @@
-import { RPCJsonSerializer, RPCSerializer } from '@orpc/client/standard'
+import { StandardRPCJsonSerializer, StandardRPCSerializer } from '@orpc/client/standard'
 import { sendStandardResponse, toStandardLazyRequest } from '@orpc/standard-server-node'
 import inject from 'light-my-request'
 import { router } from '../../../tests/shared'
@@ -113,7 +113,7 @@ describe('rpcHandler', async () => {
 
   it('standardHandler constructor', async () => {
     const options = {
-      codec: new StandardRPCCodec(new RPCSerializer(new RPCJsonSerializer())),
+      codec: new StandardRPCCodec(new StandardRPCSerializer(new StandardRPCJsonSerializer())),
       matcher: new StandardRPCMatcher(),
       interceptors: [vi.fn()],
     }

--- a/packages/server/src/adapters/node/rpc-handler.ts
+++ b/packages/server/src/adapters/node/rpc-handler.ts
@@ -4,7 +4,7 @@ import type { Context } from '../../context'
 import type { Router } from '../../router'
 import type { StandardHandleOptions, StandardRPCHandlerOptions } from '../standard'
 import type { NodeHttpHandler, NodeHttpHandleResult, NodeHttpRequest, NodeHttpResponse } from './types'
-import { RPCJsonSerializer, RPCSerializer } from '@orpc/client/standard'
+import { StandardRPCJsonSerializer, StandardRPCSerializer } from '@orpc/client/standard'
 import { sendStandardResponse, toStandardLazyRequest } from '@orpc/standard-server-node'
 import { StandardHandler, StandardRPCCodec, StandardRPCMatcher } from '../standard'
 
@@ -12,8 +12,8 @@ export class RPCHandler<T extends Context> implements NodeHttpHandler<T> {
   private readonly standardHandler: StandardHandler<T>
 
   constructor(router: Router<any, T>, options: NoInfer<StandardRPCHandlerOptions<T>> = {}) {
-    const jsonSerializer = new RPCJsonSerializer(options)
-    const serializer = new RPCSerializer(jsonSerializer)
+    const jsonSerializer = new StandardRPCJsonSerializer(options)
+    const serializer = new StandardRPCSerializer(jsonSerializer)
     const matcher = new StandardRPCMatcher()
     const codec = new StandardRPCCodec(serializer)
 

--- a/packages/server/src/adapters/node/rpc-handler.ts
+++ b/packages/server/src/adapters/node/rpc-handler.ts
@@ -2,19 +2,20 @@ import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { SendStandardResponseOptions } from '@orpc/standard-server-node'
 import type { Context } from '../../context'
 import type { Router } from '../../router'
-import type { StandardHandleOptions, StandardHandlerOptions } from '../standard'
+import type { StandardHandleOptions, StandardRPCHandlerOptions } from '../standard'
 import type { NodeHttpHandler, NodeHttpHandleResult, NodeHttpRequest, NodeHttpResponse } from './types'
-import { RPCSerializer } from '@orpc/client/standard'
+import { RPCJsonSerializer, RPCSerializer } from '@orpc/client/standard'
 import { sendStandardResponse, toStandardLazyRequest } from '@orpc/standard-server-node'
-import { RPCCodec, RPCMatcher, StandardHandler } from '../standard'
+import { StandardHandler, StandardRPCCodec, StandardRPCMatcher } from '../standard'
 
 export class RPCHandler<T extends Context> implements NodeHttpHandler<T> {
   private readonly standardHandler: StandardHandler<T>
 
-  constructor(router: Router<any, T>, options: NoInfer<StandardHandlerOptions<T>> = {}) {
-    const serializer = new RPCSerializer()
-    const matcher = new RPCMatcher()
-    const codec = new RPCCodec(serializer)
+  constructor(router: Router<any, T>, options: NoInfer<StandardRPCHandlerOptions<T>> = {}) {
+    const jsonSerializer = new RPCJsonSerializer(options)
+    const serializer = new RPCSerializer(jsonSerializer)
+    const matcher = new StandardRPCMatcher()
+    const codec = new StandardRPCCodec(serializer)
 
     this.standardHandler = new StandardHandler(router, matcher, codec, options)
   }

--- a/packages/server/src/adapters/standard/index.ts
+++ b/packages/server/src/adapters/standard/index.ts
@@ -1,4 +1,5 @@
 export * from './handler'
 export * from './rpc-codec'
+export * from './rpc-handler'
 export * from './rpc-matcher'
 export * from './types'

--- a/packages/server/src/adapters/standard/rpc-codec.test.ts
+++ b/packages/server/src/adapters/standard/rpc-codec.test.ts
@@ -1,18 +1,18 @@
 import { ORPCError } from '@orpc/contract'
 import { ping } from '../../../tests/shared'
-import { RPCCodec } from './rpc-codec'
+import { StandardRPCCodec } from './rpc-codec'
 
 beforeEach(() => {
   vi.clearAllMocks()
 })
 
-describe('rpcCodec', () => {
+describe('standardRPCCodec', () => {
   const serializer = {
     serialize: vi.fn(),
     deserialize: vi.fn(),
   } as any
 
-  const codec = new RPCCodec(serializer)
+  const codec = new StandardRPCCodec(serializer)
 
   describe('.decode', () => {
     it('with GET method', async () => {

--- a/packages/server/src/adapters/standard/rpc-codec.ts
+++ b/packages/server/src/adapters/standard/rpc-codec.ts
@@ -1,5 +1,5 @@
 import type { ORPCError } from '@orpc/client'
-import type { RPCSerializer } from '@orpc/client/standard'
+import type { StandardRPCSerializer } from '@orpc/client/standard'
 import type { StandardBody, StandardLazyRequest, StandardResponse } from '@orpc/standard-server'
 import type { AnyProcedure } from '../../procedure'
 import type { StandardCodec, StandardParams } from './types'
@@ -7,7 +7,7 @@ import { parseEmptyableJSON } from '@orpc/shared'
 
 export class StandardRPCCodec implements StandardCodec {
   constructor(
-    private readonly serializer: RPCSerializer,
+    private readonly serializer: StandardRPCSerializer,
   ) {
   }
 

--- a/packages/server/src/adapters/standard/rpc-codec.ts
+++ b/packages/server/src/adapters/standard/rpc-codec.ts
@@ -5,7 +5,7 @@ import type { AnyProcedure } from '../../procedure'
 import type { StandardCodec, StandardParams } from './types'
 import { parseEmptyableJSON } from '@orpc/shared'
 
-export class RPCCodec implements StandardCodec {
+export class StandardRPCCodec implements StandardCodec {
   constructor(
     private readonly serializer: RPCSerializer,
   ) {

--- a/packages/server/src/adapters/standard/rpc-handler.ts
+++ b/packages/server/src/adapters/standard/rpc-handler.ts
@@ -1,0 +1,5 @@
+import type { RPCJsonSerializerOptions } from '@orpc/client/standard'
+import type { Context } from '../../context'
+import type { StandardHandlerOptions } from './handler'
+
+export interface StandardRPCHandlerOptions<T extends Context> extends StandardHandlerOptions<T>, RPCJsonSerializerOptions {}

--- a/packages/server/src/adapters/standard/rpc-handler.ts
+++ b/packages/server/src/adapters/standard/rpc-handler.ts
@@ -1,5 +1,5 @@
-import type { RPCJsonSerializerOptions } from '@orpc/client/standard'
+import type { StandardRPCJsonSerializerOptions } from '@orpc/client/standard'
 import type { Context } from '../../context'
 import type { StandardHandlerOptions } from './handler'
 
-export interface StandardRPCHandlerOptions<T extends Context> extends StandardHandlerOptions<T>, RPCJsonSerializerOptions {}
+export interface StandardRPCHandlerOptions<T extends Context> extends StandardHandlerOptions<T>, StandardRPCJsonSerializerOptions {}

--- a/packages/server/src/adapters/standard/rpc-matcher.test.ts
+++ b/packages/server/src/adapters/standard/rpc-matcher.test.ts
@@ -4,11 +4,11 @@ import { os } from '../../builder'
 import { implement } from '../../implementer'
 import { unlazy } from '../../lazy'
 import { Procedure } from '../../procedure'
-import { RPCMatcher } from './rpc-matcher'
+import { StandardRPCMatcher } from './rpc-matcher'
 
-describe('rpcMatcher', () => {
+describe('standardRPCMatcher', () => {
   it('with router', async () => {
-    const rpcMatcher = new RPCMatcher()
+    const rpcMatcher = new StandardRPCMatcher()
     rpcMatcher.init(router)
 
     expect(await rpcMatcher.match('ANYTHING', '/ping')).toEqual({
@@ -36,7 +36,7 @@ describe('rpcMatcher', () => {
   })
 
   it('with implemented router', async () => {
-    const rpcMatcher = new RPCMatcher()
+    const rpcMatcher = new StandardRPCMatcher()
     rpcMatcher.init(implement(contract).$context<any>().router({
       ...router,
       pong: new Procedure({
@@ -78,7 +78,7 @@ describe('rpcMatcher', () => {
   })
 
   it('with missing implementation', async () => {
-    const rpcMatcher = new RPCMatcher()
+    const rpcMatcher = new StandardRPCMatcher()
     rpcMatcher.init(implement(contract).$context<any>().router({
       ...router,
       pong: undefined as any, // missing here
@@ -110,7 +110,7 @@ describe('rpcMatcher', () => {
     const pingLoader = vi.fn(() => Promise.resolve({ default: ping }))
     const pongLoader = vi.fn(() => Promise.resolve({ default: pong }))
 
-    const rpcMatcher = new RPCMatcher()
+    const rpcMatcher = new StandardRPCMatcher()
 
     const base = os.$context<any>()
 

--- a/packages/server/src/adapters/standard/rpc-matcher.ts
+++ b/packages/server/src/adapters/standard/rpc-matcher.ts
@@ -9,7 +9,7 @@ import { createContractedProcedure } from '../../procedure-utils'
 import { getRouter, traverseContractProcedures } from '../../router-utils'
 import { toHttpPath } from '../../utils'
 
-export class RPCMatcher implements StandardMatcher {
+export class StandardRPCMatcher implements StandardMatcher {
   private readonly tree: Record<
     HTTPPath,
     {

--- a/packages/vue-colada/src/key.ts
+++ b/packages/vue-colada/src/key.ts
@@ -1,5 +1,5 @@
 import type { EntryKey } from '@pinia/colada'
-import { RPCJsonSerializer } from '@orpc/client/standard'
+import { StandardRPCJsonSerializer } from '@orpc/client/standard'
 import { stringifyJSON } from '@orpc/shared'
 
 export interface BuildKeyOptions<TInput> {
@@ -14,7 +14,7 @@ export function buildKey<TInput>(
     return path
   }
 
-  const [json, meta] = new RPCJsonSerializer().serialize(options.input)
+  const [json, meta] = new StandardRPCJsonSerializer().serialize(options.input)
 
   return [
     ...path,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined and standardized serialization, RPC, and OpenAPI interfaces for improved consistency.
- **New Exports**
  - Expanded the public API with additional export statements, simplifying access to updated functionality.
- **Tests**
  - Updated test suites to validate the new standardized components and ensure robust integration across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->