### PR TITLE
test(client): codec base url

### DIFF
--- a/packages/client/src/adapters/standard/rpc-link-codec.test.ts
+++ b/packages/client/src/adapters/standard/rpc-link-codec.test.ts
@@ -103,6 +103,41 @@ describe('standardRPCLinkCodec', () => {
       expect(mergeStandardHeadersSpy).toBeCalledTimes(1)
       expect(request.headers).toBe(mergeStandardHeadersSpy.mock.results[0]!.value)
     })
+
+    describe('base url', () => {
+      it('works with /prefix', async () => {
+        const codec = new StandardRPCLinkCodec(serializer, {
+          url: 'http://localhost:3000/prefix',
+          method: 'GET',
+        })
+
+        const request = await codec.encode(['test'], 'input', { context: {} })
+
+        expect(request.url.toString()).toEqual('http://localhost:3000/prefix/test?data=%7B%22json%22%3A%22input%22%7D')
+      })
+
+      it('works with /prefix/', async () => {
+        const codec = new StandardRPCLinkCodec(serializer, {
+          url: 'http://localhost:3000/prefix/',
+          method: 'GET',
+        })
+
+        const request = await codec.encode(['test'], 'input', { context: {} })
+
+        expect(request.url.toString()).toEqual('http://localhost:3000/prefix/test?data=%7B%22json%22%3A%22input%22%7D')
+      })
+
+      it('works with /prefix/?a=5', async () => {
+        const codec = new StandardRPCLinkCodec(serializer, {
+          url: 'http://localhost:3000/prefix/?a=5',
+          method: 'GET',
+        })
+
+        const request = await codec.encode(['test'], 'input', { context: {} })
+
+        expect(request.url.toString()).toEqual('http://localhost:3000/prefix/test?a=5&data=%7B%22json%22%3A%22input%22%7D')
+      })
+    })
   })
 
   describe('decode', () => {

--- a/packages/openapi-client/src/adapters/standard/openapi-link-codec.test.ts
+++ b/packages/openapi-client/src/adapters/standard/openapi-link-codec.test.ts
@@ -266,6 +266,38 @@ describe('standardOpenapiLinkCodecOptions', () => {
         await expect(codec.encode(['ping'], 'invalid', { context: {}, signal })).rejects.toThrow('Invalid input')
       })
     })
+
+    describe('base url', () => {
+      it('works with /prefix', async () => {
+        const codec = new StandardOpenapiLinkCodec({ test: oc.route({ path: '/test', method: 'GET' }) }, serializer, {
+          url: 'http://localhost:3000/prefix',
+        })
+
+        const request = await codec.encode(['test'], { value: '123' }, { context: {} })
+
+        expect(request.url.toString()).toEqual('http://localhost:3000/prefix/test?value=123')
+      })
+
+      it('works with /prefix/', async () => {
+        const codec = new StandardOpenapiLinkCodec({ test: oc.route({ path: '/test', method: 'GET' }) }, serializer, {
+          url: 'http://localhost:3000/prefix/',
+        })
+
+        const request = await codec.encode(['test'], { value: '123' }, { context: {} })
+
+        expect(request.url.toString()).toEqual('http://localhost:3000/prefix/test?value=123')
+      })
+
+      it('works with /prefix/?a=5', async () => {
+        const codec = new StandardOpenapiLinkCodec({ test: oc.route({ path: '/test', method: 'GET' }) }, serializer, {
+          url: 'http://localhost:3000/prefix/?a=5',
+        })
+
+        const request = await codec.encode(['test'], { value: '123' }, { context: {} })
+
+        expect(request.url.toString()).toEqual('http://localhost:3000/prefix/test?a=5&value=123')
+      })
+    })
   })
 
   describe('.decode', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded test coverage to ensure API request URLs are constructed consistently across different base URL formats, including variations with trailing slashes and embedded query parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->