### PR TITLE
feat(server): renamed to StrictGetMethodPlugin and enabled it by default in RPCHandler

### DIFF
--- a/apps/content/.vitepress/config.ts
+++ b/apps/content/.vitepress/config.ts
@@ -110,10 +110,10 @@ export default defineConfig({
             { text: 'CORS', link: '/docs/plugins/cors' },
             { text: 'Response Headers', link: '/docs/plugins/response-headers' },
             { text: 'Batch Request/Response', link: '/docs/plugins/batch-request-response' },
-            { text: 'GET method guard', link: '/docs/plugins/get-method-guard' },
             { text: 'Client Retry', link: '/docs/plugins/client-retry' },
             { text: 'Body Limit', link: '/docs/plugins/body-limit' },
             { text: 'Simple CSRF Protection', link: '/docs/plugins/simple-csrf-protection' },
+            { text: 'Strict GET method', link: '/docs/plugins/strict-get-method' },
           ],
         },
         {

--- a/apps/content/docs/advanced/rpc-protocol.md
+++ b/apps/content/docs/advanced/rpc-protocol.md
@@ -30,7 +30,7 @@ const router = {
 Any HTTP method can be used. Input can be provided via URL query parameters or the request body.
 
 :::info
-To help prevent [Cross-Site Request Forgery (CSRF)](https://developer.mozilla.org/en-US/docs/Web/Security/Practical_implementation_guides/CSRF_prevention) attacks, you can use the [GET Method Guard Plugin](/docs/plugins/get-method-guard) to restrict the use of the `GET` method.
+You can use any method, but by default, [RPCHandler](/docs/rpc-handler) enabled [StrictGetMethodPlugin](/docs/rpc-handler#default-plugins) which blocks GET requests except for procedures explicitly allowed.
 :::
 
 ### Input in URL Query

--- a/apps/content/docs/client/rpc-link.md
+++ b/apps/content/docs/client/rpc-link.md
@@ -62,6 +62,10 @@ If a property in `ClientContext` is required, oRPC enforces its inclusion when c
 
 By default, RPCLink sends requests via `POST`. You can override this to use methods like `GET` (for browser or CDN caching) based on your requirements.
 
+::: warning
+By default, [RPCHandler](/docs/rpc-handler) enabled [StrictGetMethodPlugin](/docs/rpc-handler#default-plugins) which blocks GET requests except for procedures explicitly allowed. please refer to [StrictGetMethodPlugin](/docs/plugins/strict-get-method) for more details.
+:::
+
 ```ts twoslash
 import { RPCLink } from '@orpc/client/fetch'
 

--- a/apps/content/docs/plugins/strict-get-method.md
+++ b/apps/content/docs/plugins/strict-get-method.md
@@ -1,11 +1,15 @@
 ---
-title: GET Method Guard Plugin
-description: Enhance security by restricting GET requests to explicitly allowed procedures, mitigating Cross-Site Request Forgery (CSRF) risks.
+title: Strict GET Method Plugin
+description: Enhance security by ensuring only procedures explicitly marked to accept `GET` requests can be called using the HTTP `GET` method for RPC Protocol. This helps prevent certain types of Cross-Site Request Forgery (CSRF) attacks.
 ---
 
-# GET Method Guard Plugin
+# Strict GET Method Plugin
 
 This plugin enhances security by ensuring only procedures explicitly marked to accept `GET` requests can be called using the HTTP `GET` method for [RPC Protocol](/docs/advanced/rpc-protocol). This helps prevent certain types of [Cross-Site Request Forgery (CSRF)](https://developer.mozilla.org/en-US/docs/Web/Security/Practical_implementation_guides/CSRF_prevention) attacks.
+
+::: info
+[RPCHandler](/docs/rpc-handler) enabled this plugin by default.
+:::
 
 ## When to Use
 
@@ -29,11 +33,11 @@ const ping = os
 import { RPCHandler } from '@orpc/server/fetch'
 import { router } from './shared/planet'
 // ---cut---
-import { GetMethodGuardPlugin } from '@orpc/server/plugins'
+import { StrictGetMethodPlugin } from '@orpc/server/plugins'
 
 const handler = new RPCHandler(router, {
   plugins: [
-    new GetMethodGuardPlugin()
+    new StrictGetMethodPlugin()
   ],
 })
 ```

--- a/apps/content/docs/rpc-handler.md
+++ b/apps/content/docs/rpc-handler.md
@@ -83,3 +83,9 @@ const handler = new RPCHandler(router, {
   eventIteratorKeepAliveComment: '',
 })
 ```
+
+## Default Plugins
+
+RPCHandler is pre-configured with plugins that help enforce best practices and enhance security out of the box. By default, the following plugin is enabled:
+
+- [StrictGetMethodPlugin](/docs/plugins/strict-get-method) - Disable by setting `strictGetMethodPluginEnabled` to `false`.

--- a/packages/client/src/adapters/fetch/rpc-link.test.ts
+++ b/packages/client/src/adapters/fetch/rpc-link.test.ts
@@ -13,7 +13,9 @@ describe.each(supportedDataTypes)('rpcLink: $name', ({ value, expected }) => {
     async function assertSuccessCase(value: unknown, expected: unknown): Promise<true> {
       const handler = vi.fn(({ input }) => input)
 
-      const rpcHandler = new RPCHandler(os.handler(handler))
+      const rpcHandler = new RPCHandler(os.handler(handler), {
+        strictGetMethodPluginEnabled: false,
+      })
 
       const rpcLink = new RPCLink({
         url: 'http://api.example.com',
@@ -45,7 +47,9 @@ describe.each(supportedDataTypes)('rpcLink: $name', ({ value, expected }) => {
         })
       })
 
-      const rpcHandler = new RPCHandler(os.handler(handler))
+      const rpcHandler = new RPCHandler(os.handler(handler), {
+        strictGetMethodPluginEnabled: false,
+      })
 
       const rpcLink = new RPCLink({
         url: 'http://api.example.com',

--- a/packages/server/src/adapters/fetch/body-limit-plugin.test.ts
+++ b/packages/server/src/adapters/fetch/body-limit-plugin.test.ts
@@ -7,6 +7,7 @@ describe('bodyLimitPlugin', () => {
 
   it('should ignore for non-body request', async () => {
     const handler = new RPCHandler(os.handler(() => 'ping'), {
+      strictGetMethodPluginEnabled: false,
       plugins: [
         new BodyLimitPlugin({ maxBodySize: 22 }),
       ],

--- a/packages/server/src/adapters/fetch/rpc-handler.test.ts
+++ b/packages/server/src/adapters/fetch/rpc-handler.test.ts
@@ -1,5 +1,8 @@
 import { os } from '../../builder'
+import * as StandardModule from '../standard'
 import { RPCHandler } from './rpc-handler'
+
+const initDefaultStandardRPCHandlerOptionsSpy = vi.spyOn(StandardModule, 'initDefaultStandardRPCHandlerOptions')
 
 describe('rpcHandler', () => {
   it('works', async () => {
@@ -11,5 +14,12 @@ describe('rpcHandler', () => {
 
     await expect(response?.text()).resolves.toContain('pong')
     expect(response?.status).toBe(200)
+  })
+
+  it('should initDefaultStandardRPCHandlerOptions', async () => {
+    const options = { strictGetMethodPluginEnabled: true }
+    const handler = new RPCHandler(os.handler(() => 'pong'), options)
+
+    expect(initDefaultStandardRPCHandlerOptionsSpy).toHaveBeenCalledWith(options)
   })
 })

--- a/packages/server/src/adapters/fetch/rpc-handler.test.ts
+++ b/packages/server/src/adapters/fetch/rpc-handler.test.ts
@@ -3,7 +3,9 @@ import { RPCHandler } from './rpc-handler'
 
 describe('rpcHandler', () => {
   it('works', async () => {
-    const handler = new RPCHandler(os.handler(() => 'pong'))
+    const handler = new RPCHandler(os.handler(() => 'pong'), {
+      strictGetMethodPluginEnabled: false,
+    })
 
     const { response } = await handler.handle(new Request('https://example.com/api/v1/?data=%7B%7D'), {
       prefix: '/api/v1',

--- a/packages/server/src/adapters/fetch/rpc-handler.test.ts
+++ b/packages/server/src/adapters/fetch/rpc-handler.test.ts
@@ -1,8 +1,5 @@
 import { os } from '../../builder'
-import * as StandardModule from '../standard'
 import { RPCHandler } from './rpc-handler'
-
-const initDefaultStandardRPCHandlerOptionsSpy = vi.spyOn(StandardModule, 'initDefaultStandardRPCHandlerOptions')
 
 describe('rpcHandler', () => {
   it('works', async () => {
@@ -14,12 +11,5 @@ describe('rpcHandler', () => {
 
     await expect(response?.text()).resolves.toContain('pong')
     expect(response?.status).toBe(200)
-  })
-
-  it('should initDefaultStandardRPCHandlerOptions', async () => {
-    const options = { strictGetMethodPluginEnabled: true }
-    const handler = new RPCHandler(os.handler(() => 'pong'), options)
-
-    expect(initDefaultStandardRPCHandlerOptionsSpy).toHaveBeenCalledWith(options)
   })
 })

--- a/packages/server/src/adapters/fetch/rpc-handler.ts
+++ b/packages/server/src/adapters/fetch/rpc-handler.ts
@@ -1,20 +1,11 @@
 import type { Context } from '../../context'
 import type { Router } from '../../router'
-import type { StandardRPCHandlerOptions } from '../standard'
 import type { FetchHandlerOptions } from './handler'
-import { StandardRPCJsonSerializer, StandardRPCSerializer } from '@orpc/client/standard'
-import { initDefaultStandardRPCHandlerOptions, StandardHandler, StandardRPCCodec, StandardRPCMatcher } from '../standard'
+import { StandardRPCHandler, type StandardRPCHandlerOptions } from '../standard'
 import { FetchHandler } from './handler'
 
 export class RPCHandler<T extends Context> extends FetchHandler<T> {
   constructor(router: Router<any, T>, options: NoInfer<FetchHandlerOptions<T> & StandardRPCHandlerOptions<T>> = {}) {
-    initDefaultStandardRPCHandlerOptions(options)
-
-    const jsonSerializer = new StandardRPCJsonSerializer(options)
-    const serializer = new StandardRPCSerializer(jsonSerializer)
-    const matcher = new StandardRPCMatcher()
-    const codec = new StandardRPCCodec(serializer)
-
-    super(new StandardHandler(router, matcher, codec, options), options)
+    super(new StandardRPCHandler(router, options), options)
   }
 }

--- a/packages/server/src/adapters/fetch/rpc-handler.ts
+++ b/packages/server/src/adapters/fetch/rpc-handler.ts
@@ -3,11 +3,13 @@ import type { Router } from '../../router'
 import type { StandardRPCHandlerOptions } from '../standard'
 import type { FetchHandlerOptions } from './handler'
 import { StandardRPCJsonSerializer, StandardRPCSerializer } from '@orpc/client/standard'
-import { StandardHandler, StandardRPCCodec, StandardRPCMatcher } from '../standard'
+import { initDefaultStandardRPCHandlerOptions, StandardHandler, StandardRPCCodec, StandardRPCMatcher } from '../standard'
 import { FetchHandler } from './handler'
 
 export class RPCHandler<T extends Context> extends FetchHandler<T> {
   constructor(router: Router<any, T>, options: NoInfer<FetchHandlerOptions<T> & StandardRPCHandlerOptions<T>> = {}) {
+    initDefaultStandardRPCHandlerOptions(options)
+
     const jsonSerializer = new StandardRPCJsonSerializer(options)
     const serializer = new StandardRPCSerializer(jsonSerializer)
     const matcher = new StandardRPCMatcher()

--- a/packages/server/src/adapters/node/rpc-handler.test.ts
+++ b/packages/server/src/adapters/node/rpc-handler.test.ts
@@ -1,11 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import request from 'supertest'
 import { os } from '../../builder'
-import * as StandardModule from '../standard'
-
 import { RPCHandler } from './rpc-handler'
-
-const initDefaultStandardRPCHandlerOptionsSpy = vi.spyOn(StandardModule, 'initDefaultStandardRPCHandlerOptions')
 
 describe('rpcHandler', () => {
   it('works', async () => {
@@ -17,12 +13,5 @@ describe('rpcHandler', () => {
 
     expect(res.text).toContain('pong')
     expect(res.status).toBe(200)
-  })
-
-  it('should initDefaultStandardRPCHandlerOptions', async () => {
-    const options = { strictGetMethodPluginEnabled: true }
-    const handler = new RPCHandler(os.handler(() => 'pong'), options)
-
-    expect(initDefaultStandardRPCHandlerOptionsSpy).toHaveBeenCalledWith(options)
   })
 })

--- a/packages/server/src/adapters/node/rpc-handler.test.ts
+++ b/packages/server/src/adapters/node/rpc-handler.test.ts
@@ -1,7 +1,11 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import request from 'supertest'
 import { os } from '../../builder'
+import * as StandardModule from '../standard'
+
 import { RPCHandler } from './rpc-handler'
+
+const initDefaultStandardRPCHandlerOptionsSpy = vi.spyOn(StandardModule, 'initDefaultStandardRPCHandlerOptions')
 
 describe('rpcHandler', () => {
   it('works', async () => {
@@ -13,5 +17,12 @@ describe('rpcHandler', () => {
 
     expect(res.text).toContain('pong')
     expect(res.status).toBe(200)
+  })
+
+  it('should initDefaultStandardRPCHandlerOptions', async () => {
+    const options = { strictGetMethodPluginEnabled: true }
+    const handler = new RPCHandler(os.handler(() => 'pong'), options)
+
+    expect(initDefaultStandardRPCHandlerOptionsSpy).toHaveBeenCalledWith(options)
   })
 })

--- a/packages/server/src/adapters/node/rpc-handler.test.ts
+++ b/packages/server/src/adapters/node/rpc-handler.test.ts
@@ -5,7 +5,9 @@ import { RPCHandler } from './rpc-handler'
 
 describe('rpcHandler', () => {
   it('works', async () => {
-    const handler = new RPCHandler(os.handler(() => 'pong'))
+    const handler = new RPCHandler(os.handler(() => 'pong'), {
+      strictGetMethodPluginEnabled: false,
+    })
 
     const res = await request(async (req: IncomingMessage, res: ServerResponse) => {
       await handler.handle(req, res)

--- a/packages/server/src/adapters/node/rpc-handler.ts
+++ b/packages/server/src/adapters/node/rpc-handler.ts
@@ -3,11 +3,13 @@ import type { Router } from '../../router'
 import type { StandardRPCHandlerOptions } from '../standard'
 import type { NodeHttpHandlerOptions } from './handler'
 import { StandardRPCJsonSerializer, StandardRPCSerializer } from '@orpc/client/standard'
-import { StandardHandler, StandardRPCCodec, StandardRPCMatcher } from '../standard'
+import { initDefaultStandardRPCHandlerOptions, StandardHandler, StandardRPCCodec, StandardRPCMatcher } from '../standard'
 import { NodeHttpHandler } from './handler'
 
 export class RPCHandler<T extends Context> extends NodeHttpHandler<T> {
   constructor(router: Router<any, T>, options: NoInfer<StandardRPCHandlerOptions<T> & NodeHttpHandlerOptions<T>> = {}) {
+    initDefaultStandardRPCHandlerOptions(options)
+
     const jsonSerializer = new StandardRPCJsonSerializer(options)
     const serializer = new StandardRPCSerializer(jsonSerializer)
     const matcher = new StandardRPCMatcher()

--- a/packages/server/src/adapters/node/rpc-handler.ts
+++ b/packages/server/src/adapters/node/rpc-handler.ts
@@ -1,20 +1,11 @@
 import type { Context } from '../../context'
 import type { Router } from '../../router'
-import type { StandardRPCHandlerOptions } from '../standard'
 import type { NodeHttpHandlerOptions } from './handler'
-import { StandardRPCJsonSerializer, StandardRPCSerializer } from '@orpc/client/standard'
-import { initDefaultStandardRPCHandlerOptions, StandardHandler, StandardRPCCodec, StandardRPCMatcher } from '../standard'
+import { StandardRPCHandler, type StandardRPCHandlerOptions } from '../standard'
 import { NodeHttpHandler } from './handler'
 
 export class RPCHandler<T extends Context> extends NodeHttpHandler<T> {
   constructor(router: Router<any, T>, options: NoInfer<StandardRPCHandlerOptions<T> & NodeHttpHandlerOptions<T>> = {}) {
-    initDefaultStandardRPCHandlerOptions(options)
-
-    const jsonSerializer = new StandardRPCJsonSerializer(options)
-    const serializer = new StandardRPCSerializer(jsonSerializer)
-    const matcher = new StandardRPCMatcher()
-    const codec = new StandardRPCCodec(serializer)
-
-    super(new StandardHandler(router, matcher, codec, options), options)
+    super(new StandardRPCHandler(router, options), options)
   }
 }

--- a/packages/server/src/adapters/standard/rpc-handler.test.ts
+++ b/packages/server/src/adapters/standard/rpc-handler.test.ts
@@ -1,0 +1,25 @@
+import { describe } from 'vitest'
+import { StrictGetMethodPlugin } from '../../plugins'
+import { initDefaultStandardRPCHandlerOptions } from './rpc-handler'
+
+describe('initDefaultStandardRPCHandlerOptions', () => {
+  it('should add StrictGetMethodPlugin by default', () => {
+    const options = {} as any
+
+    initDefaultStandardRPCHandlerOptions(options)
+
+    expect(options.plugins).toEqual([
+      new StrictGetMethodPlugin(),
+    ])
+  })
+
+  it('should not add StrictGetMethodPlugin when disabled', () => {
+    const options = {
+      strictGetMethodPluginEnabled: false,
+    } as any
+
+    initDefaultStandardRPCHandlerOptions(options)
+
+    expect(options.plugins).toEqual([])
+  })
+})

--- a/packages/server/src/adapters/standard/rpc-handler.ts
+++ b/packages/server/src/adapters/standard/rpc-handler.ts
@@ -1,5 +1,23 @@
 import type { StandardRPCJsonSerializerOptions } from '@orpc/client/standard'
 import type { Context } from '../../context'
 import type { StandardHandlerOptions } from './handler'
+import { StrictGetMethodPlugin } from '../../plugins'
 
-export interface StandardRPCHandlerOptions<T extends Context> extends StandardHandlerOptions<T>, StandardRPCJsonSerializerOptions {}
+export interface StandardRPCHandlerOptions<T extends Context> extends StandardHandlerOptions<T>, StandardRPCJsonSerializerOptions {
+  /**
+   * Enables or disables the StrictGetMethodPlugin.
+   *
+   * @default true
+   */
+  strictGetMethodPluginEnabled?: boolean
+}
+
+export function initDefaultStandardRPCHandlerOptions<T extends Context>(options: StandardRPCHandlerOptions<T>): void {
+  options.plugins ??= []
+
+  const strictGetMethodPluginEnabled = options.strictGetMethodPluginEnabled ?? true
+
+  if (strictGetMethodPluginEnabled) {
+    options.plugins.push(new StrictGetMethodPlugin())
+  }
+}

--- a/packages/server/src/adapters/standard/rpc-handler.ts
+++ b/packages/server/src/adapters/standard/rpc-handler.ts
@@ -1,7 +1,10 @@
-import type { StandardRPCJsonSerializerOptions } from '@orpc/client/standard'
 import type { Context } from '../../context'
-import type { StandardHandlerOptions } from './handler'
+import type { Router } from '../../router'
+import { StandardRPCJsonSerializer, type StandardRPCJsonSerializerOptions, StandardRPCSerializer } from '@orpc/client/standard'
 import { StrictGetMethodPlugin } from '../../plugins'
+import { StandardHandler, type StandardHandlerOptions } from './handler'
+import { StandardRPCCodec } from './rpc-codec'
+import { StandardRPCMatcher } from './rpc-matcher'
 
 export interface StandardRPCHandlerOptions<T extends Context> extends StandardHandlerOptions<T>, StandardRPCJsonSerializerOptions {
   /**
@@ -12,12 +15,21 @@ export interface StandardRPCHandlerOptions<T extends Context> extends StandardHa
   strictGetMethodPluginEnabled?: boolean
 }
 
-export function initDefaultStandardRPCHandlerOptions<T extends Context>(options: StandardRPCHandlerOptions<T>): void {
-  options.plugins ??= []
+export class StandardRPCHandler<T extends Context> extends StandardHandler<T> {
+  constructor(router: Router<any, T>, options: StandardRPCHandlerOptions<T>) {
+    options.plugins ??= []
 
-  const strictGetMethodPluginEnabled = options.strictGetMethodPluginEnabled ?? true
+    const strictGetMethodPluginEnabled = options.strictGetMethodPluginEnabled ?? true
 
-  if (strictGetMethodPluginEnabled) {
-    options.plugins.push(new StrictGetMethodPlugin())
+    if (strictGetMethodPluginEnabled) {
+      options.plugins.push(new StrictGetMethodPlugin())
+    }
+
+    const jsonSerializer = new StandardRPCJsonSerializer(options)
+    const serializer = new StandardRPCSerializer(jsonSerializer)
+    const matcher = new StandardRPCMatcher()
+    const codec = new StandardRPCCodec(serializer)
+
+    super(router, matcher, codec, options)
   }
 }

--- a/packages/server/src/plugins/index.ts
+++ b/packages/server/src/plugins/index.ts
@@ -1,5 +1,5 @@
 export * from './batch'
 export * from './cors'
-export * from './get-method-guard'
 export * from './response-headers'
 export * from './simple-csrf-protection'
+export * from './strict-get-method'

--- a/packages/server/src/plugins/simple-csrf-protection.test.ts
+++ b/packages/server/src/plugins/simple-csrf-protection.test.ts
@@ -12,6 +12,7 @@ describe('simpleCsrfProtectionHandlerPlugin', () => {
   const handler = new RPCHandler({
     ping: os.handler(() => 'pong'),
   }, {
+    strictGetMethodPluginEnabled: false,
     plugins: [
       new SimpleCsrfProtectionHandlerPlugin(),
     ],
@@ -59,6 +60,7 @@ describe('simpleCsrfProtectionHandlerPlugin', () => {
     const ping = os.handler(() => 'pong')
 
     const handler = new RPCHandler({ ping }, {
+      strictGetMethodPluginEnabled: false,
       plugins: [
         new SimpleCsrfProtectionHandlerPlugin({
           exclude,

--- a/packages/server/src/plugins/strict-get-method.test.ts
+++ b/packages/server/src/plugins/strict-get-method.test.ts
@@ -1,8 +1,8 @@
 import { RPCHandler } from '../adapters/fetch'
 import { os } from '../builder'
-import { GetMethodGuardPlugin } from './get-method-guard'
+import { StrictGetMethodPlugin } from './strict-get-method'
 
-describe('getMethodGuardPlugin', () => {
+describe('strictGetMethodPlugin', () => {
   const interceptor = vi.fn(({ next }) => next())
 
   const handler = new RPCHandler({
@@ -10,7 +10,7 @@ describe('getMethodGuardPlugin', () => {
     pong: os.route({ method: 'GET' }).handler(() => 'pong'),
   }, {
     plugins: [
-      new GetMethodGuardPlugin(),
+      new StrictGetMethodPlugin(),
     ],
     rootInterceptors: [interceptor],
   })


### PR DESCRIPTION
GetMethodGuardPlugin -> StrictGetMethodPlugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated sidebar navigation and guides to reflect the shift to a stricter GET method enforcement in RPC documentation.
  - Added clarifications regarding the default behavior of the RPCHandler and the necessity for explicit permissions for GET requests.

- **Enhancements**
  - Improved RPC security defaults by enforcing strict GET request handling, with a new option to disable this behavior if needed.

- **Tests**
  - Added test cases to ensure that the new default configuration is correctly initialized and applied. 
  - Modified existing tests to incorporate the new configuration option for the RPCHandler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->