### PR TITLE
feat(client): pass isSuccess to ClientRetryPlugin onRetry returned callback

### DIFF
--- a/apps/content/docs/plugins/client-retry.md
+++ b/apps/content/docs/plugins/client-retry.md
@@ -54,7 +54,13 @@ const planets = await client.planet.list({ limit: 10 }, {
     retry: 3, // Maximum retry attempts
     retryDelay: 2000, // Delay between retries in ms
     shouldRetry: options => true, // Determines whether to retry based on the error
-    onRetry: (options) => {}, // Hook executed on each retry
+    onRetry: (options) => {
+      // Hook executed on each retry
+
+      return (isSuccess) => {
+        // Execute after the retry is complete
+      }
+    },
   }
 })
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced retry functionality now executes a callback after each retry attempt, clearly indicating success or failure. This improvement provides more robust handling during repeated operations.
  
- **Documentation**
  - Updated documentation to reflect the new retry behavior and callback structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->