### PR TITLE
feat(client)!: update standard link options

### DIFF
--- a/apps/content/docs/client/rpc-link.md
+++ b/apps/content/docs/client/rpc-link.md
@@ -71,7 +71,7 @@ interface ClientContext {
 
 const link = new RPCLink<ClientContext>({
   url: 'http://localhost:3000/rpc',
-  method: ({ context, path }) => {
+  method: ({ context }, path) => {
     if (context?.cache) {
       return 'GET'
     }

--- a/packages/client/src/adapters/fetch/link-fetch-client.test.ts
+++ b/packages/client/src/adapters/fetch/link-fetch-client.test.ts
@@ -41,7 +41,9 @@ describe('linkFetchClient', () => {
     expect(fetch).toBeCalledWith(
       toFetchRequestSpy.mock.results[0]!.value,
       { redirect: 'manual' },
-      { ...options, path: ['example'], input: { body: true } },
+      options,
+      ['example'],
+      { body: true },
     )
   })
 })

--- a/packages/client/src/adapters/fetch/link-fetch-client.ts
+++ b/packages/client/src/adapters/fetch/link-fetch-client.ts
@@ -1,14 +1,16 @@
 import type { StandardLazyResponse, StandardRequest } from '@orpc/standard-server'
 import type { ToFetchRequestOptions } from '@orpc/standard-server-fetch'
 import type { ClientContext, ClientOptions } from '../../types'
-import type { StandardLinkClient, StandardLinkInterceptorOptions } from '../standard'
+import type { StandardLinkClient } from '../standard'
 import { toFetchRequest, toStandardLazyResponse } from '@orpc/standard-server-fetch'
 
 export interface LinkFetchClientOptions<T extends ClientContext> extends ToFetchRequestOptions {
   fetch?: (
     request: Request,
     init: { redirect?: Request['redirect'] },
-    options: StandardLinkInterceptorOptions<T>,
+    options: ClientOptions<T>,
+    path: readonly string[],
+    input: unknown,
   ) => Promise<Response>
 }
 
@@ -24,7 +26,7 @@ export class LinkFetchClient<T extends ClientContext> implements StandardLinkCli
   async call(request: StandardRequest, options: ClientOptions<T>, path: readonly string[], input: unknown): Promise<StandardLazyResponse> {
     const fetchRequest = toFetchRequest(request, this.toFetchRequestOptions)
 
-    const fetchResponse = await this.fetch(fetchRequest, { redirect: 'manual' }, { ...options, path, input })
+    const fetchResponse = await this.fetch(fetchRequest, { redirect: 'manual' }, options, path, input)
 
     const lazyResponse = toStandardLazyResponse(fetchResponse)
 

--- a/packages/client/src/adapters/standard/rpc-link-codec.ts
+++ b/packages/client/src/adapters/standard/rpc-link-codec.ts
@@ -1,5 +1,4 @@
 import type { ClientContext, ClientOptions, HTTPMethod } from '../../types'
-import type { StandardLinkInterceptorOptions } from './link'
 import type { StandardRPCSerializer } from './rpc-serializer'
 import type { StandardLinkCodec } from './types'
 import { isAsyncIteratorObject, stringifyJSON, value, type Value } from '@orpc/shared'
@@ -11,21 +10,21 @@ export interface StandardRPCLinkCodecOptions<T extends ClientContext> {
   /**
    * Base url for all requests.
    */
-  url: Value<string | URL, [StandardLinkInterceptorOptions<T>]>
+  url: Value<string | URL, [options: ClientOptions<T>, path: readonly string[], input: unknown]>
 
   /**
    * The maximum length of the URL.
    *
    * @default 2083
    */
-  maxUrlLength?: Value<number, [StandardLinkInterceptorOptions<T>]>
+  maxUrlLength?: Value<number, [options: ClientOptions<T>, path: readonly string[], input: unknown]>
 
   /**
    * The method used to make the request.
    *
    * @default 'POST'
    */
-  method?: Value<HTTPMethod, [StandardLinkInterceptorOptions<T>]>
+  method?: Value<HTTPMethod, [options: ClientOptions<T>, path: readonly string[], input: unknown]>
 
   /**
    * The method to use when the payload cannot safely pass to the server with method return from method function.
@@ -38,7 +37,7 @@ export interface StandardRPCLinkCodecOptions<T extends ClientContext> {
   /**
    * Inject headers to the request.
    */
-  headers?: Value<StandardHeaders, [StandardLinkInterceptorOptions<T>]>
+  headers?: Value<StandardHeaders, [options: ClientOptions<T>, path: readonly string[], input: unknown]>
 }
 
 export class StandardRPCLinkCodec<T extends ClientContext> implements StandardLinkCodec<T> {
@@ -60,11 +59,9 @@ export class StandardRPCLinkCodec<T extends ClientContext> implements StandardLi
   }
 
   async encode(path: readonly string[], input: unknown, options: ClientOptions<T>): Promise<StandardRequest> {
-    const generalOptions = { ...options, path, input }
-
-    const expectedMethod = await value(this.expectedMethod, generalOptions)
-    let headers = await value(this.headers, generalOptions)
-    const baseUrl = await value(this.baseUrl, generalOptions)
+    const expectedMethod = await value(this.expectedMethod, options, path, input)
+    let headers = await value(this.headers, options, path, input)
+    const baseUrl = await value(this.baseUrl, options, path, input)
     const url = new URL(baseUrl)
     url.pathname = `${url.pathname.replace(/\/$/, '')}${toHttpPath(path)}`
 
@@ -79,7 +76,7 @@ export class StandardRPCLinkCodec<T extends ClientContext> implements StandardLi
       && !(serialized instanceof FormData)
       && !isAsyncIteratorObject(serialized)
     ) {
-      const maxUrlLength = await value(this.maxUrlLength, generalOptions)
+      const maxUrlLength = await value(this.maxUrlLength, options, path, input)
       const getUrl = new URL(url)
 
       getUrl.searchParams.append('data', stringifyJSON(serialized))


### PR DESCRIPTION
revert some options from "feat(client)!: update standard link interceptors and plugins options (#333)"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the ordering and handling of request parameters in the client API.
  - Enhanced overall consistency in how communication options are processed, ensuring smoother API interactions without affecting the end-user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->