### PR TITLE
feat(client, server)!: improve RPC JSON Serializer Meta

### DIFF
--- a/apps/content/docs/advanced/rpc-protocol.md
+++ b/apps/content/docs/advanced/rpc-protocol.md
@@ -39,7 +39,7 @@ url.searchParams.append('data', JSON.stringify({
     name: 'Earth',
     detached_at: '2022-01-01T00:00:00.000Z'
   },
-  meta: [[1, ['detached_at']]]
+  meta: [[1, 'detached_at']]
 }))
 
 const response = await fetch(url)
@@ -59,7 +59,7 @@ curl -X POST https://example.com/rpc/planet/create \
       "name": "Earth",
       "detached_at": "2022-01-01T00:00:00.000Z"
     },
-    "meta": [[1, ["detached_at"]]]
+    "meta": [[1, "detached_at"]]
   }'
 ```
 
@@ -78,7 +78,7 @@ form.set('data', JSON.stringify({
     thumbnail: {},
     images: [{}, {}]
   },
-  meta: [[1, ['detached_at']]],
+  meta: [[1, 'detached_at']],
   maps: [['images', 0], ['images', 1]]
 }))
 
@@ -107,7 +107,7 @@ Content-Type: application/json
     "name": "Earth",
     "detached_at": "2022-01-01T00:00:00.000Z"
   },
-  "meta": [[0, ["id"]], [1, ["detached_at"]]]
+  "meta": [[0, "id"], [1, "detached_at"]]
 }
 ```
 
@@ -139,7 +139,7 @@ An error response has an HTTP status code between `400-599` and returns an `ORPC
 
 ## Meta
 
-The `meta` field describes native data in the format `[type: number, path: (string | number)[]]`.
+The `meta` field describes native data in the format `[type: number, ...path: (string | number)[]]`.
 
 - **type**: Data type (see [Supported Types](#supported-types)).
 - **path**: Path to the data inside `json`.

--- a/packages/client/src/adapters/standard/rpc-link-codec.test.ts
+++ b/packages/client/src/adapters/standard/rpc-link-codec.test.ts
@@ -164,11 +164,11 @@ describe('standardRPCLinkCodec', () => {
         status: 200,
         raw: {},
         headers: {},
-        body: () => Promise.resolve({ meta: 'invalid' }),
+        body: () => Promise.resolve({ meta: 123 }),
       })).rejects.toThrow('Invalid RPC response format.')
 
       expect(deserializeSpy).toBeCalledTimes(1)
-      expect(deserializeSpy).toBeCalledWith({ meta: 'invalid' })
+      expect(deserializeSpy).toBeCalledWith({ meta: 123 })
     })
 
     it('error: Invalid RPC error response format.', async () => {

--- a/packages/vue-colada/src/key.test.ts
+++ b/packages/vue-colada/src/key.test.ts
@@ -10,6 +10,6 @@ describe('buildKey', () => {
 
     const date = new Date()
     expect(buildKey(['path', 'path2'], { input: { a: date } }))
-      .toEqual(['path', 'path2', { input: `{"json":{"a":"${date.toISOString()}"},"meta":[[1,["a"]]]}` }])
+      .toEqual(['path', 'path2', { input: `{"json":{"a":"${date.toISOString()}"},"meta":[[1,"a"]]}` }])
   })
 })


### PR DESCRIPTION
From `[type: number, path: (string | number)[]]` to `[type: number, ...path: (string | number)[]]` it can reduce size a bit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated advanced RPC protocol documentation to clarify metadata examples.
  
- **Refactor**
  - Improved metadata handling in the RPC serialization and deserialization processes for greater consistency and flexibility.
  
- **Tests**
  - Revised validations for error responses and key generation to align with the updated metadata structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->