### PR TITLE
docs: fix "Bracket Notation" example

### DIFF
--- a/apps/content/docs/openapi/bracket-notation.md
+++ b/apps/content/docs/openapi/bracket-notation.md
@@ -79,8 +79,8 @@ This form data is parsed as:
       { "first": "John1", "last": "Doe1" },
       { "first": "John2", "last": "Doe2" }
     ],
-    "ages": [18, null, 25],
-    "files": ["...binary data...", "...binary data..."]
+    "ages": ["18", "<empty>", "25"],
+    "files": ["<binary data>", "<binary data>"]
   }
 }
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Refined JSON examples for improved clarity and readability. The example now presents numeric values and missing data as strings, and it uses a consistent placeholder for binary data. These updates standardize the documentation's presentation, making it easier for users to understand the example structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->