### PR TITLE
docs: nuxt fix nitro link

### DIFF
--- a/apps/content/docs/integrations/nuxt.md
+++ b/apps/content/docs/integrations/nuxt.md
@@ -5,7 +5,7 @@ description: Integrate oRPC with Nuxt.js
 
 # Nuxt.js Integration
 
-[Nuxt.js](https://nuxtjs.org/) is a popular Vue.js framework for building server-side applications. It built on top of [Nitro](https://nitro.dev/) server a lightweight, high-performance Node.js runtime. For more details, see the [Node Integration](/docs/integrations/node) guide.
+[Nuxt.js](https://nuxtjs.org/) is a popular Vue.js framework for building server-side applications. It built on top of [Nitro](https://nitro.build/) server a lightweight, high-performance Node.js runtime. For more details, see the [Node Integration](/docs/integrations/node) guide.
 
 ## Basic
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the Nitro server URL in the integration documentation to ensure users are directed to the appropriate site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->