### PR TITLE
fix(server)!: remove input type in client interceptors

### DIFF
--- a/packages/react/src/action-form.ts
+++ b/packages/react/src/action-form.ts
@@ -32,7 +32,6 @@ export function createFormAction<
   ...rest: MaybeOptionalOptions<
     CreateProcedureClientOptions<
       TInitialContext,
-      TInputSchema,
       TOutputSchema,
       TErrorMap,
       TMeta,

--- a/packages/server/src/adapters/standard/handler.ts
+++ b/packages/server/src/adapters/standard/handler.ts
@@ -43,7 +43,7 @@ export interface StandardHandlerOptions<TContext extends Context> {
    * Interceptors for procedure client.
    */
   clientInterceptors?: Interceptor<
-    ProcedureClientInterceptorOptions<TContext, AnySchema, Record<never, never>, Meta>,
+    ProcedureClientInterceptorOptions<TContext, Record<never, never>, Meta>,
     InferSchemaOutput<AnySchema>,
     ErrorFromErrorMap<Record<never, never>>
   >[]

--- a/packages/server/src/implementer-procedure.ts
+++ b/packages/server/src/implementer-procedure.ts
@@ -64,7 +64,6 @@ export interface ImplementedProcedure<
     ...rest: MaybeOptionalOptions<
       CreateProcedureClientOptions<
         TInitialContext,
-        TInputSchema,
         TOutputSchema,
         TErrorMap,
         TMeta,
@@ -81,7 +80,6 @@ export interface ImplementedProcedure<
     ...rest: MaybeOptionalOptions<
       CreateProcedureClientOptions<
         TInitialContext,
-        TInputSchema,
         TOutputSchema,
         TErrorMap,
         TMeta,

--- a/packages/server/src/procedure-client.test-d.ts
+++ b/packages/server/src/procedure-client.test-d.ts
@@ -96,7 +96,7 @@ describe('createProcedureClient', () => {
           expectTypeOf(path).toEqualTypeOf<readonly string[]>()
           expectTypeOf(errors).toEqualTypeOf<ORPCErrorConstructorMap<typeof baseErrorMap>>()
           expectTypeOf(context).toEqualTypeOf<{ db: string }>()
-          expectTypeOf(input).toEqualTypeOf<{ input: number }>()
+          expectTypeOf(input).toEqualTypeOf<unknown>()
 
           const output = await next()
 

--- a/packages/server/src/procedure-client.ts
+++ b/packages/server/src/procedure-client.ts
@@ -25,12 +25,11 @@ export type ProcedureClient<
 
 export interface ProcedureClientInterceptorOptions<
   TInitialContext extends Context,
-  TInputSchema extends AnySchema,
   TErrorMap extends ErrorMap,
   TMeta extends Meta,
 > {
   context: TInitialContext
-  input: InferSchemaInput<TInputSchema>
+  input: unknown
   errors: ORPCErrorConstructorMap<TErrorMap>
   path: readonly string[]
   procedure: Procedure<Context, Context, AnySchema, AnySchema, ErrorMap, TMeta>
@@ -43,7 +42,6 @@ export interface ProcedureClientInterceptorOptions<
  */
 export type CreateProcedureClientOptions<
   TInitialContext extends Context,
-  TInputSchema extends AnySchema,
   TOutputSchema extends AnySchema,
   TErrorMap extends ErrorMap,
   TMeta extends Meta,
@@ -56,7 +54,7 @@ export type CreateProcedureClientOptions<
     path?: readonly string[]
 
     interceptors?: Interceptor<
-      ProcedureClientInterceptorOptions<TInitialContext, TInputSchema, TErrorMap, TMeta>,
+      ProcedureClientInterceptorOptions<TInitialContext, TErrorMap, TMeta>,
       InferSchemaOutput<TOutputSchema>,
       ErrorFromErrorMap<TErrorMap>
     >[]
@@ -79,7 +77,6 @@ export function createProcedureClient<
   ...[options]: MaybeOptionalOptions<
     CreateProcedureClientOptions<
       TInitialContext,
-      TInputSchema,
       TOutputSchema,
       TErrorMap,
       TMeta,

--- a/packages/server/src/procedure-decorated.ts
+++ b/packages/server/src/procedure-decorated.ts
@@ -118,7 +118,6 @@ export class DecoratedProcedure<
     ...rest: MaybeOptionalOptions<
       CreateProcedureClientOptions<
         TInitialContext,
-        TInputSchema,
         TOutputSchema,
         TErrorMap,
         TMeta,
@@ -147,7 +146,6 @@ export class DecoratedProcedure<
     ...rest: MaybeOptionalOptions<
       CreateProcedureClientOptions<
         TInitialContext,
-        TInputSchema,
         TOutputSchema,
         TErrorMap,
         TMeta,

--- a/packages/server/src/procedure-utils.ts
+++ b/packages/server/src/procedure-utils.ts
@@ -60,7 +60,6 @@ export function call<
   ...rest: MaybeOptionalOptions<
     CreateProcedureClientOptions<
       TInitialContext,
-      TInputSchema,
       TOutputSchema,
       TErrorMap,
       TMeta,

--- a/packages/server/src/router-client.ts
+++ b/packages/server/src/router-client.ts
@@ -24,7 +24,6 @@ export function createRouterClient<T extends AnyRouter, TClientContext extends C
     CreateProcedureClientOptions<
       InferRouterInitialContext<T>,
       Schema<unknown, unknown>,
-      Schema<unknown, unknown>,
       ErrorMap,
       Meta,
       TClientContext


### PR DESCRIPTION
Type input in interceptors is not safe since this input is not validated and may diff as expected type in remote call like server action envs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined procedure action configurations by removing redundant input schema specifications.
  - Enhanced consistency and simplicity across client and server interactions, improving overall developer experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->