### PR TITLE
feat(server): body limit plugin

### DIFF
--- a/apps/content/.vitepress/config.ts
+++ b/apps/content/.vitepress/config.ts
@@ -109,6 +109,7 @@ export default defineConfig({
             { text: 'CORS', link: '/docs/plugins/cors' },
             { text: 'Response Headers', link: '/docs/plugins/response-headers' },
             { text: 'Client Retry', link: '/docs/plugins/client-retry' },
+            { text: 'Body Limit', link: '/docs/plugins/body-limit' },
           ],
         },
         {

--- a/apps/content/docs/plugins/body-limit.md
+++ b/apps/content/docs/plugins/body-limit.md
@@ -1,0 +1,31 @@
+---
+title: Body Limit Plugin
+description: A plugin for oRPC to limit the request body size.
+---
+
+# Body Limit Plugin
+
+The **Body Limit Plugin** restricts the size of the request body.
+
+## Import
+
+Depending on your adapter, import the corresponding plugin:
+
+```ts
+import { BodyLimitPlugin } from '@orpc/server/fetch'
+import { BodyLimitPlugin } from '@orpc/server/node'
+```
+
+## Setup
+
+Configure the plugin with your desired maximum body size:
+
+```ts
+const handler = new RPCHandler(router, {
+  plugins: [
+    new BodyLimitPlugin({
+      maxBodySize: 1024 * 1024, // 1MB
+    }),
+  ],
+})
+```

--- a/packages/server/src/adapters/fetch/body-limit-plugin.test.ts
+++ b/packages/server/src/adapters/fetch/body-limit-plugin.test.ts
@@ -1,0 +1,76 @@
+import { os } from '../../builder'
+import { BodyLimitPlugin } from './body-limit-plugin'
+import { RPCHandler } from './rpc-handler'
+
+describe('bodyLimitPlugin', () => {
+  const size22Json = { json: { foo: 'bar' } }
+
+  it('should ignore for non-body request', async () => {
+    const handler = new RPCHandler(os.handler(() => 'ping'), {
+      plugins: [
+        new BodyLimitPlugin({ maxBodySize: 22 }),
+      ],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/?data=%7B%7D'))
+
+    await expect(response?.text()).resolves.toContain('ping')
+    expect(response?.status).toBe(200)
+  })
+
+  it('should work if body size is not exceeded', async () => {
+    const handler = new RPCHandler(os.handler(() => 'ping'), {
+      plugins: [
+        new BodyLimitPlugin({ maxBodySize: 22 }),
+      ],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(size22Json),
+    }))
+
+    await expect(response?.text()).resolves.toContain('ping')
+    expect(response?.status).toBe(200)
+  })
+
+  it('check the content-length', async () => {
+    const handler = new RPCHandler(os.handler(() => 'ping'), {
+      plugins: [
+        new BodyLimitPlugin({ maxBodySize: 21 }),
+      ],
+    })
+    const { response } = await handler.handle(new Request('https://example.com', {
+      method: 'POST',
+      headers: {
+        'content-length': '22',
+      },
+      body: JSON.stringify({}),
+    }))
+
+    await expect(response?.text()).resolves.toContain('PAYLOAD_TOO_LARGE')
+    expect(response?.status).toBe(413)
+  })
+
+  it('check the body-size', async () => {
+    const handler = new RPCHandler(os.handler(() => 'ping'), {
+      plugins: [
+        new BodyLimitPlugin({ maxBodySize: 21 }),
+      ],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(size22Json),
+    }))
+
+    await expect(response?.text()).resolves.toContain('PAYLOAD_TOO_LARGE')
+    expect(response?.status).toBe(413)
+  })
+})

--- a/packages/server/src/adapters/fetch/body-limit-plugin.ts
+++ b/packages/server/src/adapters/fetch/body-limit-plugin.ts
@@ -1,0 +1,70 @@
+import type { Context } from '../../context'
+import type { FetchHandlerOptions, FetchHandlerPlugin } from './handler'
+import { ORPCError } from '@orpc/client'
+
+export interface BodyLimitPluginOptions {
+  /**
+   * The maximum size of the body in bytes.
+   */
+  maxBodySize: number
+}
+
+export class BodyLimitPlugin<T extends Context> implements FetchHandlerPlugin<T> {
+  private readonly maxBodySize: number
+
+  constructor(options: BodyLimitPluginOptions) {
+    this.maxBodySize = options.maxBodySize
+  }
+
+  initRuntimeAdapter(options: FetchHandlerOptions<T>): void {
+    options.adapterInterceptors ??= []
+
+    options.adapterInterceptors.push(async (options) => {
+      if (!options.request.body) {
+        return options.next()
+      }
+
+      let currentBodySize = 0
+
+      const rawReader = options.request.body.getReader()
+
+      const reader = new ReadableStream({
+        start: async (controller) => {
+          try {
+            if (Number(options.request.headers.get('content-length')) > this.maxBodySize) {
+              controller.error(new ORPCError('PAYLOAD_TOO_LARGE'))
+              return
+            }
+
+            while (true) {
+              const { done, value } = await rawReader.read()
+
+              if (done) {
+                break
+              }
+
+              currentBodySize += value.length
+
+              if (currentBodySize > this.maxBodySize) {
+                controller.error(new ORPCError('PAYLOAD_TOO_LARGE'))
+                break
+              }
+
+              controller.enqueue(value)
+            }
+          }
+          finally {
+            controller.close()
+          }
+        },
+      })
+
+      const requestInit: RequestInit & { duplex: 'half' } = { body: reader, duplex: 'half' }
+
+      return options.next({
+        ...options,
+        request: new Request(options.request, requestInit),
+      })
+    })
+  }
+}

--- a/packages/server/src/adapters/fetch/index.ts
+++ b/packages/server/src/adapters/fetch/index.ts
@@ -1,2 +1,3 @@
+export * from './body-limit-plugin'
 export * from './handler'
 export * from './rpc-handler'

--- a/packages/server/src/adapters/node/body-limit-plugin.test.ts
+++ b/packages/server/src/adapters/node/body-limit-plugin.test.ts
@@ -1,0 +1,63 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import request from 'supertest'
+import { os } from '../../builder'
+import { BodyLimitPlugin } from './body-limit-plugin'
+import { RPCHandler } from './rpc-handler'
+
+describe('bodyLimitPlugin', () => {
+  const size22Json = { json: { foo: 'bar' } }
+
+  it('should work if body size is not exceeded', async () => {
+    const res = await request(async (req: IncomingMessage, res: ServerResponse) => {
+      const handler = new RPCHandler(os.handler(() => 'ping'), {
+        plugins: [
+          new BodyLimitPlugin({ maxBodySize: 22 }),
+        ],
+      })
+
+      await handler.handle(req, res)
+    })
+      .post('/')
+      .send(size22Json)
+
+    expect(res.text).toContain('ping')
+    expect(res.status).toBe(200)
+  })
+
+  it('check the content-length', async () => {
+    const res = await request(async (req: IncomingMessage, res: ServerResponse) => {
+      const handler = new RPCHandler(os.handler(() => 'ping'), {
+        plugins: [
+          new BodyLimitPlugin({ maxBodySize: 21 }),
+        ],
+      })
+
+      await handler.handle(req, res)
+    })
+      .post('/')
+      .send(size22Json)
+      .set('content-length', '22')
+
+    expect(res.text).toContain('PAYLOAD_TOO_LARGE')
+    expect(res.status).toBe(413)
+  })
+
+  it('check the body-size', async () => {
+    const res = await request(async (req: IncomingMessage, res: ServerResponse) => {
+      const handler = new RPCHandler(os.handler(() => 'ping'), {
+        plugins: [
+          new BodyLimitPlugin({ maxBodySize: 21 }),
+        ],
+      })
+
+      delete req.headers['content-length']
+
+      await handler.handle(req, res)
+    })
+      .post('/')
+      .send(size22Json)
+
+    expect(res.text).toContain('PAYLOAD_TOO_LARGE')
+    expect(res.status).toBe(413)
+  })
+})

--- a/packages/server/src/adapters/node/body-limit-plugin.ts
+++ b/packages/server/src/adapters/node/body-limit-plugin.ts
@@ -1,0 +1,54 @@
+import type { Context } from '../../context'
+import type { NodeHttpHandlerOptions, NodeHttpHandlerPlugin } from './handler'
+import { ORPCError } from '@orpc/client'
+
+export interface BodyLimitPluginOptions {
+  /**
+   * The maximum size of the body in bytes.
+   */
+  maxBodySize: number
+}
+
+export class BodyLimitPlugin<T extends Context> implements NodeHttpHandlerPlugin<T> {
+  private readonly maxBodySize: number
+
+  constructor(options: BodyLimitPluginOptions) {
+    this.maxBodySize = options.maxBodySize
+  }
+
+  initRuntimeAdapter(options: NodeHttpHandlerOptions<T>): void {
+    options.adapterInterceptors ??= []
+
+    options.adapterInterceptors.push(async (options) => {
+      let isHeaderChecked = false
+
+      const checkHeader = () => {
+        if (!isHeaderChecked && Number(options.request.headers['content-length']) > this.maxBodySize) {
+          throw new ORPCError('PAYLOAD_TOO_LARGE')
+        }
+
+        isHeaderChecked = true
+      }
+
+      const originalEmit = options.request.emit.bind(options.request)
+
+      let currentBodySize = 0
+
+      options.request.emit = (event: string, ...args: any[]) => {
+        if (event === 'data') {
+          checkHeader()
+
+          currentBodySize += args[0].length
+
+          if (currentBodySize > this.maxBodySize) {
+            throw new ORPCError('PAYLOAD_TOO_LARGE')
+          }
+        }
+
+        return originalEmit(event, ...args)
+      }
+
+      return options.next()
+    })
+  }
+}

--- a/packages/server/src/adapters/node/handler.test.ts
+++ b/packages/server/src/adapters/node/handler.test.ts
@@ -87,7 +87,7 @@ describe('nodeHttpHandlerOptions', async () => {
       request: req,
       response: res,
       sendStandardResponseOptions: handlerOptions,
-      options,
+      ...options,
       next: expect.any(Function),
     })
     expect(await interceptor.mock.results[0]!.value).toEqual({
@@ -126,7 +126,7 @@ describe('nodeHttpHandlerOptions', async () => {
       request: req,
       response: res,
       sendStandardResponseOptions: handlerOptions,
-      options,
+      ...options,
       next: expect.any(Function),
     })
     expect(await interceptor.mock.results[0]!.value).toEqual({

--- a/packages/server/src/adapters/node/index.ts
+++ b/packages/server/src/adapters/node/index.ts
@@ -1,2 +1,3 @@
+export * from './body-limit-plugin'
 export * from './handler'
 export * from './rpc-handler'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new Body Limit plugin that enforces maximum payload sizes for HTTP requests in both fetch and node environments.
- **Documentation**
	- Added a new navigation entry and documentation page detailing the plugin’s configuration and usage for managing request body limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->