### PR TITLE
test(client): event iterator for rpc link

### DIFF
--- a/packages/client/src/adapters/fetch/rpc-link.test.ts
+++ b/packages/client/src/adapters/fetch/rpc-link.test.ts
@@ -131,7 +131,7 @@ describe('standardRPCLink: event-iterator', async () => {
 
   beforeEach(() => {
     (globalThis as any).Request = class Request extends OriginalRequest {
-      constructor(input: RequestInfo, init?: RequestInit) {
+      constructor(input: any, init: any) {
         super(input, {
           ...init,
           duplex: 'half',

--- a/packages/client/src/adapters/standard/rpc-link.test.ts
+++ b/packages/client/src/adapters/standard/rpc-link.test.ts
@@ -1,4 +1,4 @@
-import { ORPCError, os } from '@orpc/server'
+import { getEventMeta, ORPCError, os, withEventMeta } from '@orpc/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { StandardRPCHandler } from '../../../../server/src/adapters/standard/rpc-handler'
 import { supportedDataTypes } from '../../../tests/shared'
@@ -29,6 +29,7 @@ describe.each(supportedDataTypes)('standardRPCLink: $name', ({ value, expected }
           return { ...response, body: () => Promise.resolve(response.body) }
         },
       }, {
+        method,
         url: new URL('http://localhost/prefix'),
       })
 
@@ -125,5 +126,87 @@ describe.each(supportedDataTypes)('standardRPCLink: $name', ({ value, expected }
         },
       })).toBe(true)
     })
+  })
+})
+
+describe('standardRPCLink: event-iterator', async () => {
+  const handler = vi.fn(({ input }) => input)
+
+  const rpcHandler = new StandardRPCHandler(os.handler(handler))
+
+  const rpcLink = new StandardRPCLink({
+    async call(request, options, path, input) {
+      const { response } = await rpcHandler.handle({ ...request, body: () => Promise.resolve(request.body) }, {
+        context: {},
+        prefix: '/prefix',
+      })
+
+      if (!response) {
+        throw new Error('No response')
+      }
+
+      return { ...response, body: () => Promise.resolve(response.body) }
+    },
+  }, {
+    url: new URL('http://localhost/prefix'),
+  })
+
+  it('on success', async () => {
+    const output = await rpcLink.call([], (async function* () {
+      yield 1
+      yield withEventMeta({ hello: 2 }, { id: '29224', retry: 8393 })
+      return withEventMeta({ hello: 3 }, { id: '391', retry: 28973 })
+    })(), { context: {} }) as any
+
+    expect(await output.next()).toEqual({ value: 1, done: false })
+
+    expect(await output.next()).toSatisfy(({ value, done }) => {
+      expect(done).toBe(false)
+      expect(value).toEqual({ hello: 2 })
+      expect(getEventMeta(value)).toEqual({ id: '29224', retry: 8393 })
+
+      return true
+    })
+
+    expect(await output.next()).toSatisfy(({ value, done }) => {
+      expect(done).toBe(true)
+      expect(value).toEqual({ hello: 3 })
+      expect(getEventMeta(value)).toEqual({ id: '391', retry: 28973 })
+
+      return true
+    })
+
+    expect(await output.next()).toEqual({ value: undefined, done: true })
+  })
+
+  it('on error', async () => {
+    const output = await rpcLink.call([], (async function* () {
+      yield 1
+      yield withEventMeta({ hello: 2 }, { id: '29224', retry: 8393 })
+      throw withEventMeta(new ORPCError('INTERNAL', {
+        data: { hello: 3 },
+      }), { id: '391', retry: 28973 })
+    })(), { context: {} }) as any
+
+    expect(await output.next()).toEqual({ value: 1, done: false })
+
+    expect(await output.next()).toSatisfy(({ value, done }) => {
+      expect(done).toBe(false)
+      expect(value).toEqual({ hello: 2 })
+      expect(getEventMeta(value)).toEqual({ id: '29224', retry: 8393 })
+
+      return true
+    })
+
+    await expect(output.next()).rejects.toSatisfy((err) => {
+      expect(err).toBeInstanceOf(ORPCError)
+      expect(err.code).toBe('INTERNAL')
+      expect(err.data).toEqual({ hello: 3 })
+      expect(getEventMeta(err)).toEqual({ id: '391', retry: 28973 })
+
+      return true
+    })
+
+    expect(await output.next()).toEqual({ value: undefined, done: true })
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added new test suites to verify event metadata propagation and error handling for asynchronous generators in RPC link functionality.
  - Enhanced test coverage for both success and error scenarios involving event-iterator style async generators.
  - Updated imports to support event metadata handling in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->