### PR TITLE
feat(query): streamedOptions

### DIFF
--- a/apps/content/docs/tanstack-query/basic.md
+++ b/apps/content/docs/tanstack-query/basic.md
@@ -31,6 +31,19 @@ const query = useQuery(orpc.planet.find.queryOptions({
 }))
 ```
 
+## Streamed Query Options Utility
+
+Use `.streamedOptions` to configure queries for [Event Iterator](/docs/event-iterator), which is built on top of [streamedQuery](https://tanstack.com/query/latest/docs/reference/streamedQuery). Use it with hooks like `useQuery`, `useSuspenseQuery`, or `prefetchQuery`.
+
+```ts
+const query = useQuery(orpc.streamed.experimental_streamedOptions({
+  input: { id: 123 }, // Specify input if needed
+  context: { cache: true }, // Provide client context if needed
+  refetchMode: 'reset', // Specify refetch mode if needed
+  // additional options...
+}))
+```
+
 ## Infinite Query Options Utility
 
 Use `.infiniteOptions` to configure infinite queries. Use it with hooks like `useInfiniteQuery`, `useSuspenseInfiniteQuery`, or `prefetchInfiniteQuery`.

--- a/packages/client/tests/shared.ts
+++ b/packages/client/tests/shared.ts
@@ -1,6 +1,6 @@
 import type { RouterClient } from '@orpc/server'
 import { RPCHandler } from '@orpc/server/fetch'
-import { router } from '../../server/tests/shared'
+import { router, streamed } from '../../server/tests/shared'
 import { createORPCClient } from '../src'
 import { RPCLink } from '../src/adapters/fetch'
 
@@ -30,6 +30,19 @@ const rpcLink = new RPCLink<ClientContext>({
 })
 
 export const orpc: RouterClient<typeof router, ClientContext> = createORPCClient(rpcLink)
+
+const streamedHandler = new RPCHandler({ streamed })
+
+export const streamedOrpc: RouterClient<{ streamed: typeof streamed }, ClientContext> = createORPCClient(new RPCLink({
+  url: 'http://localhost:3000',
+  fetch: async (url, init) => {
+    const { response } = await streamedHandler.handle(new Request(url, init), {
+      context: { db: 'postgres' },
+    })
+
+    return response ?? new Response('not found', { status: 404 })
+  },
+}))
 
 enum Test {
   A = 1,

--- a/packages/contract/tests/shared.ts
+++ b/packages/contract/tests/shared.ts
@@ -1,7 +1,7 @@
 import type { Schema } from '../src'
 import type { Meta } from '../src/meta'
 import { z } from 'zod'
-import { ContractProcedure } from '../src'
+import { ContractProcedure, eventIterator } from '../src'
 
 export const inputSchema = z.object({ input: z.number().transform(n => `${n}`) })
 
@@ -56,3 +56,18 @@ export const router = {
     pong,
   },
 }
+
+export const streamedOutputSchema = eventIterator(outputSchema)
+
+export const streamed = new ContractProcedure<
+  typeof inputSchema,
+  typeof streamedOutputSchema,
+  typeof baseErrorMap,
+  Meta
+>({
+  errorMap: baseErrorMap,
+  meta: {},
+  route: {},
+  inputSchema,
+  outputSchema: streamedOutputSchema,
+})

--- a/packages/react-query/src/key.ts
+++ b/packages/react-query/src/key.ts
@@ -1,7 +1,7 @@
 import type { PartialDeep } from '@orpc/shared'
 import type { QueryKey } from '@tanstack/react-query'
 
-export type KeyType = 'query' | 'infinite' | 'mutation' | undefined
+export type KeyType = 'query' | 'streamed' | 'infinite' | 'mutation' | undefined
 
 export interface BuildKeyOptions<TType extends KeyType, TInput> {
   type?: TType
@@ -10,10 +10,10 @@ export interface BuildKeyOptions<TType extends KeyType, TInput> {
 
 export function buildKey<TType extends KeyType, TInput>(
   path: string[],
-  options?: BuildKeyOptions<TType, TInput>,
+  options: BuildKeyOptions<TType, TInput> = {},
 ): QueryKey {
-  const withInput = options?.input !== undefined ? { input: options?.input } : {}
-  const withType = options?.type !== undefined ? { type: options?.type } : {}
+  const withInput = options.input !== undefined ? { input: options?.input } : {}
+  const withType = options.type !== undefined ? { type: options?.type } : {}
 
   return [path, {
     ...withInput,

--- a/packages/react-query/src/procedure-utils.test-d.ts
+++ b/packages/react-query/src/procedure-utils.test-d.ts
@@ -152,44 +152,44 @@ describe('ProcedureUtils', () => {
     it('can optional options', () => {
       const requiredUtils = {} as ProcedureUtils<{ batch: boolean }, 'input', UtilsOutput, Error>
 
-      utils.queryOptions()
-      utils.queryOptions({ context: { batch: true } })
-      utils.queryOptions({ input: { search: 'search' } })
-      utils.queryOptions({ input: condition ? skipToken : { search: 'search' } })
+      utils.experimental_streamedOptions()
+      utils.experimental_streamedOptions({ context: { batch: true } })
+      utils.experimental_streamedOptions({ input: { search: 'search' } })
+      utils.experimental_streamedOptions({ input: condition ? skipToken : { search: 'search' } })
 
-      requiredUtils.queryOptions({
+      requiredUtils.experimental_streamedOptions({
         context: { batch: true },
         input: 'input',
       })
-      requiredUtils.queryOptions({
+      requiredUtils.experimental_streamedOptions({
         context: { batch: true },
         input: condition ? skipToken : 'input',
       })
       // @ts-expect-error input and context is required
-      requiredUtils.queryOptions()
+      requiredUtils.experimental_streamedOptions()
       // @ts-expect-error input and context is required
-      requiredUtils.queryOptions({})
+      requiredUtils.experimental_streamedOptions({})
       // @ts-expect-error input is required
-      requiredUtils.queryOptions({ context: { batch: true } })
+      requiredUtils.experimental_streamedOptions({ context: { batch: true } })
       // @ts-expect-error context is required
-      requiredUtils.queryOptions({ input: 'input' })
+      requiredUtils.experimental_streamedOptions({ input: 'input' })
       // @ts-expect-error context is required
-      requiredUtils.queryOptions({ input: condition ? skipToken : 'input' })
+      requiredUtils.experimental_streamedOptions({ input: condition ? skipToken : 'input' })
     })
 
     it('infer correct input type', () => {
-      utils.queryOptions({ input: { cursor: 1 }, context: { batch: true } })
-      utils.queryOptions({ input: condition ? { cursor: 2 } : skipToken, context: { batch: true } })
+      utils.experimental_streamedOptions({ input: { cursor: 1 }, context: { batch: true } })
+      utils.experimental_streamedOptions({ input: condition ? { cursor: 2 } : skipToken, context: { batch: true } })
       // @ts-expect-error invalid input
-      utils.queryOptions({ input: { cursor: 'invalid' }, context: { batch: true } })
+      utils.experimental_streamedOptions({ input: { cursor: 'invalid' }, context: { batch: true } })
       // @ts-expect-error invalid input
-      utils.queryOptions({ input: condition ? { cursor: 'invalid' } : skipToken, context: { batch: true } })
+      utils.experimental_streamedOptions({ input: condition ? { cursor: 'invalid' } : skipToken, context: { batch: true } })
     })
 
     it('infer correct context type', () => {
-      utils.queryOptions({ context: { batch: true } })
+      utils.experimental_streamedOptions({ context: { batch: true } })
       // @ts-expect-error invalid context
-      utils.queryOptions({ context: { batch: 'invalid' } })
+      utils.experimental_streamedOptions({ context: { batch: 'invalid' } })
     })
 
     it('not usable in non event iterator output', () => {

--- a/packages/react-query/src/procedure-utils.test.ts
+++ b/packages/react-query/src/procedure-utils.test.ts
@@ -1,7 +1,16 @@
-import { skipToken } from '@tanstack/react-query'
+import { skipToken, experimental_streamedQuery as streamedQuery } from '@tanstack/react-query'
 import { queryClient } from '../tests/shared'
 import * as Key from './key'
 import { createProcedureUtils } from './procedure-utils'
+
+vi.mock('@tanstack/react-query', async (origin) => {
+  const original = await origin() as any
+
+  return {
+    ...original,
+    experimental_streamedQuery: vi.fn(original.experimental_streamedQuery),
+  }
+})
 
 const buildKeySpy = vi.spyOn(Key, 'buildKey')
 
@@ -57,7 +66,11 @@ describe('createProcedureUtils', () => {
         return '__3__'
       })
 
-      const options = utils.experimental_streamedOptions({ input: { search: '__search__' }, context: { batch: '__batch__' } })
+      const options = utils.experimental_streamedOptions({
+        input: { search: '__search__' },
+        context: { batch: '__batch__' },
+        refetchMode: 'replace',
+      })
 
       expect(options.enabled).toBe(true)
 
@@ -65,7 +78,15 @@ describe('createProcedureUtils', () => {
       expect(buildKeySpy).toHaveBeenCalledTimes(1)
       expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { type: 'streamed', input: { search: '__search__' } })
 
-      await expect(options.queryFn!({ signal, client: queryClient } as any)).resolves.toEqual(['__1__', '__2__'])
+      expect(options.queryFn).toBe(vi.mocked(streamedQuery).mock.results[0]!.value)
+      expect(streamedQuery).toHaveBeenCalledTimes(1)
+      expect(streamedQuery).toHaveBeenCalledWith({
+        refetchMode: 'replace',
+        queryFn: expect.any(Function),
+      })
+
+      await expect(options.queryFn!({ signal, client: queryClient, queryKey: options.queryKey } as any)).resolves.toEqual(['__1__', '__2__'])
+      expect(queryClient.getQueryData(options.queryKey)).toEqual(['__1__', '__2__'])
 
       expect(client).toHaveBeenCalledTimes(1)
       expect(client).toBeCalledWith({ search: '__search__' }, { signal, context: { batch: '__batch__' } })

--- a/packages/react-query/src/procedure-utils.test.ts
+++ b/packages/react-query/src/procedure-utils.test.ts
@@ -80,10 +80,10 @@ describe('createProcedureUtils', () => {
 
       expect(options.queryFn).toBe(vi.mocked(streamedQuery).mock.results[0]!.value)
       expect(streamedQuery).toHaveBeenCalledTimes(1)
-      expect(streamedQuery).toHaveBeenCalledWith({
+      expect(streamedQuery).toHaveBeenCalledWith(expect.objectContaining({
         refetchMode: 'replace',
         queryFn: expect.any(Function),
-      })
+      }))
 
       await expect(options.queryFn!({ signal, client: queryClient, queryKey: options.queryKey } as any)).resolves.toEqual(['__1__', '__2__'])
       expect(queryClient.getQueryData(options.queryKey)).toEqual(['__1__', '__2__'])

--- a/packages/react-query/src/procedure-utils.ts
+++ b/packages/react-query/src/procedure-utils.ts
@@ -36,7 +36,7 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
   ): NoInfer<U & Omit<QueryOptionsBase<TOutput, TError>, keyof U>>
 
   /**
-   * Generate [event-iterator](https://orpc.unnoq.com/docs/event-iterator) options used for useQuery/useSuspenseQuery/prefetchQuery/...
+   * Generate [Event Iterator](https://orpc.unnoq.com/docs/event-iterator) options used for useQuery/useSuspenseQuery/prefetchQuery/...
    * Built on top of [steamedQuery](https://tanstack.com/query/latest/docs/reference/streamedQuery)
    *
    * @see {@link https://orpc.unnoq.com/docs/tanstack-query/basic#streamed-query-options-utility Tanstack Streamed Query Options Utility Docs}

--- a/packages/react-query/src/procedure-utils.ts
+++ b/packages/react-query/src/procedure-utils.ts
@@ -2,7 +2,7 @@ import type { Client, ClientContext } from '@orpc/client'
 import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { InfiniteData } from '@tanstack/react-query'
 import type {
-  InferStreamedOutput,
+  experimental_InferStreamedOutput,
   InfiniteOptionsBase,
   InfiniteOptionsIn,
   MutationOptions,
@@ -35,11 +35,17 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
     >
   ): NoInfer<U & Omit<QueryOptionsBase<TOutput, TError>, keyof U>>
 
-  experimental_streamedOptions<U, USelectData = InferStreamedOutput<TOutput>>(
+  /**
+   * Generate [event-iterator](https://orpc.unnoq.com/docs/event-iterator) options used for useQuery/useSuspenseQuery/prefetchQuery/...
+   * Built on top of [steamedQuery](https://tanstack.com/query/latest/docs/reference/streamedQuery)
+   *
+   * @see {@link https://orpc.unnoq.com/docs/tanstack-query/basic#streamed-query-options-utility Tanstack Streamed Query Options Utility Docs}
+   */
+  experimental_streamedOptions<U, USelectData = experimental_InferStreamedOutput<TOutput>>(
     ...rest: MaybeOptionalOptions<
-      U & StreamedOptionsIn<TClientContext, TInput, InferStreamedOutput<TOutput>, TError, USelectData>
+      U & StreamedOptionsIn<TClientContext, TInput, experimental_InferStreamedOutput<TOutput>, TError, USelectData>
     >
-  ): NoInfer<U & Omit<StreamedOptionsBase<InferStreamedOutput<TOutput>, TError>, keyof U>>
+  ): NoInfer<U & Omit<StreamedOptionsBase<experimental_InferStreamedOutput<TOutput>, TError>, keyof U>>
 
   /**
    * Generate options used for useInfiniteQuery/useSuspenseInfiniteQuery/prefetchInfiniteQuery/...

--- a/packages/react-query/src/procedure-utils.ts
+++ b/packages/react-query/src/procedure-utils.ts
@@ -97,7 +97,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
         enabled: optionsIn.input !== skipToken,
         queryKey: buildKey(options.path, { type: 'streamed', input: optionsIn.input }),
         queryFn: streamedQuery({
-          refetchMode: optionsIn.refetchMode,
+          ...optionsIn,
           queryFn: async ({ signal }) => {
             if (optionsIn.input === skipToken) {
               throw new Error('queryFn should not be called with skipToken used as input')

--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -2,8 +2,6 @@ import type { ClientContext } from '@orpc/client'
 import type { SetOptional } from '@orpc/shared'
 import type { experimental_streamedQuery, QueryFunctionContext, QueryKey, SkipToken, UseInfiniteQueryOptions, UseMutationOptions, UseQueryOptions } from '@tanstack/react-query'
 
-type StreamedRefetchMode = Exclude<Parameters<typeof experimental_streamedQuery>[0]['refetchMode'], undefined>
-
 export type QueryOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TSelectData> =
   & (undefined extends TInput ? { input?: TInput | SkipToken } : { input: TInput | SkipToken })
   & (Record<never, never> extends TClientContext ? { context?: TClientContext } : { context: TClientContext })
@@ -16,11 +14,13 @@ export interface QueryOptionsBase<TOutput, TError> {
   enabled: boolean
 }
 
-export type InferStreamedOutput<TOutput> = TOutput extends AsyncIterable<infer U> ? U[] : never
+type experimental_StreamedRefetchMode = Exclude<Parameters<typeof experimental_streamedQuery>[0]['refetchMode'], undefined>
+
+export type experimental_InferStreamedOutput<TOutput> = TOutput extends AsyncIterable<infer U> ? U[] : never
 
 export type experimental_StreamedOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TSelectData> =
   & QueryOptionsIn<TClientContext, TInput, TOutput, TError, TSelectData>
-  & { refetchMode?: StreamedRefetchMode }
+  & { refetchMode?: experimental_StreamedRefetchMode }
 
 export interface experimental_StreamedOptionsBase<TOutput, TError> extends QueryOptionsBase<TOutput, TError> {
 }

--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -14,13 +14,13 @@ export interface QueryOptionsBase<TOutput, TError> {
   enabled: boolean
 }
 
-type experimental_StreamedRefetchMode = Exclude<Parameters<typeof experimental_streamedQuery>[0]['refetchMode'], undefined>
+type experimental_StreamedQueryOptions = Omit<Parameters<typeof experimental_streamedQuery>[0], 'queryFn'>
 
 export type experimental_InferStreamedOutput<TOutput> = TOutput extends AsyncIterable<infer U> ? U[] : never
 
 export type experimental_StreamedOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TSelectData> =
   & QueryOptionsIn<TClientContext, TInput, TOutput, TError, TSelectData>
-  & { refetchMode?: experimental_StreamedRefetchMode }
+  & experimental_StreamedQueryOptions
 
 export interface experimental_StreamedOptionsBase<TOutput, TError> extends QueryOptionsBase<TOutput, TError> {
 }

--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -1,6 +1,8 @@
 import type { ClientContext } from '@orpc/client'
 import type { SetOptional } from '@orpc/shared'
-import type { QueryFunctionContext, QueryKey, SkipToken, UseInfiniteQueryOptions, UseMutationOptions, UseQueryOptions } from '@tanstack/react-query'
+import type { experimental_streamedQuery, QueryFunctionContext, QueryKey, SkipToken, UseInfiniteQueryOptions, UseMutationOptions, UseQueryOptions } from '@tanstack/react-query'
+
+type StreamedRefetchMode = Exclude<Parameters<typeof experimental_streamedQuery>[0]['refetchMode'], undefined>
 
 export type QueryOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TSelectData> =
   & (undefined extends TInput ? { input?: TInput | SkipToken } : { input: TInput | SkipToken })
@@ -12,6 +14,15 @@ export interface QueryOptionsBase<TOutput, TError> {
   queryFn(ctx: QueryFunctionContext): Promise<TOutput>
   retry?(failureCount: number, error: TError): boolean // this make tanstack can infer the TError type
   enabled: boolean
+}
+
+export type InferStreamedOutput<TOutput> = TOutput extends AsyncIterable<infer U> ? U[] : never
+
+export type experimental_StreamedOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TSelectData> =
+  & QueryOptionsIn<TClientContext, TInput, TOutput, TError, TSelectData>
+  & { refetchMode?: StreamedRefetchMode }
+
+export interface experimental_StreamedOptionsBase<TOutput, TError> extends QueryOptionsBase<TOutput, TError> {
 }
 
 export type InfiniteOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TSelectData, TPageParam> =

--- a/packages/react-query/tests/e2e.test-d.ts
+++ b/packages/react-query/tests/e2e.test-d.ts
@@ -2,7 +2,7 @@ import type { InfiniteData } from '@tanstack/react-query'
 import { isDefinedError } from '@orpc/client'
 import { useInfiniteQuery, useMutation, useQueries, useQuery, useSuspenseInfiniteQuery, useSuspenseQuery } from '@tanstack/react-query'
 import { orpc as client } from '../../client/tests/shared'
-import { orpc, queryClient } from './shared'
+import { orpc, queryClient, streamedOrpc } from './shared'
 
 it('.key', () => {
   queryClient.invalidateQueries({
@@ -72,9 +72,7 @@ describe('.queryOptions', () => {
       expectTypeOf(query.error.data).toEqualTypeOf<unknown>()
     }
 
-    if (query.status === 'success') {
-      expectTypeOf(query.data).toEqualTypeOf<{ output: string }>()
-    }
+    expectTypeOf(query.data).toEqualTypeOf<{ output: string }>()
 
     useSuspenseQuery(orpc.ping.queryOptions({
       // @ts-expect-error --- input is invalid
@@ -136,12 +134,124 @@ describe('.queryOptions', () => {
     }))
 
     expectTypeOf(query).toEqualTypeOf<{ output: string }>()
+  })
+})
 
-    const query2 = await queryClient.fetchQuery(orpc.ping.queryOptions({
+describe('.streamedOptions', () => {
+  it('useQuery', () => {
+    const query = useQuery(streamedOrpc.streamed.experimental_streamedOptions({
+      input: { input: 123 },
+      retry(failureCount, error) {
+        if (isDefinedError(error) && error.code === 'BASE') {
+          expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
+        }
+
+        return false
+      },
+    }))
+
+    if (query.status === 'error' && isDefinedError(query.error) && query.error.code === 'OVERRIDE') {
+      expectTypeOf(query.error.data).toEqualTypeOf<unknown>()
+    }
+
+    if (query.status === 'success') {
+      expectTypeOf(query.data).toEqualTypeOf<{ output: string }[]>()
+    }
+
+    useQuery(orpc.ping.queryOptions({
+      // @ts-expect-error --- input is invalid
+      input: {
+        input: '123',
+      },
+    }))
+
+    useQuery(orpc.ping.queryOptions({
+      input: { input: 123 },
+      context: {
+        // @ts-expect-error --- cache is invalid
+        cache: 123,
+      },
+    }))
+  })
+
+  it('useSuspenseQuery', () => {
+    const query = useSuspenseQuery(streamedOrpc.streamed.experimental_streamedOptions({
+      input: { input: 123 },
+      retry(failureCount, error) {
+        if (isDefinedError(error) && error.code === 'BASE') {
+          expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
+        }
+
+        return false
+      },
+    }))
+
+    if (query.status === 'error' && isDefinedError(query.error) && query.error.code === 'OVERRIDE') {
+      expectTypeOf(query.error.data).toEqualTypeOf<unknown>()
+    }
+
+    expectTypeOf(query.data).toEqualTypeOf<{ output: string }[]>()
+
+    useSuspenseQuery(streamedOrpc.streamed.experimental_streamedOptions({
+      // @ts-expect-error --- input is invalid
+      input: {
+        input: '123',
+      },
+    }))
+
+    useSuspenseQuery(streamedOrpc.streamed.experimental_streamedOptions({
+      input: { input: 123 },
+      context: {
+        // @ts-expect-error --- cache is invalid
+        cache: 123,
+      },
+    }))
+  })
+
+  it('useQueries', async () => {
+    const queries = useQueries({
+      queries: [
+        streamedOrpc.streamed.experimental_streamedOptions({
+          input: { input: 123 },
+          select: data => ({ mapped: data }),
+          retry(failureCount, error) {
+            if (isDefinedError(error) && error.code === 'BASE') {
+              expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
+            }
+
+            return false
+          },
+        }),
+        orpc.nested.pong.queryOptions({
+          context: { cache: '123' },
+        }),
+      ],
+    })
+
+    // FIXME: useQueries cannot infer error
+    // if (queries[0].status === 'error' && isDefinedError(queries[0].error) && queries[0].error.code === 'OVERRIDE') {
+    //   expectTypeOf(queries[0].error.data).toEqualTypeOf<unknown>()
+    // }
+
+    if (queries[0].status === 'success') {
+      expectTypeOf(queries[0].data.mapped).toEqualTypeOf<{ output: string }[]>()
+    }
+
+    if (queries[1].status === 'error') {
+      expectTypeOf(queries[1].error).toEqualTypeOf<Error>()
+    }
+
+    if (queries[1].status === 'success') {
+      expectTypeOf(queries[1].data).toEqualTypeOf<unknown>()
+    }
+  })
+
+  it('fetchQuery', async () => {
+    const query = await queryClient.fetchQuery(streamedOrpc.streamed.experimental_streamedOptions({
       input: { input: 123 },
     }))
 
-    expectTypeOf(query2).toEqualTypeOf<{ output: string }>()
+    expectTypeOf(query).toEqualTypeOf<{ output: string }[]>()
   })
 })
 

--- a/packages/react-query/tests/e2e.test-d.ts
+++ b/packages/react-query/tests/e2e.test-d.ts
@@ -158,14 +158,14 @@ describe('.streamedOptions', () => {
       expectTypeOf(query.data).toEqualTypeOf<{ output: string }[]>()
     }
 
-    useQuery(orpc.ping.queryOptions({
+    useQuery(orpc.ping.experimental_streamedOptions({
       // @ts-expect-error --- input is invalid
       input: {
         input: '123',
       },
     }))
 
-    useQuery(orpc.ping.queryOptions({
+    useQuery(orpc.ping.experimental_streamedOptions({
       input: { input: 123 },
       context: {
         // @ts-expect-error --- cache is invalid

--- a/packages/react-query/tests/e2e.test.tsx
+++ b/packages/react-query/tests/e2e.test.tsx
@@ -94,7 +94,7 @@ it('case: with streamed/useQuery', async () => {
 })
 
 it('case: with streamed/useQuery and skipToken', async () => {
-  const { result } = renderHook(() => useQuery(orpc.nested.ping.experimental_streamedOptions({ input: skipToken }), queryClient))
+  const { result } = renderHook(() => useQuery(streamedOrpc.streamed.experimental_streamedOptions({ input: skipToken }), queryClient))
 
   expect(result.current.status).toEqual('pending')
   expect(queryClient.isFetching({ queryKey: orpc.key() })).toEqual(0)

--- a/packages/react-query/tests/shared.tsx
+++ b/packages/react-query/tests/shared.tsx
@@ -1,8 +1,9 @@
 import { QueryClient } from '@tanstack/react-query'
-import { orpc as client } from '../../client/tests/shared'
+import { orpc as client, streamedOrpc as streamedClient } from '../../client/tests/shared'
 import { createORPCReactQueryUtils } from '../src'
 
 export const orpc = createORPCReactQueryUtils(client)
+export const streamedOrpc = createORPCReactQueryUtils(streamedClient)
 
 export const queryClient = new QueryClient({
   defaultOptions: {

--- a/packages/server/tests/shared.ts
+++ b/packages/server/tests/shared.ts
@@ -1,7 +1,7 @@
 import type { Meta, Schema } from '@orpc/contract'
-import type { baseErrorMap, BaseMeta, inputSchema, outputSchema } from '../../contract/tests/shared'
+import type { baseErrorMap, BaseMeta, inputSchema, outputSchema, streamedOutputSchema } from '../../contract/tests/shared'
 import type { Context } from '../src'
-import { ping as pingContract, pong as pongContract } from '../../contract/tests/shared'
+import { ping as pingContract, pong as pongContract, streamed as streamedContract } from '../../contract/tests/shared'
 import { lazy, Procedure } from '../src'
 
 export type InitialContext = { db: string }
@@ -52,5 +52,28 @@ export const router = {
     },
   })),
 }
+
+export const streamedHandler = vi.fn(async function* ({ input }) {
+  for (let i = 0; i < input.input; i++) {
+    yield { output: i }
+  }
+
+  return 'done'
+})
+
+export const streamed = new Procedure<
+  Context,
+  Context,
+  typeof inputSchema,
+  typeof streamedOutputSchema,
+  typeof baseErrorMap,
+  Meta
+>({
+  ...streamedContract['~orpc'],
+  inputValidationIndex: 0,
+  outputValidationIndex: 0,
+  middlewares: [],
+  handler: streamedHandler,
+})
 
 export { router as contract, ping as pingContract, pong as pongContract } from '../../contract/tests/shared'

--- a/packages/solid-query/src/key.ts
+++ b/packages/solid-query/src/key.ts
@@ -1,7 +1,7 @@
 import type { PartialDeep } from '@orpc/shared'
 import type { QueryKey } from '@tanstack/solid-query'
 
-export type KeyType = 'query' | 'infinite' | 'mutation' | undefined
+export type KeyType = 'query' | 'streamed' | 'infinite' | 'mutation' | undefined
 
 export interface BuildKeyOptions<TType extends KeyType, TInput> {
   type?: TType

--- a/packages/solid-query/src/procedure-utils.test-d.ts
+++ b/packages/solid-query/src/procedure-utils.test-d.ts
@@ -133,6 +133,96 @@ describe('ProcedureUtils', () => {
     })
   })
 
+  describe('.streamedOptions', () => {
+    const utils = {} as ProcedureUtils<{ batch?: boolean }, UtilsInput, AsyncIterable<UtilsOutput[number]>, ErrorFromErrorMap<typeof baseErrorMap>>
+
+    it('can optional options', () => {
+      const requiredUtils = {} as ProcedureUtils<{ batch: boolean }, 'input', UtilsOutput, Error>
+
+      utils.queryOptions()
+      utils.queryOptions({ context: { batch: true } })
+      utils.queryOptions({ input: { search: 'search' } })
+      utils.queryOptions({ input: condition ? skipToken : { search: 'search' } })
+
+      requiredUtils.queryOptions({
+        context: { batch: true },
+        input: 'input',
+      })
+      requiredUtils.queryOptions({
+        context: { batch: true },
+        input: condition ? skipToken : 'input',
+      })
+      // @ts-expect-error input and context is required
+      requiredUtils.queryOptions()
+      // @ts-expect-error input and context is required
+      requiredUtils.queryOptions({})
+      // @ts-expect-error input is required
+      requiredUtils.queryOptions({ context: { batch: true } })
+      // @ts-expect-error context is required
+      requiredUtils.queryOptions({ input: 'input' })
+      // @ts-expect-error context is required
+      requiredUtils.queryOptions({ input: condition ? skipToken : 'input' })
+    })
+
+    it('infer correct input type', () => {
+      utils.queryOptions({ input: { cursor: 1 }, context: { batch: true } })
+      utils.queryOptions({ input: condition ? { cursor: 2 } : skipToken, context: { batch: true } })
+      // @ts-expect-error invalid input
+      utils.queryOptions({ input: { cursor: 'invalid' }, context: { batch: true } })
+      // @ts-expect-error invalid input
+      utils.queryOptions({ input: condition ? { cursor: 'invalid' } : skipToken, context: { batch: true } })
+    })
+
+    it('infer correct context type', () => {
+      utils.queryOptions({ context: { batch: true } })
+      // @ts-expect-error invalid context
+      utils.queryOptions({ context: { batch: 'invalid' } })
+    })
+
+    it('not usable in non event iterator output', () => {
+      const utils = {} as ProcedureUtils<{ batch?: boolean }, UtilsInput, UtilsOutput, ErrorFromErrorMap<typeof baseErrorMap>>
+      const query = useQuery(() => utils.experimental_streamedOptions())
+      expectTypeOf(query.data).toExtend<undefined>()
+    })
+
+    describe('works with useQuery', () => {
+      it('without initial data', () => {
+        const query = useQuery(() => utils.experimental_streamedOptions({
+          select: data => ({ mapped: data }),
+          throwOnError(error) {
+            expectTypeOf(error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap>>()
+            return false
+          },
+        }))
+
+        expectTypeOf(query.data).toEqualTypeOf<{ mapped: UtilsOutput } | undefined>()
+        expectTypeOf(query.error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap> | null>()
+      })
+
+      it('with initial data', () => {
+        const query = useQuery(() => utils.experimental_streamedOptions({
+          select: data => ({ mapped: data }),
+          initialData: [{ title: 'title' }],
+          throwOnError(error) {
+            expectTypeOf(error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap>>()
+            return false
+          },
+        }))
+
+        expectTypeOf(query.data).toEqualTypeOf<{ mapped: UtilsOutput }>()
+        expectTypeOf(query.error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap> | null>()
+      })
+    })
+
+    it('works with fetchQuery', () => {
+      expectTypeOf(
+        queryClient.fetchQuery(utils.experimental_streamedOptions()),
+      ).toEqualTypeOf<
+        Promise<UtilsOutput>
+      >()
+    })
+  })
+
   describe('.infiniteOptions', () => {
     const getNextPageParam = {} as GetNextPageParamFunction<number, UtilsOutput>
     const initialPageParam = 1

--- a/packages/solid-query/src/procedure-utils.test-d.ts
+++ b/packages/solid-query/src/procedure-utils.test-d.ts
@@ -139,44 +139,44 @@ describe('ProcedureUtils', () => {
     it('can optional options', () => {
       const requiredUtils = {} as ProcedureUtils<{ batch: boolean }, 'input', UtilsOutput, Error>
 
-      utils.queryOptions()
-      utils.queryOptions({ context: { batch: true } })
-      utils.queryOptions({ input: { search: 'search' } })
-      utils.queryOptions({ input: condition ? skipToken : { search: 'search' } })
+      utils.experimental_streamedOptions()
+      utils.experimental_streamedOptions({ context: { batch: true } })
+      utils.experimental_streamedOptions({ input: { search: 'search' } })
+      utils.experimental_streamedOptions({ input: condition ? skipToken : { search: 'search' } })
 
-      requiredUtils.queryOptions({
+      requiredUtils.experimental_streamedOptions({
         context: { batch: true },
         input: 'input',
       })
-      requiredUtils.queryOptions({
+      requiredUtils.experimental_streamedOptions({
         context: { batch: true },
         input: condition ? skipToken : 'input',
       })
       // @ts-expect-error input and context is required
-      requiredUtils.queryOptions()
+      requiredUtils.experimental_streamedOptions()
       // @ts-expect-error input and context is required
-      requiredUtils.queryOptions({})
+      requiredUtils.experimental_streamedOptions({})
       // @ts-expect-error input is required
-      requiredUtils.queryOptions({ context: { batch: true } })
+      requiredUtils.experimental_streamedOptions({ context: { batch: true } })
       // @ts-expect-error context is required
-      requiredUtils.queryOptions({ input: 'input' })
+      requiredUtils.experimental_streamedOptions({ input: 'input' })
       // @ts-expect-error context is required
-      requiredUtils.queryOptions({ input: condition ? skipToken : 'input' })
+      requiredUtils.experimental_streamedOptions({ input: condition ? skipToken : 'input' })
     })
 
     it('infer correct input type', () => {
-      utils.queryOptions({ input: { cursor: 1 }, context: { batch: true } })
-      utils.queryOptions({ input: condition ? { cursor: 2 } : skipToken, context: { batch: true } })
+      utils.experimental_streamedOptions({ input: { cursor: 1 }, context: { batch: true } })
+      utils.experimental_streamedOptions({ input: condition ? { cursor: 2 } : skipToken, context: { batch: true } })
       // @ts-expect-error invalid input
-      utils.queryOptions({ input: { cursor: 'invalid' }, context: { batch: true } })
+      utils.experimental_streamedOptions({ input: { cursor: 'invalid' }, context: { batch: true } })
       // @ts-expect-error invalid input
-      utils.queryOptions({ input: condition ? { cursor: 'invalid' } : skipToken, context: { batch: true } })
+      utils.experimental_streamedOptions({ input: condition ? { cursor: 'invalid' } : skipToken, context: { batch: true } })
     })
 
     it('infer correct context type', () => {
-      utils.queryOptions({ context: { batch: true } })
+      utils.experimental_streamedOptions({ context: { batch: true } })
       // @ts-expect-error invalid context
-      utils.queryOptions({ context: { batch: 'invalid' } })
+      utils.experimental_streamedOptions({ context: { batch: 'invalid' } })
     })
 
     it('not usable in non event iterator output', () => {

--- a/packages/solid-query/src/procedure-utils.test.ts
+++ b/packages/solid-query/src/procedure-utils.test.ts
@@ -1,10 +1,21 @@
-import { skipToken } from '@tanstack/solid-query'
+import { experimental_streamedQuery, skipToken } from '@tanstack/solid-query'
+import { queryClient } from '../tests/shared'
 import * as Key from './key'
 import { createProcedureUtils } from './procedure-utils'
+
+vi.mock('@tanstack/solid-query', async (origin) => {
+  const original = await origin() as any
+
+  return {
+    ...original,
+    experimental_streamedQuery: vi.fn(original.experimental_streamedQuery),
+  }
+})
 
 const buildKeySpy = vi.spyOn(Key, 'buildKey')
 
 beforeEach(() => {
+  queryClient.clear()
   vi.clearAllMocks()
 })
 
@@ -44,6 +55,63 @@ describe('createProcedureUtils', () => {
 
       expect(() => options.queryFn!({ signal } as any)).toThrow('queryFn should not be called with skipToken used as input')
       expect(client).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  describe('.streamedOptions', () => {
+    it('without skipToken', async () => {
+      client.mockImplementationOnce(async function* (input) {
+        yield '__1__'
+        yield '__2__'
+        return '__3__'
+      })
+
+      const options = utils.experimental_streamedOptions({
+        input: { search: '__search__' },
+        context: { batch: '__batch__' },
+        refetchMode: 'replace',
+      })
+
+      expect(options.enabled).toBe(true)
+
+      expect(options.queryKey).toBe(buildKeySpy.mock.results[0]!.value)
+      expect(buildKeySpy).toHaveBeenCalledTimes(1)
+      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { type: 'streamed', input: { search: '__search__' } })
+
+      expect(options.queryFn).toBe(vi.mocked(experimental_streamedQuery).mock.results[0]!.value)
+      expect(experimental_streamedQuery).toHaveBeenCalledTimes(1)
+      expect(experimental_streamedQuery).toHaveBeenCalledWith({
+        refetchMode: 'replace',
+        queryFn: expect.any(Function),
+      })
+
+      await expect(options.queryFn!({ signal, client: queryClient, queryKey: options.queryKey } as any)).resolves.toEqual(['__1__', '__2__'])
+      expect(queryClient.getQueryData(options.queryKey)).toEqual(['__1__', '__2__'])
+
+      expect(client).toHaveBeenCalledTimes(1)
+      expect(client).toBeCalledWith({ search: '__search__' }, { signal, context: { batch: '__batch__' } })
+    })
+
+    it('with skipToken', async () => {
+      const options = utils.experimental_streamedOptions({ input: skipToken, context: { batch: '__batch__' } })
+
+      expect(options.enabled).toBe(false)
+
+      expect(options.queryKey).toBe(buildKeySpy.mock.results[0]!.value)
+      expect(buildKeySpy).toHaveBeenCalledTimes(1)
+      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { type: 'streamed', input: skipToken })
+
+      await expect(options.queryFn!({ signal, client: queryClient } as any)).rejects.toThrow('queryFn should not be called with skipToken used as input')
+      expect(client).toHaveBeenCalledTimes(0)
+    })
+
+    it('with unsupported output', async () => {
+      client.mockResolvedValueOnce('__1__')
+      const options = utils.experimental_streamedOptions({ input: { search: '__search__' }, context: { batch: '__batch__' } })
+
+      await expect(options.queryFn!({ signal, client: queryClient } as any)).rejects.toThrow('streamedQuery requires an event iterator output')
+      expect(client).toHaveBeenCalledTimes(1)
+      expect(client).toBeCalledWith({ search: '__search__' }, { signal, context: { batch: '__batch__' } })
     })
   })
 

--- a/packages/solid-query/src/procedure-utils.test.ts
+++ b/packages/solid-query/src/procedure-utils.test.ts
@@ -80,10 +80,10 @@ describe('createProcedureUtils', () => {
 
       expect(options.queryFn).toBe(vi.mocked(experimental_streamedQuery).mock.results[0]!.value)
       expect(experimental_streamedQuery).toHaveBeenCalledTimes(1)
-      expect(experimental_streamedQuery).toHaveBeenCalledWith({
+      expect(experimental_streamedQuery).toHaveBeenCalledWith(expect.objectContaining({
         refetchMode: 'replace',
         queryFn: expect.any(Function),
-      })
+      }))
 
       await expect(options.queryFn!({ signal, client: queryClient, queryKey: options.queryKey } as any)).resolves.toEqual(['__1__', '__2__'])
       expect(queryClient.getQueryData(options.queryKey)).toEqual(['__1__', '__2__'])

--- a/packages/solid-query/src/procedure-utils.ts
+++ b/packages/solid-query/src/procedure-utils.ts
@@ -87,7 +87,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
         enabled: optionsIn.input !== skipToken,
         queryKey: buildKey(options.path, { type: 'streamed', input: optionsIn.input }),
         queryFn: experimental_streamedQuery({
-          refetchMode: optionsIn.refetchMode,
+          ...optionsIn,
           queryFn: async ({ signal }) => {
             if (optionsIn.input === skipToken) {
               throw new Error('queryFn should not be called with skipToken used as input')

--- a/packages/solid-query/src/procedure-utils.ts
+++ b/packages/solid-query/src/procedure-utils.ts
@@ -26,7 +26,7 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
   ): NoInfer<U & Omit<QueryOptionsBase<TOutput, TError>, keyof U>>
 
   /**
-   * Generate [event-iterator](https://orpc.unnoq.com/docs/event-iterator) options used for useQuery/prefetchQuery/...
+   * Generate [Event Iterator](https://orpc.unnoq.com/docs/event-iterator) options used for useQuery/prefetchQuery/...
    * Built on top of [steamedQuery](https://tanstack.com/query/latest/docs/reference/streamedQuery)
    *
    * @see {@link https://orpc.unnoq.com/docs/tanstack-query/basic#streamed-query-options-utility Tanstack Streamed Query Options Utility Docs}

--- a/packages/solid-query/src/procedure-utils.ts
+++ b/packages/solid-query/src/procedure-utils.ts
@@ -26,7 +26,7 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
   ): NoInfer<U & Omit<QueryOptionsBase<TOutput, TError>, keyof U>>
 
   /**
-   * Generate [event-iterator](https://orpc.unnoq.com/docs/event-iterator) options used for useQuery/useSuspenseQuery/prefetchQuery/...
+   * Generate [event-iterator](https://orpc.unnoq.com/docs/event-iterator) options used for useQuery/prefetchQuery/...
    * Built on top of [steamedQuery](https://tanstack.com/query/latest/docs/reference/streamedQuery)
    *
    * @see {@link https://orpc.unnoq.com/docs/tanstack-query/basic#streamed-query-options-utility Tanstack Streamed Query Options Utility Docs}

--- a/packages/solid-query/src/procedure-utils.ts
+++ b/packages/solid-query/src/procedure-utils.ts
@@ -1,8 +1,9 @@
 import type { Client, ClientContext } from '@orpc/client'
 import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { InfiniteData } from '@tanstack/solid-query'
-import type { InfiniteOptionsBase, InfiniteOptionsIn, MutationOptions, MutationOptionsIn, QueryOptionsBase, QueryOptionsIn } from './types'
-import { skipToken } from '@tanstack/solid-query'
+import type { experimental_InferStreamedOutput, experimental_StreamedOptionsBase, experimental_StreamedOptionsIn, InfiniteOptionsBase, InfiniteOptionsIn, MutationOptions, MutationOptionsIn, QueryOptionsBase, QueryOptionsIn } from './types'
+import { isAsyncIteratorObject } from '@orpc/shared'
+import { experimental_streamedQuery, skipToken } from '@tanstack/solid-query'
 import { buildKey } from './key'
 
 export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TOutput, TError> {
@@ -23,6 +24,18 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
       U & QueryOptionsIn<TClientContext, TInput, TOutput, TError, USelectData>
     >
   ): NoInfer<U & Omit<QueryOptionsBase<TOutput, TError>, keyof U>>
+
+  /**
+   * Generate [event-iterator](https://orpc.unnoq.com/docs/event-iterator) options used for useQuery/useSuspenseQuery/prefetchQuery/...
+   * Built on top of [steamedQuery](https://tanstack.com/query/latest/docs/reference/streamedQuery)
+   *
+   * @see {@link https://orpc.unnoq.com/docs/tanstack-query/basic#streamed-query-options-utility Tanstack Streamed Query Options Utility Docs}
+   */
+  experimental_streamedOptions<U, USelectData = experimental_InferStreamedOutput<TOutput>>(
+    ...rest: MaybeOptionalOptions<
+      U & experimental_StreamedOptionsIn<TClientContext, TInput, experimental_InferStreamedOutput<TOutput>, TError, USelectData>
+    >
+  ): NoInfer<U & Omit<experimental_StreamedOptionsBase<experimental_InferStreamedOutput<TOutput>, TError>, keyof U>>
 
   /**
    * Generate options used for createInfiniteQuery/prefetchInfiniteQuery/...
@@ -65,6 +78,30 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
           return client(optionsIn.input, { signal, context: optionsIn.context })
         },
         enabled: optionsIn.input !== skipToken,
+        ...optionsIn,
+      }
+    },
+
+    experimental_streamedOptions(...[optionsIn = {} as any]) {
+      return {
+        enabled: optionsIn.input !== skipToken,
+        queryKey: buildKey(options.path, { type: 'streamed', input: optionsIn.input }),
+        queryFn: experimental_streamedQuery({
+          refetchMode: optionsIn.refetchMode,
+          queryFn: async ({ signal }) => {
+            if (optionsIn.input === skipToken) {
+              throw new Error('queryFn should not be called with skipToken used as input')
+            }
+
+            const output = await client(optionsIn.input, { signal, context: optionsIn.context })
+
+            if (!isAsyncIteratorObject(output)) {
+              throw new Error('streamedQuery requires an event iterator output')
+            }
+
+            return output
+          },
+        }),
         ...optionsIn,
       }
     },

--- a/packages/solid-query/src/types.ts
+++ b/packages/solid-query/src/types.ts
@@ -7,6 +7,7 @@ import type {
   SolidInfiniteQueryOptions,
   SolidMutationOptions,
   SolidQueryOptions,
+  experimental_streamedQuery as streamedQuery,
 } from '@tanstack/solid-query'
 
 export type QueryOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TSelectData> =
@@ -19,6 +20,17 @@ export interface QueryOptionsBase<TOutput, TError> {
   queryFn(ctx: QueryFunctionContext): Promise<TOutput>
   retry?(failureCount: number, error: TError): boolean // this make tanstack can infer the TError type
   enabled: boolean
+}
+
+type experimental_StreamedRefetchMode = Exclude<Parameters<typeof streamedQuery>[0]['refetchMode'], undefined>
+
+export type experimental_InferStreamedOutput<TOutput> = TOutput extends AsyncIterable<infer U> ? U[] : never
+
+export type experimental_StreamedOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TSelectData> =
+  & QueryOptionsIn<TClientContext, TInput, TOutput, TError, TSelectData>
+  & { refetchMode?: experimental_StreamedRefetchMode }
+
+export interface experimental_StreamedOptionsBase<TOutput, TError> extends QueryOptionsBase<TOutput, TError> {
 }
 
 export type InfiniteOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TSelectData, TPageParam> =

--- a/packages/solid-query/src/types.ts
+++ b/packages/solid-query/src/types.ts
@@ -22,13 +22,13 @@ export interface QueryOptionsBase<TOutput, TError> {
   enabled: boolean
 }
 
-type experimental_StreamedRefetchMode = Exclude<Parameters<typeof streamedQuery>[0]['refetchMode'], undefined>
+type experimental_StreamedQueryOptions = Omit<Parameters<typeof streamedQuery>[0]['refetchMode'], 'queryFn'>
 
 export type experimental_InferStreamedOutput<TOutput> = TOutput extends AsyncIterable<infer U> ? U[] : never
 
 export type experimental_StreamedOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TSelectData> =
   & QueryOptionsIn<TClientContext, TInput, TOutput, TError, TSelectData>
-  & { refetchMode?: experimental_StreamedRefetchMode }
+  & experimental_StreamedQueryOptions
 
 export interface experimental_StreamedOptionsBase<TOutput, TError> extends QueryOptionsBase<TOutput, TError> {
 }

--- a/packages/solid-query/tests/e2e.test-d.ts
+++ b/packages/solid-query/tests/e2e.test-d.ts
@@ -2,7 +2,7 @@ import type { InfiniteData } from '@tanstack/react-query'
 import { isDefinedError } from '@orpc/client'
 import { useInfiniteQuery, useMutation, useQueries, useQuery } from '@tanstack/solid-query'
 import { orpc as client } from '../../client/tests/shared'
-import { orpc, queryClient } from './shared'
+import { orpc, queryClient, streamedOrpc } from './shared'
 
 it('.key', () => {
   queryClient.invalidateQueries({
@@ -106,6 +106,90 @@ describe('.queryOptions', () => {
     }))
 
     expectTypeOf(query2).toEqualTypeOf<{ output: string }>()
+  })
+})
+
+describe('.streamedOptions', () => {
+  it('useQuery', () => {
+    const query = useQuery(() => streamedOrpc.streamed.experimental_streamedOptions({
+      input: { input: 123 },
+      retry(failureCount, error) {
+        if (isDefinedError(error) && error.code === 'BASE') {
+          expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
+        }
+
+        return false
+      },
+    }))
+
+    if (query.status === 'error' && isDefinedError(query.error) && query.error.code === 'OVERRIDE') {
+      expectTypeOf(query.error.data).toEqualTypeOf<unknown>()
+    }
+
+    if (query.status === 'success') {
+      expectTypeOf(query.data).toEqualTypeOf<{ output: string }[]>()
+    }
+
+    useQuery(() => orpc.ping.queryOptions({
+      // @ts-expect-error --- input is invalid
+      input: {
+        input: '123',
+      },
+    }))
+
+    useQuery(() => orpc.ping.queryOptions({
+      input: { input: 123 },
+      context: {
+        // @ts-expect-error --- cache is invalid
+        cache: 123,
+      },
+    }))
+  })
+
+  it('useQueries', async () => {
+    const queries = useQueries(() => ({
+      queries: [
+        streamedOrpc.streamed.experimental_streamedOptions({
+          input: { input: 123 },
+          select: data => ({ mapped: data }),
+          retry(failureCount, error) {
+            if (isDefinedError(error) && error.code === 'BASE') {
+              expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
+            }
+
+            return false
+          },
+        }),
+        orpc.nested.pong.queryOptions({
+          context: { cache: '123' },
+        }),
+      ],
+    }))
+
+    // FIXME: useQueries cannot infer error
+    // if (queries[0].status === 'error' && isDefinedError(queries[0].error) && queries[0].error.code === 'OVERRIDE') {
+    //   expectTypeOf(queries[0].error.data).toEqualTypeOf<unknown>()
+    // }
+
+    if (queries[0].status === 'success') {
+      expectTypeOf(queries[0].data.mapped).toEqualTypeOf<{ output: string }[]>()
+    }
+
+    if (queries[1].status === 'error') {
+      expectTypeOf(queries[1].error).toEqualTypeOf<Error>()
+    }
+
+    if (queries[1].status === 'success') {
+      expectTypeOf(queries[1].data).toEqualTypeOf<unknown>()
+    }
+  })
+
+  it('fetchQuery', async () => {
+    const query = await queryClient.fetchQuery(streamedOrpc.streamed.experimental_streamedOptions({
+      input: { input: 123 },
+    }))
+
+    expectTypeOf(query).toEqualTypeOf<{ output: string }[]>()
   })
 })
 

--- a/packages/solid-query/tests/e2e.test-d.ts
+++ b/packages/solid-query/tests/e2e.test-d.ts
@@ -130,14 +130,14 @@ describe('.streamedOptions', () => {
       expectTypeOf(query.data).toEqualTypeOf<{ output: string }[]>()
     }
 
-    useQuery(() => orpc.ping.queryOptions({
+    useQuery(() => orpc.ping.experimental_streamedOptions({
       // @ts-expect-error --- input is invalid
       input: {
         input: '123',
       },
     }))
 
-    useQuery(() => orpc.ping.queryOptions({
+    useQuery(() => orpc.ping.experimental_streamedOptions({
       input: { input: 123 },
       context: {
         // @ts-expect-error --- cache is invalid

--- a/packages/solid-query/tests/e2e.test.tsx
+++ b/packages/solid-query/tests/e2e.test.tsx
@@ -2,8 +2,8 @@ import { isDefinedError } from '@orpc/client'
 import { ORPCError } from '@orpc/contract'
 import { renderHook } from '@solidjs/testing-library'
 import { skipToken, useInfiniteQuery, useMutation, useQuery } from '@tanstack/solid-query'
-import { pingHandler } from '../../server/tests/shared'
-import { orpc, queryClient } from './shared'
+import { pingHandler, streamedHandler } from '../../server/tests/shared'
+import { orpc, queryClient, streamedOrpc } from './shared'
 
 beforeEach(() => {
   queryClient.clear()
@@ -56,6 +56,53 @@ it('case: with useQuery with skipToken', async () => {
 
   expect(query.status).toEqual('pending')
   expect(queryClient.isFetching({ queryKey: orpc.key() })).toEqual(0)
+})
+
+it('case: with streamed/useQuery', async () => {
+  const { result } = renderHook(() => useQuery(() => streamedOrpc.streamed.experimental_streamedOptions({
+    refetchMode: 'append',
+    input: { input: 2 },
+  }), () => queryClient))
+
+  expect(queryClient.isFetching({ queryKey: streamedOrpc.key() })).toEqual(1)
+  expect(queryClient.isFetching({ queryKey: streamedOrpc.streamed.key() })).toEqual(1)
+  expect(queryClient.isFetching({ queryKey: streamedOrpc.streamed.key({ input: { input: 2 } }) })).toEqual(1)
+  expect(queryClient.isFetching({ queryKey: streamedOrpc.streamed.key({ input: { input: 2 }, type: 'streamed' }) })).toEqual(1)
+
+  expect(queryClient.isFetching({ queryKey: streamedOrpc.streamed.key({ input: { input: 234 }, type: 'query' }) })).toEqual(0)
+  expect(queryClient.isFetching({ queryKey: streamedOrpc.streamed.key({ input: { input: 2 }, type: 'infinite' }) })).toEqual(0)
+  expect(queryClient.isFetching({ queryKey: streamedOrpc.key({ type: 'infinite' }) })).toEqual(0)
+
+  await vi.waitFor(() => expect(result.data).toEqual([{ output: '0' }, { output: '1' }]))
+
+  expect(
+    queryClient.getQueryData(streamedOrpc.streamed.key({ input: { input: 2 }, type: 'streamed' })),
+  ).toEqual([{ output: '0' }, { output: '1' }])
+
+  // make sure refetch mode works
+  result.refetch()
+  await vi.waitFor(() => expect(result.data).toEqual([{ output: '0' }, { output: '1' }, { output: '0' }, { output: '1' }]))
+
+  streamedHandler.mockRejectedValueOnce(new ORPCError('OVERRIDE'))
+  result.refetch()
+
+  await vi.waitFor(() => {
+    expect((result as any).error).toBeInstanceOf(ORPCError)
+    expect((result as any).error).toSatisfy(isDefinedError)
+    expect((result as any).error.code).toEqual('OVERRIDE')
+  })
+})
+
+it('case: with streamed/useQuery and skipToken', async () => {
+  const { result } = renderHook(() => useQuery(() => streamedOrpc.streamed.experimental_streamedOptions({ input: skipToken }), () => queryClient))
+
+  expect(result.status).toEqual('pending')
+  expect(queryClient.isFetching({ queryKey: orpc.key() })).toEqual(0)
+
+  await new Promise(resolve => setTimeout(resolve, 10))
+
+  expect(queryClient.isFetching({ queryKey: orpc.key() })).toEqual(0)
+  expect(result.status).toEqual('pending')
 })
 
 it('case: with useInfiniteQuery', async () => {

--- a/packages/solid-query/tests/shared.tsx
+++ b/packages/solid-query/tests/shared.tsx
@@ -1,8 +1,9 @@
 import { QueryClient } from '@tanstack/solid-query'
-import { orpc as client } from '../../client/tests/shared'
+import { orpc as client, streamedOrpc as streamedClient } from '../../client/tests/shared'
 import { createORPCSolidQueryUtils } from '../src'
 
 export const orpc = createORPCSolidQueryUtils(client)
+export const streamedOrpc = createORPCSolidQueryUtils(streamedClient)
 
 export const queryClient = new QueryClient({
   defaultOptions: {

--- a/packages/svelte-query/src/key.ts
+++ b/packages/svelte-query/src/key.ts
@@ -1,7 +1,7 @@
 import type { PartialDeep } from '@orpc/shared'
 import type { QueryKey } from '@tanstack/svelte-query'
 
-export type KeyType = 'query' | 'infinite' | 'mutation' | undefined
+export type KeyType = 'query' | 'streamed' | 'infinite' | 'mutation' | undefined
 
 export interface BuildKeyOptions<TType extends KeyType, TInput> {
   type?: TType

--- a/packages/svelte-query/src/procedure-utils.test-d.ts
+++ b/packages/svelte-query/src/procedure-utils.test-d.ts
@@ -140,44 +140,44 @@ describe('ProcedureUtils', () => {
     it('can optional options', () => {
       const requiredUtils = {} as ProcedureUtils<{ batch: boolean }, 'input', UtilsOutput, Error>
 
-      utils.queryOptions()
-      utils.queryOptions({ context: { batch: true } })
-      utils.queryOptions({ input: { search: 'search' } })
-      utils.queryOptions({ input: condition ? skipToken : { search: 'search' } })
+      utils.experimental_streamedOptions()
+      utils.experimental_streamedOptions({ context: { batch: true } })
+      utils.experimental_streamedOptions({ input: { search: 'search' } })
+      utils.experimental_streamedOptions({ input: condition ? skipToken : { search: 'search' } })
 
-      requiredUtils.queryOptions({
+      requiredUtils.experimental_streamedOptions({
         context: { batch: true },
         input: 'input',
       })
-      requiredUtils.queryOptions({
+      requiredUtils.experimental_streamedOptions({
         context: { batch: true },
         input: condition ? skipToken : 'input',
       })
       // @ts-expect-error input and context is required
-      requiredUtils.queryOptions()
+      requiredUtils.experimental_streamedOptions()
       // @ts-expect-error input and context is required
-      requiredUtils.queryOptions({})
+      requiredUtils.experimental_streamedOptions({})
       // @ts-expect-error input is required
-      requiredUtils.queryOptions({ context: { batch: true } })
+      requiredUtils.experimental_streamedOptions({ context: { batch: true } })
       // @ts-expect-error context is required
-      requiredUtils.queryOptions({ input: 'input' })
+      requiredUtils.experimental_streamedOptions({ input: 'input' })
       // @ts-expect-error context is required
-      requiredUtils.queryOptions({ input: condition ? skipToken : 'input' })
+      requiredUtils.experimental_streamedOptions({ input: condition ? skipToken : 'input' })
     })
 
     it('infer correct input type', () => {
-      utils.queryOptions({ input: { cursor: 1 }, context: { batch: true } })
-      utils.queryOptions({ input: condition ? { cursor: 2 } : skipToken, context: { batch: true } })
+      utils.experimental_streamedOptions({ input: { cursor: 1 }, context: { batch: true } })
+      utils.experimental_streamedOptions({ input: condition ? { cursor: 2 } : skipToken, context: { batch: true } })
       // @ts-expect-error invalid input
-      utils.queryOptions({ input: { cursor: 'invalid' }, context: { batch: true } })
+      utils.experimental_streamedOptions({ input: { cursor: 'invalid' }, context: { batch: true } })
       // @ts-expect-error invalid input
-      utils.queryOptions({ input: condition ? { cursor: 'invalid' } : skipToken, context: { batch: true } })
+      utils.experimental_streamedOptions({ input: condition ? { cursor: 'invalid' } : skipToken, context: { batch: true } })
     })
 
     it('infer correct context type', () => {
-      utils.queryOptions({ context: { batch: true } })
+      utils.experimental_streamedOptions({ context: { batch: true } })
       // @ts-expect-error invalid context
-      utils.queryOptions({ context: { batch: 'invalid' } })
+      utils.experimental_streamedOptions({ context: { batch: 'invalid' } })
     })
 
     it('not usable in non event iterator output', () => {

--- a/packages/svelte-query/src/procedure-utils.test-d.ts
+++ b/packages/svelte-query/src/procedure-utils.test-d.ts
@@ -134,6 +134,96 @@ describe('ProcedureUtils', () => {
     })
   })
 
+  describe('.streamedOptions', () => {
+    const utils = {} as ProcedureUtils<{ batch?: boolean }, UtilsInput, AsyncIterable<UtilsOutput[number]>, ErrorFromErrorMap<typeof baseErrorMap>>
+
+    it('can optional options', () => {
+      const requiredUtils = {} as ProcedureUtils<{ batch: boolean }, 'input', UtilsOutput, Error>
+
+      utils.queryOptions()
+      utils.queryOptions({ context: { batch: true } })
+      utils.queryOptions({ input: { search: 'search' } })
+      utils.queryOptions({ input: condition ? skipToken : { search: 'search' } })
+
+      requiredUtils.queryOptions({
+        context: { batch: true },
+        input: 'input',
+      })
+      requiredUtils.queryOptions({
+        context: { batch: true },
+        input: condition ? skipToken : 'input',
+      })
+      // @ts-expect-error input and context is required
+      requiredUtils.queryOptions()
+      // @ts-expect-error input and context is required
+      requiredUtils.queryOptions({})
+      // @ts-expect-error input is required
+      requiredUtils.queryOptions({ context: { batch: true } })
+      // @ts-expect-error context is required
+      requiredUtils.queryOptions({ input: 'input' })
+      // @ts-expect-error context is required
+      requiredUtils.queryOptions({ input: condition ? skipToken : 'input' })
+    })
+
+    it('infer correct input type', () => {
+      utils.queryOptions({ input: { cursor: 1 }, context: { batch: true } })
+      utils.queryOptions({ input: condition ? { cursor: 2 } : skipToken, context: { batch: true } })
+      // @ts-expect-error invalid input
+      utils.queryOptions({ input: { cursor: 'invalid' }, context: { batch: true } })
+      // @ts-expect-error invalid input
+      utils.queryOptions({ input: condition ? { cursor: 'invalid' } : skipToken, context: { batch: true } })
+    })
+
+    it('infer correct context type', () => {
+      utils.queryOptions({ context: { batch: true } })
+      // @ts-expect-error invalid context
+      utils.queryOptions({ context: { batch: 'invalid' } })
+    })
+
+    it('not usable in non event iterator output', () => {
+      const utils = {} as ProcedureUtils<{ batch?: boolean }, UtilsInput, UtilsOutput, ErrorFromErrorMap<typeof baseErrorMap>>
+      const query = createQuery(utils.experimental_streamedOptions())
+      expectTypeOf(get(query).data).toExtend<undefined>()
+    })
+
+    describe('works with useQuery', () => {
+      it('without initial data', () => {
+        const query = createQuery(utils.experimental_streamedOptions({
+          select: data => ({ mapped: data }),
+          throwOnError(error) {
+            expectTypeOf(error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap>>()
+            return false
+          },
+        }))
+
+        expectTypeOf(get(query).data).toEqualTypeOf<{ mapped: UtilsOutput } | undefined>()
+        expectTypeOf(get(query).error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap> | null>()
+      })
+
+      it('with initial data', () => {
+        const query = createQuery(utils.experimental_streamedOptions({
+          select: data => ({ mapped: data }),
+          initialData: [{ title: 'title' }],
+          throwOnError(error) {
+            expectTypeOf(error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap>>()
+            return false
+          },
+        }))
+
+        expectTypeOf(get(query).data).toEqualTypeOf<{ mapped: UtilsOutput }>()
+        expectTypeOf(get(query).error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap> | null>()
+      })
+    })
+
+    it('works with fetchQuery', () => {
+      expectTypeOf(
+        queryClient.fetchQuery(utils.experimental_streamedOptions()),
+      ).toEqualTypeOf<
+        Promise<UtilsOutput>
+      >()
+    })
+  })
+
   describe('.infiniteOptions', () => {
     const getNextPageParam = {} as GetNextPageParamFunction<number, UtilsOutput>
     const initialPageParam = 1

--- a/packages/svelte-query/src/procedure-utils.test.tsx
+++ b/packages/svelte-query/src/procedure-utils.test.tsx
@@ -1,10 +1,21 @@
-import { skipToken } from '@tanstack/svelte-query'
+import { experimental_streamedQuery, skipToken } from '@tanstack/svelte-query'
+import { queryClient } from '../tests/shared'
 import * as Key from './key'
 import { createProcedureUtils } from './procedure-utils'
+
+vi.mock('@tanstack/svelte-query', async (origin) => {
+  const original = await origin() as any
+
+  return {
+    ...original,
+    experimental_streamedQuery: vi.fn(original.experimental_streamedQuery),
+  }
+})
 
 const buildKeySpy = vi.spyOn(Key, 'buildKey')
 
 beforeEach(() => {
+  queryClient.clear()
   vi.clearAllMocks()
 })
 
@@ -44,6 +55,63 @@ describe('createProcedureUtils', () => {
 
       expect(() => options.queryFn!({ signal } as any)).toThrow('queryFn should not be called with skipToken used as input')
       expect(client).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  describe('.streamedOptions', () => {
+    it('without skipToken', async () => {
+      client.mockImplementationOnce(async function* (input) {
+        yield '__1__'
+        yield '__2__'
+        return '__3__'
+      })
+
+      const options = utils.experimental_streamedOptions({
+        input: { search: '__search__' },
+        context: { batch: '__batch__' },
+        refetchMode: 'replace',
+      })
+
+      expect(options.enabled).toBe(true)
+
+      expect(options.queryKey).toBe(buildKeySpy.mock.results[0]!.value)
+      expect(buildKeySpy).toHaveBeenCalledTimes(1)
+      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { type: 'streamed', input: { search: '__search__' } })
+
+      expect(options.queryFn).toBe(vi.mocked(experimental_streamedQuery).mock.results[0]!.value)
+      expect(experimental_streamedQuery).toHaveBeenCalledTimes(1)
+      expect(experimental_streamedQuery).toHaveBeenCalledWith({
+        refetchMode: 'replace',
+        queryFn: expect.any(Function),
+      })
+
+      await expect(options.queryFn!({ signal, client: queryClient, queryKey: options.queryKey } as any)).resolves.toEqual(['__1__', '__2__'])
+      expect(queryClient.getQueryData(options.queryKey)).toEqual(['__1__', '__2__'])
+
+      expect(client).toHaveBeenCalledTimes(1)
+      expect(client).toBeCalledWith({ search: '__search__' }, { signal, context: { batch: '__batch__' } })
+    })
+
+    it('with skipToken', async () => {
+      const options = utils.experimental_streamedOptions({ input: skipToken, context: { batch: '__batch__' } })
+
+      expect(options.enabled).toBe(false)
+
+      expect(options.queryKey).toBe(buildKeySpy.mock.results[0]!.value)
+      expect(buildKeySpy).toHaveBeenCalledTimes(1)
+      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { type: 'streamed', input: skipToken })
+
+      await expect(options.queryFn!({ signal, client: queryClient } as any)).rejects.toThrow('queryFn should not be called with skipToken used as input')
+      expect(client).toHaveBeenCalledTimes(0)
+    })
+
+    it('with unsupported output', async () => {
+      client.mockResolvedValueOnce('__1__')
+      const options = utils.experimental_streamedOptions({ input: { search: '__search__' }, context: { batch: '__batch__' } })
+
+      await expect(options.queryFn!({ signal, client: queryClient } as any)).rejects.toThrow('streamedQuery requires an event iterator output')
+      expect(client).toHaveBeenCalledTimes(1)
+      expect(client).toBeCalledWith({ search: '__search__' }, { signal, context: { batch: '__batch__' } })
     })
   })
 

--- a/packages/svelte-query/src/procedure-utils.test.tsx
+++ b/packages/svelte-query/src/procedure-utils.test.tsx
@@ -80,10 +80,10 @@ describe('createProcedureUtils', () => {
 
       expect(options.queryFn).toBe(vi.mocked(experimental_streamedQuery).mock.results[0]!.value)
       expect(experimental_streamedQuery).toHaveBeenCalledTimes(1)
-      expect(experimental_streamedQuery).toHaveBeenCalledWith({
+      expect(experimental_streamedQuery).toHaveBeenCalledWith(expect.objectContaining({
         refetchMode: 'replace',
         queryFn: expect.any(Function),
-      })
+      }))
 
       await expect(options.queryFn!({ signal, client: queryClient, queryKey: options.queryKey } as any)).resolves.toEqual(['__1__', '__2__'])
       expect(queryClient.getQueryData(options.queryKey)).toEqual(['__1__', '__2__'])

--- a/packages/svelte-query/src/procedure-utils.ts
+++ b/packages/svelte-query/src/procedure-utils.ts
@@ -87,7 +87,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
         enabled: optionsIn.input !== skipToken,
         queryKey: buildKey(options.path, { type: 'streamed', input: optionsIn.input }),
         queryFn: experimental_streamedQuery({
-          refetchMode: optionsIn.refetchMode,
+          ...optionsIn,
           queryFn: async ({ signal }) => {
             if (optionsIn.input === skipToken) {
               throw new Error('queryFn should not be called with skipToken used as input')

--- a/packages/svelte-query/src/procedure-utils.ts
+++ b/packages/svelte-query/src/procedure-utils.ts
@@ -26,7 +26,7 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
   ): NoInfer<U & Omit<QueryOptionsBase<TOutput, TError>, keyof U>>
 
   /**
-   * Generate [event-iterator](https://orpc.unnoq.com/docs/event-iterator) options used for useQuery/prefetchQuery/...
+   * Generate [Event Iterator](https://orpc.unnoq.com/docs/event-iterator) options used for useQuery/prefetchQuery/...
    * Built on top of [steamedQuery](https://tanstack.com/query/latest/docs/reference/streamedQuery)
    *
    * @see {@link https://orpc.unnoq.com/docs/tanstack-query/basic#streamed-query-options-utility Tanstack Streamed Query Options Utility Docs}

--- a/packages/svelte-query/src/procedure-utils.ts
+++ b/packages/svelte-query/src/procedure-utils.ts
@@ -1,8 +1,9 @@
 import type { Client, ClientContext } from '@orpc/client'
 import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { InfiniteData } from '@tanstack/svelte-query'
-import type { InfiniteOptionsBase, InfiniteOptionsIn, MutationOptions, MutationOptionsIn, QueryOptionsBase, QueryOptionsIn } from './types'
-import { skipToken } from '@tanstack/svelte-query'
+import type { experimental_InferStreamedOutput, experimental_StreamedOptionsBase, experimental_StreamedOptionsIn, InfiniteOptionsBase, InfiniteOptionsIn, MutationOptions, MutationOptionsIn, QueryOptionsBase, QueryOptionsIn } from './types'
+import { isAsyncIteratorObject } from '@orpc/shared'
+import { experimental_streamedQuery, skipToken } from '@tanstack/svelte-query'
 import { buildKey } from './key'
 
 export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TOutput, TError> {
@@ -23,6 +24,18 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
       U & QueryOptionsIn<TClientContext, TInput, TOutput, TError, USelectData>
     >
   ): NoInfer<U & Omit<QueryOptionsBase<TOutput, TError>, keyof U>>
+
+  /**
+   * Generate [event-iterator](https://orpc.unnoq.com/docs/event-iterator) options used for useQuery/prefetchQuery/...
+   * Built on top of [steamedQuery](https://tanstack.com/query/latest/docs/reference/streamedQuery)
+   *
+   * @see {@link https://orpc.unnoq.com/docs/tanstack-query/basic#streamed-query-options-utility Tanstack Streamed Query Options Utility Docs}
+   */
+  experimental_streamedOptions<U, USelectData = experimental_InferStreamedOutput<TOutput>>(
+    ...rest: MaybeOptionalOptions<
+      U & experimental_StreamedOptionsIn<TClientContext, TInput, experimental_InferStreamedOutput<TOutput>, TError, USelectData>
+    >
+  ): NoInfer<U & Omit<experimental_StreamedOptionsBase<experimental_InferStreamedOutput<TOutput>, TError>, keyof U>>
 
   /**
    * Generate options used for createInfiniteQuery/prefetchInfiniteQuery/...
@@ -65,6 +78,30 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
           return client(optionsIn.input, { signal, context: optionsIn.context })
         },
         enabled: optionsIn.input !== skipToken,
+        ...optionsIn,
+      }
+    },
+
+    experimental_streamedOptions(...[optionsIn = {} as any]) {
+      return {
+        enabled: optionsIn.input !== skipToken,
+        queryKey: buildKey(options.path, { type: 'streamed', input: optionsIn.input }),
+        queryFn: experimental_streamedQuery({
+          refetchMode: optionsIn.refetchMode,
+          queryFn: async ({ signal }) => {
+            if (optionsIn.input === skipToken) {
+              throw new Error('queryFn should not be called with skipToken used as input')
+            }
+
+            const output = await client(optionsIn.input, { signal, context: optionsIn.context })
+
+            if (!isAsyncIteratorObject(output)) {
+              throw new Error('streamedQuery requires an event iterator output')
+            }
+
+            return output
+          },
+        }),
         ...optionsIn,
       }
     },

--- a/packages/svelte-query/src/types.ts
+++ b/packages/svelte-query/src/types.ts
@@ -4,6 +4,7 @@ import type {
   CreateInfiniteQueryOptions,
   CreateMutationOptions,
   CreateQueryOptions,
+  experimental_streamedQuery,
   QueryFunctionContext,
   QueryKey,
   SkipToken,
@@ -19,6 +20,17 @@ export interface QueryOptionsBase<TOutput, TError> {
   queryFn(ctx: QueryFunctionContext): Promise<TOutput>
   retry?(failureCount: number, error: TError): boolean // this make tanstack can infer the TError type
   enabled: boolean
+}
+
+type experimental_StreamedRefetchMode = Exclude<Parameters<typeof experimental_streamedQuery>[0]['refetchMode'], undefined>
+
+export type experimental_InferStreamedOutput<TOutput> = TOutput extends AsyncIterable<infer U> ? U[] : never
+
+export type experimental_StreamedOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TSelectData> =
+  & QueryOptionsIn<TClientContext, TInput, TOutput, TError, TSelectData>
+  & { refetchMode?: experimental_StreamedRefetchMode }
+
+export interface experimental_StreamedOptionsBase<TOutput, TError> extends QueryOptionsBase<TOutput, TError> {
 }
 
 export type InfiniteOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TSelectData, TPageParam> =

--- a/packages/svelte-query/src/types.ts
+++ b/packages/svelte-query/src/types.ts
@@ -22,13 +22,13 @@ export interface QueryOptionsBase<TOutput, TError> {
   enabled: boolean
 }
 
-type experimental_StreamedRefetchMode = Exclude<Parameters<typeof experimental_streamedQuery>[0]['refetchMode'], undefined>
+type experimental_StreamedQueryOptions = Omit<Parameters<typeof experimental_streamedQuery>[0], 'queryFn'>
 
 export type experimental_InferStreamedOutput<TOutput> = TOutput extends AsyncIterable<infer U> ? U[] : never
 
 export type experimental_StreamedOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TSelectData> =
   & QueryOptionsIn<TClientContext, TInput, TOutput, TError, TSelectData>
-  & { refetchMode?: experimental_StreamedRefetchMode }
+  & experimental_StreamedQueryOptions
 
 export interface experimental_StreamedOptionsBase<TOutput, TError> extends QueryOptionsBase<TOutput, TError> {
 }

--- a/packages/svelte-query/tests/e2e.test-d.ts
+++ b/packages/svelte-query/tests/e2e.test-d.ts
@@ -137,14 +137,14 @@ describe('.streamedOptions', () => {
       expectTypeOf(query.data).toEqualTypeOf<{ output: string }[]>()
     }
 
-    createQuery(orpc.ping.queryOptions({
+    createQuery(orpc.ping.experimental_streamedOptions({
       // @ts-expect-error --- input is invalid
       input: {
         input: '123',
       },
     }))
 
-    createQuery(orpc.ping.queryOptions({
+    createQuery(orpc.ping.experimental_streamedOptions({
       input: { input: 123 },
       context: {
         // @ts-expect-error --- cache is invalid

--- a/packages/svelte-query/tests/e2e.test-d.ts
+++ b/packages/svelte-query/tests/e2e.test-d.ts
@@ -3,7 +3,7 @@ import { isDefinedError } from '@orpc/client'
 import { createInfiniteQuery, createMutation, createQueries, createQuery } from '@tanstack/svelte-query'
 import { get } from 'svelte/store'
 import { orpc as client } from '../../client/tests/shared'
-import { orpc, queryClient } from './shared'
+import { orpc, queryClient, streamedOrpc } from './shared'
 
 it('.key', () => {
   queryClient.invalidateQueries({
@@ -111,6 +111,94 @@ describe('.queryOptions', () => {
     }))
 
     expectTypeOf(query2).toEqualTypeOf<{ output: string }>()
+  })
+})
+
+describe('.streamedOptions', () => {
+  it('createQuery', () => {
+    const queryStore = createQuery(streamedOrpc.streamed.experimental_streamedOptions({
+      input: { input: 123 },
+      retry(failureCount, error) {
+        if (isDefinedError(error) && error.code === 'BASE') {
+          expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
+        }
+
+        return false
+      },
+    }))
+
+    const query = get(queryStore)
+
+    if (query.status === 'error' && isDefinedError(query.error) && query.error.code === 'OVERRIDE') {
+      expectTypeOf(query.error.data).toEqualTypeOf<unknown>()
+    }
+
+    if (query.status === 'success') {
+      expectTypeOf(query.data).toEqualTypeOf<{ output: string }[]>()
+    }
+
+    createQuery(orpc.ping.queryOptions({
+      // @ts-expect-error --- input is invalid
+      input: {
+        input: '123',
+      },
+    }))
+
+    createQuery(orpc.ping.queryOptions({
+      input: { input: 123 },
+      context: {
+        // @ts-expect-error --- cache is invalid
+        cache: 123,
+      },
+    }))
+  })
+
+  it('createQueries', async () => {
+    const queriesStore = createQueries({
+      queries: [
+        streamedOrpc.streamed.experimental_streamedOptions({
+          input: { input: 123 },
+          select: data => ({ mapped: data }),
+          retry(failureCount, error) {
+            if (isDefinedError(error) && error.code === 'BASE') {
+              expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
+            }
+
+            return false
+          },
+        }),
+        orpc.nested.pong.queryOptions({
+          context: { cache: '123' },
+        }),
+      ],
+    })
+
+    const queries = get(queriesStore)
+
+    // FIXME: useQueries cannot infer error
+    // if (queries[0].status === 'error' && isDefinedError(queries[0].error) && queries[0].error.code === 'OVERRIDE') {
+    //   expectTypeOf(queries[0].error.data).toEqualTypeOf<unknown>()
+    // }
+
+    if (queries[0].status === 'success') {
+      expectTypeOf(queries[0].data.mapped).toEqualTypeOf<{ output: string }[]>()
+    }
+
+    if (queries[1].status === 'error') {
+      expectTypeOf(queries[1].error).toEqualTypeOf<Error>()
+    }
+
+    if (queries[1].status === 'success') {
+      expectTypeOf(queries[1].data).toEqualTypeOf<unknown>()
+    }
+  })
+
+  it('fetchQuery', async () => {
+    const query = await queryClient.fetchQuery(streamedOrpc.streamed.experimental_streamedOptions({
+      input: { input: 123 },
+    }))
+
+    expectTypeOf(query).toEqualTypeOf<{ output: string }[]>()
   })
 })
 

--- a/packages/svelte-query/tests/e2e.test.tsx
+++ b/packages/svelte-query/tests/e2e.test.tsx
@@ -2,8 +2,8 @@ import { isDefinedError } from '@orpc/client'
 import { ORPCError } from '@orpc/contract'
 import { createInfiniteQuery, createMutation, createQuery, skipToken } from '@tanstack/svelte-query'
 import { get } from 'svelte/store'
-import { pingHandler } from '../../server/tests/shared'
-import { orpc, queryClient } from './shared'
+import { pingHandler, streamedHandler } from '../../server/tests/shared'
+import { orpc, queryClient, streamedOrpc } from './shared'
 
 beforeEach(() => {
   queryClient.clear()
@@ -61,6 +61,53 @@ it('case: with createQuery and skipToken', { todo: true }, async () => {
 
   expect(get(query).status).toEqual('pending')
   expect(queryClient.isFetching({ queryKey: orpc.key() })).toEqual(0)
+})
+
+it('case: with streamed/createQuery', { todo: true }, async () => {
+  const query = createQuery(streamedOrpc.streamed.experimental_streamedOptions({
+    refetchMode: 'append',
+    input: { input: 2 },
+  }), queryClient)
+
+  expect(queryClient.isFetching({ queryKey: streamedOrpc.key() })).toEqual(1)
+  expect(queryClient.isFetching({ queryKey: streamedOrpc.streamed.key() })).toEqual(1)
+  expect(queryClient.isFetching({ queryKey: streamedOrpc.streamed.key({ input: { input: 2 } }) })).toEqual(1)
+  expect(queryClient.isFetching({ queryKey: streamedOrpc.streamed.key({ input: { input: 2 }, type: 'streamed' }) })).toEqual(1)
+
+  expect(queryClient.isFetching({ queryKey: streamedOrpc.streamed.key({ input: { input: 234 }, type: 'query' }) })).toEqual(0)
+  expect(queryClient.isFetching({ queryKey: streamedOrpc.streamed.key({ input: { input: 2 }, type: 'infinite' }) })).toEqual(0)
+  expect(queryClient.isFetching({ queryKey: streamedOrpc.key({ type: 'infinite' }) })).toEqual(0)
+
+  await vi.waitFor(() => expect(get(query).data).toEqual([{ output: '0' }, { output: '1' }]))
+
+  expect(
+    queryClient.getQueryData(streamedOrpc.streamed.key({ input: { input: 2 }, type: 'streamed' })),
+  ).toEqual([{ output: '0' }, { output: '1' }])
+
+  // make sure refetch mode works
+  get(query).refetch()
+  await vi.waitFor(() => expect(get(query).data).toEqual([{ output: '0' }, { output: '1' }, { output: '0' }, { output: '1' }]))
+
+  streamedHandler.mockRejectedValueOnce(new ORPCError('OVERRIDE'))
+  get(query).refetch()
+
+  await vi.waitFor(() => {
+    expect((get(query) as any).error).toBeInstanceOf(ORPCError)
+    expect((get(query) as any).error).toSatisfy(isDefinedError)
+    expect((get(query) as any).error.code).toEqual('OVERRIDE')
+  })
+})
+
+it('case: with streamed/createQuery and skipToken', { todo: true }, async () => {
+  const query = createQuery(streamedOrpc.streamed.experimental_streamedOptions({ input: skipToken }), queryClient)
+
+  expect(get(query).status).toEqual('pending')
+  expect(queryClient.isFetching({ queryKey: orpc.key() })).toEqual(0)
+
+  await new Promise(resolve => setTimeout(resolve, 10))
+
+  expect(queryClient.isFetching({ queryKey: orpc.key() })).toEqual(0)
+  expect(get(query).status).toEqual('pending')
 })
 
 it('case: with createInfiniteQuery', { todo: true }, async () => {

--- a/packages/svelte-query/tests/shared.tsx
+++ b/packages/svelte-query/tests/shared.tsx
@@ -1,8 +1,9 @@
 import { QueryClient } from '@tanstack/svelte-query'
-import { orpc as client } from '../../client/tests/shared'
+import { orpc as client, streamedOrpc as streamedClient } from '../../client/tests/shared'
 import { createORPCSvelteQueryUtils } from '../src'
 
 export const orpc = createORPCSvelteQueryUtils(client)
+export const streamedOrpc = createORPCSvelteQueryUtils(streamedClient)
 
 export const queryClient = new QueryClient({
   defaultOptions: {

--- a/packages/vue-query/src/key.ts
+++ b/packages/vue-query/src/key.ts
@@ -3,7 +3,7 @@ import type { QueryKey } from '@tanstack/vue-query'
 
 // TODO: this file duplicate with react query
 
-export type KeyType = 'query' | 'infinite' | 'mutation' | undefined
+export type KeyType = 'query' | 'streamed' | 'infinite' | 'mutation' | undefined
 
 export interface BuildKeyOptions<TType extends KeyType, TInput> {
   type?: TType

--- a/packages/vue-query/src/procedure-utils.test.ts
+++ b/packages/vue-query/src/procedure-utils.test.ts
@@ -176,6 +176,15 @@ describe('createProcedureUtils', () => {
       expect(client).toHaveBeenCalledTimes(1)
       expect(client).toBeCalledWith({ search: '__search__' }, { signal, context: { batch: '__batch__' } })
     })
+
+    it('with unsupported output', async () => {
+      client.mockResolvedValueOnce('__1__')
+      const options = utils.experimental_streamedOptions({ input: { search: '__search__' }, context: { batch: '__batch__' } })
+
+      await expect(options.queryFn!({ signal, client: queryClient } as any)).rejects.toThrow('streamedQuery requires an event iterator output')
+      expect(client).toHaveBeenCalledTimes(1)
+      expect(client).toBeCalledWith({ search: '__search__' }, { signal, context: { batch: '__batch__' } })
+    })
   })
 
   describe('.infiniteOptions', () => {

--- a/packages/vue-query/src/procedure-utils.test.ts
+++ b/packages/vue-query/src/procedure-utils.test.ts
@@ -108,10 +108,10 @@ describe('createProcedureUtils', () => {
 
       expect(options.queryFn).toBe(vi.mocked(experimental_streamedQuery).mock.results[0]!.value)
       expect(experimental_streamedQuery).toHaveBeenCalledTimes(1)
-      expect(experimental_streamedQuery).toHaveBeenCalledWith({
+      expect(experimental_streamedQuery).toHaveBeenCalledWith(expect.objectContaining({
         refetchMode: 'replace',
         queryFn: expect.any(Function),
-      })
+      }))
 
       await expect(options.queryFn!({ signal, client: queryClient, queryKey: options.queryKey } as any)).resolves.toEqual(['__1__', '__2__'])
       expect(queryClient.getQueryData(options.queryKey)).toEqual(['__1__', '__2__'])
@@ -166,9 +166,9 @@ describe('createProcedureUtils', () => {
 
       expect(options.queryFn).toBe(vi.mocked(experimental_streamedQuery).mock.results[0]!.value)
       expect(experimental_streamedQuery).toHaveBeenCalledTimes(1)
-      expect(experimental_streamedQuery).toHaveBeenCalledWith({
+      expect(experimental_streamedQuery).toHaveBeenCalledWith(expect.objectContaining({
         queryFn: expect.any(Function),
-      })
+      }))
 
       await expect(options.queryFn!({ signal, client: queryClient, queryKey: options.queryKey } as any)).resolves.toEqual(['__1__', '__2__'])
       expect(queryClient.getQueryData(options.queryKey)).toEqual(['__1__', '__2__'])

--- a/packages/vue-query/src/procedure-utils.test.ts
+++ b/packages/vue-query/src/procedure-utils.test.ts
@@ -1,11 +1,22 @@
-import { skipToken } from '@tanstack/vue-query'
+import { experimental_streamedQuery, skipToken } from '@tanstack/vue-query'
 import { computed, ref } from 'vue'
+import { queryClient } from '../tests/shared'
 import * as Key from './key'
 import { createProcedureUtils } from './procedure-utils'
+
+vi.mock('@tanstack/vue-query', async (origin) => {
+  const original = await origin() as any
+
+  return {
+    ...original,
+    experimental_streamedQuery: vi.fn(original.experimental_streamedQuery),
+  }
+})
 
 const buildKeySpy = vi.spyOn(Key, 'buildKey')
 
 beforeEach(() => {
+  queryClient.clear()
   vi.clearAllMocks()
 })
 
@@ -70,6 +81,98 @@ describe('createProcedureUtils', () => {
       expect(buildKeySpy).toHaveBeenNthCalledWith(2, ['ping'], { type: 'query', input: { search: '__search__' } })
 
       await expect(options.queryFn!({ signal } as any)).resolves.toEqual('__output__')
+      expect(client).toHaveBeenCalledTimes(1)
+      expect(client).toBeCalledWith({ search: '__search__' }, { signal, context: { batch: '__batch__' } })
+    })
+  })
+
+  describe('.streamedOptions', async () => {
+    it('without skipToken', async () => {
+      client.mockImplementationOnce(async function* (input) {
+        yield '__1__'
+        yield '__2__'
+        return '__3__'
+      })
+
+      const options = utils.experimental_streamedOptions({
+        input: computed(() => ({ search: ref('__search__') })),
+        context: { batch: '__batch__' },
+        refetchMode: 'replace',
+      })
+
+      expect(options.enabled.value).toBe(true)
+
+      expect(options.queryKey.value).toBe(buildKeySpy.mock.results[0]!.value)
+      expect(buildKeySpy).toHaveBeenCalledTimes(1)
+      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { type: 'streamed', input: { search: '__search__' } })
+
+      expect(options.queryFn).toBe(vi.mocked(experimental_streamedQuery).mock.results[0]!.value)
+      expect(experimental_streamedQuery).toHaveBeenCalledTimes(1)
+      expect(experimental_streamedQuery).toHaveBeenCalledWith({
+        refetchMode: 'replace',
+        queryFn: expect.any(Function),
+      })
+
+      await expect(options.queryFn!({ signal, client: queryClient, queryKey: options.queryKey } as any)).resolves.toEqual(['__1__', '__2__'])
+      expect(queryClient.getQueryData(options.queryKey)).toEqual(['__1__', '__2__'])
+
+      expect(client).toHaveBeenCalledTimes(1)
+      expect(client).toBeCalledWith({ search: '__search__' }, { signal, context: { batch: '__batch__' } })
+    })
+
+    it('with skipToken', async () => {
+      const options = utils.experimental_streamedOptions({ input: skipToken, context: { batch: '__batch__' } })
+
+      expect(options.enabled.value).toBe(false)
+
+      expect(options.queryKey.value).toBe(buildKeySpy.mock.results[0]!.value)
+      expect(buildKeySpy).toHaveBeenCalledTimes(1)
+      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { type: 'streamed', input: skipToken })
+
+      await expect(options.queryFn!({ signal, client: queryClient, queryKey: options.queryKey } as any)).rejects.toThrow('queryFn should not be called with skipToken used as input')
+      expect(client).toHaveBeenCalledTimes(0)
+    })
+
+    it('with ref', async () => {
+      client.mockImplementationOnce(async function* (input) {
+        yield '__1__'
+        yield '__2__'
+        return '__3__'
+      })
+
+      const input = ref<any>(skipToken)
+
+      const options = utils.experimental_streamedOptions({
+        input,
+        context: { batch: '__batch__' },
+      })
+
+      expect(options.enabled.value).toBe(false)
+
+      expect(options.queryKey.value).toBe(buildKeySpy.mock.results[0]!.value)
+      expect(buildKeySpy).toHaveBeenCalledTimes(1)
+      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { type: 'streamed', input: skipToken })
+
+      await expect(options.queryFn!({ signal, client: queryClient } as any)).rejects.toThrow('queryFn should not be called with skipToken used as input')
+      expect(client).toHaveBeenCalledTimes(0)
+
+      input.value = computed(() => ({ search: ref('__search__') }))
+
+      expect(options.enabled.value).toBe(true)
+
+      expect(options.queryKey.value).toBe(buildKeySpy.mock.results[1]!.value)
+      expect(buildKeySpy).toHaveBeenCalledTimes(2)
+      expect(buildKeySpy).toHaveBeenNthCalledWith(2, ['ping'], { type: 'streamed', input: { search: '__search__' } })
+
+      expect(options.queryFn).toBe(vi.mocked(experimental_streamedQuery).mock.results[0]!.value)
+      expect(experimental_streamedQuery).toHaveBeenCalledTimes(1)
+      expect(experimental_streamedQuery).toHaveBeenCalledWith({
+        queryFn: expect.any(Function),
+      })
+
+      await expect(options.queryFn!({ signal, client: queryClient, queryKey: options.queryKey } as any)).resolves.toEqual(['__1__', '__2__'])
+      expect(queryClient.getQueryData(options.queryKey)).toEqual(['__1__', '__2__'])
+
       expect(client).toHaveBeenCalledTimes(1)
       expect(client).toBeCalledWith({ search: '__search__' }, { signal, context: { batch: '__batch__' } })
     })

--- a/packages/vue-query/src/procedure-utils.ts
+++ b/packages/vue-query/src/procedure-utils.ts
@@ -28,7 +28,7 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
   ): NoInfer<U & Omit<QueryOptionsBase<TOutput, TError>, keyof U>>
 
   /**
-   * Generate [event-iterator](https://orpc.unnoq.com/docs/event-iterator) options used for useQuery/prefetchQuery/...
+   * Generate [Event Iterator](https://orpc.unnoq.com/docs/event-iterator) options used for useQuery/prefetchQuery/...
    * Built on top of [steamedQuery](https://tanstack.com/query/latest/docs/reference/streamedQuery)
    *
    * @see {@link https://orpc.unnoq.com/docs/tanstack-query/basic#streamed-query-options-utility Tanstack Streamed Query Options Utility Docs}

--- a/packages/vue-query/src/procedure-utils.ts
+++ b/packages/vue-query/src/procedure-utils.ts
@@ -91,7 +91,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
         enabled: computed(() => unrefDeep(optionsIn.input) !== skipToken),
         queryKey: computed(() => buildKey(options.path, { type: 'streamed', input: unrefDeep(optionsIn.input) })),
         queryFn: experimental_streamedQuery({
-          refetchMode: optionsIn.refetchMode,
+          ...optionsIn,
           queryFn: async ({ signal }) => {
             const input = unrefDeep(optionsIn.input)
 

--- a/packages/vue-query/src/procedure-utils.ts
+++ b/packages/vue-query/src/procedure-utils.ts
@@ -1,8 +1,9 @@
 import type { Client, ClientContext } from '@orpc/client'
 import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { InfiniteData } from '@tanstack/vue-query'
-import type { InfiniteOptionsBase, InfiniteOptionsIn, MutationOptions, MutationOptionsIn, QueryOptionsBase, QueryOptionsIn } from './types'
-import { skipToken } from '@tanstack/vue-query'
+import type { experimental_InferStreamedOutput, experimental_StreamedOptionsBase, experimental_StreamedOptionsIn, InfiniteOptionsBase, InfiniteOptionsIn, MutationOptions, MutationOptionsIn, QueryOptionsBase, QueryOptionsIn } from './types'
+import { isAsyncIteratorObject } from '@orpc/shared'
+import { experimental_streamedQuery, skipToken } from '@tanstack/vue-query'
 import { computed } from 'vue'
 import { buildKey } from './key'
 import { unrefDeep } from './utils'
@@ -25,6 +26,18 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
       U & QueryOptionsIn<TClientContext, TInput, TOutput, TError, USelectData>
     >
   ): NoInfer<U & Omit<QueryOptionsBase<TOutput, TError>, keyof U>>
+
+  /**
+   * Generate [event-iterator](https://orpc.unnoq.com/docs/event-iterator) options used for useQuery/prefetchQuery/...
+   * Built on top of [steamedQuery](https://tanstack.com/query/latest/docs/reference/streamedQuery)
+   *
+   * @see {@link https://orpc.unnoq.com/docs/tanstack-query/basic#streamed-query-options-utility Tanstack Streamed Query Options Utility Docs}
+   */
+  experimental_streamedOptions<U, USelectData = experimental_InferStreamedOutput<TOutput>>(
+    ...rest: MaybeOptionalOptions<
+      U & experimental_StreamedOptionsIn<TClientContext, TInput, experimental_InferStreamedOutput<TOutput>, TError, USelectData>
+    >
+  ): NoInfer<U & Omit<experimental_StreamedOptionsBase<experimental_InferStreamedOutput<TOutput>, TError>, keyof U>>
 
   /**
    * Generate options used for useInfiniteQuery/prefetchInfiniteQuery/...
@@ -69,6 +82,32 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
           return client(input, { signal, context: unrefDeep(optionsIn.context) })
         },
         enabled: computed(() => unrefDeep(optionsIn.input) !== skipToken),
+        ...optionsIn,
+      }
+    },
+
+    experimental_streamedOptions(...[optionsIn = {} as any]) {
+      return {
+        enabled: computed(() => unrefDeep(optionsIn.input) !== skipToken),
+        queryKey: computed(() => buildKey(options.path, { type: 'streamed', input: unrefDeep(optionsIn.input) })),
+        queryFn: experimental_streamedQuery({
+          refetchMode: optionsIn.refetchMode,
+          queryFn: async ({ signal }) => {
+            const input = unrefDeep(optionsIn.input)
+
+            if (input === skipToken) {
+              throw new Error('queryFn should not be called with skipToken used as input')
+            }
+
+            const output = await client(input, { signal, context: optionsIn.context })
+
+            if (!isAsyncIteratorObject(output)) {
+              throw new Error('streamedQuery requires an event iterator output')
+            }
+
+            return output
+          },
+        }),
         ...optionsIn,
       }
     },

--- a/packages/vue-query/src/procedure-utils.ts
+++ b/packages/vue-query/src/procedure-utils.ts
@@ -99,7 +99,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
               throw new Error('queryFn should not be called with skipToken used as input')
             }
 
-            const output = await client(input, { signal, context: optionsIn.context })
+            const output = await client(input, { signal, context: unrefDeep(optionsIn.context) })
 
             if (!isAsyncIteratorObject(output)) {
               throw new Error('streamedQuery requires an event iterator output')

--- a/packages/vue-query/src/types.ts
+++ b/packages/vue-query/src/types.ts
@@ -35,13 +35,13 @@ export interface QueryOptionsBase<TOutput, TError> {
   enabled: ComputedRef<boolean>
 }
 
-type experimental_StreamedRefetchMode = Exclude<Parameters<typeof experimental_streamedQuery>[0]['refetchMode'], undefined>
+type experimental_StreamedQueryOptions = Omit<Parameters<typeof experimental_streamedQuery>[0], 'queryFn'>
 
 export type experimental_InferStreamedOutput<TOutput> = TOutput extends AsyncIterable<infer U> ? U[] : never
 
 export type experimental_StreamedOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TSelectData> =
   & QueryOptionsIn<TClientContext, TInput, TOutput, TError, TSelectData>
-  & { refetchMode?: experimental_StreamedRefetchMode }
+  & experimental_StreamedQueryOptions
 
 export interface experimental_StreamedOptionsBase<TOutput, TError> extends QueryOptionsBase<TOutput, TError> {
 }

--- a/packages/vue-query/src/types.ts
+++ b/packages/vue-query/src/types.ts
@@ -1,6 +1,6 @@
 import type { ClientContext } from '@orpc/client'
 import type { AnyFunction } from '@orpc/shared'
-import type { InfiniteQueryObserverOptions, MutationObserverOptions, QueryFunctionContext, QueryKey, QueryObserverOptions, SkipToken } from '@tanstack/vue-query'
+import type { experimental_streamedQuery, InfiniteQueryObserverOptions, MutationObserverOptions, QueryFunctionContext, QueryKey, QueryObserverOptions, SkipToken } from '@tanstack/vue-query'
 import type { ComputedRef, MaybeRef, MaybeRefOrGetter } from 'vue'
 
 /**
@@ -33,6 +33,17 @@ export interface QueryOptionsBase<TOutput, TError> {
   queryFn(ctx: QueryFunctionContext): Promise<TOutput>
   retry?(failureCount: number, error: TError): boolean // this help tanstack can infer TError
   enabled: ComputedRef<boolean>
+}
+
+type experimental_StreamedRefetchMode = Exclude<Parameters<typeof experimental_streamedQuery>[0]['refetchMode'], undefined>
+
+export type experimental_InferStreamedOutput<TOutput> = TOutput extends AsyncIterable<infer U> ? U[] : never
+
+export type experimental_StreamedOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TSelectData> =
+  & QueryOptionsIn<TClientContext, TInput, TOutput, TError, TSelectData>
+  & { refetchMode?: experimental_StreamedRefetchMode }
+
+export interface experimental_StreamedOptionsBase<TOutput, TError> extends QueryOptionsBase<TOutput, TError> {
 }
 
 export type InfiniteOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TSelectData, TPageParam> =

--- a/packages/vue-query/tests/e2e.test-d.ts
+++ b/packages/vue-query/tests/e2e.test-d.ts
@@ -3,7 +3,7 @@ import { isDefinedError } from '@orpc/client'
 import { useInfiniteQuery, useMutation, useQueries, useQuery } from '@tanstack/vue-query'
 import { computed, ref } from 'vue'
 import { orpc as client } from '../../client/tests/shared'
-import { orpc, queryClient } from './shared'
+import { orpc, queryClient, streamedOrpc } from './shared'
 
 it('.key', () => {
   queryClient.invalidateQueries({
@@ -103,6 +103,88 @@ describe('.queryOptions', () => {
     }))
 
     expectTypeOf(query2).toEqualTypeOf<{ output: string }>()
+  })
+})
+
+describe('.streamedOptions', () => {
+  it('useQuery', () => {
+    const query = useQuery(streamedOrpc.streamed.experimental_streamedOptions({
+      input: computed(() => ({ input: 123 })),
+      retry(failureCount, error) {
+        if (isDefinedError(error) && error.code === 'BASE') {
+          expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
+        }
+
+        return false
+      },
+    }))
+
+    if (query.status.value === 'error' && isDefinedError(query.error.value) && query.error.value.code === 'OVERRIDE') {
+      expectTypeOf(query.error.value.data).toEqualTypeOf<unknown>()
+    }
+
+    expectTypeOf(query.data.value).toEqualTypeOf<{ output: string }[] | undefined>()
+
+    useQuery(orpc.ping.experimental_streamedOptions({
+      // @ts-expect-error --- input is invalid
+      input: {
+        input: '123',
+      },
+    }))
+
+    useQuery(orpc.ping.experimental_streamedOptions({
+      input: { input: 123 },
+      // @ts-expect-error --- cache is invalid
+      context: {
+        cache: 123,
+      },
+    }))
+  })
+
+  it('useQueries', async () => {
+    const queries = useQueries({
+      queries: [
+        streamedOrpc.streamed.experimental_streamedOptions({
+          input: { input: 123 },
+          select: data => ({ mapped: data }),
+          retry(failureCount, error) {
+            if (isDefinedError(error) && error.code === 'BASE') {
+              expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
+            }
+
+            return false
+          },
+        }),
+        orpc.nested.pong.queryOptions({
+          context: { cache: '123' },
+        }),
+      ],
+    })
+
+    // FIXME: useQueries cannot infer error
+    // if (queries[0].status === 'error' && isDefinedError(queries[0].error) && queries[0].error.code === 'OVERRIDE') {
+    //   expectTypeOf(queries[0].error.data).toEqualTypeOf<unknown>()
+    // }
+
+    if (queries.value[0].status === 'success') {
+      expectTypeOf(queries.value[0].data.mapped).toEqualTypeOf<{ output: string }[]>()
+    }
+
+    if (queries.value[1].status === 'error') {
+      expectTypeOf(queries.value[1].error).toEqualTypeOf<Error>()
+    }
+
+    if (queries.value[1].status === 'success') {
+      expectTypeOf(queries.value[1].data).toEqualTypeOf<unknown>()
+    }
+  })
+
+  it('fetchQuery', async () => {
+    const query = await queryClient.fetchQuery(streamedOrpc.streamed.experimental_streamedOptions({
+      input: { input: 123 },
+    }))
+
+    expectTypeOf(query).toEqualTypeOf<{ output: string }[]>()
   })
 })
 

--- a/packages/vue-query/tests/shared.tsx
+++ b/packages/vue-query/tests/shared.tsx
@@ -1,8 +1,9 @@
 import { QueryClient } from '@tanstack/vue-query'
-import { orpc as client } from '../../client/tests/shared'
+import { orpc as client, streamedOrpc as streamedClient } from '../../client/tests/shared'
 import { createORPCVueQueryUtils } from '../src'
 
 export const orpc = createORPCVueQueryUtils(client)
+export const streamedOrpc = createORPCVueQueryUtils(streamedClient)
 
 export const queryClient = new QueryClient({
   defaultOptions: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced experimental streamed query support in React, Solid, Svelte, and Vue Query integrations, enabling queries with async iterable/event iterator outputs.
  - Added `experimental_streamedOptions` method for configuring streamed queries with refetch modes and improved type inference.
  - Added a new documentation section detailing streamed query configuration and usage.
- **Tests**
  - Added extensive tests validating type safety, runtime behavior, error handling, and integration of streamed query options across all supported frameworks.
- **Documentation**
  - Expanded documentation with guidance on the new streamed query utilities.
- **Chores**
  - Added exports and setup for streamed query clients and utilities in test and shared modules across frameworks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->