### PR TITLE
fix(client, server): prevent toJSON problem

### DIFF
--- a/packages/client/src/adapters/standard/rpc-json-serializer.test.ts
+++ b/packages/client/src/adapters/standard/rpc-json-serializer.test.ts
@@ -40,6 +40,16 @@ const customSupportedDataTypes: { name: string, value: unknown, expected: unknow
     value: new Person2('unnoq - 2', [{ nested: new Date('2023-01-02') }, /uic/gi]),
     expected: new Person2('unnoq - 2', [{ nested: new Date('2023-01-02') }, /uic/gi]),
   },
+  {
+    name: 'should not resolve toJSON',
+    value: { value: { toJSON: () => 'hello' } },
+    expected: { value: { } },
+  },
+  {
+    name: 'should resolve invalid toJSON',
+    value: { value: { toJSON: 'hello' } },
+    expected: { value: { toJSON: 'hello' } },
+  },
 ]
 
 describe.each([
@@ -66,7 +76,14 @@ describe.each([
   function assert(value: unknown, expected: unknown) {
     const [json, meta, maps, blobs] = serializer.serialize(value)
 
-    const deserialized = serializer.deserialize(json, meta, maps, (i: number) => blobs[i]!)
+    const result = JSON.parse(JSON.stringify({ json, meta, maps }))
+
+    const deserialized = serializer.deserialize(
+      result.json,
+      result.meta,
+      result.maps,
+      (i: number) => blobs[i]!,
+    )
     expect(deserialized).toEqual(expected)
   }
 

--- a/packages/client/src/adapters/standard/rpc-json-serializer.ts
+++ b/packages/client/src/adapters/standard/rpc-json-serializer.ts
@@ -112,6 +112,15 @@ export class StandardRPCJsonSerializer {
       const json: Record<string, unknown> = {}
 
       for (const k in data) {
+        /**
+         * Skip custom toJSON methods to avoid JSON.stringify invoking them,
+         * which could cause meta and serialized data mismatches during deserialization.
+         * Instead, rely on custom serializers.
+         */
+        if (k === 'toJSON' && typeof data[k] === 'function') {
+          continue
+        }
+
         json[k] = this.serialize(data[k], [...segments, k], meta, maps, blobs)[0]
       }
 

--- a/packages/openapi-client/src/adapters/standard/openapi-json-serializer.test.ts
+++ b/packages/openapi-client/src/adapters/standard/openapi-json-serializer.test.ts
@@ -145,6 +145,14 @@ const customSupportedDataTypes: TestCase[] = [
     data: new Person2('unnoq - 2', [{ nested: new Date('2023-01-02') }, /uic/gi]),
     expected: { name: 'unnoq - 2', data: [{ nested: '2023-01-02T00:00:00.000Z' }, '/uic/gi'] },
   },
+  {
+    data: { value: { toJSON: () => 'hello' } },
+    expected: { value: { } },
+  },
+  {
+    data: { value: { toJSON: 'hello' } },
+    expected: { value: { toJSON: 'hello' } },
+  },
 ]
 
 describe.each<TestCase>([

--- a/packages/openapi-client/src/adapters/standard/openapi-json-serializer.ts
+++ b/packages/openapi-client/src/adapters/standard/openapi-json-serializer.ts
@@ -49,6 +49,15 @@ export class StandardOpenAPIJsonSerializer {
       const json: Record<string, unknown> = {}
 
       for (const k in data) {
+        /**
+         * Skip custom toJSON methods to avoid JSON.stringify invoking them,
+         * which could cause meta and serialized data mismatches during deserialization.
+         * Instead, rely on custom serializers.
+         */
+        if (k === 'toJSON' && typeof data[k] === 'function') {
+          continue
+        }
+
         json[k] = this.serialize(data[k], hasBlobRef)[0]
       }
 


### PR DESCRIPTION
Skip custom toJSON methods to avoid JSON.stringify invoking them,
which could cause meta and serialized data mismatches during deserialization.
Instead, rely on custom serializers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced JSON serialization to ensure consistent data handling by bypassing unintended custom conversion routines.
  
- **Tests**
  - Expanded coverage with new cases that validate the improved behavior in processing objects with custom conversion logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->