### PR TITLE
feat(openapi): exclude procedures from spec generation

### DIFF
--- a/apps/content/docs/openapi/openapi-specification.md
+++ b/apps/content/docs/openapi/openapi-specification.md
@@ -114,7 +114,7 @@ You can exclude a procedure from the OpenAPI specification using the `exclude` o
 
 ```ts
 const spec = await generator.generate(router, {
-  exclude: procedure => !!procedure['~orpc'].route.tags?.includes('admin'),
+  exclude: (procedure, path) => !!procedure['~orpc'].route.tags?.includes('admin'),
 })
 ```
 

--- a/apps/content/docs/openapi/openapi-specification.md
+++ b/apps/content/docs/openapi/openapi-specification.md
@@ -108,6 +108,16 @@ const specFromRouter = await openAPIGenerator.generate(router, {
 Features prefixed with `experimental_` are unstable and may lack some functionality.
 :::
 
+## Excluding Procedures
+
+You can exclude a procedure from the OpenAPI specification using the `exclude` option:
+
+```ts
+const spec = await generator.generate(router, {
+  exclude: procedure => !!procedure['~orpc'].route.tags?.includes('admin'),
+})
+```
+
 ## Operation Metadata
 
 You can enrich your API documentation by specifying operation metadata using the `.route` or `.tag`:

--- a/packages/openapi/src/openapi-generator.test.ts
+++ b/packages/openapi/src/openapi-generator.test.ts
@@ -752,22 +752,39 @@ it.each([
   }
 })
 
-it('openAPIGenerator.generate throw right away if unknown error', async () => {
-  const openAPIGenerator = new OpenAPIGenerator({
-    schemaConverters: [
-      {
-        condition: () => true,
-        convert: () => {
-          throw new Error('unknown error')
+describe('openAPIGenerator', () => {
+  it('openAPIGenerator.generate throw right away if unknown error', async () => {
+    const openAPIGenerator = new OpenAPIGenerator({
+      schemaConverters: [
+        {
+          condition: () => true,
+          convert: () => {
+            throw new Error('unknown error')
+          },
         },
+      ],
+    })
+
+    await expect(openAPIGenerator.generate(oc, {
+      info: {
+        title: 'test',
+        version: '1.0.0',
       },
-    ],
+    })).rejects.toThrow('unknown error')
   })
 
-  await expect(openAPIGenerator.generate(oc, {
-    info: {
-      title: 'test',
-      version: '1.0.0',
-    },
-  })).rejects.toThrow('unknown error')
+  it('openAPIGenerator.generate respect exclude option', async () => {
+    const openAPIGenerator = new OpenAPIGenerator({
+    })
+
+    const exclude = vi.fn(() => true)
+
+    await expect(openAPIGenerator.generate({ ping: oc }, { exclude })).resolves.toEqual({
+      openapi: '3.1.1',
+      info: { title: 'API Reference', version: '0.0.0' },
+    })
+
+    expect(exclude).toHaveBeenCalledTimes(1)
+    expect(exclude).toHaveBeenCalledWith(oc, ['ping'])
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for excluding specific procedures from the generated OpenAPI specification using a new `exclude` option.  
- **Documentation**
  - Updated documentation to include instructions and examples on how to use the new exclusion feature.  
- **Tests**
  - Added and reorganized tests to verify that the exclusion option works as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->