### PR TITLE
feat(server): allow .concat middlewares with narrowed input types

### DIFF
--- a/apps/content/docs/middleware.md
+++ b/apps/content/docs/middleware.md
@@ -121,6 +121,20 @@ const pong = os
   })
 ```
 
+::: info
+You can adapt a middleware to accept a different input shape by using `.mapInput`.
+
+```ts
+const canUpdate = os.middleware(async ({ context, next }, input: number) => {
+  return next()
+})
+
+// Transform middleware to accept a new input shape
+const mappedCanUpdate = canUpdate.mapInput((input: { id: number }) => input.id)
+```
+
+:::
+
 ## Middleware Output
 
 Middleware can also modify the output of a handler, such as implementing caching mechanisms.
@@ -150,6 +164,10 @@ const concatMiddleware = aMiddleware
   .concat(os.middleware(async ({ next }) => next()))
   .concat(anotherMiddleware)
 ```
+
+::: info
+If you want to concatenate two middlewares with different input types, you can use `.mapInput` to align their input types before concatenation.
+:::
 
 ## Built-in Middlewares
 

--- a/packages/server/src/middleware-decorated.test-d.ts
+++ b/packages/server/src/middleware-decorated.test-d.ts
@@ -10,7 +10,7 @@ import type { Procedure } from './procedure'
 const decorated = {} as DecoratedMiddleware<
   CurrentContext,
   { extra: boolean },
-  { input: string },
+  { input1: string, input2: string },
   { output: number },
   ORPCErrorConstructorMap<typeof baseErrorMap>,
   BaseMeta
@@ -22,7 +22,7 @@ describe('DecoratedMiddleware', () => {
       Middleware<
         CurrentContext,
         { extra: boolean },
-        { input: string },
+        { input1: string, input2: string },
         { output: number },
         ORPCErrorConstructorMap<typeof baseErrorMap>,
         BaseMeta
@@ -31,7 +31,7 @@ describe('DecoratedMiddleware', () => {
   })
 
   it('.mapInput', () => {
-    const mapped = decorated.mapInput((input: 'input') => ({ input }))
+    const mapped = decorated.mapInput((input: 'input') => ({ input1: input, input2: input }))
 
     expectTypeOf(mapped).toEqualTypeOf<
       DecoratedMiddleware<
@@ -50,8 +50,7 @@ describe('DecoratedMiddleware', () => {
 
   describe('.concat', () => {
     it('without map input', () => {
-      const applied = decorated.concat(({ context, next, path, procedure, errors, signal }, input, output) => {
-        expectTypeOf(input).toEqualTypeOf<{ input: string }>()
+      const applied = decorated.concat(({ context, next, path, procedure, errors, signal }, input: { input1: string }, output) => {
         expectTypeOf(context).toEqualTypeOf<Omit<CurrentContext, 'extra'> & { extra: boolean }>()
         expectTypeOf(path).toEqualTypeOf<readonly string[]>()
         expectTypeOf(procedure).toEqualTypeOf<
@@ -72,7 +71,7 @@ describe('DecoratedMiddleware', () => {
         DecoratedMiddleware<
           CurrentContext & Record<never, never>,
           Omit<{ extra: boolean }, never> & { extra2: boolean },
-          { input: string },
+          { input1: string, input2: string },
           { output: number },
           ORPCErrorConstructorMap<typeof baseErrorMap>,
           BaseMeta
@@ -81,6 +80,8 @@ describe('DecoratedMiddleware', () => {
 
       // @ts-expect-error --- invalid TInContext
       decorated.concat({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>)
+      // @ts-expect-error --- input is not match
+      decorated.concat(({ next }, input: { invalid: string }) => next({}))
       // @ts-expect-error --- output is not match
       decorated.concat(({ next }, input, output: MiddlewareOutputFn<'invalid'>) => next({}))
       // @ts-expect-error --- conflict context
@@ -104,9 +105,7 @@ describe('DecoratedMiddleware', () => {
             extra2: true,
           },
         })
-      }, (input) => {
-        expectTypeOf(input).toEqualTypeOf<{ input: string }>()
-
+      }, (input: { input1: string }) => {
         return { mapped: true }
       })
 
@@ -114,7 +113,7 @@ describe('DecoratedMiddleware', () => {
         DecoratedMiddleware<
           CurrentContext & Record<never, never>,
           Omit<{ extra: boolean }, never> & { extra2: boolean },
-          { input: string },
+          { input1: string, input2: string },
           { output: number },
           ORPCErrorConstructorMap<typeof baseErrorMap>,
           BaseMeta
@@ -129,6 +128,8 @@ describe('DecoratedMiddleware', () => {
 
       // @ts-expect-error --- invalid TInContext
       decorated.concat({} as Middleware<{ auth: 'invalid' }, any, any, any, any, any>, () => { })
+      // @ts-expect-error --- input is not match
+      decorated.concat(({ next }, input: { mapped: boolean }) => next({}), (input: { invalid: string }) => ({ mapped: true }))
       // @ts-expect-error --- output is not match
       decorated.concat(({ next }, input, output: MiddlewareOutputFn<'invalid'>) => next({}), input => ({ mapped: true }))
       // @ts-expect-error --- conflict context
@@ -142,7 +143,7 @@ describe('DecoratedMiddleware', () => {
         DecoratedMiddleware<
           CurrentContext & Omit<{ cacheable?: boolean } & Record<never, never>, 'db' | 'auth' | 'extra'>,
           Omit<{ extra: boolean }, never> & Record<never, never>,
-          { input: string },
+          { input1: string, input2: string },
           { output: number },
           ORPCErrorConstructorMap<typeof baseErrorMap>,
           BaseMeta
@@ -153,7 +154,7 @@ describe('DecoratedMiddleware', () => {
         DecoratedMiddleware<
           CurrentContext & Omit<{ cacheable?: boolean } & Record<never, never>, 'db' | 'auth' | 'extra'>,
           Omit<{ extra: boolean }, never> & Record<never, never>,
-          { input: string },
+          { input1: string, input2: string },
           { output: number },
           ORPCErrorConstructorMap<typeof baseErrorMap>,
           BaseMeta

--- a/packages/server/src/middleware-decorated.ts
+++ b/packages/server/src/middleware-decorated.ts
@@ -27,12 +27,13 @@ export interface DecoratedMiddleware<
    */
   concat<
     UOutContext extends IntersectPick<MergedCurrentContext<TInContext, TOutContext>, UOutContext>,
+    UInput extends TInput,
     UInContext extends Context = MergedCurrentContext<TInContext, TOutContext>,
   >(
     middleware: Middleware<
       UInContext | MergedCurrentContext<TInContext, TOutContext>,
       UOutContext,
-      TInput,
+      UInput,
       TOutput,
       TErrorConstructorMap,
       TMeta
@@ -40,7 +41,7 @@ export interface DecoratedMiddleware<
   ): DecoratedMiddleware<
     MergedInitialContext<TInContext, UInContext, MergedCurrentContext<TInContext, TOutContext>>,
     MergedCurrentContext<TOutContext, UOutContext>,
-    TInput,
+    UInput,
     TOutput,
     TErrorConstructorMap,
     TMeta
@@ -54,6 +55,7 @@ export interface DecoratedMiddleware<
    */
   concat<
     UOutContext extends IntersectPick<MergedCurrentContext<TInContext, TOutContext>, UOutContext>,
+    UInput extends TInput,
     UMappedInput,
     UInContext extends Context = MergedCurrentContext<TInContext, TOutContext>,
   >(
@@ -65,11 +67,11 @@ export interface DecoratedMiddleware<
       TErrorConstructorMap,
       TMeta
     >,
-    mapInput: MapInputMiddleware<TInput, UMappedInput>,
+    mapInput: MapInputMiddleware<UInput, UMappedInput>,
   ): DecoratedMiddleware<
     MergedInitialContext<TInContext, UInContext, MergedCurrentContext<TInContext, TOutContext>>,
     MergedCurrentContext<TOutContext, UOutContext>,
-    TInput,
+    UInput,
     TOutput,
     TErrorConstructorMap,
     TMeta


### PR DESCRIPTION
For example, if middleware A accepts unknown as input, B can now specify a more specific input type (e.g., number, { id: string }, etc.). Previously, both A and B were required to use unknown for the input type when concatenated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved middleware documentation with new notes and examples on using input mapping and aligning input types when composing middleware.

- **Bug Fixes**
  - Enhanced type safety and flexibility for middleware input types, ensuring better compatibility when chaining or transforming middleware.

- **Tests**
  - Updated and expanded tests to verify correct handling and rejection of new input shapes in middleware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->