### PR TITLE
fix(contract, server): remove redundant `description` in .errors

### DIFF
--- a/packages/contract/src/error.ts
+++ b/packages/contract/src/error.ts
@@ -19,7 +19,6 @@ export class ValidationError extends Error {
 export interface ErrorMapItem<TDataSchema extends AnySchema> {
   status?: number
   message?: string
-  description?: string
   data?: TDataSchema
 }
 


### PR DESCRIPTION
ORPCError not have description, this is mistake

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined error reporting by simplifying error details, resulting in more consistent and concise error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->