### PR TITLE
fix(server): ensure `.actionable` throws Next.js errors

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -66,6 +66,7 @@
     "@orpc/standard-server-node": "workspace:*"
   },
   "devDependencies": {
+    "next": "^15.3.0",
     "supertest": "^7.1.0"
   }
 }

--- a/packages/server/src/procedure-action.test.ts
+++ b/packages/server/src/procedure-action.test.ts
@@ -1,4 +1,5 @@
 import { ORPCError } from '@orpc/client'
+import { forbidden, notFound, redirect, unauthorized } from 'next/navigation'
 import { createActionableClient } from './procedure-action'
 
 describe('createActionableClient', () => {
@@ -33,5 +34,20 @@ describe('createActionableClient', () => {
     const result = await (action as any)('input', 'second')
     expect(result).toEqual([null, '__mocked__'])
     expect(client).toHaveBeenCalledWith('input')
+  })
+
+  it.each([
+    [() => redirect('/foo')],
+    [() => forbidden()],
+    [() => unauthorized()],
+    [() => notFound()],
+  ])('should rethrow next.js error', async (error) => {
+    (process as any).env.__NEXT_EXPERIMENTAL_AUTH_INTERRUPTS = true
+
+    client.mockImplementationOnce(() => {
+      error()
+    })
+
+    await expect(action('input')).rejects.toThrowError()
   })
 })

--- a/packages/server/src/procedure-action.ts
+++ b/packages/server/src/procedure-action.ts
@@ -35,6 +35,15 @@ export function createActionableClient<TInput, TOutput, TError>(
       return [null, await client(input)]
     }
     catch (error) {
+      if (
+        error instanceof Error
+        && 'digest' in error
+        && typeof error.digest === 'string'
+        && error.digest.startsWith('NEXT_')
+      ) {
+        throw error
+      }
+
       return [toORPCError(error).toJSON(), undefined]
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,6 +336,9 @@ importers:
         specifier: workspace:*
         version: link:../standard-server-node
     devDependencies:
+      next:
+        specifier: ^15.3.0
+        version: 15.3.0(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       supertest:
         specifier: ^7.1.0
         version: 7.1.0
@@ -623,7 +626,7 @@ importers:
         version: 3.5.13(typescript@5.8.3)
       vue-router:
         specifier: latest
-        version: 4.5.0(vue@3.5.13(typescript@5.8.3))
+        version: 4.5.1(vue@3.5.13(typescript@5.8.3))
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -7111,8 +7114,8 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
-  vue-router@4.5.0:
-    resolution: {integrity: sha512-HDuk+PuH5monfNuY+ct49mNmkCRK4xJAV9Ts4z9UFc4rzdDnxQLyCMGGc8pKhZhHTVzfanpNwB/lwqevcBwI4w==}
+  vue-router@4.5.1:
+    resolution: {integrity: sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==}
     peerDependencies:
       vue: ^3.2.0
 
@@ -12524,13 +12527,13 @@ snapshots:
       unctx: 2.4.1
       unimport: 4.2.0
       unplugin: 2.3.2
-      unplugin-vue-router: 0.12.0(vue-router@4.5.0(vue@3.5.13(typescript@5.8.3)))(vue@3.5.13(typescript@5.8.3))
+      unplugin-vue-router: 0.12.0(vue-router@4.5.1(vue@3.5.13(typescript@5.8.3)))(vue@3.5.13(typescript@5.8.3))
       unstorage: 1.15.0(db0@0.3.1)(ioredis@5.6.1)
       untyped: 2.0.0
       vue: 3.5.13(typescript@5.8.3)
       vue-bundle-renderer: 2.1.1
       vue-devtools-stub: 0.1.0
-      vue-router: 4.5.0(vue@3.5.13(typescript@5.8.3))
+      vue-router: 4.5.1(vue@3.5.13(typescript@5.8.3))
     optionalDependencies:
       '@parcel/watcher': 2.5.1
       '@types/node': 22.14.1
@@ -14087,7 +14090,7 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.2
 
-  unplugin-vue-router@0.12.0(vue-router@4.5.0(vue@3.5.13(typescript@5.8.3)))(vue@3.5.13(typescript@5.8.3)):
+  unplugin-vue-router@0.12.0(vue-router@4.5.1(vue@3.5.13(typescript@5.8.3)))(vue@3.5.13(typescript@5.8.3)):
     dependencies:
       '@babel/types': 7.27.0
       '@vue-macros/common': 1.16.1(vue@3.5.13(typescript@5.8.3))
@@ -14105,7 +14108,7 @@ snapshots:
       unplugin-utils: 0.2.4
       yaml: 2.7.1
     optionalDependencies:
-      vue-router: 4.5.0(vue@3.5.13(typescript@5.8.3))
+      vue-router: 4.5.1(vue@3.5.13(typescript@5.8.3))
     transitivePeerDependencies:
       - vue
 
@@ -14580,7 +14583,7 @@ snapshots:
     dependencies:
       vue: 3.5.13(typescript@5.8.3)
 
-  vue-router@4.5.0(vue@3.5.13(typescript@5.8.3)):
+  vue-router@4.5.1(vue@3.5.13(typescript@5.8.3)):
     dependencies:
       '@vue/devtools-api': 6.6.4
       vue: 3.5.13(typescript@5.8.3)


### PR DESCRIPTION
Close #450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to ensure specific Next.js navigation errors are re-thrown instead of being handled internally.

- **Tests**
  - Added new tests to verify correct behavior when specific Next.js navigation errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->