### PR TITLE
feat(server): enhance ts error for `.use`

### DIFF
--- a/packages/server/src/builder-variants.test-d.ts
+++ b/packages/server/src/builder-variants.test-d.ts
@@ -99,8 +99,8 @@ describe('BuilderWithMiddlewares', () => {
         >
       >()
 
-      // invalid TInContext
-      expectTypeOf(builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)).toEqualTypeOf<never>()
+      // @ts-expect-error --- invalid TInContext
+      builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)
       // @ts-expect-error --- input is not match
       builder.use(({ next }, input: 'invalid') => next({}))
       // @ts-expect-error --- output is not match
@@ -358,8 +358,8 @@ describe('ProcedureBuilder', () => {
         >
       >()
 
-      // invalid TInContext
-      expectTypeOf(builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)).toEqualTypeOf<never>()
+      // @ts-expect-error --- invalid TInContext
+      builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)
       // @ts-expect-error --- input is not match
       builder.use(({ next }, input: 'invalid') => next({}))
       // @ts-expect-error --- output is not match
@@ -552,8 +552,8 @@ describe('ProcedureBuilderWithInput', () => {
         >
       >()
 
-      // invalid TInContext
-      expectTypeOf(builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)).toEqualTypeOf<never>()
+      // @ts-expect-error --- invalid TInContext
+      builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)
       // @ts-expect-error --- input is not match
       builder.use(({ next }, input: 'invalid') => next({}))
       // @ts-expect-error --- output is not match
@@ -600,8 +600,8 @@ describe('ProcedureBuilderWithInput', () => {
         input => ({ invalid: true }),
       )
 
-      // invalid TInContext
-      expectTypeOf(builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>, () => { })).toEqualTypeOf<never>()
+      // @ts-expect-error --- invalid TInContext
+      builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>, () => {})
       // @ts-expect-error --- input is not match
       builder.use(({ next }, input: 'invalid') => next({}), input => ({ mapped: true }))
       // @ts-expect-error --- output is not match
@@ -789,8 +789,8 @@ describe('ProcedureBuilderWithOutput', () => {
         >
       >()
 
-      // invalid TInContext
-      expectTypeOf(builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)).toEqualTypeOf<never>()
+      // @ts-expect-error --- invalid TInContext
+      builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)
       // @ts-expect-error --- input is not match
       builder.use(({ next }, input: 'invalid') => next({}))
       // @ts-expect-error --- output is not match
@@ -970,8 +970,8 @@ describe('ProcedureBuilderWithInputOutput', () => {
         >
       >()
 
-      // invalid TInContext
-      expectTypeOf(builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)).toEqualTypeOf<never>()
+      // @ts-expect-error --- invalid TInContext
+      builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)
       // @ts-expect-error --- input is not match
       builder.use(({ next }, input: 'invalid') => next({}))
       // @ts-expect-error --- output is not match
@@ -1018,8 +1018,8 @@ describe('ProcedureBuilderWithInputOutput', () => {
         input => ({ invalid: true }),
       )
 
-      // invalid TInContext
-      expectTypeOf(builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>, () => { })).toEqualTypeOf<never>()
+      // @ts-expect-error --- invalid TInContext
+      builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>, () => {})
       // @ts-expect-error --- input is not match
       builder.use(({ next }, input: 'invalid') => next({}), input => ({ mapped: true }))
       // @ts-expect-error --- output is not match
@@ -1163,8 +1163,8 @@ describe('RouterBuilder', () => {
         >
       >()
 
-      // invalid TInContext
-      expectTypeOf(builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)).toEqualTypeOf<never>()
+      // @ts-expect-error --- invalid TInContext
+      builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)
       // @ts-expect-error --- input is not match
       builder.use(({ next }, input: 'invalid') => next({}))
       // @ts-expect-error --- output is not match

--- a/packages/server/src/builder-variants.ts
+++ b/packages/server/src/builder-variants.ts
@@ -1,6 +1,7 @@
 import type { AnySchema, ContractRouter, ErrorMap, HTTPPath, InferSchemaInput, InferSchemaOutput, MergedErrorMap, Meta, Route, Schema } from '@orpc/contract'
+import type { IntersectPick } from '@orpc/shared'
 import type { BuilderDef } from './builder'
-import type { Context, ContextExtendsGuard, MergedCurrentContext, MergedInitialContext } from './context'
+import type { Context, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
 import type { Lazy } from './lazy'
 import type { MapInputMiddleware, Middleware } from './middleware'
@@ -30,7 +31,7 @@ export interface BuilderWithMiddlewares<
     TMeta
   >
 
-  'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
+  'use'<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -39,15 +40,14 @@ export interface BuilderWithMiddlewares<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<TCurrentContext, UInContext>
-    & BuilderWithMiddlewares<
-      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
-      MergedCurrentContext<TCurrentContext, UOutContext>,
-      TInputSchema,
-      TOutputSchema,
-      TErrorMap,
-      TMeta
-    >
+  ): BuilderWithMiddlewares<
+    MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+    MergedCurrentContext<TCurrentContext, UOutContext>,
+    TInputSchema,
+    TOutputSchema,
+    TErrorMap,
+    TMeta
+  >
 
   'meta'(
     meta: TMeta,
@@ -103,7 +103,7 @@ export interface ProcedureBuilder<
     TMeta
   >
 
-  'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
+  'use'<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -112,15 +112,14 @@ export interface ProcedureBuilder<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<TCurrentContext, UInContext>
-    & ProcedureBuilder<
-      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
-      MergedCurrentContext<TCurrentContext, UOutContext>,
-      TInputSchema,
-      TOutputSchema,
-      TErrorMap,
-      TMeta
-    >
+  ): ProcedureBuilder<
+    MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+    MergedCurrentContext<TCurrentContext, UOutContext>,
+    TInputSchema,
+    TOutputSchema,
+    TErrorMap,
+    TMeta
+  >
 
   'meta'(
     meta: TMeta,
@@ -157,7 +156,7 @@ export interface ProcedureBuilderWithInput<
     errors: U,
   ): ProcedureBuilderWithInput<TInitialContext, TCurrentContext, TInputSchema, TOutputSchema, MergedErrorMap<TErrorMap, U>, TMeta>
 
-  'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
+  'use'<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -166,17 +165,16 @@ export interface ProcedureBuilderWithInput<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<TCurrentContext, UInContext>
-    & ProcedureBuilderWithInput<
-      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
-      MergedCurrentContext<TCurrentContext, UOutContext>,
-      TInputSchema,
-      TOutputSchema,
-      TErrorMap,
-      TMeta
-    >
+  ): ProcedureBuilderWithInput<
+    MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+    MergedCurrentContext<TCurrentContext, UOutContext>,
+    TInputSchema,
+    TOutputSchema,
+    TErrorMap,
+    TMeta
+  >
 
-  'use'<UOutContext extends Context, UInput, UInContext extends Context = TCurrentContext>(
+  'use'<UOutContext extends Context, UInput, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -186,15 +184,14 @@ export interface ProcedureBuilderWithInput<
       TMeta
     >,
     mapInput: MapInputMiddleware<InferSchemaOutput<TInputSchema>, UInput>,
-  ): ContextExtendsGuard<TCurrentContext, UInContext>
-    & ProcedureBuilderWithInput<
-      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
-      MergedCurrentContext<TCurrentContext, UOutContext>,
-      TInputSchema,
-      TOutputSchema,
-      TErrorMap,
-      TMeta
-    >
+  ): ProcedureBuilderWithInput<
+    MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+    MergedCurrentContext<TCurrentContext, UOutContext>,
+    TInputSchema,
+    TOutputSchema,
+    TErrorMap,
+    TMeta
+  >
 
   'meta'(
     meta: TMeta,
@@ -234,7 +231,7 @@ export interface ProcedureBuilderWithOutput<
     TMeta
   >
 
-  'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
+  'use'<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -243,15 +240,14 @@ export interface ProcedureBuilderWithOutput<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<TCurrentContext, UInContext>
-    & ProcedureBuilderWithOutput<
-      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
-      MergedCurrentContext<TCurrentContext, UOutContext>,
-      TInputSchema,
-      TOutputSchema,
-      TErrorMap,
-      TMeta
-    >
+  ): ProcedureBuilderWithOutput<
+    MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+    MergedCurrentContext<TCurrentContext, UOutContext>,
+    TInputSchema,
+    TOutputSchema,
+    TErrorMap,
+    TMeta
+  >
 
   'meta'(
     meta: TMeta,
@@ -284,7 +280,7 @@ export interface ProcedureBuilderWithInputOutput<
     errors: U,
   ): ProcedureBuilderWithInputOutput<TInitialContext, TCurrentContext, TInputSchema, TOutputSchema, MergedErrorMap<TErrorMap, U>, TMeta>
 
-  'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
+  'use'<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -293,17 +289,16 @@ export interface ProcedureBuilderWithInputOutput<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<TCurrentContext, UInContext>
-    & ProcedureBuilderWithInputOutput<
-      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
-      MergedCurrentContext<TCurrentContext, UOutContext>,
-      TInputSchema,
-      TOutputSchema,
-      TErrorMap,
-      TMeta
-    >
+  ): ProcedureBuilderWithInputOutput<
+    MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+    MergedCurrentContext<TCurrentContext, UOutContext>,
+    TInputSchema,
+    TOutputSchema,
+    TErrorMap,
+    TMeta
+  >
 
-  'use'<UOutContext extends Context, UInput, UInContext extends Context = TCurrentContext>(
+  'use'<UOutContext extends Context, UInput, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -313,15 +308,14 @@ export interface ProcedureBuilderWithInputOutput<
       TMeta
     >,
     mapInput: MapInputMiddleware<InferSchemaOutput<TInputSchema>, UInput>,
-  ): ContextExtendsGuard<TCurrentContext, UInContext>
-    & ProcedureBuilderWithInputOutput<
-      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
-      MergedCurrentContext<TCurrentContext, UOutContext>,
-      TInputSchema,
-      TOutputSchema,
-      TErrorMap,
-      TMeta
-    >
+  ): ProcedureBuilderWithInputOutput<
+    MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+    MergedCurrentContext<TCurrentContext, UOutContext>,
+    TInputSchema,
+    TOutputSchema,
+    TErrorMap,
+    TMeta
+  >
 
   'meta'(
     meta: TMeta,
@@ -348,7 +342,7 @@ export interface RouterBuilder<
     errors: U,
   ): RouterBuilder<TInitialContext, TCurrentContext, MergedErrorMap<TErrorMap, U>, TMeta>
 
-  'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
+  'use'<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -357,13 +351,12 @@ export interface RouterBuilder<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<TCurrentContext, UInContext>
-    & RouterBuilder<
-      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
-      MergedCurrentContext<TCurrentContext, UOutContext>,
-      TErrorMap,
-      TMeta
-    >
+  ): RouterBuilder<
+    MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+    MergedCurrentContext<TCurrentContext, UOutContext>,
+    TErrorMap,
+    TMeta
+  >
 
   'prefix'(prefix: HTTPPath): RouterBuilder<TInitialContext, TCurrentContext, TErrorMap, TMeta>
 

--- a/packages/server/src/builder-variants.ts
+++ b/packages/server/src/builder-variants.ts
@@ -1,5 +1,4 @@
 import type { AnySchema, ContractRouter, ErrorMap, HTTPPath, InferSchemaInput, InferSchemaOutput, MergedErrorMap, Meta, Route, Schema } from '@orpc/contract'
-import type { IntersectPick } from '@orpc/shared'
 import type { BuilderDef } from './builder'
 import type { Context, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
@@ -31,9 +30,9 @@ export interface BuilderWithMiddlewares<
     TMeta
   >
 
-  'use'<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
+  'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      UInContext,
+      UInContext | TCurrentContext,
       UOutContext,
       unknown,
       unknown,
@@ -103,9 +102,9 @@ export interface ProcedureBuilder<
     TMeta
   >
 
-  'use'<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
+  'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      UInContext,
+      UInContext | TCurrentContext,
       UOutContext,
       unknown,
       unknown,
@@ -156,9 +155,9 @@ export interface ProcedureBuilderWithInput<
     errors: U,
   ): ProcedureBuilderWithInput<TInitialContext, TCurrentContext, TInputSchema, TOutputSchema, MergedErrorMap<TErrorMap, U>, TMeta>
 
-  'use'<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
+  'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      UInContext,
+      UInContext | TCurrentContext,
       UOutContext,
       InferSchemaOutput<TInputSchema>,
       unknown,
@@ -174,9 +173,9 @@ export interface ProcedureBuilderWithInput<
     TMeta
   >
 
-  'use'<UOutContext extends Context, UInput, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
+  'use'<UOutContext extends Context, UInput, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      UInContext,
+      UInContext | TCurrentContext,
       UOutContext,
       UInput,
       unknown,
@@ -231,9 +230,9 @@ export interface ProcedureBuilderWithOutput<
     TMeta
   >
 
-  'use'<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
+  'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      UInContext,
+      UInContext | TCurrentContext,
       UOutContext,
       unknown,
       InferSchemaInput<TOutputSchema>,
@@ -280,9 +279,9 @@ export interface ProcedureBuilderWithInputOutput<
     errors: U,
   ): ProcedureBuilderWithInputOutput<TInitialContext, TCurrentContext, TInputSchema, TOutputSchema, MergedErrorMap<TErrorMap, U>, TMeta>
 
-  'use'<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
+  'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      UInContext,
+      UInContext | TCurrentContext,
       UOutContext,
       InferSchemaOutput<TInputSchema>,
       InferSchemaInput<TOutputSchema>,
@@ -298,9 +297,9 @@ export interface ProcedureBuilderWithInputOutput<
     TMeta
   >
 
-  'use'<UOutContext extends Context, UInput, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
+  'use'<UOutContext extends Context, UInput, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      UInContext,
+      UInContext | TCurrentContext,
       UOutContext,
       UInput,
       InferSchemaInput<TOutputSchema>,
@@ -342,9 +341,9 @@ export interface RouterBuilder<
     errors: U,
   ): RouterBuilder<TInitialContext, TCurrentContext, MergedErrorMap<TErrorMap, U>, TMeta>
 
-  'use'<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
+  'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      UInContext,
+      UInContext | TCurrentContext,
       UOutContext,
       unknown,
       unknown,

--- a/packages/server/src/builder.test-d.ts
+++ b/packages/server/src/builder.test-d.ts
@@ -241,77 +241,18 @@ describe('Builder', () => {
         >
       >()
 
-      // invalid TInContext
-      expectTypeOf(builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)).toEqualTypeOf<never>()
+      // @ts-expect-error --- Invalid TInContext
+      builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)
       // @ts-expect-error --- input is not match
       builder.use(({ next }, input: 'invalid') => next({}))
       // @ts-expect-error --- output is not match
       builder.use(({ next }, input, output: MiddlewareOutputFn<'invalid'>) => next({}))
     })
 
-    it('with map input', () => {
-      const applied = builder.use(({ context, next, path, procedure, errors, signal }, input: { mapped: boolean }, output) => {
-        expectTypeOf(input).toEqualTypeOf<{ mapped: boolean }>()
-        expectTypeOf(context).toEqualTypeOf<CurrentContext>()
-        expectTypeOf(path).toEqualTypeOf<readonly string[]>()
-        expectTypeOf(procedure).toEqualTypeOf<
-          Procedure<Context, Context, AnySchema, AnySchema, ErrorMap, BaseMeta>
-        >()
-        expectTypeOf(output).toEqualTypeOf<MiddlewareOutputFn<unknown>>()
-        expectTypeOf(errors).toEqualTypeOf<ORPCErrorConstructorMap<typeof baseErrorMap>>()
-        expectTypeOf(signal).toEqualTypeOf<undefined | InstanceType<typeof AbortSignal>>()
-
-        return next({
-          context: {
-            extra: true,
-          },
-        })
-      }, (input) => {
-        expectTypeOf(input).toEqualTypeOf<unknown>()
-
-        return { mapped: true }
-      })
-
-      expectTypeOf(applied).toEqualTypeOf<
-        BuilderWithMiddlewares<
-          InitialContext & Record<never, never>,
-          Omit<CurrentContext, 'extra'> & { extra: boolean },
-          typeof inputSchema,
-          typeof outputSchema,
-          typeof baseErrorMap,
-          BaseMeta
-        >
-      >()
-
-      builder.use(
-        ({ context, next, path, procedure, errors, signal }, input: { mapped: boolean }, output) => next(),
-        // @ts-expect-error --- invalid map input
-        input => ({ invalid: true }),
-      )
-
-      // invalid TInContext
-      expectTypeOf(builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>, () => { })).toEqualTypeOf<never>()
-      // @ts-expect-error --- input is not match
-      builder.use(({ next }, input: 'invalid') => next({}), input => ({ mapped: true }))
-      // @ts-expect-error --- output is not match
-      builder.use(({ next }, input, output: MiddlewareOutputFn<'invalid'>) => next({}), input => ({ mapped: true }))
-    })
-
     it('with TInContext', () => {
       const mid = {} as Middleware<{ cacheable?: boolean } & Record<never, never>, Record<never, never>, unknown, unknown, ORPCErrorConstructorMap<any>, BaseMeta>
 
       expectTypeOf(builder.use(mid)).toEqualTypeOf<
-        BuilderWithMiddlewares<
-          InitialContext & { cacheable?: boolean },
-          Omit<CurrentContext, never> & Record<never, never>,
-          typeof inputSchema,
-          typeof outputSchema,
-          typeof baseErrorMap,
-          BaseMeta
-        >
-      >()
-
-      expectTypeOf(builder.use(mid, () => { })).toEqualTypeOf<
         BuilderWithMiddlewares<
           InitialContext & { cacheable?: boolean },
           Omit<CurrentContext, never> & Record<never, never>,

--- a/packages/server/src/builder.test-d.ts
+++ b/packages/server/src/builder.test-d.ts
@@ -173,18 +173,15 @@ describe('Builder', () => {
           })
         }),
       ).toEqualTypeOf<
-        DecoratedMiddleware<InitialContext, { extra: boolean }, unknown, any, ORPCErrorConstructorMap<any>, BaseMeta>
+        DecoratedMiddleware<InitialContext, { extra: boolean }, unknown, any, any, BaseMeta>
       >()
-
-      // @ts-expect-error --- conflict context
-      builder.middleware(({ next }) => next({ db: 123 }))
     })
 
     it('can type input and output', () => {
       expectTypeOf(
         builder.middleware(({ next }, input: 'input', output: MiddlewareOutputFn<'output'>) => next()),
       ).toEqualTypeOf<
-        DecoratedMiddleware<InitialContext, Record<never, never>, 'input', 'output', ORPCErrorConstructorMap<any>, BaseMeta>
+        DecoratedMiddleware<InitialContext, Record<never, never>, 'input', 'output', any, BaseMeta>
       >()
     })
   })

--- a/packages/server/src/builder.test.ts
+++ b/packages/server/src/builder.test.ts
@@ -167,6 +167,7 @@ describe('builder', () => {
         mapInput: (map: any) => [mid, map] as any,
       }) as any)
 
+      // @ts-expect-error --- this builder support .use with map input but not type
       const applied = builder.use(mid2, map2)
 
       expect(applied).instanceOf(Builder)

--- a/packages/server/src/builder.ts
+++ b/packages/server/src/builder.ts
@@ -1,5 +1,4 @@
 import type { AnySchema, ContractProcedureDef, ContractRouter, ErrorMap, HTTPPath, MergedErrorMap, Meta, Route, Schema } from '@orpc/contract'
-import type { IntersectPick } from '@orpc/shared'
 import type { BuilderWithMiddlewares, ProcedureBuilder, ProcedureBuilderWithInput, ProcedureBuilderWithOutput, RouterBuilder } from './builder-variants'
 import type { Context, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
@@ -120,7 +119,7 @@ export class Builder<
 
   middleware<UOutContext extends Context, TInput, TOutput = any>( // = any here is important to make middleware can be used in any output by default
     middleware: Middleware<TInitialContext, UOutContext, TInput, TOutput, ORPCErrorConstructorMap<TErrorMap>, TMeta>,
-  ): DecoratedMiddleware<TInitialContext, UOutContext, TInput, TOutput, ORPCErrorConstructorMap<any>, TMeta> { // ORPCErrorConstructorMap<any> ensures middleware can used in any procedure
+  ): DecoratedMiddleware<TInitialContext, UOutContext, TInput, TOutput, any, TMeta> { // any ensures middleware can used in any procedure
     return decorateMiddleware(middleware)
   }
 
@@ -133,9 +132,9 @@ export class Builder<
     })
   }
 
-  use<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
+  use<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      UInContext,
+      UInContext | TCurrentContext,
       UOutContext,
       unknown,
       unknown,

--- a/packages/server/src/builder.ts
+++ b/packages/server/src/builder.ts
@@ -1,6 +1,7 @@
 import type { AnySchema, ContractProcedureDef, ContractRouter, ErrorMap, HTTPPath, MergedErrorMap, Meta, Route, Schema } from '@orpc/contract'
+import type { IntersectPick } from '@orpc/shared'
 import type { BuilderWithMiddlewares, ProcedureBuilder, ProcedureBuilderWithInput, ProcedureBuilderWithOutput, RouterBuilder } from './builder-variants'
-import type { Context, ContextExtendsGuard, MergedCurrentContext, MergedInitialContext } from './context'
+import type { Context, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
 import type { Lazy } from './lazy'
 import type { AnyMiddleware, MapInputMiddleware, Middleware } from './middleware'
@@ -132,7 +133,7 @@ export class Builder<
     })
   }
 
-  use<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
+  use<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -141,35 +142,14 @@ export class Builder<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<TCurrentContext, UInContext>
-    & BuilderWithMiddlewares<
-      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
-      MergedCurrentContext<TCurrentContext, UOutContext>,
-      TInputSchema,
-      TOutputSchema,
-      TErrorMap,
-      TMeta
-    >
-
-  use<UOutContext extends Context, UInput, UInContext extends Context = TCurrentContext>(
-    middleware: Middleware<
-      UInContext,
-      UOutContext,
-      UInput,
-      unknown,
-      ORPCErrorConstructorMap<TErrorMap>,
-      TMeta
-    >,
-    mapInput: MapInputMiddleware<unknown, UInput>,
-  ): ContextExtendsGuard<TCurrentContext, UInContext>
-    & BuilderWithMiddlewares<
-      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
-      MergedCurrentContext<TCurrentContext, UOutContext>,
-      TInputSchema,
-      TOutputSchema,
-      TErrorMap,
-      TMeta
-    >
+  ): BuilderWithMiddlewares<
+    MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+    MergedCurrentContext<TCurrentContext, UOutContext>,
+    TInputSchema,
+    TOutputSchema,
+    TErrorMap,
+    TMeta
+  >
 
   use(
     middleware: AnyMiddleware,
@@ -191,7 +171,7 @@ export class Builder<
     return new Builder({
       ...this['~orpc'],
       meta: mergeMeta(this['~orpc'].meta, meta),
-    })
+    }) as any
   }
 
   route(
@@ -200,7 +180,7 @@ export class Builder<
     return new Builder({
       ...this['~orpc'],
       route: mergeRoute(this['~orpc'].route, route),
-    })
+    }) as any
   }
 
   input<USchema extends AnySchema>(

--- a/packages/server/src/context.test-d.ts
+++ b/packages/server/src/context.test-d.ts
@@ -1,4 +1,4 @@
-import type { ContextExtendsGuard, MergedCurrentContext, MergedInitialContext } from './context'
+import type { MergedCurrentContext, MergedInitialContext } from './context'
 
 it('MergedInitialContext', () => {
   expectTypeOf<MergedInitialContext<{ a: string }, { b: number }, { c: string }>>().toMatchTypeOf<{ a: string, b: number }>()
@@ -9,31 +9,4 @@ it('MergedInitialContext', () => {
 it('MergedCurrentContext', () => {
   expectTypeOf<MergedCurrentContext<{ a: string }, { b: number }>>().toMatchTypeOf<{ a: string, b: number }>()
   expectTypeOf<MergedCurrentContext<{ a: string }, { a: number }>>().toMatchTypeOf<{ a: number }>()
-})
-
-interface Empty {
-
-}
-
-it('ContextExtendsGuard', () => {
-  expectTypeOf < ContextExtendsGuard< { a: string, b: string }, { a: string }>>().toEqualTypeOf<unknown>()
-  expectTypeOf<ContextExtendsGuard<{ a: string }, { a: string }>>().toEqualTypeOf<unknown>()
-  expectTypeOf < ContextExtendsGuard< { a: string, b: string }, Empty>>().toEqualTypeOf<unknown>()
-  expectTypeOf < ContextExtendsGuard< { a: string, b: string }, Record<never, never>>>().toEqualTypeOf<unknown>()
-  expectTypeOf<ContextExtendsGuard<Empty, { a?: string }>>().toEqualTypeOf<unknown>()
-
-  expectTypeOf < ContextExtendsGuard < { a: string }, { a: string, b: string }>>().toEqualTypeOf<never>()
-  expectTypeOf < ContextExtendsGuard < { a: number }, { a: string }>>().toEqualTypeOf<never>()
-  expectTypeOf<ContextExtendsGuard<Empty, { a: string }>>().toEqualTypeOf<never>()
-
-  expectTypeOf<ContextExtendsGuard<{ a: string, b: string }, { g?: string }>>().toEqualTypeOf<never>()
-  expectTypeOf<ContextExtendsGuard<{ b: string }, { a?: string }>>().toEqualTypeOf<never>()
-  expectTypeOf<ContextExtendsGuard<{ b?: string }, { a?: string }>>().toEqualTypeOf<never>()
-
-  /**
-   * We can use `& Record<never, never>` to deal with `has no properties in common with type` error
-   */
-  expectTypeOf<ContextExtendsGuard<{ a: string, b: string }, { g?: string } & Record<never, never>>>().toEqualTypeOf<unknown>()
-  expectTypeOf<ContextExtendsGuard<{ b: string }, { a?: string } & Record<never, never>>>().toEqualTypeOf<unknown>()
-  expectTypeOf<ContextExtendsGuard<{ b?: string }, { a?: string } & Record<never, never>>>().toEqualTypeOf<unknown>()
 })

--- a/packages/server/src/context.ts
+++ b/packages/server/src/context.ts
@@ -14,5 +14,3 @@ export function mergeCurrentContext<T extends Context, U extends Context>(
 ): MergedCurrentContext<T, U> {
   return { ...context, ...other }
 }
-
-export type ContextExtendsGuard<T extends Context, U extends Context> = T extends U ? unknown : never

--- a/packages/server/src/implementer-procedure.test-d.ts
+++ b/packages/server/src/implementer-procedure.test-d.ts
@@ -90,8 +90,8 @@ describe('ImplementedProcedure', () => {
         >
       >()
 
-      // invalid TInContext
-      expectTypeOf(implemented.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)).toEqualTypeOf<never>()
+      // @ts-expect-error --- invalid TInContext
+      implemented.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)
       // @ts-expect-error --- input is not match
       implemented.use(({ next }, input: 'invalid') => next({}))
       // @ts-expect-error --- output is not match
@@ -129,8 +129,8 @@ describe('ImplementedProcedure', () => {
         >
       >()
 
-      // invalid TInContext
-      expectTypeOf(implemented.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>, () => {})).toEqualTypeOf<never>()
+      // @ts-expect-error --- invalid TInContext
+      implemented.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>, () => { })
       // @ts-expect-error --- input is not match
       implemented.use(({ next }, input: 'invalid') => next({}), () => {})
       // @ts-expect-error --- output is not match
@@ -265,8 +265,8 @@ describe('ProcedureImplementer', () => {
         >
       >()
 
-      // invalid TInContext
-      expectTypeOf(builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)).toEqualTypeOf<never>()
+      // @ts-expect-error --- invalid TInContext
+      builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)
       // @ts-expect-error --- input is not match
       builder.use(({ next }, input: 'invalid') => next({}))
       // @ts-expect-error --- output is not match
@@ -313,8 +313,8 @@ describe('ProcedureImplementer', () => {
         input => ({ invalid: true }),
       )
 
-      // invalid TInContext
-      expectTypeOf(builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>, () => {})).toEqualTypeOf<never>()
+      // @ts-expect-error --- invalid TInContext
+      builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>, () => { })
       // @ts-expect-error --- input is not match
       builder.use(({ next }, input: 'invalid') => next({}), input => ({ mapped: true }))
       // @ts-expect-error --- output is not match

--- a/packages/server/src/implementer-procedure.test-d.ts
+++ b/packages/server/src/implementer-procedure.test-d.ts
@@ -96,8 +96,8 @@ describe('ImplementedProcedure', () => {
       implemented.use(({ next }, input: 'invalid') => next({}))
       // @ts-expect-error --- output is not match
       implemented.use(({ next }, input, output: MiddlewareOutputFn<'invalid'>) => next({}))
-      // conflict context
-      expectTypeOf(implemented.use(({ next }) => next({ context: { db: undefined } }))).toEqualTypeOf<never>()
+      // @ts-expect-error --- conflict context
+      implemented.use(({ next }) => next({ context: { db: undefined } }))
     })
 
     it('with map input', () => {
@@ -135,8 +135,8 @@ describe('ImplementedProcedure', () => {
       implemented.use(({ next }, input: 'invalid') => next({}), () => {})
       // @ts-expect-error --- output is not match
       implemented.use(({ next }, input, output: MiddlewareOutputFn<'invalid'>) => next({}), () => {})
-      // conflict context but not detected
-      expectTypeOf(implemented.use(({ next }) => next({ context: { db: undefined } }), () => {})).toEqualTypeOf<never>()
+      // @ts-expect-error --- conflict context
+      implemented.use(({ next }) => next({ context: { db: undefined } }), () => { })
     })
 
     it('with TInContext', () => {

--- a/packages/server/src/implementer-procedure.ts
+++ b/packages/server/src/implementer-procedure.ts
@@ -1,6 +1,6 @@
 import type { ClientContext, ClientRest } from '@orpc/client'
 import type { AnySchema, ErrorMap, InferSchemaInput, InferSchemaOutput, Meta } from '@orpc/contract'
-import type { MaybeOptionalOptions } from '@orpc/shared'
+import type { IntersectPick, MaybeOptionalOptions } from '@orpc/shared'
 import type { BuilderDef } from './builder'
 import type { Context, ContextExtendsGuard, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
@@ -19,7 +19,7 @@ export interface ImplementedProcedure<
   TErrorMap extends ErrorMap,
   TMeta extends Meta,
 > extends Procedure<TInitialContext, TCurrentContext, TInputSchema, TOutputSchema, TErrorMap, TMeta> {
-  use<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
+  use<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -28,8 +28,7 @@ export interface ImplementedProcedure<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<TCurrentContext, UInContext>
-    & ContextExtendsGuard<MergedCurrentContext<TCurrentContext, UOutContext>, TCurrentContext>
+  ): ContextExtendsGuard<MergedCurrentContext<TCurrentContext, UOutContext>, TCurrentContext>
     & ImplementedProcedure<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,
@@ -39,7 +38,7 @@ export interface ImplementedProcedure<
       TMeta
     >
 
-  use<UOutContext extends Context, UInput, UInContext extends Context = TCurrentContext>(
+  use<UOutContext extends Context, UInput, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -49,8 +48,7 @@ export interface ImplementedProcedure<
       TMeta
     >,
     mapInput: MapInputMiddleware<InferSchemaOutput<TInputSchema>, UInput>,
-  ): ContextExtendsGuard<TCurrentContext, UInContext>
-    & ContextExtendsGuard<MergedCurrentContext<TCurrentContext, UOutContext>, TCurrentContext>
+  ): ContextExtendsGuard<MergedCurrentContext<TCurrentContext, UOutContext>, TCurrentContext>
     & ImplementedProcedure<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,
@@ -108,7 +106,7 @@ export interface ProcedureImplementer<
 > {
   '~orpc': BuilderDef<TInputSchema, TOutputSchema, TErrorMap, TMeta>
 
-  'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
+  'use'<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -117,17 +115,16 @@ export interface ProcedureImplementer<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<TCurrentContext, UInContext>
-    & ProcedureImplementer<
-      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
-      MergedCurrentContext<TCurrentContext, UOutContext>,
-      TInputSchema,
-      TOutputSchema,
-      TErrorMap,
-      TMeta
-    >
+  ): ProcedureImplementer<
+    MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+    MergedCurrentContext<TCurrentContext, UOutContext>,
+    TInputSchema,
+    TOutputSchema,
+    TErrorMap,
+    TMeta
+  >
 
-  'use'<UOutContext extends Context, UInput, UInContext extends Context = TCurrentContext>(
+  'use'<UOutContext extends Context, UInput, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -137,15 +134,14 @@ export interface ProcedureImplementer<
       TMeta
     >,
     mapInput: MapInputMiddleware<InferSchemaOutput<TInputSchema>, UInput>,
-  ): ContextExtendsGuard<TCurrentContext, UInContext>
-    & ProcedureImplementer<
-      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
-      MergedCurrentContext<TCurrentContext, UOutContext>,
-      TInputSchema,
-      TOutputSchema,
-      TErrorMap,
-      TMeta
-    >
+  ): ProcedureImplementer<
+    MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+    MergedCurrentContext<TCurrentContext, UOutContext>,
+    TInputSchema,
+    TOutputSchema,
+    TErrorMap,
+    TMeta
+  >
 
   'handler'(
     handler: ProcedureHandler<TCurrentContext, InferSchemaOutput<TInputSchema>, InferSchemaInput<TOutputSchema>, TErrorMap, TMeta>,

--- a/packages/server/src/implementer-procedure.ts
+++ b/packages/server/src/implementer-procedure.ts
@@ -19,9 +19,9 @@ export interface ImplementedProcedure<
   TErrorMap extends ErrorMap,
   TMeta extends Meta,
 > extends Procedure<TInitialContext, TCurrentContext, TInputSchema, TOutputSchema, TErrorMap, TMeta> {
-  use<UOutContext extends IntersectPick<TCurrentContext, UOutContext>, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
+  use<UOutContext extends IntersectPick<TCurrentContext, UOutContext>, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      UInContext,
+      UInContext | TCurrentContext,
       UOutContext,
       InferSchemaOutput<TInputSchema>,
       InferSchemaInput<TOutputSchema>,
@@ -37,9 +37,9 @@ export interface ImplementedProcedure<
     TMeta
   >
 
-  use<UOutContext extends IntersectPick<TCurrentContext, UOutContext>, UInput, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
+  use<UOutContext extends IntersectPick<TCurrentContext, UOutContext>, UInput, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      UInContext,
+      UInContext | TCurrentContext,
       UOutContext,
       UInput,
       InferSchemaInput<TOutputSchema>,
@@ -104,9 +104,9 @@ export interface ProcedureImplementer<
 > {
   '~orpc': BuilderDef<TInputSchema, TOutputSchema, TErrorMap, TMeta>
 
-  'use'<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
+  'use'<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      UInContext,
+      UInContext | TCurrentContext,
       UOutContext,
       InferSchemaOutput<TInputSchema>,
       InferSchemaInput<TOutputSchema>,
@@ -122,9 +122,9 @@ export interface ProcedureImplementer<
     TMeta
   >
 
-  'use'<UOutContext extends Context, UInput, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
+  'use'<UOutContext extends Context, UInput, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      UInContext,
+      UInContext | TCurrentContext,
       UOutContext,
       UInput,
       InferSchemaInput<TOutputSchema>,

--- a/packages/server/src/implementer-procedure.ts
+++ b/packages/server/src/implementer-procedure.ts
@@ -2,7 +2,7 @@ import type { ClientContext, ClientRest } from '@orpc/client'
 import type { AnySchema, ErrorMap, InferSchemaInput, InferSchemaOutput, Meta } from '@orpc/contract'
 import type { IntersectPick, MaybeOptionalOptions } from '@orpc/shared'
 import type { BuilderDef } from './builder'
-import type { Context, ContextExtendsGuard, MergedCurrentContext, MergedInitialContext } from './context'
+import type { Context, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
 import type { MapInputMiddleware, Middleware } from './middleware'
 import type { Procedure, ProcedureHandler } from './procedure'
@@ -19,7 +19,7 @@ export interface ImplementedProcedure<
   TErrorMap extends ErrorMap,
   TMeta extends Meta,
 > extends Procedure<TInitialContext, TCurrentContext, TInputSchema, TOutputSchema, TErrorMap, TMeta> {
-  use<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
+  use<UOutContext extends IntersectPick<TCurrentContext, UOutContext>, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -28,17 +28,16 @@ export interface ImplementedProcedure<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<MergedCurrentContext<TCurrentContext, UOutContext>, TCurrentContext>
-    & ImplementedProcedure<
-      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
-      MergedCurrentContext<TCurrentContext, UOutContext>,
-      TInputSchema,
-      TOutputSchema,
-      TErrorMap,
-      TMeta
-    >
+  ): ImplementedProcedure<
+    MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+    MergedCurrentContext<TCurrentContext, UOutContext>,
+    TInputSchema,
+    TOutputSchema,
+    TErrorMap,
+    TMeta
+  >
 
-  use<UOutContext extends Context, UInput, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
+  use<UOutContext extends IntersectPick<TCurrentContext, UOutContext>, UInput, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -48,15 +47,14 @@ export interface ImplementedProcedure<
       TMeta
     >,
     mapInput: MapInputMiddleware<InferSchemaOutput<TInputSchema>, UInput>,
-  ): ContextExtendsGuard<MergedCurrentContext<TCurrentContext, UOutContext>, TCurrentContext>
-    & ImplementedProcedure<
-      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
-      MergedCurrentContext<TCurrentContext, UOutContext>,
-      TInputSchema,
-      TOutputSchema,
-      TErrorMap,
-      TMeta
-    >
+  ): ImplementedProcedure<
+    MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+    MergedCurrentContext<TCurrentContext, UOutContext>,
+    TInputSchema,
+    TOutputSchema,
+    TErrorMap,
+    TMeta
+  >
 
   /**
    * Make this procedure callable (works like a function while still being a procedure).

--- a/packages/server/src/implementer-variants.test-d.ts
+++ b/packages/server/src/implementer-variants.test-d.ts
@@ -47,8 +47,8 @@ describe('ImplementerWithMiddlewares', () => {
           >
         >()
 
-        // invalid TInContext
-        expectTypeOf(implementer.nested.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)).toEqualTypeOf<never>()
+        // @ts-expect-error --- invalid TInContext
+        implementer.nested.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)
         // @ts-expect-error --- input is not match
         implementer.use(({ next }, input: 'invalid') => next({}))
         // @ts-expect-error --- output is not match

--- a/packages/server/src/implementer-variants.ts
+++ b/packages/server/src/implementer-variants.ts
@@ -1,5 +1,6 @@
 import type { AnyContractRouter, ContractProcedure, InferContractRouterErrorMap, InferContractRouterMeta } from '@orpc/contract'
-import type { Context, ContextExtendsGuard, MergedCurrentContext, MergedInitialContext } from './context'
+import type { IntersectPick } from '@orpc/shared'
+import type { Context, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
 import type { ProcedureImplementer } from './implementer-procedure'
 import type { Lazy } from './lazy'
@@ -12,7 +13,7 @@ export interface RouterImplementerWithMiddlewares<
   TInitialContext extends Context,
   TCurrentContext extends Context,
 > {
-  use<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
+  use<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -21,12 +22,11 @@ export interface RouterImplementerWithMiddlewares<
       ORPCErrorConstructorMap<InferContractRouterErrorMap<T>>,
       InferContractRouterMeta<T>
     >,
-  ): ContextExtendsGuard<TCurrentContext, UInContext>
-    & ImplementerInternalWithMiddlewares<
-      T,
-      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
-      MergedCurrentContext<TCurrentContext, UOutContext>
-    >
+  ): ImplementerInternalWithMiddlewares<
+    T,
+    MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+    MergedCurrentContext<TCurrentContext, UOutContext>
+  >
 
   router<U extends Router<T, TCurrentContext>>(
     router: U): EnhancedRouter<U, TInitialContext, TCurrentContext, Record<never, never>>

--- a/packages/server/src/implementer-variants.ts
+++ b/packages/server/src/implementer-variants.ts
@@ -1,5 +1,4 @@
 import type { AnyContractRouter, ContractProcedure, InferContractRouterErrorMap, InferContractRouterMeta } from '@orpc/contract'
-import type { IntersectPick } from '@orpc/shared'
 import type { Context, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
 import type { ProcedureImplementer } from './implementer-procedure'
@@ -13,9 +12,9 @@ export interface RouterImplementerWithMiddlewares<
   TInitialContext extends Context,
   TCurrentContext extends Context,
 > {
-  use<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
+  use<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      UInContext,
+      UInContext | TCurrentContext,
       UOutContext,
       unknown,
       unknown,

--- a/packages/server/src/implementer.test-d.ts
+++ b/packages/server/src/implementer.test-d.ts
@@ -116,8 +116,8 @@ describe('Implementer', () => {
           >
         >()
 
-        // invalid TInContext
-        expectTypeOf(implementer.nested.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)).toEqualTypeOf<never>()
+        // @ts-expect-error --- invalid TInContext
+        implementer.nested.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)
         // @ts-expect-error --- input is not match
         implementer.use(({ next }, input: 'invalid') => next({}))
         // @ts-expect-error --- output is not match

--- a/packages/server/src/implementer.test-d.ts
+++ b/packages/server/src/implementer.test-d.ts
@@ -63,13 +63,10 @@ describe('Implementer', () => {
             { extra: boolean },
             unknown,
             any,
-            ORPCErrorConstructorMap<any>,
+            any,
             Meta | BaseMeta
           >
         >()
-
-        // @ts-expect-error --- conflict context
-        implementer.middleware(({ next }) => next({ db: 123 }))
       })
 
       it('can type input and output', () => {
@@ -81,7 +78,7 @@ describe('Implementer', () => {
             Record<never, never>,
             'input',
             'output',
-            ORPCErrorConstructorMap<any>,
+            any,
             Meta | BaseMeta
           >
         >()

--- a/packages/server/src/implementer.ts
+++ b/packages/server/src/implementer.ts
@@ -1,6 +1,6 @@
 import type { AnyContractRouter, ContractProcedure, InferContractRouterErrorMap, InferContractRouterMeta } from '@orpc/contract'
-import type { AnyFunction } from '@orpc/shared'
-import type { Context, ContextExtendsGuard, MergedCurrentContext, MergedInitialContext } from './context'
+import type { AnyFunction, IntersectPick } from '@orpc/shared'
+import type { Context, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
 import type { ProcedureImplementer } from './implementer-procedure'
 import type { ImplementerInternalWithMiddlewares } from './implementer-variants'
@@ -32,7 +32,7 @@ export interface RouterImplementer<
     >,
   ): DecoratedMiddleware<TInitialContext, UOutContext, TInput, TOutput, ORPCErrorConstructorMap<any>, InferContractRouterMeta<T>> // ORPCErrorConstructorMap<any> ensures middleware can used in any procedure
 
-  use<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
+  use<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -41,12 +41,11 @@ export interface RouterImplementer<
       ORPCErrorConstructorMap<InferContractRouterErrorMap<T>>,
       InferContractRouterMeta<T>
     >,
-  ): ContextExtendsGuard<TCurrentContext, UInContext>
-    & ImplementerInternalWithMiddlewares<
-      T,
-      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
-      MergedCurrentContext<TCurrentContext, UOutContext>
-    >
+  ): ImplementerInternalWithMiddlewares<
+    T,
+    MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+    MergedCurrentContext<TCurrentContext, UOutContext>
+  >
 
   router<U extends Router<T, TCurrentContext>>(
     router: U): EnhancedRouter<U, TInitialContext, TCurrentContext, Record<never, never>>

--- a/packages/server/src/implementer.ts
+++ b/packages/server/src/implementer.ts
@@ -1,5 +1,5 @@
 import type { AnyContractRouter, ContractProcedure, InferContractRouterErrorMap, InferContractRouterMeta } from '@orpc/contract'
-import type { AnyFunction, IntersectPick } from '@orpc/shared'
+import type { AnyFunction } from '@orpc/shared'
 import type { Context, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
 import type { ProcedureImplementer } from './implementer-procedure'
@@ -30,11 +30,11 @@ export interface RouterImplementer<
       ORPCErrorConstructorMap<InferContractRouterErrorMap<T>>,
       InferContractRouterMeta<T>
     >,
-  ): DecoratedMiddleware<TInitialContext, UOutContext, TInput, TOutput, ORPCErrorConstructorMap<any>, InferContractRouterMeta<T>> // ORPCErrorConstructorMap<any> ensures middleware can used in any procedure
+  ): DecoratedMiddleware<TInitialContext, UOutContext, TInput, TOutput, any, InferContractRouterMeta<T>> // any ensures middleware can used in any procedure
 
-  use<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
+  use<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      UInContext,
+      UInContext | TCurrentContext,
       UOutContext,
       unknown,
       unknown,

--- a/packages/server/src/middleware-decorated.test-d.ts
+++ b/packages/server/src/middleware-decorated.test-d.ts
@@ -79,8 +79,8 @@ describe('DecoratedMiddleware', () => {
         >
       >()
 
-      // invalid TInContext
-      expectTypeOf(decorated.concat({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)).toEqualTypeOf<never>()
+      // @ts-expect-error --- invalid TInContext
+      decorated.concat({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)
       // @ts-expect-error --- output is not match
       decorated.concat(({ next }, input, output: MiddlewareOutputFn<'invalid'>) => next({}))
     })
@@ -125,8 +125,8 @@ describe('DecoratedMiddleware', () => {
         input => ({ invalid: true }),
       )
 
-      // invalid TInContext
-      expectTypeOf(decorated.concat({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>, () => { })).toEqualTypeOf<never>()
+      // @ts-expect-error --- invalid TInContext
+      decorated.concat({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>, () => { })
       // @ts-expect-error --- output is not match
       decorated.concat(({ next }, input, output: MiddlewareOutputFn<'invalid'>) => next({}), input => ({ mapped: true }))
     })

--- a/packages/server/src/middleware-decorated.ts
+++ b/packages/server/src/middleware-decorated.ts
@@ -1,5 +1,4 @@
 import type { Meta } from '@orpc/contract'
-import type { IntersectPick } from '@orpc/shared'
 import type { Context, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
 import type { AnyMiddleware, MapInputMiddleware, Middleware } from './middleware'
@@ -18,10 +17,10 @@ export interface DecoratedMiddleware<
 
   concat<
     UOutContext extends Context,
-    UInContext extends IntersectPick<MergedCurrentContext<TInContext, TOutContext>, UInContext> = MergedCurrentContext<TInContext, TOutContext>,
+    UInContext extends Context = MergedCurrentContext<TInContext, TOutContext>,
   >(
     middleware: Middleware<
-      UInContext,
+      UInContext | MergedCurrentContext<TInContext, TOutContext>,
       UOutContext,
       TInput,
       TOutput,
@@ -40,10 +39,10 @@ export interface DecoratedMiddleware<
   concat<
     UOutContext extends Context,
     UMappedInput,
-    UInContext extends IntersectPick<MergedCurrentContext<TInContext, TOutContext>, UInContext> = MergedCurrentContext<TInContext, TOutContext>,
+    UInContext extends Context = MergedCurrentContext<TInContext, TOutContext>,
   >(
     middleware: Middleware<
-      UInContext,
+      UInContext | MergedCurrentContext<TInContext, TOutContext>,
       UOutContext,
       UMappedInput,
       TOutput,

--- a/packages/server/src/middleware-decorated.ts
+++ b/packages/server/src/middleware-decorated.ts
@@ -1,5 +1,6 @@
 import type { Meta } from '@orpc/contract'
-import type { Context, ContextExtendsGuard, MergedCurrentContext, MergedInitialContext } from './context'
+import type { IntersectPick } from '@orpc/shared'
+import type { Context, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
 import type { AnyMiddleware, MapInputMiddleware, Middleware } from './middleware'
 
@@ -15,7 +16,10 @@ export interface DecoratedMiddleware<
     map: MapInputMiddleware<UInput, TInput>,
   ): DecoratedMiddleware<TInContext, TOutContext, UInput, TOutput, TErrorConstructorMap, TMeta>
 
-  concat<UOutContext extends Context, UInContext extends Context = MergedCurrentContext<TInContext, TOutContext>>(
+  concat<
+    UOutContext extends Context,
+    UInContext extends IntersectPick<MergedCurrentContext<TInContext, TOutContext>, UInContext> = MergedCurrentContext<TInContext, TOutContext>,
+  >(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -24,20 +28,19 @@ export interface DecoratedMiddleware<
       TErrorConstructorMap,
       TMeta
     >,
-  ): ContextExtendsGuard<MergedCurrentContext<TInContext, TOutContext>, UInContext>
-    & DecoratedMiddleware<
-      MergedInitialContext<TInContext, UInContext, MergedCurrentContext<TInContext, TOutContext>>,
-      MergedCurrentContext<TOutContext, UOutContext>,
-      TInput,
-      TOutput,
-      TErrorConstructorMap,
-      TMeta
-    >
+  ): DecoratedMiddleware<
+    MergedInitialContext<TInContext, UInContext, MergedCurrentContext<TInContext, TOutContext>>,
+    MergedCurrentContext<TOutContext, UOutContext>,
+    TInput,
+    TOutput,
+    TErrorConstructorMap,
+    TMeta
+  >
 
   concat<
     UOutContext extends Context,
     UMappedInput,
-    UInContext extends Context = MergedCurrentContext<TInContext, TOutContext>,
+    UInContext extends IntersectPick<MergedCurrentContext<TInContext, TOutContext>, UInContext> = MergedCurrentContext<TInContext, TOutContext>,
   >(
     middleware: Middleware<
       UInContext,
@@ -48,15 +51,14 @@ export interface DecoratedMiddleware<
       TMeta
     >,
     mapInput: MapInputMiddleware<TInput, UMappedInput>,
-  ): ContextExtendsGuard<MergedCurrentContext<TInContext, TOutContext>, UInContext>
-    & DecoratedMiddleware<
-      MergedInitialContext<TInContext, UInContext, MergedCurrentContext<TInContext, TOutContext>>,
-      MergedCurrentContext<TOutContext, UOutContext>,
-      TInput,
-      TOutput,
-      TErrorConstructorMap,
-      TMeta
-    >
+  ): DecoratedMiddleware<
+    MergedInitialContext<TInContext, UInContext, MergedCurrentContext<TInContext, TOutContext>>,
+    MergedCurrentContext<TOutContext, UOutContext>,
+    TInput,
+    TOutput,
+    TErrorConstructorMap,
+    TMeta
+  >
 }
 
 export function decorateMiddleware<

--- a/packages/server/src/procedure-decorated.test-d.ts
+++ b/packages/server/src/procedure-decorated.test-d.ts
@@ -124,8 +124,8 @@ describe('DecoratedProcedure', () => {
       builder.use(({ next }, input: 'invalid') => next({}))
       // @ts-expect-error --- output is not match
       builder.use(({ next }, input, output: MiddlewareOutputFn<'invalid'>) => next({}))
-      // conflict context but not detected
-      expectTypeOf(builder.use(({ next }) => next({ context: { db: undefined } }))).toEqualTypeOf<never>()
+      // @ts-expect-error --- conflict context
+      builder.use(({ next }) => next({ context: { db: undefined } }))
     })
 
     it('with map input', () => {
@@ -163,8 +163,8 @@ describe('DecoratedProcedure', () => {
       builder.use(({ next }, input: 'invalid') => next({}), () => {})
       // @ts-expect-error --- output is not match
       builder.use(({ next }, input, output: MiddlewareOutputFn<'invalid'>) => next({}), () => {})
-      // conflict context but not detected
-      expectTypeOf(builder.use(({ next }) => next({ context: { db: undefined } }), () => {})).toEqualTypeOf<never>()
+      // @ts-expect-error --- conflict context
+      builder.use(({ next }) => next({ context: { db: undefined } }), () => { })
     })
 
     it('with TInContext', () => {

--- a/packages/server/src/procedure-decorated.test-d.ts
+++ b/packages/server/src/procedure-decorated.test-d.ts
@@ -118,8 +118,8 @@ describe('DecoratedProcedure', () => {
         >
       >()
 
-      // invalid TInContext
-      expectTypeOf(builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)).toEqualTypeOf<never>()
+      // @ts-expect-error --- invalid TInContext
+      builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)
       // @ts-expect-error --- input is not match
       builder.use(({ next }, input: 'invalid') => next({}))
       // @ts-expect-error --- output is not match
@@ -157,8 +157,8 @@ describe('DecoratedProcedure', () => {
         >
       >()
 
-      // invalid TInContext
-      expectTypeOf(builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>, () => { })).toEqualTypeOf<never>()
+      // @ts-expect-error --- invalid TInContext
+      builder.use({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>, () => {})
       // @ts-expect-error --- input is not match
       builder.use(({ next }, input: 'invalid') => next({}), () => {})
       // @ts-expect-error --- output is not match

--- a/packages/server/src/procedure-decorated.ts
+++ b/packages/server/src/procedure-decorated.ts
@@ -1,6 +1,6 @@
 import type { ClientContext, ClientRest } from '@orpc/client'
 import type { AnySchema, ErrorMap, InferSchemaInput, InferSchemaOutput, MergedErrorMap, Meta, Route } from '@orpc/contract'
-import type { MaybeOptionalOptions } from '@orpc/shared'
+import type { IntersectPick, MaybeOptionalOptions } from '@orpc/shared'
 import type { Context, ContextExtendsGuard, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
 import type { AnyMiddleware, MapInputMiddleware, Middleware } from './middleware'
@@ -53,7 +53,7 @@ export class DecoratedProcedure<
     })
   }
 
-  use<UOutContext extends Context, UInContext extends Context = TCurrentContext>(
+  use<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -62,8 +62,7 @@ export class DecoratedProcedure<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<TCurrentContext, UInContext>
-    & ContextExtendsGuard<MergedCurrentContext<TCurrentContext, UOutContext>, TCurrentContext>
+  ): ContextExtendsGuard<MergedCurrentContext<TCurrentContext, UOutContext>, TCurrentContext>
     & DecoratedProcedure<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,
@@ -73,7 +72,7 @@ export class DecoratedProcedure<
       TMeta
     >
 
-  use<UOutContext extends Context, UInput, UInContext extends Context = TCurrentContext>(
+  use<UOutContext extends Context, UInput, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -83,8 +82,7 @@ export class DecoratedProcedure<
       TMeta
     >,
     mapInput: MapInputMiddleware<InferSchemaOutput<TInputSchema>, UInput>,
-  ): ContextExtendsGuard<TCurrentContext, UInContext>
-    & ContextExtendsGuard<MergedCurrentContext<TCurrentContext, UOutContext>, TCurrentContext>
+  ): ContextExtendsGuard<MergedCurrentContext<TCurrentContext, UOutContext>, TCurrentContext>
     & DecoratedProcedure<
       MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
       MergedCurrentContext<TCurrentContext, UOutContext>,

--- a/packages/server/src/procedure-decorated.ts
+++ b/packages/server/src/procedure-decorated.ts
@@ -53,9 +53,9 @@ export class DecoratedProcedure<
     })
   }
 
-  use<UOutContext extends IntersectPick<TCurrentContext, UOutContext>, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
+  use<UOutContext extends IntersectPick<TCurrentContext, UOutContext>, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      UInContext,
+      UInContext | TCurrentContext,
       UOutContext,
       InferSchemaOutput<TInputSchema>,
       InferSchemaInput<TOutputSchema>,
@@ -71,9 +71,9 @@ export class DecoratedProcedure<
     TMeta
   >
 
-  use<UOutContext extends IntersectPick<TCurrentContext, UOutContext>, UInput, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
+  use<UOutContext extends IntersectPick<TCurrentContext, UOutContext>, UInput, UInContext extends Context = TCurrentContext>(
     middleware: Middleware<
-      UInContext,
+      UInContext | TCurrentContext,
       UOutContext,
       UInput,
       InferSchemaInput<TOutputSchema>,

--- a/packages/server/src/procedure-decorated.ts
+++ b/packages/server/src/procedure-decorated.ts
@@ -1,7 +1,7 @@
 import type { ClientContext, ClientRest } from '@orpc/client'
 import type { AnySchema, ErrorMap, InferSchemaInput, InferSchemaOutput, MergedErrorMap, Meta, Route } from '@orpc/contract'
 import type { IntersectPick, MaybeOptionalOptions } from '@orpc/shared'
-import type { Context, ContextExtendsGuard, MergedCurrentContext, MergedInitialContext } from './context'
+import type { Context, MergedCurrentContext, MergedInitialContext } from './context'
 import type { ORPCErrorConstructorMap } from './error'
 import type { AnyMiddleware, MapInputMiddleware, Middleware } from './middleware'
 import type { CreateProcedureClientOptions, ProcedureClient } from './procedure-client'
@@ -53,7 +53,7 @@ export class DecoratedProcedure<
     })
   }
 
-  use<UOutContext extends Context, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
+  use<UOutContext extends IntersectPick<TCurrentContext, UOutContext>, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -62,17 +62,16 @@ export class DecoratedProcedure<
       ORPCErrorConstructorMap<TErrorMap>,
       TMeta
     >,
-  ): ContextExtendsGuard<MergedCurrentContext<TCurrentContext, UOutContext>, TCurrentContext>
-    & DecoratedProcedure<
-      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
-      MergedCurrentContext<TCurrentContext, UOutContext>,
-      TInputSchema,
-      TOutputSchema,
-      TErrorMap,
-      TMeta
-    >
+  ): DecoratedProcedure<
+    MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+    MergedCurrentContext<TCurrentContext, UOutContext>,
+    TInputSchema,
+    TOutputSchema,
+    TErrorMap,
+    TMeta
+  >
 
-  use<UOutContext extends Context, UInput, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
+  use<UOutContext extends IntersectPick<TCurrentContext, UOutContext>, UInput, UInContext extends IntersectPick<TCurrentContext, UInContext> = TCurrentContext>(
     middleware: Middleware<
       UInContext,
       UOutContext,
@@ -82,15 +81,14 @@ export class DecoratedProcedure<
       TMeta
     >,
     mapInput: MapInputMiddleware<InferSchemaOutput<TInputSchema>, UInput>,
-  ): ContextExtendsGuard<MergedCurrentContext<TCurrentContext, UOutContext>, TCurrentContext>
-    & DecoratedProcedure<
-      MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
-      MergedCurrentContext<TCurrentContext, UOutContext>,
-      TInputSchema,
-      TOutputSchema,
-      TErrorMap,
-      TMeta
-    >
+  ): DecoratedProcedure<
+    MergedInitialContext<TInitialContext, UInContext, TCurrentContext>,
+    MergedCurrentContext<TCurrentContext, UOutContext>,
+    TInputSchema,
+    TOutputSchema,
+    TErrorMap,
+    TMeta
+  >
 
   use(middleware: AnyMiddleware, mapInput?: MapInputMiddleware<any, any>): DecoratedProcedure<any, any, any, any, any, any> {
     const mapped = mapInput

--- a/packages/shared/src/types.test-d.ts
+++ b/packages/shared/src/types.test-d.ts
@@ -17,7 +17,7 @@ it('MaybeOptionalOptions', () => {
 
   b()
   // @ts-expect-error - options is invalid
-  a({ b: '1' })
+  b({ b: '1' })
   b({ b: 1 })
 })
 

--- a/packages/shared/src/types.test-d.ts
+++ b/packages/shared/src/types.test-d.ts
@@ -1,0 +1,35 @@
+import type { IntersectPick, MaybeOptionalOptions, SetOptional } from './types'
+
+it('MaybeOptionalOptions', () => {
+  const a = (...[options]: MaybeOptionalOptions<{ a: number }>) => {
+    expectTypeOf(options).toEqualTypeOf<{ a: number }>()
+  }
+
+  // @ts-expect-error - options is required
+  a()
+  // @ts-expect-error - options is invalid
+  a({ a: '1' })
+  a({ a: 1 })
+
+  const b = (...[options]: MaybeOptionalOptions<{ b?: number }>) => {
+    expectTypeOf(options).toEqualTypeOf<{ b?: number } | undefined>()
+  }
+
+  b()
+  // @ts-expect-error - options is invalid
+  a({ b: '1' })
+  b({ b: 1 })
+})
+
+it('SetOptional', () => {
+  expectTypeOf<SetOptional<{ a: number }, 'a'>>().toMatchTypeOf<{ a?: number }>()
+  expectTypeOf<SetOptional<{ a?: number }, 'a'>>().toMatchTypeOf<{ a?: number }>()
+})
+
+interface Empty {}
+
+it('IntersectPick', () => {
+  expectTypeOf<IntersectPick<{ a: number }, { a: number, b: number }>>().toEqualTypeOf<{ a: number }>()
+  expectTypeOf<IntersectPick<{ a: number, b: number }, { b: number }>>().toEqualTypeOf<{ b: number }>()
+  expectTypeOf<IntersectPick<{ a: number }, { b: number }>>().toEqualTypeOf<Empty>()
+})

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -3,3 +3,5 @@ export type MaybeOptionalOptions<TOptions> = Record<never, never> extends TOptio
   : [options: TOptions]
 
 export type SetOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
+
+export type IntersectPick<T, U> = Pick<T, keyof T & keyof U>


### PR DESCRIPTION
BEFORE: The `.use` method might return `never` if the required conditions are not met; 
NOW: it throw a TypeScript error to indicate the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined middleware and procedure method signatures to enhance type safety and flexibility.
  - Removed redundant types and constructs for a cleaner, more maintainable internal API.
  - Introduced a new type alias `IntersectPick` to facilitate type intersections.

- **Tests**
  - Updated error handling annotations to clearly indicate expected TypeScript errors, resulting in more concise tests.
  - Added new unit tests for utility types to ensure type correctness.

- **Chores**
  - Cleaned up unused type definitions and import statements to improve overall code maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->