### PR TITLE
fix(query): improve compatibility with useQueries and useSuspenseQueries

### DIFF
--- a/packages/react-query/src/procedure-utils.test-d.ts
+++ b/packages/react-query/src/procedure-utils.test-d.ts
@@ -129,7 +129,7 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput | undefined>()
 
       expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
-      expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
+      expectTypeOf(queries[1].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
     })
 
     it('works with useSuspenseQueries', () => {
@@ -149,7 +149,7 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput>()
 
       expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
-      expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
+      expectTypeOf(queries[1].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
     })
 
     it('works with fetchQuery', () => {
@@ -255,7 +255,7 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput | undefined>()
 
       expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
-      expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
+      expectTypeOf(queries[1].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
     })
 
     it('works with useSuspenseQueries', () => {
@@ -275,7 +275,7 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput>()
 
       expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
-      expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
+      expectTypeOf(queries[1].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
     })
 
     it('works with fetchQuery', () => {

--- a/packages/react-query/src/procedure-utils.test-d.ts
+++ b/packages/react-query/src/procedure-utils.test-d.ts
@@ -3,7 +3,7 @@ import type { ErrorFromErrorMap } from '@orpc/contract'
 import type { GetNextPageParamFunction, InfiniteData } from '@tanstack/react-query'
 import type { baseErrorMap } from '../../contract/tests/shared'
 import type { ProcedureUtils } from './procedure-utils'
-import { skipToken, useInfiniteQuery, useMutation, useQueries, useQuery, useSuspenseInfiniteQuery, useSuspenseQuery } from '@tanstack/react-query'
+import { skipToken, useInfiniteQuery, useMutation, useQueries, useQuery, useSuspenseInfiniteQuery, useSuspenseQueries, useSuspenseQuery } from '@tanstack/react-query'
 import { queryClient } from '../tests/shared'
 
 describe('ProcedureUtils', () => {
@@ -92,10 +92,6 @@ describe('ProcedureUtils', () => {
         const query = useQuery(utils.queryOptions({
           select: data => ({ mapped: data }),
           initialData: [{ title: 'title' }],
-          throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap>>()
-            return false
-          },
         }))
 
         expectTypeOf(query.data).toEqualTypeOf<{ mapped: UtilsOutput }>()
@@ -132,9 +128,28 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries[0].data).toEqualTypeOf<{ mapped: UtilsOutput } | undefined>()
       expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput | undefined>()
 
-      // FIXME: useQueries cannot infer error
-      // expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
-      // expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
+    })
+
+    it('works with useSuspenseQueries', () => {
+      const queries = useSuspenseQueries({
+        queries: [
+          utils.queryOptions({
+            select: data => ({ mapped: data }),
+          }),
+          utils.queryOptions({
+            input: { search: 'search' },
+            context: { batch: true },
+          }),
+        ],
+      })
+
+      expectTypeOf(queries[0].data).toEqualTypeOf<{ mapped: UtilsOutput }>()
+      expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput>()
+
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
     })
 
     it('works with fetchQuery', () => {
@@ -216,15 +231,51 @@ describe('ProcedureUtils', () => {
         const query = useQuery(utils.experimental_streamedOptions({
           select: data => ({ mapped: data }),
           initialData: [{ title: 'title' }],
-          throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap>>()
-            return false
-          },
         }))
 
         expectTypeOf(query.data).toEqualTypeOf<{ mapped: UtilsOutput }>()
         expectTypeOf(query.error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap> | null>()
       })
+    })
+
+    it('works with useQueries', async () => {
+      const queries = useQueries({
+        queries: [
+          utils.experimental_streamedOptions({
+            select: data => ({ mapped: data }),
+          }),
+          utils.experimental_streamedOptions({
+            input: { search: 'search' },
+            context: { batch: true },
+          }),
+        ],
+      })
+
+      expectTypeOf(queries[0].data).toEqualTypeOf<{ mapped: UtilsOutput } | undefined>()
+      expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput | undefined>()
+
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
+    })
+
+    it('works with useSuspenseQueries', () => {
+      const queries = useSuspenseQueries({
+        queries: [
+          utils.experimental_streamedOptions({
+            select: data => ({ mapped: data }),
+          }),
+          utils.experimental_streamedOptions({
+            input: { search: 'search' },
+            context: { batch: true },
+          }),
+        ],
+      })
+
+      expectTypeOf(queries[0].data).toEqualTypeOf<{ mapped: UtilsOutput }>()
+      expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput>()
+
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
     })
 
     it('works with fetchQuery', () => {
@@ -368,10 +419,6 @@ describe('ProcedureUtils', () => {
           getNextPageParam,
           initialPageParam,
           select: data => ({ mapped: data }),
-          throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap>>()
-            return false
-          },
           initialData: { pageParams: [1], pages: [[{ title: 'title' }]] },
         }))
 

--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -10,7 +10,7 @@ export type QueryOptionsIn<TClientContext extends ClientContext, TInput, TOutput
 export interface QueryOptionsBase<TOutput, TError> {
   queryKey: QueryKey
   queryFn(ctx: QueryFunctionContext): Promise<TOutput>
-  retry?(failureCount: number, error: TError): boolean // this make tanstack can infer the TError type
+  throwOnError?(error: TError): boolean // This make TQ can infer TError
   enabled: boolean
 }
 
@@ -33,7 +33,7 @@ export type InfiniteOptionsIn<TClientContext extends ClientContext, TInput, TOut
 export interface InfiniteOptionsBase<TOutput, TError, TPageParam> {
   queryKey: QueryKey
   queryFn(ctx: QueryFunctionContext<QueryKey, TPageParam>): Promise<TOutput>
-  retry?(failureCount: number, error: TError): boolean // this make tanstack can infer the TError type
+  throwOnError?(error: TError): boolean // This make TQ can infer TError
   enabled: boolean
 }
 

--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -10,7 +10,7 @@ export type QueryOptionsIn<TClientContext extends ClientContext, TInput, TOutput
 export interface QueryOptionsBase<TOutput, TError> {
   queryKey: QueryKey
   queryFn(ctx: QueryFunctionContext): Promise<TOutput>
-  throwOnError?(error: TError): boolean // This make TQ can infer TError
+  throwOnError?(error: TError): boolean // Help TQ infer TError
   enabled: boolean
 }
 
@@ -33,7 +33,7 @@ export type InfiniteOptionsIn<TClientContext extends ClientContext, TInput, TOut
 export interface InfiniteOptionsBase<TOutput, TError, TPageParam> {
   queryKey: QueryKey
   queryFn(ctx: QueryFunctionContext<QueryKey, TPageParam>): Promise<TOutput>
-  throwOnError?(error: TError): boolean // This make TQ can infer TError
+  throwOnError?(error: TError): boolean // Help TQ infer TError
   enabled: boolean
 }
 

--- a/packages/solid-query/src/procedure-utils.test-d.ts
+++ b/packages/solid-query/src/procedure-utils.test-d.ts
@@ -116,7 +116,7 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput | undefined>()
 
       expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
-      expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
+      expectTypeOf(queries[1].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
     })
 
     it('works with fetchQuery', () => {
@@ -222,7 +222,7 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput | undefined>()
 
       expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
-      expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
+      expectTypeOf(queries[1].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
     })
 
     it('works with fetchQuery', () => {

--- a/packages/solid-query/src/procedure-utils.test-d.ts
+++ b/packages/solid-query/src/procedure-utils.test-d.ts
@@ -92,10 +92,6 @@ describe('ProcedureUtils', () => {
         const query = useQuery(() => utils.queryOptions({
           select: data => ({ mapped: data }),
           initialData: [{ title: 'title' }],
-          throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap>>()
-            return false
-          },
         }))
 
         expectTypeOf(query.data).toEqualTypeOf<{ mapped: UtilsOutput }>()
@@ -119,9 +115,8 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries[0].data).toEqualTypeOf<{ mapped: UtilsOutput } | undefined>()
       expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput | undefined>()
 
-      // FIXME: useQueries cannot infer error
-      // expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
-      // expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
     })
 
     it('works with fetchQuery', () => {
@@ -203,15 +198,31 @@ describe('ProcedureUtils', () => {
         const query = useQuery(() => utils.experimental_streamedOptions({
           select: data => ({ mapped: data }),
           initialData: [{ title: 'title' }],
-          throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap>>()
-            return false
-          },
         }))
 
         expectTypeOf(query.data).toEqualTypeOf<{ mapped: UtilsOutput }>()
         expectTypeOf(query.error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap> | null>()
       })
+    })
+
+    it('works with useQueries', async () => {
+      const queries = useQueries(() => ({
+        queries: [
+          utils.experimental_streamedOptions({
+            select: data => ({ mapped: data }),
+          }),
+          utils.experimental_streamedOptions({
+            input: { search: 'search' },
+            context: { batch: true },
+          }),
+        ],
+      }))
+
+      expectTypeOf(queries[0].data).toEqualTypeOf<{ mapped: UtilsOutput } | undefined>()
+      expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput | undefined>()
+
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
     })
 
     it('works with fetchQuery', () => {
@@ -355,10 +366,6 @@ describe('ProcedureUtils', () => {
           getNextPageParam,
           initialPageParam,
           select: data => ({ mapped: data }),
-          throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap>>()
-            return false
-          },
           initialData: { pageParams: [1], pages: [[{ title: 'title' }]] },
         }))
 

--- a/packages/solid-query/src/types.ts
+++ b/packages/solid-query/src/types.ts
@@ -18,7 +18,7 @@ export type QueryOptionsIn<TClientContext extends ClientContext, TInput, TOutput
 export interface QueryOptionsBase<TOutput, TError> {
   queryKey: QueryKey
   queryFn(ctx: QueryFunctionContext): Promise<TOutput>
-  retry?(failureCount: number, error: TError): boolean // this make tanstack can infer the TError type
+  throwOnError?(error: TError): boolean // Help TQ infer TError
   enabled: boolean
 }
 
@@ -41,7 +41,7 @@ export type InfiniteOptionsIn<TClientContext extends ClientContext, TInput, TOut
 export interface InfiniteOptionsBase<TOutput, TError, TPageParam> {
   queryKey: QueryKey
   queryFn(ctx: QueryFunctionContext<QueryKey, TPageParam>): Promise<TOutput>
-  retry?(failureCount: number, error: TError): boolean // this make tanstack can infer the TError type
+  throwOnError?(error: TError): boolean // Help TQ infer TError
   enabled: boolean
 }
 

--- a/packages/solid-query/tests/e2e.test-d.ts
+++ b/packages/solid-query/tests/e2e.test-d.ts
@@ -76,10 +76,9 @@ describe('.queryOptions', () => {
       ],
     }))
 
-    // FIXME: useQueries cannot infer error
-    // if (queries[0].status === 'error' && isDefinedError(queries[0].error) && queries[0].error.code === 'OVERRIDE') {
-    //   expectTypeOf(queries[0].error.data).toEqualTypeOf<unknown>()
-    // }
+    if (queries[0].status === 'error' && isDefinedError(queries[0].error) && queries[0].error.code === 'BASE') {
+      expectTypeOf(queries[0].error.data).toEqualTypeOf<{ output: string }>()
+    }
 
     if (queries[0].status === 'success') {
       expectTypeOf(queries[0].data.mapped).toEqualTypeOf<{ output: string }>()
@@ -166,10 +165,9 @@ describe('.streamedOptions', () => {
       ],
     }))
 
-    // FIXME: useQueries cannot infer error
-    // if (queries[0].status === 'error' && isDefinedError(queries[0].error) && queries[0].error.code === 'OVERRIDE') {
-    //   expectTypeOf(queries[0].error.data).toEqualTypeOf<unknown>()
-    // }
+    if (queries[0].status === 'error' && isDefinedError(queries[0].error) && queries[0].error.code === 'BASE') {
+      expectTypeOf(queries[0].error.data).toEqualTypeOf<{ output: string }>()
+    }
 
     if (queries[0].status === 'success') {
       expectTypeOf(queries[0].data.mapped).toEqualTypeOf<{ output: string }[]>()

--- a/packages/svelte-query/src/types.ts
+++ b/packages/svelte-query/src/types.ts
@@ -18,7 +18,7 @@ export type QueryOptionsIn<TClientContext extends ClientContext, TInput, TOutput
 export interface QueryOptionsBase<TOutput, TError> {
   queryKey: QueryKey
   queryFn(ctx: QueryFunctionContext): Promise<TOutput>
-  retry?(failureCount: number, error: TError): boolean // this make tanstack can infer the TError type
+  throwOnError?(error: TError): boolean // Help TQ infer TError
   enabled: boolean
 }
 
@@ -41,7 +41,7 @@ export type InfiniteOptionsIn<TClientContext extends ClientContext, TInput, TOut
 export interface InfiniteOptionsBase<TOutput, TError, TPageParam> {
   queryKey: QueryKey
   queryFn(ctx: QueryFunctionContext<QueryKey, TPageParam>): Promise<TOutput>
-  retry?(failureCount: number, error: TError): boolean // this make tanstack can infer the TError type
+  throwOnError?(error: TError): boolean // Help TQ infer TError
   enabled: boolean
 }
 

--- a/packages/svelte-query/tests/e2e.test-d.ts
+++ b/packages/svelte-query/tests/e2e.test-d.ts
@@ -81,10 +81,9 @@ describe('.queryOptions', () => {
 
     const queries = get(queriesStore)
 
-    // FIXME: createQueries cannot infer error
-    // if (queries[0].status === 'error' && isDefinedError(queries[0].error) && queries[0].error.code === 'OVERRIDE') {
-    //   expectTypeOf(queries[0].error.data).toEqualTypeOf<unknown>()
-    // }
+    if (queries[0].status === 'error' && isDefinedError(queries[0].error) && queries[0].error.code === 'BASE') {
+      expectTypeOf(queries[0].error.data).toEqualTypeOf<{ output: string }>()
+    }
 
     if (queries[0].status === 'success') {
       expectTypeOf(queries[0].data.mapped).toEqualTypeOf<{ output: string }>()
@@ -175,10 +174,9 @@ describe('.streamedOptions', () => {
 
     const queries = get(queriesStore)
 
-    // FIXME: useQueries cannot infer error
-    // if (queries[0].status === 'error' && isDefinedError(queries[0].error) && queries[0].error.code === 'OVERRIDE') {
-    //   expectTypeOf(queries[0].error.data).toEqualTypeOf<unknown>()
-    // }
+    if (queries[0].status === 'error' && isDefinedError(queries[0].error) && queries[0].error.code === 'BASE') {
+      expectTypeOf(queries[0].error.data).toEqualTypeOf<{ output: string }>()
+    }
 
     if (queries[0].status === 'success') {
       expectTypeOf(queries[0].data.mapped).toEqualTypeOf<{ output: string }[]>()

--- a/packages/vue-query/src/procedure-utils.test-d.ts
+++ b/packages/vue-query/src/procedure-utils.test-d.ts
@@ -112,10 +112,6 @@ describe('ProcedureUtils', () => {
         const query = useQuery(utils.queryOptions({
           select: data => ({ mapped: data }),
           initialData: [{ title: 'title' }],
-          throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap>>()
-            return false
-          },
         }))
 
         expectTypeOf(query.data.value).toEqualTypeOf<{ mapped: UtilsOutput }>()
@@ -428,23 +424,19 @@ describe('ProcedureUtils', () => {
         expectTypeOf(query.error.value).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap> | null>()
       })
 
-      // Don't know why but seem tanstack/vue-query doesn't handle initialData like react-query
-      // it('with initial data', () => {
-      //   const query = useInfiniteQuery(utils.infiniteOptions({
-      //     input: () => ({}),
-      //     initialData: { pageParams: [1], pages: [[{ title: 'title' }]] },
-      //     getNextPageParam,
-      //     initialPageParam,
-      //     select: data => ({ mapped: data }),
-      //     throwOnError(error) {
-      //       expectTypeOf(error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap>>()
-      //       return false
-      //     },
-      //   }))
+      it('with initial data', () => {
+        const query = useInfiniteQuery(utils.infiniteOptions({
+          input: () => ({}),
+          initialData: { pageParams: [1], pages: [[{ title: 'title' }]] },
+          getNextPageParam,
+          initialPageParam,
+          select: data => ({ mapped: data }),
+        }))
 
-      //   expectTypeOf(query.data.value).toEqualTypeOf<{ mapped: InfiniteData<UtilsOutput, number> }>()
-      //   expectTypeOf(query.error.value).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap> | null>()
-      // })
+        // FIXME: Don't know why but seem tanstack/vue-query doesn't handle initialData like react-query
+        // expectTypeOf(query.data.value).toEqualTypeOf<{ mapped: InfiniteData<UtilsOutput, number> }>()
+        expectTypeOf(query.error.value).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap> | null>()
+      })
     })
 
     it('works with fetchInfiniteQuery', () => {

--- a/packages/vue-query/src/types.ts
+++ b/packages/vue-query/src/types.ts
@@ -31,7 +31,7 @@ export type QueryOptionsIn<TClientContext extends ClientContext, TInput, TOutput
 export interface QueryOptionsBase<TOutput, TError> {
   queryKey: ComputedRef<QueryKey>
   queryFn(ctx: QueryFunctionContext): Promise<TOutput>
-  retry?(failureCount: number, error: TError): boolean // this help tanstack can infer TError
+  throwOnError?(error: TError): boolean // Help TQ infer TError
   enabled: ComputedRef<boolean>
 }
 
@@ -62,7 +62,7 @@ export type InfiniteOptionsIn<TClientContext extends ClientContext, TInput, TOut
 export interface InfiniteOptionsBase<TOutput, TError, TPageParam> {
   queryKey: ComputedRef<QueryKey>
   queryFn(ctx: QueryFunctionContext<QueryKey, TPageParam>): Promise<TOutput>
-  retry?(failureCount: number, error: TError): boolean // this help tanstack can infer TError
+  throwOnError?(error: TError): boolean // Help TQ infer TError
   enabled: ComputedRef<boolean>
 }
 

--- a/packages/vue-query/tests/e2e.test-d.ts
+++ b/packages/vue-query/tests/e2e.test-d.ts
@@ -74,8 +74,8 @@ describe('.queryOptions', () => {
       ],
     })
 
-    if (isDefinedError(queries.value[0].error) && queries.value[0].error.code === 'OVERRIDE') {
-      expectTypeOf(queries.value[0].error.data).toEqualTypeOf<unknown>()
+    if (isDefinedError(queries.value[0].error) && queries.value[0].error.code === 'BASE') {
+      expectTypeOf(queries.value[0].error.data).toEqualTypeOf<{ output: string }>()
     }
 
     if (queries.value[0].status === 'success') {
@@ -161,10 +161,9 @@ describe('.streamedOptions', () => {
       ],
     })
 
-    // FIXME: useQueries cannot infer error
-    // if (queries[0].status === 'error' && isDefinedError(queries[0].error) && queries[0].error.code === 'OVERRIDE') {
-    //   expectTypeOf(queries[0].error.data).toEqualTypeOf<unknown>()
-    // }
+    if (queries.value[0].status === 'error' && isDefinedError(queries.value[0].error) && queries.value[0].error.code === 'BASE') {
+      expectTypeOf(queries.value[0].error.data).toEqualTypeOf<{ output: string }>()
+    }
 
     if (queries.value[0].status === 'success') {
       expectTypeOf(queries.value[0].data.mapped).toEqualTypeOf<{ output: string }[]>()


### PR DESCRIPTION
Fixed: https://github.com/unnoq/orpc/issues/519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved type inference and error handling for multi-query hooks across React, Solid, Svelte, and Vue integrations.
  - Added new test cases to verify correct error and data type inference for multi-query and streamed query scenarios.

- **Bug Fixes**
  - Enhanced error type assertions in tests for multi-query hooks, ensuring accurate type checks.

- **Refactor**
  - Replaced the optional `retry` method with `throwOnError` in query option interfaces to improve error type inference and consistency.

- **Tests**
  - Expanded and updated test coverage for error and data types in multi-query and streamed query scenarios.
  - Simplified tests by removing redundant error handling callbacks in certain cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->