### PR TITLE
fix(client): set `last-event-id` header when sending

### DIFF
--- a/packages/client/src/adapters/standard/rpc-link-codec.test.ts
+++ b/packages/client/src/adapters/standard/rpc-link-codec.test.ts
@@ -97,6 +97,47 @@ describe('standardRPCLinkCodec', () => {
       expect(serializeSpy).toBeCalledTimes(1)
       expect(serializeSpy).toBeCalledWith(input)
     })
+
+    describe('last-event-id', async () => {
+      it('should set', async () => {
+        const codec = new StandardRPCLinkCodec(serializer, {
+          url: 'http://localhost:3000',
+          method,
+          headers: () => ({ 'x-custom-header': 'custom-value' }),
+        })
+
+        const request = await codec.encode(['test'], 'input', { context: {}, lastEventId: '1' })
+
+        expect(request.headers['x-custom-header']).toEqual('custom-value')
+        expect(request.headers['last-event-id']).toEqual('1')
+      })
+
+      it('should merged', async () => {
+        const codec = new StandardRPCLinkCodec(serializer, {
+          url: 'http://localhost:3000',
+          method,
+          headers: () => ({ 'x-custom-header': 'custom-value', 'last-event-id': '2' }),
+        })
+
+        const request = await codec.encode(['test'], 'input', { context: {}, lastEventId: '1' })
+
+        expect(request.headers['x-custom-header']).toEqual('custom-value')
+        expect(request.headers['last-event-id']).toEqual(['2', '1'])
+      })
+
+      it('should merged 2', async () => {
+        const codec = new StandardRPCLinkCodec(serializer, {
+          url: 'http://localhost:3000',
+          method,
+          headers: () => ({ 'x-custom-header': 'custom-value', 'last-event-id': ['2', '3'] }),
+        })
+
+        const request = await codec.encode(['test'], 'input', { context: {}, lastEventId: '1' })
+
+        expect(request.headers['x-custom-header']).toEqual('custom-value')
+        expect(request.headers['last-event-id']).toEqual(['2', '3', '1'])
+      })
+    })
   })
 
   describe('decode', () => {

--- a/packages/client/src/adapters/standard/rpc-link-codec.ts
+++ b/packages/client/src/adapters/standard/rpc-link-codec.ts
@@ -77,9 +77,21 @@ export class StandardRPCLinkCodec<T extends ClientContext> implements StandardLi
 
   async encode(path: readonly string[], input: unknown, options: ClientOptionsOut<any>): Promise<StandardRequest> {
     const expectedMethod = await value(this.expectedMethod, options, path, input)
-    const headers = await value(this.headers, options, path, input)
+    const headers = { ...await value(this.headers, options, path, input) }
     const baseUrl = await value(this.baseUrl, options, path, input)
     const url = new URL(`${trim(baseUrl.toString(), '/')}/${path.map(encodeURIComponent).join('/')}`)
+
+    if (options.lastEventId !== undefined) {
+      if (Array.isArray(headers['last-event-id'])) {
+        headers['last-event-id'] = [...headers['last-event-id'], options.lastEventId]
+      }
+      else if (headers['last-event-id'] !== undefined) {
+        headers['last-event-id'] = [headers['last-event-id'], options.lastEventId]
+      }
+      else {
+        headers['last-event-id'] = options.lastEventId
+      }
+    }
 
     const serialized = this.serializer.serialize(input)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the handling of event identifier headers by improving the merging process for new and existing values. This update ensures that event identifiers are combined reliably without unintended modifications.

- **Tests**
  - Introduced comprehensive validations to confirm the correct behavior of header merging under various scenarios, further bolstering system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->