### PR TITLE
feat(standard-server): support React Native by explicitly checking body

### DIFF
--- a/apps/content/.vitepress/config.ts
+++ b/apps/content/.vitepress/config.ts
@@ -101,6 +101,7 @@ export default defineConfig({
             { text: 'SvelteKit', link: '/docs/integrations/svelte-kit' },
             { text: 'Remix', link: '/docs/integrations/remix' },
             { text: 'SolidStart', link: '/docs/integrations/solid-start' },
+            { text: 'React Native', link: '/docs/integrations/react-native' },
           ],
         },
         {

--- a/apps/content/docs/integrations/react-native.md
+++ b/apps/content/docs/integrations/react-native.md
@@ -1,0 +1,32 @@
+---
+title: React Native Integration
+description: Seamlessly integrate oRPC with React Native
+---
+
+# React Native Integration
+
+[React Native](https://reactnative.dev/) is a framework for building native apps using React.
+
+## Fetch Link
+
+React Native includes a [Fetch API](https://reactnative.dev/docs/network), so you can use oRPC out of the box.
+
+::: warning
+However, the Fetch API in React Native has limitations. oRPC features like `File`, `Blob`, and `AsyncIteratorObject` aren't supported. Follow [Support Stream #27741](https://github.com/facebook/react-native/issues/27741) for updates.
+:::
+
+```ts
+import { RPCLink } from '@orpc/client/fetch'
+
+const link = new RPCLink({
+  url: 'http://localhost:3000/rpc',
+  headers: async ({ context }) => ({
+    'x-api-key': context?.something ?? ''
+  })
+  // fetch: <-- polyfill fetch if needed
+})
+```
+
+::: info
+The `link` can be any supported oRPC link, such as [RPCLink](/docs/client/rpc-link), [OpenAPILink](/docs/openapi/client/openapi-link), or another custom link.
+:::

--- a/packages/standard-server-fetch/src/body.ts
+++ b/packages/standard-server-fetch/src/body.ts
@@ -5,7 +5,11 @@ import { generateContentDisposition, getFilenameFromContentDisposition } from '@
 import { toEventIterator, toEventStream } from './event-iterator'
 
 export async function toStandardBody(re: Request | Response): Promise<StandardBody> {
-  if (!re.body) {
+  /**
+   * In native environments like React Native, the body may be `undefined` due to lack of streaming support.
+   * Therefore, we explicitly check for `null` to indicate an intentionally empty body.
+   */
+  if (re.body === null) {
     return undefined
   }
 


### PR DESCRIPTION
By explicitly check for `null` to indicate an intentionally empty body instead of relying on a truthy body check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added documentation for integrating oRPC with React Native, including usage examples and notes on supported features.
  - Updated the sidebar to include React Native in the list of integrations.

- **Bug Fixes**
  - Improved handling of empty request bodies to better support native environments like React Native.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->