### PR TITLE
feat(server): check prefix inside handlers

### DIFF
--- a/apps/content/docs/integrations/bun.md
+++ b/apps/content/docs/integrations/bun.md
@@ -21,17 +21,13 @@ const handler = new RPCHandler(router, {
 
 Bun.serve({
   async fetch(request: Request) {
-    const url = new URL(request.url)
+    const { matched, response } = await handler.handle(request, {
+      prefix: '/rpc',
+      context: {} // Provide initial context if needed
+    })
 
-    if (url.pathname.startsWith('/rpc')) {
-      const { response } = await handler.handle(request, {
-        prefix: '/rpc',
-        context: {} // Provide initial context if needed
-      })
-
-      if (response) {
-        return response
-      }
+    if (matched) {
+      return response
     }
 
     return new Response('Not found', { status: 404 })

--- a/apps/content/docs/integrations/cloudflare-workers.md
+++ b/apps/content/docs/integrations/cloudflare-workers.md
@@ -21,17 +21,13 @@ const handler = new RPCHandler(router, {
 
 export default {
   async fetch(request: Request, env: any, ctx: ExecutionContext): Promise<Response> {
-    const url = new URL(request.url)
+    const { matched, response } = await handler.handle(request, {
+      prefix: '/rpc',
+      context: {} // Provide initial context if needed
+    })
 
-    if (url.pathname.startsWith('/rpc')) {
-      const { response } = await handler.handle(request, {
-        prefix: '/rpc',
-        context: {} // Provide initial context if needed
-      })
-
-      if (response) {
-        return response
-      }
+    if (matched) {
+      return response
     }
 
     return new Response('Not found', { status: 404 })

--- a/apps/content/docs/integrations/deno.md
+++ b/apps/content/docs/integrations/deno.md
@@ -20,17 +20,13 @@ const handler = new RPCHandler(router, {
 })
 
 Deno.serve(async (request) => {
-  const url = new URL(request.url)
+  const { matched, response } = await handler.handle(request, {
+    prefix: '/rpc',
+    context: {} // Provide initial context if needed
+  })
 
-  if (url.pathname.startsWith('/rpc')) {
-    const { response } = await handler.handle(request, {
-      prefix: '/rpc',
-      context: {} // Provide initial context if needed
-    })
-
-    if (response) {
-      return response
-    }
+  if (matched) {
+    return response
   }
 
   return new Response('Not found', { status: 404 })

--- a/apps/content/docs/integrations/fetch-server.md
+++ b/apps/content/docs/integrations/fetch-server.md
@@ -20,16 +20,13 @@ const handler = new RPCHandler(router, {
 })
 
 export async function fetch(request: Request): Promise<Response> {
-  const url = new URL(request.url)
+  const { matched, response } = await handler.handle(request, {
+    prefix: '/rpc',
+    context: {} // Provide initial context if needed
+  })
 
-  if (url.pathname.startsWith('/rpc')) {
-    const { response } = await handler.handle(request, {
-      prefix: '/rpc',
-      context: {} // Provide initial context if needed
-    })
-
-    if (response)
-      return response
+  if (matched) {
+    return response
   }
 
   return new Response('Not found', { status: 404 })

--- a/apps/content/docs/integrations/node.md
+++ b/apps/content/docs/integrations/node.md
@@ -25,15 +25,13 @@ const handler = new RPCHandler(router, {
 })
 
 const server = createServer(async (req, res) => {
-  if (req.url.startsWith('/rpc')) {
-    const { matched } = await handler.handle(req, res, {
-      prefix: '/rpc',
-      context: {} // Provide initial context if needed
-    })
+  const { matched } = await handler.handle(req, res, {
+    prefix: '/rpc',
+    context: {} // Provide initial context if needed
+  })
 
-    if (matched) {
-      return
-    }
+  if (matched) {
+    return
   }
 
   res.statusCode = 404
@@ -64,15 +62,13 @@ const server = createSecureServer({
   key: fs.readFileSync('key.pem'),
   cert: fs.readFileSync('cert.pem'),
 }, async (req, res) => {
-  if (req.url.startsWith('/rpc')) {
-    const { matched } = await handler.handle(req, res, {
-      prefix: '/rpc',
-      context: {}, // Provide initial context if needed
-    })
+  const { matched } = await handler.handle(req, res, {
+    prefix: '/rpc',
+    context: {}, // Provide initial context if needed
+  })
 
-    if (matched) {
-      return
-    }
+  if (matched) {
+    return
   }
 
   res.statusCode = 404

--- a/apps/content/docs/openapi/openapi-handler.md
+++ b/apps/content/docs/openapi/openapi-handler.md
@@ -77,16 +77,13 @@ const handler = new OpenAPIHandler(router, {
 })
 
 export default async function fetch(request: Request) {
-  const url = new URL(request.url)
+  const { matched, response } = await handler.handle(request, {
+    prefix: '/api',
+    context: {} // Add initial context if needed
+  })
 
-  if (url.pathname.startsWith('/api')) {
-    const result = await handler.handle(request, {
-      prefix: '/api',
-      context: {} // Add initial context if needed
-    })
-
-    if (result.matched)
-      return result.response
+  if (matched) {
+    response
   }
 
   return new Response('Not Found', { status: 404 })

--- a/apps/content/docs/openapi/scalar.md
+++ b/apps/content/docs/openapi/scalar.md
@@ -30,14 +30,12 @@ const openAPIGenerator = new OpenAPIGenerator({
 })
 
 const server = createServer(async (req, res) => {
-  if (req.url?.startsWith('/api')) {
-    const { matched } = await openAPIHandler.handle(req, res, {
-      prefix: '/api',
-    })
+  const { matched } = await openAPIHandler.handle(req, res, {
+    prefix: '/api',
+  })
 
-    if (matched) {
-      return
-    }
+  if (matched) {
+    return
   }
 
   if (req.url === '/spec.json') {

--- a/apps/content/docs/rpc-handler.md
+++ b/apps/content/docs/rpc-handler.md
@@ -55,17 +55,13 @@ const handler = new RPCHandler(router, {
 })
 
 export default async function fetch(request: Request) {
-  const url = new URL(request.url)
+  const { matched, response } = await handler.handle(request, {
+    prefix: '/rpc',
+    context: {} // Provide initial context if required
+  })
 
-  if (url.pathname.startWith('/rpc')) {
-    const result = await handler.handle(request, {
-      prefix: '/rpc',
-      context: {} // Provide initial context if required
-    })
-
-    if (result.matched) {
-      return result.response
-    }
+  if (matched) {
+    return response
   }
 
   return new Response('Not Found', { status: 404 })

--- a/packages/client/src/adapters/standard/rpc-link-codec.ts
+++ b/packages/client/src/adapters/standard/rpc-link-codec.ts
@@ -2,7 +2,7 @@ import type { StandardHeaders, StandardLazyResponse, StandardRequest } from '@or
 import type { ClientContext, ClientOptions } from '../../types'
 import type { StandardRPCSerializer } from './rpc-serializer'
 import type { StandardLinkCodec } from './types'
-import { isAsyncIteratorObject, stringifyJSON, trim, value, type Value } from '@orpc/shared'
+import { isAsyncIteratorObject, stringifyJSON, value, type Value } from '@orpc/shared'
 import { ORPCError } from '../../error'
 
 type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
@@ -79,7 +79,7 @@ export class StandardRPCLinkCodec<T extends ClientContext> implements StandardLi
     const expectedMethod = await value(this.expectedMethod, options, path, input)
     const headers = { ...await value(this.headers, options, path, input) }
     const baseUrl = await value(this.baseUrl, options, path, input)
-    const url = new URL(`${trim(baseUrl.toString(), '/')}/${path.map(encodeURIComponent).join('/')}`)
+    const url = new URL(`${baseUrl.toString().replace(/\/$/, '')}/${path.map(encodeURIComponent).join('/')}`)
 
     if (options.lastEventId !== undefined) {
       if (Array.isArray(headers['last-event-id'])) {

--- a/packages/server/src/adapters/standard/handler.test.ts
+++ b/packages/server/src/adapters/standard/handler.test.ts
@@ -340,4 +340,22 @@ describe('standardHandler', () => {
     expect(init).toHaveBeenCalledOnce()
     expect(init).toHaveBeenCalledWith(options)
   })
+
+  it('should check prefix first', async () => {
+    const result = await handler.handle({
+      raw: { adapter: '' },
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+      },
+      url: new URL('http://localhost/users/1'),
+      body: vi.fn(),
+      signal,
+    }, {
+      context: { db: 'postgres' },
+      prefix: '/invalid',
+    })
+
+    expect(result).toEqual({ matched: false, response: undefined })
+  })
 })

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,5 +10,5 @@ export * from './object'
 export * from './types'
 export * from './value'
 
-export { group, guard, mapEntries, mapValues, omit, trim } from 'radash'
+export { group, guard, mapEntries, mapValues, omit } from 'radash'
 export type { IsEqual, IsNever, PartialDeep, Promisable } from 'type-fest'

--- a/playgrounds/contract-first/src/main.ts
+++ b/playgrounds/contract-first/src/main.ts
@@ -38,26 +38,22 @@ const server = createServer(async (req, res) => {
     ? { user: { id: 'test', name: 'John Doe', email: 'john@doe.com' } }
     : {}
 
-  if (req.url?.startsWith('/api')) {
-    const { matched } = await openAPIHandler.handle(req, res, {
-      prefix: '/api',
-      context,
-    })
+  const api = await openAPIHandler.handle(req, res, {
+    prefix: '/api',
+    context,
+  })
 
-    if (matched) {
-      return
-    }
+  if (api.matched) {
+    return
   }
 
-  if (req.url?.startsWith('/rpc')) {
-    const { matched } = await rpcHandler.handle(req, res, {
-      prefix: '/rpc',
-      context,
-    })
+  const rpc = await rpcHandler.handle(req, res, {
+    prefix: '/rpc',
+    context,
+  })
 
-    if (matched) {
-      return
-    }
+  if (rpc.matched) {
+    return
   }
 
   if (req.url === '/spec.json') {


### PR DESCRIPTION
Mean you don't need manually check prefix, oRPC do that for you

Before:

```ts
export async function fetch(request: Request): Promise<Response> {
  const url = new URL(request.url)

  if (url.pathname.startsWith('/rpc')) {
    const { response } = await handler.handle(request, {
      prefix: '/rpc',
      context: {} // Provide initial context if needed
    })

    if (response)
      return response
  }

  return new Response('Not found', { status: 404 })
}
```

After:

```ts
export async function fetch(request: Request): Promise<Response> {
  const { matched, response } = await handler.handle(request, {
    prefix: '/rpc',
    context: {} // Provide initial context if needed
  })

  if (matched) {
    return response
  }

  return new Response('Not found', { status: 404 })
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined request processing across various integrations to ensure consistent API and RPC responses, including reliable handling of unmatched requests.
- **Tests**
  - Added coverage to verify proper behavior when an invalid request prefix is provided.
- **Chores**
  - Updated URL formatting to standardize trailing slash removal and removed an unused utility for cleaner maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->