### PR TITLE
feat(client, server): custom `RPC JSON Serializer`

### DIFF
--- a/apps/content/.vitepress/config.ts
+++ b/apps/content/.vitepress/config.ts
@@ -145,7 +145,8 @@ export default defineConfig({
           items: [
             { text: 'Validation Errors', link: '/docs/advanced/validation-errors' },
             { text: 'RPC Protocol', link: '/docs/advanced/rpc-protocol' },
-            { text: 'exceeds the maximum length ...', link: '/docs/advanced/exceeds-the-maximum-length-problem' },
+            { text: 'RPC JSON Serializer', link: '/docs/advanced/rpc-json-serializer' },
+            { text: 'Exceeds the maximum length ...', link: '/docs/advanced/exceeds-the-maximum-length-problem' },
           ],
         },
         {

--- a/apps/content/docs/advanced/rpc-json-serializer.md
+++ b/apps/content/docs/advanced/rpc-json-serializer.md
@@ -43,7 +43,7 @@ Extend native types by creating your own `StandardRPCJsonCustomSerializer` and a
    ```
 
    ::: warning
-   Ensure the `type` is unique and greater than `20` to avoid conflicts with [built-in types](/docs/advanced/rpc-protocol#supported-types).
+   Ensure the `type` is unique and greater than `20` to avoid conflicts with [built-in types](/docs/advanced/rpc-protocol#supported-types) in the future.
    :::
 
 2. **Use Your Custom Serializer**

--- a/apps/content/docs/advanced/rpc-json-serializer.md
+++ b/apps/content/docs/advanced/rpc-json-serializer.md
@@ -1,0 +1,83 @@
+---
+title: RPC JSON Serializer
+description: Extend or override the standard RPC JSON serializer.
+---
+
+# RPC JSON Serializer
+
+This serializer handles JSON payloads for the [RPC Protocol](/docs/advanced/rpc-protocol) and supports [native data types](/docs/rpc-handler#supported-data-types).
+
+## Extending Native Data Types
+
+Extend native types by creating your own `StandardRPCJsonCustomSerializer` and adding it to the `customJsonSerializers` option.
+
+1. **Define Your Custom Serializer**
+
+   ```ts twoslash
+   import type { StandardRPCJsonCustomSerializer } from '@orpc/client/standard'
+
+   export class User {
+     constructor(
+       public readonly id: string,
+       public readonly name: string,
+       public readonly email: string,
+       public readonly age: number,
+     ) {}
+
+     toJSON() {
+       return {
+         id: this.id,
+         name: this.name,
+         email: this.email,
+         age: this.age,
+       }
+     }
+   }
+
+   export const userSerializer: StandardRPCJsonCustomSerializer = {
+     type: 21,
+     condition: data => data instanceof User,
+     serialize: data => data.toJSON(),
+     deserialize: data => new User(data.id, data.name, data.email, data.age),
+   }
+   ```
+
+   ::: warning
+   Ensure the `type` is unique and greater than `20` to avoid conflicts with [built-in types](/docs/advanced/rpc-protocol#supported-types).
+   :::
+
+2. **Use Your Custom Serializer**
+
+   ```ts twoslash
+   import type { StandardRPCJsonCustomSerializer } from '@orpc/client/standard'
+   import { RPCHandler } from '@orpc/server/fetch'
+   import { RPCLink } from '@orpc/client/fetch'
+   declare const router: Record<never, never>
+   declare const userSerializer: StandardRPCJsonCustomSerializer
+   // ---cut---
+   const handler = new RPCHandler(router, {
+     customJsonSerializers: [userSerializer], // [!code highlight]
+   })
+
+   const link = new RPCLink({
+     url: 'https://example.com/rpc',
+     customJsonSerializers: [userSerializer], // [!code highlight]
+   })
+   ```
+
+## Overriding Built-in Types
+
+You can override built-in types by matching their `type` with the [built-in types](/docs/advanced/rpc-protocol#supported-types).
+
+For example, oRPC represents `undefined` only in array items and ignores it in objects. To override this behavior:
+
+```ts twoslash
+import { StandardRPCJsonCustomSerializer } from '@orpc/client/standard'
+
+export const undefinedSerializer: StandardRPCJsonCustomSerializer = {
+  type: 3, // Match the built-in undefined type. [!code highlight]
+  condition: data => data === undefined,
+  serialize: data => null, // JSON cannot represent undefined, so use null.
+  deserialize: data => undefined,
+}
+```

--- a/apps/content/docs/advanced/rpc-json-serializer.md
+++ b/apps/content/docs/advanced/rpc-json-serializer.md
@@ -9,12 +9,12 @@ This serializer handles JSON payloads for the [RPC Protocol](/docs/advanced/rpc-
 
 ## Extending Native Data Types
 
-Extend native types by creating your own `StandardRPCJsonCustomSerializer` and adding it to the `customJsonSerializers` option.
+Extend native types by creating your own `StandardRPCCustomJsonSerializer` and adding it to the `customJsonSerializers` option.
 
 1. **Define Your Custom Serializer**
 
    ```ts twoslash
-   import type { StandardRPCJsonCustomSerializer } from '@orpc/client/standard'
+   import type { StandardRPCCustomJsonSerializer } from '@orpc/client/standard'
 
    export class User {
      constructor(
@@ -34,7 +34,7 @@ Extend native types by creating your own `StandardRPCJsonCustomSerializer` and a
      }
    }
 
-   export const userSerializer: StandardRPCJsonCustomSerializer = {
+   export const userSerializer: StandardRPCCustomJsonSerializer = {
      type: 21,
      condition: data => data instanceof User,
      serialize: data => data.toJSON(),
@@ -49,11 +49,11 @@ Extend native types by creating your own `StandardRPCJsonCustomSerializer` and a
 2. **Use Your Custom Serializer**
 
    ```ts twoslash
-   import type { StandardRPCJsonCustomSerializer } from '@orpc/client/standard'
+   import type { StandardRPCCustomJsonSerializer } from '@orpc/client/standard'
    import { RPCHandler } from '@orpc/server/fetch'
    import { RPCLink } from '@orpc/client/fetch'
    declare const router: Record<never, never>
-   declare const userSerializer: StandardRPCJsonCustomSerializer
+   declare const userSerializer: StandardRPCCustomJsonSerializer
    // ---cut---
    const handler = new RPCHandler(router, {
      customJsonSerializers: [userSerializer], // [!code highlight]
@@ -72,9 +72,9 @@ You can override built-in types by matching their `type` with the [built-in type
 For example, oRPC represents `undefined` only in array items and ignores it in objects. To override this behavior:
 
 ```ts twoslash
-import { StandardRPCJsonCustomSerializer } from '@orpc/client/standard'
+import { StandardRPCCustomJsonSerializer } from '@orpc/client/standard'
 
-export const undefinedSerializer: StandardRPCJsonCustomSerializer = {
+export const undefinedSerializer: StandardRPCCustomJsonSerializer = {
   type: 3, // Match the built-in undefined type. [!code highlight]
   condition: data => data === undefined,
   serialize: data => null, // JSON cannot represent undefined, so use null.

--- a/apps/content/docs/best-practices/dedupe-middleware.md
+++ b/apps/content/docs/best-practices/dedupe-middleware.md
@@ -1,6 +1,6 @@
 ---
-Title: Dedupe Middleware
-Description: Enhance oRPC middleware performance by avoiding redundant executions.
+title: Dedupe Middleware
+description: Enhance oRPC middleware performance by avoiding redundant executions.
 ---
 
 # Dedupe Middleware

--- a/apps/content/docs/lifecycle.md
+++ b/apps/content/docs/lifecycle.md
@@ -1,6 +1,6 @@
 ---
-Title: Lifecycle
-Description: Master the oRPC lifecycle to confidently implement and customize your procedures.
+title: Lifecycle
+description: Master the oRPC lifecycle to confidently implement and customize your procedures.
 ---
 
 # Lifecycle

--- a/apps/content/docs/metadata.md
+++ b/apps/content/docs/metadata.md
@@ -1,6 +1,6 @@
 ---
-Title: Metadata
-Description: Enhance your procedures with metadata.
+title: Metadata
+description: Enhance your procedures with metadata.
 ---
 
 # Metadata

--- a/packages/client/src/adapters/standard/rpc-json-serializer.test.ts
+++ b/packages/client/src/adapters/standard/rpc-json-serializer.test.ts
@@ -1,0 +1,143 @@
+import { supportedDataTypes } from '../../../tests/shared'
+import { StandardRPCJsonSerializer } from './rpc-json-serializer'
+
+class Person {
+  constructor(
+    public name: string,
+    public date: Date,
+  ) {}
+
+  toJSON() {
+    return {
+      name: this.name,
+      date: this.date,
+    }
+  }
+}
+
+class Person2 {
+  constructor(
+    public name: string,
+    public data: any,
+  ) { }
+
+  toJSON() {
+    return {
+      name: this.name,
+      data: this.data,
+    }
+  }
+}
+
+const customSupportedDataTypes: { name: string, value: unknown, expected: unknown }[] = [
+  {
+    name: 'person - 1',
+    value: new Person('unnoq', new Date('2023-01-01')),
+    expected: new Person('unnoq', new Date('2023-01-01')),
+  },
+  {
+    name: 'person - 2',
+    value: new Person2('unnoq - 2', [{ nested: new Date('2023-01-02') }, /uic/gi]),
+    expected: new Person2('unnoq - 2', [{ nested: new Date('2023-01-02') }, /uic/gi]),
+  },
+]
+
+describe.each([
+  ...supportedDataTypes,
+  ...customSupportedDataTypes,
+])('standardRPCJsonSerializer: $name', ({ value, expected }) => {
+  const serializer = new StandardRPCJsonSerializer({
+    customJsonSerializers: [
+      {
+        type: 20,
+        condition: data => data instanceof Person,
+        serialize: data => data.toJSON(),
+        deserialize: data => new Person(data.name, data.date),
+      },
+      {
+        type: 21,
+        condition: data => data instanceof Person2,
+        serialize: data => data.toJSON(),
+        deserialize: data => new Person2(data.name, data.data),
+      },
+    ],
+  })
+
+  function assert(value: unknown, expected: unknown) {
+    const [json, meta, maps, blobs] = serializer.serialize(value)
+
+    const deserialized = serializer.deserialize(json, meta, maps, (i: number) => blobs[i]!)
+    expect(deserialized).toEqual(expected)
+  }
+
+  it('flat', () => {
+    assert(value, expected)
+  })
+
+  it('nested object', () => {
+    assert({
+      data: value,
+      nested: {
+        data: value,
+      },
+    }, {
+      data: expected,
+      nested: {
+        data: expected,
+      },
+    })
+  })
+
+  it('nested array', () => {
+    assert([value, [value]], [expected, [expected]])
+  })
+
+  it('complex', () => {
+    assert({
+      'date': new Date('2023-01-01'),
+      'regexp': /uic/gi,
+      'url': new URL('https://unnoq.com'),
+      '!@#$%^^&()[]>?<~_<:"~+!_': value,
+      'list': [value],
+      'map': new Map([[value, value]]),
+      'set': new Set([value]),
+      'nested': {
+        nested: value,
+      },
+    }, {
+      'date': new Date('2023-01-01'),
+      'regexp': /uic/gi,
+      'url': new URL('https://unnoq.com'),
+      '!@#$%^^&()[]>?<~_<:"~+!_': expected,
+      'list': [expected],
+      'map': new Map([[expected, expected]]),
+      'set': new Set([expected]),
+      'nested': {
+        nested: expected,
+      },
+    })
+  })
+})
+
+describe('standardRPCJsonSerializer: custom serializers', () => {
+  it('should throw when type is duplicated', () => {
+    expect(() => {
+      return new StandardRPCJsonSerializer({
+        customJsonSerializers: [
+          {
+            type: 20,
+            condition: data => data instanceof Person,
+            serialize: data => data.toJSON(),
+            deserialize: data => new Person(data.name, data.date),
+          },
+          {
+            type: 20,
+            condition: data => data instanceof Person,
+            serialize: data => data.toJSON(),
+            deserialize: data => new Person(data.name, data.date),
+          },
+        ],
+      })
+    }).toThrow('Custom serializer type must be unique.')
+  })
+})

--- a/packages/client/src/adapters/standard/rpc-json-serializer.ts
+++ b/packages/client/src/adapters/standard/rpc-json-serializer.ts
@@ -1,13 +1,15 @@
 import { isObject, type Segment } from '@orpc/shared'
 
-const TYPE_BIGINT = 0
-const TYPE_DATE = 1
-const TYPE_NAN = 2
-const TYPE_UNDEFINED = 3
-const TYPE_URL = 4
-const TYPE_REGEXP = 5
-const TYPE_SET = 6
-const TYPE_MAP = 7
+export const STANDARD_RPC_JSON_SERIALIZER_BUILT_IN_TYPES = {
+  BIGINT: 0,
+  DATE: 1,
+  NAN: 2,
+  UNDEFINED: 3,
+  URL: 4,
+  REGEXP: 5,
+  SET: 6,
+  MAP: 7,
+} as const
 
 export type StandardRPCJsonSerializedMeta = [number, Segment[]][]
 export type StandardRPCJsonSerialized = [json: unknown, meta: StandardRPCJsonSerializedMeta, maps: Segment[][], blobs: Blob[]]
@@ -52,12 +54,12 @@ export class StandardRPCJsonSerializer {
     }
 
     if (typeof data === 'bigint') {
-      meta.push([TYPE_BIGINT, segments])
+      meta.push([STANDARD_RPC_JSON_SERIALIZER_BUILT_IN_TYPES.BIGINT, segments])
       return [data.toString(), meta, maps, blobs]
     }
 
     if (data instanceof Date) {
-      meta.push([TYPE_DATE, segments])
+      meta.push([STANDARD_RPC_JSON_SERIALIZER_BUILT_IN_TYPES.DATE, segments])
 
       if (Number.isNaN(data.getTime())) {
         return [null, meta, maps, blobs]
@@ -67,36 +69,36 @@ export class StandardRPCJsonSerializer {
     }
 
     if (Number.isNaN(data)) {
-      meta.push([TYPE_NAN, segments])
+      meta.push([STANDARD_RPC_JSON_SERIALIZER_BUILT_IN_TYPES.NAN, segments])
       return [null, meta, maps, blobs]
     }
 
     if (data instanceof URL) {
-      meta.push([TYPE_URL, segments])
+      meta.push([STANDARD_RPC_JSON_SERIALIZER_BUILT_IN_TYPES.URL, segments])
       return [data.toString(), meta, maps, blobs]
     }
 
     if (data instanceof RegExp) {
-      meta.push([TYPE_REGEXP, segments])
+      meta.push([STANDARD_RPC_JSON_SERIALIZER_BUILT_IN_TYPES.REGEXP, segments])
       return [data.toString(), meta, maps, blobs]
     }
 
     if (data instanceof Set) {
       const result = this.serialize(Array.from(data), segments, meta, maps, blobs)
-      meta.push([TYPE_SET, segments])
+      meta.push([STANDARD_RPC_JSON_SERIALIZER_BUILT_IN_TYPES.SET, segments])
       return result
     }
 
     if (data instanceof Map) {
       const result = this.serialize(Array.from(data.entries()), segments, meta, maps, blobs)
-      meta.push([TYPE_MAP, segments])
+      meta.push([STANDARD_RPC_JSON_SERIALIZER_BUILT_IN_TYPES.MAP, segments])
       return result
     }
 
     if (Array.isArray(data)) {
       const json = data.map((v, i) => {
         if (v === undefined) {
-          meta.push([TYPE_UNDEFINED, [...segments, i]])
+          meta.push([STANDARD_RPC_JSON_SERIALIZER_BUILT_IN_TYPES.UNDEFINED, [...segments, i]])
           return v
         }
 
@@ -157,27 +159,27 @@ export class StandardRPCJsonSerializer {
       }
 
       switch (type) {
-        case TYPE_BIGINT:
+        case STANDARD_RPC_JSON_SERIALIZER_BUILT_IN_TYPES.BIGINT:
           currentRef[preSegment] = BigInt(currentRef[preSegment])
           break
 
-        case TYPE_DATE:
+        case STANDARD_RPC_JSON_SERIALIZER_BUILT_IN_TYPES.DATE:
           currentRef[preSegment] = new Date(currentRef[preSegment] ?? 'Invalid Date')
           break
 
-        case TYPE_NAN:
+        case STANDARD_RPC_JSON_SERIALIZER_BUILT_IN_TYPES.NAN:
           currentRef[preSegment] = Number.NaN
           break
 
-        case TYPE_UNDEFINED:
+        case STANDARD_RPC_JSON_SERIALIZER_BUILT_IN_TYPES.UNDEFINED:
           currentRef[preSegment] = undefined
           break
 
-        case TYPE_URL:
+        case STANDARD_RPC_JSON_SERIALIZER_BUILT_IN_TYPES.URL:
           currentRef[preSegment] = new URL(currentRef[preSegment])
           break
 
-        case TYPE_REGEXP: {
+        case STANDARD_RPC_JSON_SERIALIZER_BUILT_IN_TYPES.REGEXP: {
           const [, pattern, flags] = currentRef[preSegment].match(/^\/(.*)\/([a-z]*)$/)
 
           currentRef[preSegment] = new RegExp(pattern!, flags)
@@ -185,11 +187,11 @@ export class StandardRPCJsonSerializer {
           break
         }
 
-        case TYPE_SET:
+        case STANDARD_RPC_JSON_SERIALIZER_BUILT_IN_TYPES.SET:
           currentRef[preSegment] = new Set(currentRef[preSegment])
           break
 
-        case TYPE_MAP:
+        case STANDARD_RPC_JSON_SERIALIZER_BUILT_IN_TYPES.MAP:
           currentRef[preSegment] = new Map(currentRef[preSegment])
           break
       }

--- a/packages/client/src/adapters/standard/rpc-json-serializer.ts
+++ b/packages/client/src/adapters/standard/rpc-json-serializer.ts
@@ -14,7 +14,7 @@ export const STANDARD_RPC_JSON_SERIALIZER_BUILT_IN_TYPES = {
 export type StandardRPCJsonSerializedMeta = [number, Segment[]][]
 export type StandardRPCJsonSerialized = [json: unknown, meta: StandardRPCJsonSerializedMeta, maps: Segment[][], blobs: Blob[]]
 
-export interface StandardRPCJsonCustomSerializer {
+export interface StandardRPCCustomJsonSerializer {
   type: number
   condition(data: unknown): boolean
   serialize(data: any): unknown
@@ -22,11 +22,11 @@ export interface StandardRPCJsonCustomSerializer {
 }
 
 export interface StandardRPCJsonSerializerOptions {
-  customJsonSerializers?: readonly StandardRPCJsonCustomSerializer[]
+  customJsonSerializers?: readonly StandardRPCCustomJsonSerializer[]
 }
 
 export class StandardRPCJsonSerializer {
-  private readonly customSerializers: readonly StandardRPCJsonCustomSerializer[]
+  private readonly customSerializers: readonly StandardRPCCustomJsonSerializer[]
 
   constructor(options: StandardRPCJsonSerializerOptions = {}) {
     this.customSerializers = options.customJsonSerializers ?? []

--- a/packages/client/src/adapters/standard/rpc-json-serializer.ts
+++ b/packages/client/src/adapters/standard/rpc-json-serializer.ts
@@ -20,11 +20,11 @@ export interface StandardRPCJsonCustomSerializer {
 }
 
 export interface StandardRPCJsonSerializerOptions {
-  customJsonSerializers?: StandardRPCJsonCustomSerializer[]
+  customJsonSerializers?: readonly StandardRPCJsonCustomSerializer[]
 }
 
 export class StandardRPCJsonSerializer {
-  private readonly customSerializers: StandardRPCJsonCustomSerializer[]
+  private readonly customSerializers: readonly StandardRPCJsonCustomSerializer[]
 
   constructor(options: StandardRPCJsonSerializerOptions = {}) {
     this.customSerializers = options.customJsonSerializers ?? []


### PR DESCRIPTION
The way to extend or override built-in types support by RPC Protocol

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the navigation sidebar with a refreshed "Advanced" section that now highlights RPC JSON Serializer and reintroduces the maximum length topic with corrected labeling.
  - Introduced a comprehensive guide for customizing RPC JSON serialization, offering step-by-step instructions for creating tailored serializers.

- **Documentation**
  - Standardized metadata formatting across documentation pages for improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->