### PR TITLE
feat(client)!: update standard link interceptors and plugins options

### DIFF
--- a/apps/content/docs/client/rpc-link.md
+++ b/apps/content/docs/client/rpc-link.md
@@ -71,7 +71,7 @@ interface ClientContext {
 
 const link = new RPCLink<ClientContext>({
   url: 'http://localhost:3000/rpc',
-  method: ({ context }, path) => {
+  method: ({ context, path }) => {
     if (context?.cache) {
       return 'GET'
     }

--- a/apps/content/docs/plugins/client-retry.md
+++ b/apps/content/docs/plugins/client-retry.md
@@ -26,7 +26,7 @@ const link = new RPCLink<ORPCClientContext>({
   plugins: [
     new ClientRetryPlugin({
       default: { // Optional override for default options
-        retry: (options, path) => {
+        retry: ({ path }) => {
           if (path.join('.') === 'planet.list') {
             return 2
           }

--- a/packages/client/src/adapters/fetch/link-fetch-client.test.ts
+++ b/packages/client/src/adapters/fetch/link-fetch-client.test.ts
@@ -41,9 +41,7 @@ describe('linkFetchClient', () => {
     expect(fetch).toBeCalledWith(
       toFetchRequestSpy.mock.results[0]!.value,
       { redirect: 'manual' },
-      options,
-      ['example'],
-      { body: true },
+      { ...options, path: ['example'], input: { body: true } },
     )
   })
 })

--- a/packages/client/src/adapters/fetch/link-fetch-client.ts
+++ b/packages/client/src/adapters/fetch/link-fetch-client.ts
@@ -1,16 +1,14 @@
 import type { StandardLazyResponse, StandardRequest } from '@orpc/standard-server'
 import type { ToFetchRequestOptions } from '@orpc/standard-server-fetch'
 import type { ClientContext, ClientOptions } from '../../types'
-import type { StandardLinkClient } from '../standard'
+import type { StandardLinkClient, StandardLinkInterceptorOptions } from '../standard'
 import { toFetchRequest, toStandardLazyResponse } from '@orpc/standard-server-fetch'
 
 export interface LinkFetchClientOptions<T extends ClientContext> extends ToFetchRequestOptions {
   fetch?: (
     request: Request,
     init: { redirect?: Request['redirect'] },
-    options: ClientOptions<T>,
-    path: readonly string[],
-    input: unknown
+    options: StandardLinkInterceptorOptions<T>,
   ) => Promise<Response>
 }
 
@@ -26,7 +24,7 @@ export class LinkFetchClient<T extends ClientContext> implements StandardLinkCli
   async call(request: StandardRequest, options: ClientOptions<T>, path: readonly string[], input: unknown): Promise<StandardLazyResponse> {
     const fetchRequest = toFetchRequest(request, this.toFetchRequestOptions)
 
-    const fetchResponse = await this.fetch(fetchRequest, { redirect: 'manual' }, options, path, input)
+    const fetchResponse = await this.fetch(fetchRequest, { redirect: 'manual' }, { ...options, path, input })
 
     const lazyResponse = toStandardLazyResponse(fetchResponse)
 

--- a/packages/client/src/adapters/fetch/rpc-link.test.ts
+++ b/packages/client/src/adapters/fetch/rpc-link.test.ts
@@ -18,8 +18,7 @@ describe.each(supportedDataTypes)('rpcLink: $name', ({ value, expected }) => {
       const rpcLink = new RPCLink({
         url: 'http://api.example.com',
         method,
-        fetch: async (url, init) => {
-          const request = new Request(url, init)
+        fetch: async (request) => {
           const { matched, response } = await rpcHandler.handle(request)
 
           if (matched) {
@@ -51,8 +50,7 @@ describe.each(supportedDataTypes)('rpcLink: $name', ({ value, expected }) => {
       const rpcLink = new RPCLink({
         url: 'http://api.example.com',
         method,
-        fetch: async (url, init) => {
-          const request = new Request(url, init)
+        fetch: async (request) => {
           const { matched, response } = await rpcHandler.handle(request)
 
           if (matched) {

--- a/packages/client/src/adapters/standard/link.test.ts
+++ b/packages/client/src/adapters/standard/link.test.ts
@@ -43,13 +43,20 @@ describe('standardLink', () => {
       next: expect.any(Function),
       path: ['planet', 'create'],
       input: { name: 'Earth' },
-      options: { context, signal, lastEventId },
+      context,
+      signal,
+      lastEventId,
     })
 
     expect(clientInterceptor).toHaveBeenCalledTimes(1)
     expect(clientInterceptor).toHaveBeenCalledWith({
       next: expect.any(Function),
       request: '__standard_request__',
+      path: ['planet', 'create'],
+      input: { name: 'Earth' },
+      context,
+      signal,
+      lastEventId,
     })
   })
 

--- a/packages/client/src/adapters/standard/link.ts
+++ b/packages/client/src/adapters/standard/link.ts
@@ -10,9 +10,18 @@ export interface StandardLinkPlugin<T extends ClientContext> {
   init?(options: StandardLinkOptions<T>): void
 }
 
+export interface StandardLinkInterceptorOptions<T extends ClientContext> extends ClientOptions<T> {
+  path: readonly string[]
+  input: unknown
+}
+
+export interface StandardLinkClientInterceptorOptions<T extends ClientContext> extends StandardLinkInterceptorOptions<T> {
+  request: StandardRequest
+}
+
 export interface StandardLinkOptions<T extends ClientContext> {
-  interceptors?: Interceptor<{ path: readonly string[], input: unknown, options: ClientOptions<T> }, unknown, ThrowableError>[]
-  clientInterceptors?: Interceptor<{ request: StandardRequest }, StandardLazyResponse, ThrowableError>[]
+  interceptors?: Interceptor<StandardLinkInterceptorOptions<T>, unknown, ThrowableError>[]
+  clientInterceptors?: Interceptor<StandardLinkClientInterceptorOptions<T>, StandardLazyResponse, ThrowableError>[]
   plugins?: StandardLinkPlugin<T>[]
 }
 
@@ -34,7 +43,7 @@ export class StandardLink<T extends ClientContext> implements ClientLink<T> {
   }
 
   call(path: readonly string[], input: unknown, options: ClientOptions<T>): Promise<unknown> {
-    return intercept(this.interceptors, { path, input, options }, async ({ path, input, options }) => {
+    return intercept(this.interceptors, { ...options, path, input }, async ({ path, input, ...options }) => {
       const output = await this.#call(path, input, options)
 
       return output
@@ -46,8 +55,8 @@ export class StandardLink<T extends ClientContext> implements ClientLink<T> {
 
     const response = await intercept(
       this.clientInterceptors,
-      { request },
-      ({ request }) => this.sender.call(request, options, path, input),
+      { ...options, input, path, request },
+      ({ input, path, request, ...options }) => this.sender.call(request, options, path, input),
     )
 
     const output = await this.codec.decode(response, options, path, input)

--- a/packages/client/src/plugins/retry.test.ts
+++ b/packages/client/src/plugins/retry.test.ts
@@ -58,7 +58,7 @@ describe('clientRetryPlugin', () => {
 
     expect(handlerFn).toHaveBeenCalledTimes(4)
     expect(retry).toHaveBeenCalledTimes(1)
-    expect(retry).toHaveBeenCalledWith({ context: { retry, retryDelay: 0 } }, [], 'hello')
+    expect(retry).toHaveBeenCalledWith(expect.objectContaining({ context: { retry, retryDelay: 0 }, path: [], input: 'hello' }))
   })
 
   it('should not retry if success', async () => {
@@ -100,17 +100,24 @@ describe('clientRetryPlugin', () => {
     expect(shouldRetry).toHaveBeenCalledTimes(2)
     expect(shouldRetry).toHaveBeenNthCalledWith(
       1,
-      { attemptIndex: 0, error: expect.any(ORPCError) },
-      expect.objectContaining({ context: { retry: 3, shouldRetry, retryDelay: 0 } }),
-      [],
-      'hello',
+      expect.objectContaining({
+        attemptIndex: 0,
+        error: expect.any(ORPCError),
+        context: { retry: 3, shouldRetry, retryDelay: 0 },
+        input: 'hello',
+        path: [],
+      }),
     )
+
     expect(shouldRetry).toHaveBeenNthCalledWith(
       2,
-      { attemptIndex: 1, error: expect.any(ORPCError) },
-      expect.objectContaining({ context: { retry: 3, shouldRetry, retryDelay: 0 } }),
-      [],
-      'hello',
+      expect.objectContaining({
+        attemptIndex: 1,
+        error: expect.any(ORPCError),
+        context: { retry: 3, shouldRetry, retryDelay: 0 },
+        input: 'hello',
+        path: [],
+      }),
     )
   })
 
@@ -127,24 +134,33 @@ describe('clientRetryPlugin', () => {
     expect(onRetry).toHaveBeenCalledTimes(3)
     expect(onRetry).toHaveBeenNthCalledWith(
       1,
-      { attemptIndex: 0, error: expect.any(ORPCError) },
-      expect.objectContaining({ context: { retry: 3, retryDelay: 0, onRetry } }),
-      [],
-      'hello',
+      expect.objectContaining({
+        attemptIndex: 0,
+        error: expect.any(ORPCError),
+        context: { retry: 3, retryDelay: 0, onRetry },
+        input: 'hello',
+        path: [],
+      }),
     )
     expect(onRetry).toHaveBeenNthCalledWith(
       2,
-      { attemptIndex: 1, error: expect.any(ORPCError) },
-      expect.objectContaining({ context: { retry: 3, retryDelay: 0, onRetry } }),
-      [],
-      'hello',
+      expect.objectContaining({
+        attemptIndex: 1,
+        error: expect.any(ORPCError),
+        context: { retry: 3, retryDelay: 0, onRetry },
+        input: 'hello',
+        path: [],
+      }),
     )
     expect(onRetry).toHaveBeenNthCalledWith(
       3,
-      { attemptIndex: 2, error: expect.any(ORPCError) },
-      expect.objectContaining({ context: { retry: 3, retryDelay: 0, onRetry } }),
-      [],
-      'hello',
+      expect.objectContaining({
+        attemptIndex: 2,
+        error: expect.any(ORPCError),
+        context: { retry: 3, retryDelay: 0, onRetry },
+        input: 'hello',
+        path: [],
+      }),
     )
 
     expect(clean).toHaveBeenCalledTimes(3)
@@ -262,10 +278,13 @@ describe('clientRetryPlugin', () => {
       expect(shouldRetry).toHaveBeenCalledTimes(1)
       expect(shouldRetry).toHaveBeenNthCalledWith(
         1,
-        expect.objectContaining({ error: expect.any(Error), lastEventId: '5', lastEventRetry: 5678 }),
-        expect.objectContaining({ lastEventId: '5' }),
-        [],
-        'hello',
+        expect.objectContaining({
+          error: expect.any(Error),
+          lastEventId: '5',
+          lastEventRetry: 5678,
+          input: 'hello',
+          path: [],
+        }),
       )
     })
 
@@ -317,10 +336,13 @@ describe('clientRetryPlugin', () => {
       expect(shouldRetry).toHaveBeenCalledTimes(1)
       expect(shouldRetry).toHaveBeenNthCalledWith(
         1,
-        expect.objectContaining({ error: expect.any(Error), lastEventId: '10', lastEventRetry: 1234 }),
-        expect.objectContaining({ lastEventId: '10' }),
-        [],
-        'hello',
+        expect.objectContaining({
+          error: expect.any(Error),
+          lastEventId: '10',
+          lastEventRetry: 1234,
+          input: 'hello',
+          path: [],
+        }),
       )
     })
 
@@ -361,17 +383,23 @@ describe('clientRetryPlugin', () => {
       expect(shouldRetry).toHaveBeenCalledTimes(2)
       expect(shouldRetry).toHaveBeenNthCalledWith(
         1,
-        { attemptIndex: 0, error: expect.any(ORPCError) },
-        expect.objectContaining({ context: { retry: 3, shouldRetry, retryDelay: 0 } }),
-        [],
-        'hello',
+        expect.objectContaining({
+          attemptIndex: 0,
+          error: expect.any(ORPCError),
+          context: { retry: 3, shouldRetry, retryDelay: 0 },
+          input: 'hello',
+          path: [],
+        }),
       )
       expect(shouldRetry).toHaveBeenNthCalledWith(
         2,
-        { attemptIndex: 1, error: expect.any(ORPCError) },
-        expect.objectContaining({ context: { retry: 3, shouldRetry, retryDelay: 0 } }),
-        [],
-        'hello',
+        expect.objectContaining({
+          attemptIndex: 1,
+          error: expect.any(ORPCError),
+          context: { retry: 3, shouldRetry, retryDelay: 0 },
+          input: 'hello',
+          path: [],
+        }),
       )
     })
 
@@ -393,24 +421,36 @@ describe('clientRetryPlugin', () => {
       expect(onRetry).toHaveBeenCalledTimes(3)
       expect(onRetry).toHaveBeenNthCalledWith(
         1,
-        { attemptIndex: 0, error: expect.any(ORPCError), lastEventId: '0' },
-        expect.objectContaining({ context: { retry: 3, retryDelay: 0, onRetry } }),
-        [],
-        'hello',
+        expect.objectContaining({
+          attemptIndex: 0,
+          error: expect.any(ORPCError),
+          lastEventId: '0',
+          context: { retry: 3, retryDelay: 0, onRetry },
+          input: 'hello',
+          path: [],
+        }),
       )
       expect(onRetry).toHaveBeenNthCalledWith(
         2,
-        { attemptIndex: 1, error: expect.any(ORPCError), lastEventId: '1' },
-        expect.objectContaining({ context: { retry: 3, retryDelay: 0, onRetry } }),
-        [],
-        'hello',
+        expect.objectContaining({
+          attemptIndex: 1,
+          error: expect.any(ORPCError),
+          lastEventId: '1',
+          context: { retry: 3, retryDelay: 0, onRetry },
+          input: 'hello',
+          path: [],
+        }),
       )
       expect(onRetry).toHaveBeenNthCalledWith(
         3,
-        { attemptIndex: 2, error: expect.any(ORPCError), lastEventId: '2' },
-        expect.objectContaining({ context: { retry: 3, retryDelay: 0, onRetry } }),
-        [],
-        'hello',
+        expect.objectContaining({
+          attemptIndex: 2,
+          error: expect.any(ORPCError),
+          lastEventId: '2',
+          context: { retry: 3, retryDelay: 0, onRetry },
+          input: 'hello',
+          path: [],
+        }),
       )
 
       expect(clean).toHaveBeenCalledTimes(3)

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -5,9 +5,15 @@ export type HTTPMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
 
 export type ClientContext = Record<PropertyKey, any>
 
-export type FriendlyClientOptions<TClientContext extends ClientContext> =
-  & { signal?: AbortSignal, lastEventId?: string | undefined }
-  & (Record<never, never> extends TClientContext ? { context?: TClientContext } : { context: TClientContext })
+export interface ClientOptions<T extends ClientContext> {
+  signal?: AbortSignal
+  lastEventId?: string | undefined
+  context: T
+}
+
+export type FriendlyClientOptions<T extends ClientContext> =
+  & Omit<ClientOptions<T>, 'context'>
+  & (Record<never, never> extends T ? { context?: T } : { context: T })
 
 export type ClientRest<TClientContext extends ClientContext, TInput> = Record<never, never> extends TClientContext
   ? undefined extends TInput
@@ -26,10 +32,6 @@ export type NestedClient<TClientContext extends ClientContext> = Client<TClientC
 }
 
 export type InferClientContext<T extends NestedClient<any>> = T extends NestedClient<infer U> ? U : never
-
-export type ClientOptions<TClientContext extends ClientContext> = FriendlyClientOptions<TClientContext> & {
-  context: TClientContext
-}
 
 export interface ClientLink<TClientContext extends ClientContext> {
   call: (path: readonly string[], input: unknown, options: ClientOptions<TClientContext>) => Promise<unknown>

--- a/packages/openapi-client/src/adapters/fetch/openapi-link.test.ts
+++ b/packages/openapi-client/src/adapters/fetch/openapi-link.test.ts
@@ -16,8 +16,7 @@ describe('openAPILink', () => {
 
   const link = new OpenAPILink(router, {
     url: 'http://localhost:3000/api',
-    fetch: async (url, init) => {
-      const request = new Request(url, init)
+    fetch: async (request) => {
       const { matched, response } = await handler.handle(request, {
         prefix: '/api',
       })


### PR DESCRIPTION
This update change options related to `RPCLink` and `OpenAPILink` from receive 3 args like this `options, input, path` to this `{ context, input, path }`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Consolidated parameters across client calls and interceptors into a unified object structure.
  - Updated options and type definitions to enforce required properties, enhancing clarity and type safety.
  - Streamlined retry operations for clearer error handling and more consistent behavior.

- **Tests**
  - Revised test cases to align with the new parameter structure, ensuring a reliable and maintainable validation process.
  - Updated fetch function signatures in test cases to accept a single `request` parameter, simplifying the interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->