### PR TITLE
feat(client)!: remove Content-Disposition requirement from RPC serializer

### DIFF
--- a/apps/content/docs/advanced/rpc-protocol.md
+++ b/apps/content/docs/advanced/rpc-protocol.md
@@ -45,10 +45,6 @@ url.searchParams.append('data', JSON.stringify({
 const response = await fetch(url)
 ```
 
-::: info
-The payload can be empty (`undefined`).
-:::
-
 ### Input in Request Body
 
 ```bash
@@ -62,10 +58,6 @@ curl -X POST https://example.com/rpc/planet/create \
     "meta": [[1, "detached_at"]]
   }'
 ```
-
-::: info
-The payload can be empty (`undefined`).
-:::
 
 ### Input with File
 
@@ -91,10 +83,6 @@ const response = await fetch('https://example.com/rpc/planet/create', {
 })
 ```
 
-::: info
-The input can be empty (`undefined`) or binary data (`blob/file`).
-:::
-
 ## Success Response
 
 ```http
@@ -112,10 +100,6 @@ Content-Type: application/json
 ```
 
 A success response has an HTTP status code between `200-299` and returns the procedure's output.
-
-::: info
-The payload can be empty (`undefined`) or binary data (`blob/file`).
-:::
 
 ## Error Response
 

--- a/packages/client/src/adapters/standard/rpc-link-codec.test.ts
+++ b/packages/client/src/adapters/standard/rpc-link-codec.test.ts
@@ -38,23 +38,6 @@ describe('standardRPCLinkCodec', () => {
       }))
     })
 
-    it('with method=GET & input=undefined', async () => {
-      method.mockResolvedValueOnce('GET')
-
-      const signal = AbortSignal.timeout(100)
-      const output = await codec.encode(['test'], undefined, { context: {}, signal })
-
-      expect(output).toEqual(expect.objectContaining({
-        url: new URL(`http://localhost:3000/test?data=`),
-        method: 'GET',
-        headers: {
-          'x-custom-header': 'custom-value',
-        },
-        body: undefined,
-        signal,
-      }))
-    })
-
     it('with method=POST', async () => {
       method.mockResolvedValueOnce('POST')
 

--- a/packages/client/src/adapters/standard/rpc-link-codec.ts
+++ b/packages/client/src/adapters/standard/rpc-link-codec.ts
@@ -98,13 +98,12 @@ export class StandardRPCLinkCodec<T extends ClientContext> implements StandardLi
     if (
       expectedMethod === 'GET'
       && !(serialized instanceof FormData)
-      && !(serialized instanceof Blob)
       && !isAsyncIteratorObject(serialized)
     ) {
       const maxUrlLength = await value(this.maxUrlLength, options, path, input)
       const getUrl = new URL(url)
 
-      getUrl.searchParams.append('data', stringifyJSON(serialized) ?? '')
+      getUrl.searchParams.append('data', stringifyJSON(serialized))
 
       if (getUrl.toString().length <= maxUrlLength) {
         return {

--- a/packages/client/src/adapters/standard/rpc-serializer.ts
+++ b/packages/client/src/adapters/standard/rpc-serializer.ts
@@ -9,7 +9,7 @@ export class StandardRPCSerializer {
     private readonly jsonSerializer: StandardRPCJsonSerializer,
   ) {}
 
-  serialize(data: unknown): unknown {
+  serialize(data: unknown): object {
     if (isAsyncIteratorObject(data)) {
       return mapEventIterator(data, {
         value: async (value: unknown) => this.#serialize(value, false),
@@ -28,11 +28,7 @@ export class StandardRPCSerializer {
   #serialize(
     data: unknown,
     enableFormData: boolean,
-  ): unknown {
-    if (data === undefined || data instanceof Blob) {
-      return data
-    }
-
+  ): object {
     const [json, meta_, maps, blobs] = this.jsonSerializer.serialize(data)
 
     const meta = meta_.length === 0 ? undefined : meta_
@@ -82,10 +78,6 @@ export class StandardRPCSerializer {
   }
 
   #deserialize(data: unknown): unknown {
-    if (data === undefined || data instanceof Blob) {
-      return data
-    }
-
     if (!(data instanceof FormData)) {
       return this.jsonSerializer.deserialize((data as any).json, (data as any).meta ?? [])
     }


### PR DESCRIPTION
Closes: https://github.com/unnoq/orpc/discussions/263
Related: https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_response_header

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the encoding logic for data requests so that GET requests now construct URLs more precisely.
  - Streamlined serialization routines to consistently return structured data, ensuring reliable handling of transmitted data.
- **Documentation**
  - Removed redundant notes regarding the potential for empty (`undefined`) payloads across multiple sections of the RPC protocol documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->