### PR TITLE
docs: remove undefined `serve` helper from nextjs integration

### DIFF
--- a/apps/content/docs/integrations/nextjs.md
+++ b/apps/content/docs/integrations/nextjs.md
@@ -16,7 +16,7 @@ oRPC also supports [Server Action](/docs/server-action) out-of-the-box.
 ::: code-group
 
 ```ts [app/rpc/[[...rest]].ts]
-import { RPCHandler, serve } from '@orpc/server/fetch'
+import { RPCHandler } from '@orpc/server/fetch'
 
 const handler = new RPCHandler(router)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Next.js App Router example by adjusting the import statement for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->