### PR TITLE
fix(standard-server): unify empty body parsing behavior across envs

### DIFF
--- a/packages/standard-server-fetch/src/body.ts
+++ b/packages/standard-server-fetch/src/body.ts
@@ -5,14 +5,6 @@ import { generateContentDisposition, getFilenameFromContentDisposition } from '@
 import { toEventIterator, toEventStream } from './event-iterator'
 
 export async function toStandardBody(re: Request | Response): Promise<StandardBody> {
-  /**
-   * In native environments like React Native, the body may be `undefined` due to lack of streaming support.
-   * Therefore, we explicitly check for `null` to indicate an intentionally empty body.
-   */
-  if (re.body === null) {
-    return undefined
-  }
-
   const contentDisposition = re.headers.get('content-disposition')
 
   if (typeof contentDisposition === 'string') {

--- a/packages/standard-server-fetch/src/event-iterator.test.ts
+++ b/packages/standard-server-fetch/src/event-iterator.test.ts
@@ -82,6 +82,13 @@ describe('toEventIterator', () => {
     await expect(stream.getReader().closed).resolves.toBe(undefined)
   })
 
+  it('with empty stream', async () => {
+    const generator = toEventIterator(null)
+    expect(generator).toSatisfy(isAsyncIteratorObject)
+    expect(await generator.next()).toEqual({ done: true, value: undefined })
+    expect(await generator.next()).toEqual({ done: true, value: undefined })
+  })
+
   it('with error event', async () => {
     const stream = new ReadableStream<string>({
       async pull(controller) {

--- a/packages/standard-server-node/src/body.ts
+++ b/packages/standard-server-node/src/body.ts
@@ -8,12 +8,6 @@ import { flattenHeader, generateContentDisposition, getFilenameFromContentDispos
 import { toEventIterator, toEventStream } from './event-iterator'
 
 export async function toStandardBody(req: NodeHttpRequest): Promise<StandardBody> {
-  const method = req.method ?? 'GET'
-
-  if (method === 'GET' || method === 'HEAD') {
-    return undefined
-  }
-
   const contentDisposition = req.headers['content-disposition']
   const contentType = req.headers['content-type']
 


### PR DESCRIPTION
Empty body parsing can be `undefined` in some environments (e.g., Bun), but now it always follows the headers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of empty or null input streams, ensuring consistent behavior and preventing errors.
	- Adjusted body processing logic to handle all HTTP methods, including GET and HEAD, for more robust request handling.

- **Tests**
	- Added a new test to verify correct behavior when processing empty streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->