### PR TITLE
feat(client, server): allow numbers and symbols as context keys

### DIFF
--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -3,7 +3,7 @@ import type { PromiseWithError } from '@orpc/shared'
 export type HTTPPath = `/${string}`
 export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
 
-export type ClientContext = Record<string, any>
+export type ClientContext = Record<PropertyKey, any>
 
 export type FriendlyClientOptions<TClientContext extends ClientContext> =
   & { signal?: AbortSignal, lastEventId?: string | undefined }

--- a/packages/server/src/context.ts
+++ b/packages/server/src/context.ts
@@ -1,4 +1,4 @@
-export type Context = Record<string, any>
+export type Context = Record<PropertyKey, any>
 
 export type MergedInitialContext<
   TInitial extends Context,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved context data type definitions to support a wider range of key formats (including numbers and symbols) for enhanced flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->