### PR TITLE
feat(client)!: update `ClientRetryPlugin` options

### DIFF
--- a/apps/content/docs/plugins/client-retry.md
+++ b/apps/content/docs/plugins/client-retry.md
@@ -55,7 +55,7 @@ const planets = await client.planet.list({ limit: 10 }, {
 By default, retries are disabled unless a `retry` count is explicitly set.
 
 - **retry:** Maximum retry attempts before throwing an error (default: `0`).
-- **retryDelay:** Delay between retries (default: `(o) => o.eventIteratorLastRetry ?? 2000`).
+- **retryDelay:** Delay between retries (default: `(o) => o.lastEventRetry ?? 2000`).
 - **shouldRetry:** Function that determines whether to retry (default: `true`).
   :::
 


### PR DESCRIPTION
- rename `eventIteratorLastRetry`  ⇾ `lastEventRetry`
- rename `eventIteratorLastEventId` ⇾ `lastEventId`
- add some missing tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Updated plugin documentation to reflect the revised default retry configuration.
  
- **New Features**
  - Enhanced the retry mechanism with a customizable decision process and improved error context during retry attempts.
  
- **Refactor**
  - Streamlined internal retry logic by standardizing parameter naming for improved clarity and consistency. 
  - Updated default retry delay configuration for better functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->