### PR TITLE
feat(standard-server): AWS Lambda Adapter

### DIFF
--- a/apps/content/docs/adapters/http.md
+++ b/apps/content/docs/adapters/http.md
@@ -9,10 +9,11 @@ oRPC includes built-in HTTP support, making it easy to expose RPC endpoints in a
 
 ## Server Adapters
 
-| Adapter | Target                                                                                                                     |
-| ------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `fetch` | [MDN Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) (Browser, Bun, Deno, Cloudflare Workers, etc.) |
-| `node`  | Node.js built-in [`http`](https://nodejs.org/api/http.html)/[`http2`](https://nodejs.org/api/http2.html)                   |
+| Adapter      | Target                                                                                                                     |
+| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `fetch`      | [MDN Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) (Browser, Bun, Deno, Cloudflare Workers, etc.) |
+| `node`       | Node.js built-in [`http`](https://nodejs.org/api/http.html)/[`http2`](https://nodejs.org/api/http2.html)                   |
+| `aws-lambda` | [AWS Lambda](https://aws.amazon.com/lambda/)                                                                               |
 
 ::: code-group
 
@@ -117,6 +118,34 @@ Deno.serve(async (request) => {
   }
 
   return new Response('Not found', { status: 404 })
+})
+```
+
+```ts [aws-lambda]
+import { experimental_RPCHandler as RPCHandler } from '@orpc/server/aws-lambda'
+
+const rpcHandler = new RPCHandler(router)
+
+/**
+ * oRPC only supports [AWS Lambda response streaming](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-response-streaming/).
+ * If you need support chunked responses, use a combination of Hono's `aws-lambda` adapter and oRPC.
+ */
+export const handler = awslambda.streamifyResponse(async (event, responseStream, context) => {
+  const { matched } = await rpcHandler.handle(event, responseStream, {
+    prefix: '/rpc',
+    context: {} // Provide initial context if needed
+  })
+
+  if (matched) {
+    return
+  }
+
+  awslambda.HttpResponseStream.from(responseStream, {
+    statusCode: 404,
+  })
+
+  responseStream.write('Not found')
+  responseStream.end()
 })
 ```
 

--- a/apps/content/docs/adapters/http.md
+++ b/apps/content/docs/adapters/http.md
@@ -122,6 +122,7 @@ Deno.serve(async (request) => {
 ```
 
 ```ts [aws-lambda]
+import { APIGatewayProxyEventV2 } from 'aws-lambda'
 import { experimental_RPCHandler as RPCHandler } from '@orpc/server/aws-lambda'
 
 const rpcHandler = new RPCHandler(router)
@@ -130,7 +131,7 @@ const rpcHandler = new RPCHandler(router)
  * oRPC only supports [AWS Lambda response streaming](https://aws.amazon.com/blogs/compute/introducing-aws-lambda-response-streaming/).
  * If you need support chunked responses, use a combination of Hono's `aws-lambda` adapter and oRPC.
  */
-export const handler = awslambda.streamifyResponse(async (event, responseStream, context) => {
+export const handler = awslambda.streamifyResponse<APIGatewayProxyEventV2>(async (event, responseStream, context) => {
   const { matched } = await rpcHandler.handle(event, responseStream, {
     prefix: '/rpc',
     context: {} // Provide initial context if needed

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -39,6 +39,11 @@
         "types": "./dist/adapters/node/index.d.mts",
         "import": "./dist/adapters/node/index.mjs",
         "default": "./dist/adapters/node/index.mjs"
+      },
+      "./aws-lambda": {
+        "types": "./dist/adapters/aws-lambda/index.d.mts",
+        "import": "./dist/adapters/aws-lambda/index.mjs",
+        "default": "./dist/adapters/aws-lambda/index.mjs"
       }
     }
   },
@@ -47,7 +52,8 @@
     "./plugins": "./src/plugins/index.ts",
     "./standard": "./src/adapters/standard/index.ts",
     "./fetch": "./src/adapters/fetch/index.ts",
-    "./node": "./src/adapters/node/index.ts"
+    "./node": "./src/adapters/node/index.ts",
+    "./aws-lambda": "./src/adapters/aws-lambda/index.ts"
   },
   "files": [
     "dist"

--- a/packages/openapi/src/adapters/aws-lambda/index.ts
+++ b/packages/openapi/src/adapters/aws-lambda/index.ts
@@ -1,0 +1,1 @@
+export * from './openapi-handler'

--- a/packages/openapi/src/adapters/aws-lambda/openapi-handler.test.ts
+++ b/packages/openapi/src/adapters/aws-lambda/openapi-handler.test.ts
@@ -1,6 +1,6 @@
 import { os } from '@orpc/server'
 import { sendStandardResponse, toStandardLazyRequest } from '@orpc/standard-server-aws-lambda'
-import { OpenAPIHandler } from './openapi-handler'
+import { experimental_OpenAPIHandler as OpenAPIHandler } from './openapi-handler'
 
 vi.mock('@orpc/standard-server-aws-lambda', () => ({
   toStandardLazyRequest: vi.fn(),

--- a/packages/openapi/src/adapters/aws-lambda/openapi-handler.test.ts
+++ b/packages/openapi/src/adapters/aws-lambda/openapi-handler.test.ts
@@ -1,0 +1,80 @@
+import { os } from '@orpc/server'
+import { sendStandardResponse, toStandardLazyRequest } from '@orpc/standard-server-aws-lambda'
+import { OpenAPIHandler } from './openapi-handler'
+
+vi.mock('@orpc/standard-server-aws-lambda', () => ({
+  toStandardLazyRequest: vi.fn(),
+  sendStandardResponse: vi.fn(),
+}))
+
+vi.mock('../standard', async origin => ({
+  ...await origin(),
+  StandardHandler: vi.fn(),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('openAPIHandler', async () => {
+  const handlerOptions = { eventIteratorKeepAliveComment: '__test__' }
+
+  const handler = new OpenAPIHandler({
+    ping: os.route({ method: 'GET' }).handler(({ input }) => ({ output: input })),
+  }, handlerOptions)
+
+  const event: any = { req: true }
+  const responseStream: any = { res: true }
+
+  const standardRequest = {
+    method: 'GET',
+    url: new URL('https://example.com/api/v1/ping?key=value'),
+    headers: {
+      'content-type': 'application/json',
+      'content-length': '12',
+    },
+    body: () => Promise.resolve('value'),
+    signal: undefined,
+  }
+
+  it('on match', async () => {
+    vi.mocked(toStandardLazyRequest).mockReturnValueOnce(standardRequest)
+    const options = { prefix: '/api/v1', context: { db: 'postgres' } } as const
+
+    const result = await handler.handle(event, responseStream, options)
+
+    expect(result).toEqual({
+      matched: true,
+    })
+
+    expect(toStandardLazyRequest).toHaveBeenCalledOnce()
+    expect(toStandardLazyRequest).toHaveBeenCalledWith(event)
+
+    expect(sendStandardResponse).toHaveBeenCalledOnce()
+    expect(sendStandardResponse).toHaveBeenCalledWith(responseStream, {
+      status: 200,
+      headers: {},
+      body: { output: { key: 'value' } },
+    }, handlerOptions)
+  })
+
+  it('on mismatch', async () => {
+    vi.mocked(toStandardLazyRequest).mockReturnValueOnce({
+      ...standardRequest,
+      url: new URL('https://example.com/api/v1/not-found'),
+    })
+
+    const options = { prefix: '/api/v1', context: { db: 'postgres' } } as const
+    const result = await handler.handle(event, responseStream, options)
+
+    expect(result).toEqual({
+      matched: false,
+      response: undefined,
+    })
+
+    expect(toStandardLazyRequest).toHaveBeenCalledOnce()
+    expect(toStandardLazyRequest).toHaveBeenCalledWith(event)
+
+    expect(sendStandardResponse).not.toHaveBeenCalled()
+  })
+})

--- a/packages/openapi/src/adapters/aws-lambda/openapi-handler.test.ts
+++ b/packages/openapi/src/adapters/aws-lambda/openapi-handler.test.ts
@@ -48,7 +48,7 @@ describe('openAPIHandler', async () => {
     })
 
     expect(toStandardLazyRequest).toHaveBeenCalledOnce()
-    expect(toStandardLazyRequest).toHaveBeenCalledWith(event)
+    expect(toStandardLazyRequest).toHaveBeenCalledWith(event, responseStream)
 
     expect(sendStandardResponse).toHaveBeenCalledOnce()
     expect(sendStandardResponse).toHaveBeenCalledWith(responseStream, {
@@ -73,7 +73,7 @@ describe('openAPIHandler', async () => {
     })
 
     expect(toStandardLazyRequest).toHaveBeenCalledOnce()
-    expect(toStandardLazyRequest).toHaveBeenCalledWith(event)
+    expect(toStandardLazyRequest).toHaveBeenCalledWith(event, responseStream)
 
     expect(sendStandardResponse).not.toHaveBeenCalled()
   })

--- a/packages/openapi/src/adapters/aws-lambda/openapi-handler.ts
+++ b/packages/openapi/src/adapters/aws-lambda/openapi-handler.ts
@@ -1,0 +1,17 @@
+import type { Context, Router } from '@orpc/server'
+import type { AwsLambdaHandlerOptions } from '@orpc/server/aws-lambda'
+import type { StandardOpenAPIHandlerOptions } from '../standard'
+import { AwsLambdaHandler } from '@orpc/server/aws-lambda'
+import { StandardOpenAPIHandler } from '../standard'
+
+/**
+ * OpenAPI Handler for AWS Lambda.
+ *
+ * @see {@link https://orpc.unnoq.com/docs/openapi/openapi-handler OpenAPI Handler Docs}
+ * @see {@link https://orpc.unnoq.com/docs/adapters/http HTTP Adapter Docs}
+ */
+export class OpenAPIHandler<T extends Context> extends AwsLambdaHandler<T> {
+  constructor(router: Router<any, T>, options: NoInfer<StandardOpenAPIHandlerOptions<T> & AwsLambdaHandlerOptions> = {}) {
+    super(new StandardOpenAPIHandler(router, options), options)
+  }
+}

--- a/packages/openapi/src/adapters/aws-lambda/openapi-handler.ts
+++ b/packages/openapi/src/adapters/aws-lambda/openapi-handler.ts
@@ -10,7 +10,7 @@ import { StandardOpenAPIHandler } from '../standard'
  * @see {@link https://orpc.unnoq.com/docs/openapi/openapi-handler OpenAPI Handler Docs}
  * @see {@link https://orpc.unnoq.com/docs/adapters/http HTTP Adapter Docs}
  */
-export class OpenAPIHandler<T extends Context> extends AwsLambdaHandler<T> {
+export class experimental_OpenAPIHandler<T extends Context> extends AwsLambdaHandler<T> {
   constructor(router: Router<any, T>, options: NoInfer<StandardOpenAPIHandlerOptions<T> & AwsLambdaHandlerOptions> = {}) {
     super(new StandardOpenAPIHandler(router, options), options)
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -40,6 +40,11 @@
         "import": "./dist/adapters/node/index.mjs",
         "default": "./dist/adapters/node/index.mjs"
       },
+      "./aws-lambda": {
+        "types": "./dist/adapters/aws-lambda/index.d.mts",
+        "import": "./dist/adapters/aws-lambda/index.mjs",
+        "default": "./dist/adapters/aws-lambda/index.mjs"
+      },
       "./websocket": {
         "types": "./dist/adapters/websocket/index.d.mts",
         "import": "./dist/adapters/websocket/index.mjs",
@@ -73,6 +78,7 @@
     "./standard": "./src/adapters/standard/index.ts",
     "./fetch": "./src/adapters/fetch/index.ts",
     "./node": "./src/adapters/node/index.ts",
+    "./aws-lambda": "./src/adapters/aws-lambda/index.ts",
     "./websocket": "./src/adapters/websocket/index.ts",
     "./crossws": "./src/adapters/crossws/index.ts",
     "./ws": "./src/adapters/ws/index.ts",
@@ -104,6 +110,7 @@
     "@orpc/contract": "workspace:*",
     "@orpc/shared": "workspace:*",
     "@orpc/standard-server": "workspace:*",
+    "@orpc/standard-server-aws-lambda": "workspace:*",
     "@orpc/standard-server-fetch": "workspace:*",
     "@orpc/standard-server-node": "workspace:*",
     "@orpc/standard-server-peer": "workspace:*"

--- a/packages/server/src/adapters/aws-lambda/handler.ts
+++ b/packages/server/src/adapters/aws-lambda/handler.ts
@@ -1,5 +1,5 @@
 import type { MaybeOptionalOptions } from '@orpc/shared'
-import type { APIGatewayEvent, ResponseStream, SendStandardResponseOptions } from '@orpc/standard-server-aws-lambda'
+import type { APIGatewayProxyEventV2, ResponseStream, SendStandardResponseOptions } from '@orpc/standard-server-aws-lambda'
 import type { Context } from '../../context'
 import type { StandardHandler } from '../standard'
 import type { FriendlyStandardHandleOptions } from '../standard/utils'
@@ -24,11 +24,11 @@ export class AwsLambdaHandler<T extends Context> {
   }
 
   async handle(
-    event: APIGatewayEvent,
+    event: APIGatewayProxyEventV2,
     responseStream: ResponseStream,
     ...rest: MaybeOptionalOptions<FriendlyStandardHandleOptions<T>>
   ): Promise<AwsLambdaHandleResult> {
-    const standardRequest = toStandardLazyRequest(event)
+    const standardRequest = toStandardLazyRequest(event, responseStream)
 
     const options = resolveFriendlyStandardHandleOptions(resolveMaybeOptionalOptions(rest))
     const result = await this.standardHandler.handle(standardRequest, options)

--- a/packages/server/src/adapters/aws-lambda/handler.ts
+++ b/packages/server/src/adapters/aws-lambda/handler.ts
@@ -1,0 +1,44 @@
+import type { MaybeOptionalOptions } from '@orpc/shared'
+import type { APIGatewayEvent, ResponseStream, SendStandardResponseOptions } from '@orpc/standard-server-aws-lambda'
+import type { Context } from '../../context'
+import type { StandardHandler } from '../standard'
+import type { FriendlyStandardHandleOptions } from '../standard/utils'
+import { resolveMaybeOptionalOptions } from '@orpc/shared'
+import { sendStandardResponse, toStandardLazyRequest } from '@orpc/standard-server-aws-lambda'
+import { resolveFriendlyStandardHandleOptions } from '../standard/utils'
+
+export interface AwsLambdaHandlerOptions extends SendStandardResponseOptions {
+
+}
+
+export type AwsLambdaHandleResult = { matched: true } | { matched: false }
+
+export class AwsLambdaHandler<T extends Context> {
+  private readonly sendStandardResponseOptions: SendStandardResponseOptions
+
+  constructor(
+    private readonly standardHandler: StandardHandler<T>,
+    options: AwsLambdaHandlerOptions = {},
+  ) {
+    this.sendStandardResponseOptions = options
+  }
+
+  async handle(
+    event: APIGatewayEvent,
+    responseStream: ResponseStream,
+    ...rest: MaybeOptionalOptions<FriendlyStandardHandleOptions<T>>
+  ): Promise<AwsLambdaHandleResult> {
+    const standardRequest = toStandardLazyRequest(event)
+
+    const options = resolveFriendlyStandardHandleOptions(resolveMaybeOptionalOptions(rest))
+    const result = await this.standardHandler.handle(standardRequest, options)
+
+    if (!result.matched) {
+      return { matched: false }
+    }
+
+    await sendStandardResponse(responseStream, result.response, this.sendStandardResponseOptions)
+
+    return { matched: true }
+  }
+}

--- a/packages/server/src/adapters/aws-lambda/index.ts
+++ b/packages/server/src/adapters/aws-lambda/index.ts
@@ -1,0 +1,2 @@
+export * from './handler'
+export * from './rpc-handler'

--- a/packages/server/src/adapters/aws-lambda/rpc-handler.test.ts
+++ b/packages/server/src/adapters/aws-lambda/rpc-handler.test.ts
@@ -49,7 +49,7 @@ describe('rpcHandler', async () => {
     })
 
     expect(toStandardLazyRequest).toHaveBeenCalledOnce()
-    expect(toStandardLazyRequest).toHaveBeenCalledWith(event)
+    expect(toStandardLazyRequest).toHaveBeenCalledWith(event, responseStream)
 
     expect(sendStandardResponse).toHaveBeenCalledOnce()
     expect(sendStandardResponse).toHaveBeenCalledWith(responseStream, {
@@ -76,7 +76,7 @@ describe('rpcHandler', async () => {
     })
 
     expect(toStandardLazyRequest).toHaveBeenCalledOnce()
-    expect(toStandardLazyRequest).toHaveBeenCalledWith(event)
+    expect(toStandardLazyRequest).toHaveBeenCalledWith(event, responseStream)
 
     expect(sendStandardResponse).not.toHaveBeenCalled()
   })
@@ -96,7 +96,7 @@ describe('rpcHandler', async () => {
     })
 
     expect(toStandardLazyRequest).toHaveBeenCalledOnce()
-    expect(toStandardLazyRequest).toHaveBeenCalledWith(event)
+    expect(toStandardLazyRequest).toHaveBeenCalledWith(event, responseStream)
 
     expect(sendStandardResponse).toHaveBeenCalledOnce()
     expect(sendStandardResponse).toHaveBeenCalledWith(responseStream, {

--- a/packages/server/src/adapters/aws-lambda/rpc-handler.test.ts
+++ b/packages/server/src/adapters/aws-lambda/rpc-handler.test.ts
@@ -1,6 +1,6 @@
 import { sendStandardResponse, toStandardLazyRequest } from '@orpc/standard-server-aws-lambda'
 import { os } from '../../builder'
-import { RPCHandler } from './rpc-handler'
+import { experimental_RPCHandler as RPCHandler } from './rpc-handler'
 
 vi.mock('@orpc/standard-server-aws-lambda', () => ({
   toStandardLazyRequest: vi.fn(),

--- a/packages/server/src/adapters/aws-lambda/rpc-handler.test.ts
+++ b/packages/server/src/adapters/aws-lambda/rpc-handler.test.ts
@@ -1,0 +1,112 @@
+import { sendStandardResponse, toStandardLazyRequest } from '@orpc/standard-server-aws-lambda'
+import { os } from '../../builder'
+import { RPCHandler } from './rpc-handler'
+
+vi.mock('@orpc/standard-server-aws-lambda', () => ({
+  toStandardLazyRequest: vi.fn(),
+  sendStandardResponse: vi.fn(),
+}))
+
+vi.mock('../standard', async origin => ({
+  ...await origin(),
+  StandardHandler: vi.fn(),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('rpcHandler', async () => {
+  const handlerOptions = { eventIteratorKeepAliveComment: '__test__' }
+
+  const handler = new RPCHandler({
+    ping: os.route({ method: 'GET' }).handler(({ input }) => ({ output: input })),
+    pong: os.handler(({ input }) => ({ output: input })),
+  }, handlerOptions)
+
+  const event: any = { req: true }
+  const responseStream: any = { res: true }
+
+  const standardRequest = {
+    method: 'POST',
+    url: new URL('https://example.com/api/v1/ping'),
+    headers: {
+      'content-type': 'application/json',
+      'content-length': '12',
+    },
+    body: () => Promise.resolve({ json: 'value' }),
+    signal: undefined,
+  }
+
+  it('on match', async () => {
+    vi.mocked(toStandardLazyRequest).mockReturnValueOnce(standardRequest)
+    const options = { prefix: '/api/v1', context: { db: 'postgres' } } as const
+
+    const result = await handler.handle(event, responseStream, options)
+
+    expect(result).toEqual({
+      matched: true,
+    })
+
+    expect(toStandardLazyRequest).toHaveBeenCalledOnce()
+    expect(toStandardLazyRequest).toHaveBeenCalledWith(event)
+
+    expect(sendStandardResponse).toHaveBeenCalledOnce()
+    expect(sendStandardResponse).toHaveBeenCalledWith(responseStream, {
+      status: 200,
+      headers: {},
+      body: {
+        json: { output: 'value' },
+      },
+    }, handlerOptions)
+  })
+
+  it('on mismatch', async () => {
+    vi.mocked(toStandardLazyRequest).mockReturnValueOnce({
+      ...standardRequest,
+      url: new URL('https://example.com/api/v1/not-found'),
+    })
+
+    const options = { prefix: '/api/v1', context: { db: 'postgres' } } as const
+    const result = await handler.handle(event, responseStream, options)
+
+    expect(result).toEqual({
+      matched: false,
+      response: undefined,
+    })
+
+    expect(toStandardLazyRequest).toHaveBeenCalledOnce()
+    expect(toStandardLazyRequest).toHaveBeenCalledWith(event)
+
+    expect(sendStandardResponse).not.toHaveBeenCalled()
+  })
+
+  it('strict GET method by default', async () => {
+    vi.mocked(toStandardLazyRequest).mockReturnValueOnce({
+      ...standardRequest,
+      url: new URL('https://example.com/api/v1/pong?data=%7B%22json%22%3A%22value%22%7D'),
+      method: 'GET',
+    })
+
+    const options = { prefix: '/api/v1', context: { db: 'postgres' } } as const
+    const result = await handler.handle(event, responseStream, options)
+
+    expect(result).toEqual({
+      matched: true,
+    })
+
+    expect(toStandardLazyRequest).toHaveBeenCalledOnce()
+    expect(toStandardLazyRequest).toHaveBeenCalledWith(event)
+
+    expect(sendStandardResponse).toHaveBeenCalledOnce()
+    expect(sendStandardResponse).toHaveBeenCalledWith(responseStream, {
+      status: 405,
+      headers: {},
+      body: {
+        json: expect.objectContaining({
+          message: 'Method Not Supported',
+        }),
+      },
+    }, handlerOptions)
+  })
+})

--- a/packages/server/src/adapters/aws-lambda/rpc-handler.ts
+++ b/packages/server/src/adapters/aws-lambda/rpc-handler.ts
@@ -1,0 +1,33 @@
+import type { Context } from '../../context'
+import type { Router } from '../../router'
+import type { StandardRPCHandlerOptions } from '../standard'
+import type { AwsLambdaHandlerOptions } from './handler'
+import { StrictGetMethodPlugin } from '../../plugins'
+import { StandardRPCHandler } from '../standard'
+import { AwsLambdaHandler } from './handler'
+
+export type RPCHandlerOptions<T extends Context> = AwsLambdaHandlerOptions & StandardRPCHandlerOptions<T> & {
+  /**
+   * Enables or disables the StrictGetMethodPlugin.
+   *
+   * @default true
+   */
+  strictGetMethodPluginEnabled?: boolean
+}
+
+/**
+ * RPC Handler for AWS Lambda.
+ *
+ * @see {@link https://orpc.unnoq.com/docs/rpc-handler RPC Handler Docs}
+ * @see {@link https://orpc.unnoq.com/docs/adapters/http HTTP Adapter Docs}
+ */
+export class RPCHandler<T extends Context> extends AwsLambdaHandler<T> {
+  constructor(router: Router<any, T>, options: NoInfer<RPCHandlerOptions<T>> = {}) {
+    if (options.strictGetMethodPluginEnabled ?? true) {
+      options.plugins ??= []
+      options.plugins.push(new StrictGetMethodPlugin())
+    }
+
+    super(new StandardRPCHandler(router, options), options)
+  }
+}

--- a/packages/server/src/adapters/aws-lambda/rpc-handler.ts
+++ b/packages/server/src/adapters/aws-lambda/rpc-handler.ts
@@ -21,7 +21,7 @@ export type RPCHandlerOptions<T extends Context> = AwsLambdaHandlerOptions & Sta
  * @see {@link https://orpc.unnoq.com/docs/rpc-handler RPC Handler Docs}
  * @see {@link https://orpc.unnoq.com/docs/adapters/http HTTP Adapter Docs}
  */
-export class RPCHandler<T extends Context> extends AwsLambdaHandler<T> {
+export class experimental_RPCHandler<T extends Context> extends AwsLambdaHandler<T> {
   constructor(router: Router<any, T>, options: NoInfer<RPCHandlerOptions<T>> = {}) {
     if (options.strictGetMethodPluginEnabled ?? true) {
       options.plugins ??= []

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -6,6 +6,7 @@
     { "path": "../standard-server" },
     { "path": "../standard-server-fetch" },
     { "path": "../standard-server-node" },
+    { "path": "../standard-server-aws-lambda" },
     { "path": "../standard-server-peer" },
     { "path": "../shared" }
   ],

--- a/packages/standard-server-aws-lambda/.gitignore
+++ b/packages/standard-server-aws-lambda/.gitignore
@@ -1,0 +1,26 @@
+# Hidden folders and files
+.*
+!.gitignore
+!.*.example
+
+# Common generated folders
+logs/
+node_modules/
+out/
+dist/
+dist-ssr/
+build/
+coverage/
+temp/
+
+# Common generated files
+*.log
+*.log.*
+*.tsbuildinfo
+*.vitest-temp.json
+vite.config.ts.timestamp-*
+vitest.config.ts.timestamp-*
+
+# Common manual ignore files
+*.local
+*.pem

--- a/packages/standard-server-aws-lambda/README.md
+++ b/packages/standard-server-aws-lambda/README.md
@@ -1,0 +1,78 @@
+<div align="center">
+  <image align="center" src="https://orpc.unnoq.com/logo.webp" width=280 alt="oRPC logo" />
+</div>
+
+<h1></h1>
+
+<div align="center">
+  <a href="https://codecov.io/gh/unnoq/orpc">
+    <img alt="codecov" src="https://codecov.io/gh/unnoq/orpc/branch/main/graph/badge.svg">
+  </a>
+  <a href="https://www.npmjs.com/package/@orpc/standard-server-aws-lambda">
+    <img alt="weekly downloads" src="https://img.shields.io/npm/dw/%40orpc%2Fstandard-server-aws-lambda?logo=npm" />
+  </a>
+  <a href="https://github.com/unnoq/orpc/blob/main/LICENSE">
+    <img alt="MIT License" src="https://img.shields.io/github/license/unnoq/orpc?logo=open-source-initiative" />
+  </a>
+  <a href="https://discord.gg/TXEbwRBvQn">
+    <img alt="Discord" src="https://img.shields.io/discord/1308966753044398161?color=7389D8&label&logo=discord&logoColor=ffffff" />
+  </a>
+</div>
+
+<h3 align="center">Typesafe APIs Made Simple 🪄</h3>
+
+**oRPC is a powerful combination of RPC and OpenAPI**, makes it easy to build APIs that are end-to-end type-safe and adhere to OpenAPI standards
+
+---
+
+## Highlights
+
+- **🔗 End-to-End Type Safety**: Ensure type-safe inputs, outputs, and errors from client to server.
+- **📘 First-Class OpenAPI**: Built-in support that fully adheres to the OpenAPI standard.
+- **📝 Contract-First Development**: Optionally define your API contract before implementation.
+- **⚙️ Framework Integrations**: Seamlessly integrate with TanStack Query (React, Vue, Solid, Svelte), Pinia Colada, and more.
+- **🚀 Server Actions**: Fully compatible with React Server Actions on Next.js, TanStack Start, and other platforms.
+- **🔠 Standard Schema Support**: Works out of the box with Zod, Valibot, ArkType, and other schema validators.
+- **🗃️ Native Types**: Supports native types like Date, File, Blob, BigInt, URL, and more.
+- **⏱️ Lazy Router**: Enhance cold start times with our lazy routing feature.
+- **📡 SSE & Streaming**: Enjoy full type-safe support for SSE and streaming.
+- **🌍 Multi-Runtime Support**: Fast and lightweight on Cloudflare, Deno, Bun, Node.js, and beyond.
+- **🔌 Extendability**: Easily extend functionality with plugins, middleware, and interceptors.
+- **🛡️ Reliability**: Well-tested, TypeScript-based, production-ready, and MIT licensed.
+
+## Documentation
+
+You can find the full documentation [here](https://orpc.unnoq.com).
+
+## Packages
+
+- [@orpc/contract](https://www.npmjs.com/package/@orpc/contract): Build your API contract.
+- [@orpc/server](https://www.npmjs.com/package/@orpc/server): Build your API or implement API contract.
+- [@orpc/client](https://www.npmjs.com/package/@orpc/client): Consume your API on the client with type-safety.
+- [@orpc/nest](https://www.npmjs.com/package/@orpc/nest): Deeply integrate oRPC with NestJS.
+- [@orpc/react](https://www.npmjs.com/package/@orpc/react): Utilities for integrating oRPC with React and React Server Actions.
+- [@orpc/react-query](https://www.npmjs.com/package/@orpc/react-query): Integration with [React Query](https://tanstack.com/query/latest/docs/framework/react/overview).
+- [@orpc/vue-query](https://www.npmjs.com/package/@orpc/vue-query): Integration with [Vue Query](https://tanstack.com/query/latest/docs/framework/vue/overview).
+- [@orpc/solid-query](https://www.npmjs.com/package/@orpc/solid-query): Integration with [Solid Query](https://tanstack.com/query/latest/docs/framework/solid/overview).
+- [@orpc/svelte-query](https://www.npmjs.com/package/@orpc/svelte-query): Integration with [Svelte Query](https://tanstack.com/query/latest/docs/framework/svelte/overview).
+- [@orpc/vue-colada](https://www.npmjs.com/package/@orpc/vue-colada): Integration with [Pinia Colada](https://pinia-colada.esm.dev/).
+- [@orpc/openapi](https://www.npmjs.com/package/@orpc/openapi): Generate OpenAPI specs and handle OpenAPI requests.
+- [@orpc/zod](https://www.npmjs.com/package/@orpc/zod): More schemas that [Zod](https://zod.dev/) doesn't support yet.
+- [@orpc/valibot](https://www.npmjs.com/package/@orpc/valibot): OpenAPI spec generation from [Valibot](https://valibot.dev/).
+- [@orpc/arktype](https://www.npmjs.com/package/@orpc/arktype): OpenAPI spec generation from [ArkType](https://arktype.io/).
+
+## `@orpc/standard-server-aws-lambda`
+
+[AWS Lambda](https://aws.amazon.com/lambda/) server adapter for oRPC.
+
+## Sponsors
+
+<p align="center">
+  <a href="https://cdn.jsdelivr.net/gh/unnoq/unnoq/sponsors.svg">
+    <img src='https://cdn.jsdelivr.net/gh/unnoq/unnoq/sponsors.svg'/>
+  </a>
+</p>
+
+## License
+
+Distributed under the MIT License. See [LICENSE](https://github.com/unnoq/orpc/blob/main/LICENSE) for more information.

--- a/packages/standard-server-aws-lambda/package.json
+++ b/packages/standard-server-aws-lambda/package.json
@@ -40,6 +40,7 @@
     "@orpc/standard-server": "workspace:*"
   },
   "devDependencies": {
-    "@types/aws-lambda": "^8.10.149"
+    "@types/aws-lambda": "^8.10.149",
+    "@types/node": "^22.15.17"
   }
 }

--- a/packages/standard-server-aws-lambda/package.json
+++ b/packages/standard-server-aws-lambda/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@orpc/standard-server-aws-lambda",
+  "type": "module",
+  "version": "0.0.0",
+  "license": "MIT",
+  "homepage": "https://orpc.unnoq.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unnoq/orpc.git",
+    "directory": "packages/standard-server-aws-lambda"
+  },
+  "keywords": [
+    "orpc"
+  ],
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "unbuild",
+    "build:watch": "pnpm run build --watch",
+    "type:check": "tsc -b"
+  },
+  "peerDependencies": {
+    "@types/aws-lambda": "*"
+  },
+  "dependencies": {
+    "@orpc/shared": "workspace:*",
+    "@orpc/standard-server": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.149"
+  }
+}

--- a/packages/standard-server-aws-lambda/package.json
+++ b/packages/standard-server-aws-lambda/package.json
@@ -32,14 +32,6 @@
     "build:watch": "pnpm run build --watch",
     "type:check": "tsc -b"
   },
-  "peerDependencies": {
-    "@types/aws-lambda": "*"
-  },
-  "peerDependenciesMeta": {
-    "@types/aws-lambda": {
-      "optional": true
-    }
-  },
   "dependencies": {
     "@orpc/shared": "workspace:*",
     "@orpc/standard-server": "workspace:*"

--- a/packages/standard-server-aws-lambda/package.json
+++ b/packages/standard-server-aws-lambda/package.json
@@ -35,6 +35,11 @@
   "peerDependencies": {
     "@types/aws-lambda": "*"
   },
+  "peerDependenciesMeta": {
+    "@types/aws-lambda": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "@orpc/shared": "workspace:*",
     "@orpc/standard-server": "workspace:*"

--- a/packages/standard-server-aws-lambda/src/body.test.ts
+++ b/packages/standard-server-aws-lambda/src/body.test.ts
@@ -1,0 +1,511 @@
+import { Buffer } from 'node:buffer'
+import { Readable } from 'node:stream'
+import { isAsyncIteratorObject } from '@orpc/shared'
+import * as StandardServerModule from '@orpc/standard-server'
+import { toLambdaBody, toStandardBody } from './body'
+import * as EventIteratorModule from './event-iterator'
+
+const toEventStreamSpy = vi.spyOn(EventIteratorModule, 'toEventStream')
+const generateContentDispositionSpy = vi.spyOn(StandardServerModule, 'generateContentDisposition')
+const getFilenameFromContentDispositionSpy = vi.spyOn(StandardServerModule, 'getFilenameFromContentDisposition')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe.each([true, false])('toStandardBody: base64=%s', (isBase64Encoded) => {
+  it('undefined', async () => {
+    const standardBody = await toStandardBody({
+      body: null,
+      headers: {},
+      httpMethod: 'POST',
+      isBase64Encoded,
+      multiValueHeaders: {},
+      multiValueQueryStringParameters: {},
+      path: '/',
+      pathParameters: {},
+      queryStringParameters: {},
+      requestContext: {} as any,
+      resource: '',
+      stageVariables: {},
+    })
+
+    expect(standardBody).toBe(undefined)
+  })
+
+  it('json', async () => {
+    const standardBody = await toStandardBody({
+      body: Buffer.from(JSON.stringify({ foo: 'bar' })).toString(isBase64Encoded ? 'base64' : 'utf8'),
+      headers: {
+        'content-type': 'application/json',
+      },
+      httpMethod: 'POST',
+      isBase64Encoded,
+      multiValueHeaders: {},
+      multiValueQueryStringParameters: {},
+      path: '/',
+      pathParameters: {},
+      queryStringParameters: {},
+      requestContext: {} as any,
+      resource: '',
+      stageVariables: {},
+    })
+
+    expect(standardBody).toEqual({ foo: 'bar' })
+  })
+
+  it('json but empty body', async () => {
+    const standardBody = await toStandardBody({
+      body: Buffer.from('').toString(isBase64Encoded ? 'base64' : 'utf8'),
+      headers: {
+        'content-type': 'application/json',
+      },
+      httpMethod: 'POST',
+      isBase64Encoded,
+      multiValueHeaders: {},
+      multiValueQueryStringParameters: {},
+      path: '/',
+      pathParameters: {},
+      queryStringParameters: {},
+      requestContext: {} as any,
+      resource: '',
+      stageVariables: {},
+    })
+
+    expect(standardBody).toEqual(undefined)
+  })
+
+  it('event iterator', async () => {
+    const standardBody: any = await toStandardBody({
+      body: Buffer.from('event: message\ndata: 123\n\nevent: done\ndata: 456\n\n').toString(isBase64Encoded ? 'base64' : 'utf8'),
+      headers: {
+        'content-type': 'text/event-stream',
+      },
+      httpMethod: 'POST',
+      isBase64Encoded,
+      multiValueHeaders: {},
+      multiValueQueryStringParameters: {},
+      path: '/',
+      pathParameters: {},
+      queryStringParameters: {},
+      requestContext: {} as any,
+      resource: '',
+      stageVariables: {},
+    })
+
+    expect(standardBody).toSatisfy(isAsyncIteratorObject)
+
+    expect(await standardBody.next()).toEqual({ done: false, value: 123 })
+    expect(await standardBody.next()).toEqual({ done: true, value: 456 })
+  })
+
+  it('text', async () => {
+    const standardBody: any = await toStandardBody({
+      body: Buffer.from('foo').toString(isBase64Encoded ? 'base64' : 'utf8'),
+      headers: {
+        'content-type': 'text/plain',
+      },
+      httpMethod: 'POST',
+      isBase64Encoded,
+      multiValueHeaders: {},
+      multiValueQueryStringParameters: {},
+      path: '/',
+      pathParameters: {},
+      queryStringParameters: {},
+      requestContext: {} as any,
+      resource: '',
+      stageVariables: {},
+    })
+
+    expect(standardBody).toBe('foo')
+  })
+
+  it('form-data', async () => {
+    const form = new FormData()
+    form.append('foo', 'bar')
+    form.append('bar', 'baz')
+    const res = new Response(form)
+
+    const standardBody: any = await toStandardBody({
+      body: Buffer.from(await res.arrayBuffer()).toString('base64'),
+      headers: {
+        'content-type': res.headers.get('content-type')!,
+      },
+      httpMethod: 'POST',
+      isBase64Encoded: true,
+      multiValueHeaders: {},
+      multiValueQueryStringParameters: {},
+      path: '/',
+      pathParameters: {},
+      queryStringParameters: {},
+      requestContext: {} as any,
+      resource: '',
+      stageVariables: {},
+    })
+
+    expect(standardBody).toBeInstanceOf(FormData)
+    expect(standardBody.get('foo')).toBe('bar')
+    expect(standardBody.get('bar')).toBe('baz')
+  })
+
+  it('form-data (empty)', async () => {
+    await expect(toStandardBody({
+      body: null,
+      headers: {
+        'content-type': 'multipart/form-data; boundary=foo',
+      },
+      httpMethod: 'POST',
+      isBase64Encoded: true,
+      multiValueHeaders: {},
+      multiValueQueryStringParameters: {},
+      path: '/',
+      pathParameters: {},
+      queryStringParameters: {},
+      requestContext: {} as any,
+      resource: '',
+      stageVariables: {},
+    })).rejects.toThrow('Failed to parse body as FormData')
+  })
+
+  it('url-search-params', async () => {
+    const standardBody: any = await toStandardBody({
+      body: Buffer.from('foo=bar&bar=baz').toString(isBase64Encoded ? 'base64' : 'utf8'),
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      httpMethod: 'POST',
+      isBase64Encoded,
+      multiValueHeaders: {},
+      multiValueQueryStringParameters: {},
+      path: '/',
+      pathParameters: {},
+      queryStringParameters: {},
+      requestContext: {} as any,
+      resource: '',
+      stageVariables: {},
+    })
+
+    expect(standardBody).toEqual(new URLSearchParams('foo=bar&bar=baz'))
+  })
+
+  it('url-search-params (empty)', async () => {
+    const standardBody: any = await toStandardBody({
+      body: null,
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      httpMethod: 'POST',
+      isBase64Encoded,
+      multiValueHeaders: {},
+      multiValueQueryStringParameters: {},
+      path: '/',
+      pathParameters: {},
+      queryStringParameters: {},
+      requestContext: {} as any,
+      resource: '',
+      stageVariables: {},
+    })
+
+    expect(standardBody).toEqual(new URLSearchParams())
+  })
+
+  it('blob', async () => {
+    const standardBody: any = await toStandardBody({
+      body: Buffer.from('foo').toString(isBase64Encoded ? 'base64' : 'utf8'),
+      headers: {
+        'content-type': 'application/pdf',
+      },
+      httpMethod: 'POST',
+      isBase64Encoded,
+      multiValueHeaders: {},
+      multiValueQueryStringParameters: {},
+      path: '/',
+      pathParameters: {},
+      queryStringParameters: {},
+      requestContext: {} as any,
+      resource: '',
+      stageVariables: {},
+    })
+
+    expect(standardBody).toBeInstanceOf(File)
+    expect(standardBody.name).toBe('blob')
+    expect(standardBody.type).toBe('application/pdf')
+    expect(await standardBody.text()).toBe('foo')
+
+    expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledTimes(0)
+  })
+
+  it('blob (empty)', async () => {
+    const standardBody: any = await toStandardBody({
+      body: null,
+      headers: {
+        'content-type': 'application/pdf',
+      },
+      httpMethod: 'POST',
+      isBase64Encoded,
+      multiValueHeaders: {},
+      multiValueQueryStringParameters: {},
+      path: '/',
+      pathParameters: {},
+      queryStringParameters: {},
+      requestContext: {} as any,
+      resource: '',
+      stageVariables: {},
+    })
+
+    expect(standardBody).toBeInstanceOf(File)
+    expect(standardBody.name).toBe('blob')
+    expect(standardBody.type).toBe('application/pdf')
+    expect(await standardBody.text()).toBe('')
+
+    expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledTimes(0)
+  })
+
+  it('file', async () => {
+    getFilenameFromContentDispositionSpy.mockReturnValue('__name__')
+
+    const standardBody: any = await toStandardBody({
+      body: Buffer.from(JSON.stringify({ value: 123 })).toString(isBase64Encoded ? 'base64' : 'utf8'),
+      headers: {
+        'content-type': 'application/json',
+        'content-disposition': 'attachment; filename="foo.pdf"',
+      },
+      httpMethod: 'POST',
+      isBase64Encoded,
+      multiValueHeaders: {},
+      multiValueQueryStringParameters: {},
+      path: '/',
+      pathParameters: {},
+      queryStringParameters: {},
+      requestContext: {} as any,
+      resource: '',
+      stageVariables: {},
+    })
+
+    expect(standardBody).toBeInstanceOf(File)
+    expect(standardBody.name).toBe('__name__')
+    expect(standardBody.type).toBe('application/json')
+    expect(await standardBody.text()).toBe('{"value":123}')
+
+    expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledTimes(1)
+    expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledWith('attachment; filename="foo.pdf"')
+  })
+
+  it('file with content-disposition (no filename)', async () => {
+    getFilenameFromContentDispositionSpy.mockReturnValue(undefined)
+
+    const standardBody: any = await toStandardBody({
+      body: Buffer.from(JSON.stringify({ value: 123 })).toString(isBase64Encoded ? 'base64' : 'utf8'),
+      headers: {
+        'content-type': 'application/json',
+        'content-disposition': 'attachment',
+      },
+      httpMethod: 'POST',
+      isBase64Encoded,
+      multiValueHeaders: {},
+      multiValueQueryStringParameters: {},
+      path: '/',
+      pathParameters: {},
+      queryStringParameters: {},
+      requestContext: {} as any,
+      resource: '',
+      stageVariables: {},
+    })
+
+    expect(standardBody).toBeInstanceOf(File)
+    expect(standardBody.name).toBe('blob')
+    expect(standardBody.type).toBe('application/json')
+    expect(await standardBody.text()).toBe('{"value":123}')
+
+    expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledTimes(1)
+    expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledWith('attachment')
+  })
+
+  it('file (no content-type)', async () => {
+    getFilenameFromContentDispositionSpy.mockReturnValue(undefined)
+
+    const standardBody: any = await toStandardBody({
+      body: Buffer.from(JSON.stringify({ value: 123 })).toString(isBase64Encoded ? 'base64' : 'utf8'),
+      headers: {
+        'content-disposition': 'attachment',
+      },
+      httpMethod: 'POST',
+      isBase64Encoded,
+      multiValueHeaders: {},
+      multiValueQueryStringParameters: {},
+      path: '/',
+      pathParameters: {},
+      queryStringParameters: {},
+      requestContext: {} as any,
+      resource: '',
+      stageVariables: {},
+    })
+
+    expect(standardBody).toBeInstanceOf(File)
+    expect(standardBody.name).toBe('blob')
+    expect(standardBody.type).toBe('')
+    expect(await standardBody.text()).toBe('{"value":123}')
+
+    expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledTimes(1)
+    expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledWith('attachment')
+  })
+})
+
+describe('toLambdaBody', () => {
+  const baseHeaders = {
+    'content-type': 'application/json',
+    'x-custom-header': 'custom-value',
+  }
+
+  it('undefined', () => {
+    const [body, headers] = toLambdaBody(undefined, baseHeaders, {})
+
+    expect(body).toBe(undefined)
+    expect(headers).toEqual({
+      'x-custom-header': 'custom-value',
+    })
+  })
+
+  it('json', () => {
+    const [body, headers] = toLambdaBody({ foo: 'bar' }, baseHeaders, {})
+
+    expect(body).toBe('{"foo":"bar"}')
+    expect(headers).toEqual({
+      'content-type': 'application/json',
+      'x-custom-header': 'custom-value',
+    })
+  })
+
+  it('form-data', async () => {
+    const form = new FormData()
+    form.append('foo', 'bar')
+    form.append('bar', 'baz')
+
+    const [body, headers] = toLambdaBody(form, baseHeaders, {})
+
+    expect(body).toBeInstanceOf(Readable)
+    expect(headers).toEqual({
+      'x-custom-header': 'custom-value',
+      'content-type': expect.stringMatching(/multipart\/form-data; .+/),
+    })
+
+    const response = new Response(body, {
+      headers,
+    })
+    const resForm = await response.formData()
+
+    expect(resForm.get('foo')).toBe('bar')
+    expect(resForm.get('bar')).toBe('baz')
+  })
+
+  it('url-search-params', async () => {
+    const query = new URLSearchParams('foo=bar&bar=baz')
+    const [body, headers] = toLambdaBody(query, baseHeaders, {})
+
+    expect(body).toBe('foo=bar&bar=baz')
+    expect(headers).toEqual({
+      'x-custom-header': 'custom-value',
+      'content-type': 'application/x-www-form-urlencoded',
+    })
+  })
+
+  it('blob', async () => {
+    const blob = new Blob(['foo'], { type: 'application/pdf' })
+    generateContentDispositionSpy.mockReturnValue('__mocked__')
+    const [body, headers] = toLambdaBody(blob, baseHeaders, {})
+
+    expect(body).toBeInstanceOf(Readable)
+    expect(headers).toEqual({
+      'content-disposition': '__mocked__',
+      'content-length': '3',
+      'content-type': 'application/pdf',
+      'x-custom-header': 'custom-value',
+    })
+
+    expect(generateContentDispositionSpy).toHaveBeenCalledTimes(1)
+    expect(generateContentDispositionSpy).toHaveBeenCalledWith('blob')
+
+    const response = new Response(body, {
+      headers,
+    })
+    const resBlob = await response.blob()
+
+    expect(resBlob.type).toBe('application/pdf')
+    expect(await resBlob.text()).toBe('foo')
+  })
+
+  it('file', async () => {
+    const blob = new File(['foo'], 'foo.pdf', { type: 'application/pdf' })
+    generateContentDispositionSpy.mockReturnValue('__mocked__')
+
+    const [body, headers] = toLambdaBody(blob, baseHeaders, {})
+
+    expect(body).instanceOf(Readable)
+    expect(headers).toEqual({
+      'content-disposition': '__mocked__',
+      'content-length': '3',
+      'content-type': 'application/pdf',
+      'x-custom-header': 'custom-value',
+    })
+
+    expect(generateContentDispositionSpy).toHaveBeenCalledTimes(1)
+    expect(generateContentDispositionSpy).toHaveBeenCalledWith('foo.pdf')
+
+    const response = new Response(body, {
+      headers,
+    })
+    const resBlob = await response.blob()
+
+    expect(resBlob.type).toBe('application/pdf')
+    expect(await resBlob.text()).toBe('foo')
+  })
+
+  it('file with content-disposition', async () => {
+    const blob = new File(['foo'], 'foo.pdf', { type: 'application/pdf' })
+
+    const [body, headers] = toLambdaBody(blob, { ...baseHeaders, 'content-disposition': 'attachment; filename="foo.pdf"' }, {})
+
+    expect(body).instanceOf(Readable)
+    expect(headers).toEqual({
+      'content-disposition': 'attachment; filename="foo.pdf"',
+      'content-length': '3',
+      'content-type': 'application/pdf',
+      'x-custom-header': 'custom-value',
+    })
+
+    expect(generateContentDispositionSpy).toHaveBeenCalledTimes(0)
+
+    const response = new Response(body, {
+      headers,
+    })
+    const resBlob = await response.blob()
+
+    expect(resBlob.type).toBe('application/pdf')
+    expect(await resBlob.text()).toBe('foo')
+  })
+
+  it('async generator', async () => {
+    async function* gen() {
+      yield 123
+      return 456
+    }
+    const options = { eventIteratorKeepAliveEnabled: true }
+    const iterator = gen()
+    const [body, headers] = toLambdaBody(iterator, baseHeaders, options)
+
+    expect(toEventStreamSpy).toHaveBeenCalledWith(iterator, options)
+
+    expect(body).toBeInstanceOf(Readable)
+    expect(headers).toEqual({
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache',
+      'connection': 'keep-alive',
+      'x-custom-header': 'custom-value',
+    })
+
+    const reader = Readable.toWeb((body as Readable)).pipeThrough(new TextDecoderStream()).getReader()
+
+    expect(await reader.read()).toEqual({ done: false, value: 'event: message\ndata: 123\n\n' })
+    expect(await reader.read()).toEqual({ done: false, value: 'event: done\ndata: 456\n\n' })
+  })
+})

--- a/packages/standard-server-aws-lambda/src/body.test.ts
+++ b/packages/standard-server-aws-lambda/src/body.test.ts
@@ -16,18 +16,17 @@ beforeEach(() => {
 describe.each([true, false])('toStandardBody: base64=%s', (isBase64Encoded) => {
   it('undefined', async () => {
     const standardBody = await toStandardBody({
-      body: null,
+      body: undefined,
       headers: {},
-      httpMethod: 'POST',
       isBase64Encoded,
-      multiValueHeaders: {},
-      multiValueQueryStringParameters: {},
-      path: '/',
+      rawPath: '/',
       pathParameters: {},
       queryStringParameters: {},
       requestContext: {} as any,
-      resource: '',
       stageVariables: {},
+      rawQueryString: '',
+      routeKey: '$default',
+      version: '2.0',
     })
 
     expect(standardBody).toBe(undefined)
@@ -39,16 +38,15 @@ describe.each([true, false])('toStandardBody: base64=%s', (isBase64Encoded) => {
       headers: {
         'content-type': 'application/json',
       },
-      httpMethod: 'POST',
       isBase64Encoded,
-      multiValueHeaders: {},
-      multiValueQueryStringParameters: {},
-      path: '/',
+      rawPath: '/',
       pathParameters: {},
       queryStringParameters: {},
       requestContext: {} as any,
-      resource: '',
       stageVariables: {},
+      rawQueryString: '',
+      routeKey: '$default',
+      version: '2.0',
     })
 
     expect(standardBody).toEqual({ foo: 'bar' })
@@ -60,16 +58,15 @@ describe.each([true, false])('toStandardBody: base64=%s', (isBase64Encoded) => {
       headers: {
         'content-type': 'application/json',
       },
-      httpMethod: 'POST',
       isBase64Encoded,
-      multiValueHeaders: {},
-      multiValueQueryStringParameters: {},
-      path: '/',
+      rawPath: '/',
       pathParameters: {},
       queryStringParameters: {},
       requestContext: {} as any,
-      resource: '',
       stageVariables: {},
+      rawQueryString: '',
+      routeKey: '$default',
+      version: '2.0',
     })
 
     expect(standardBody).toEqual(undefined)
@@ -81,16 +78,15 @@ describe.each([true, false])('toStandardBody: base64=%s', (isBase64Encoded) => {
       headers: {
         'content-type': 'text/event-stream',
       },
-      httpMethod: 'POST',
       isBase64Encoded,
-      multiValueHeaders: {},
-      multiValueQueryStringParameters: {},
-      path: '/',
+      rawPath: '/',
       pathParameters: {},
       queryStringParameters: {},
       requestContext: {} as any,
-      resource: '',
       stageVariables: {},
+      rawQueryString: '',
+      routeKey: '$default',
+      version: '2.0',
     })
 
     expect(standardBody).toSatisfy(isAsyncIteratorObject)
@@ -105,16 +101,15 @@ describe.each([true, false])('toStandardBody: base64=%s', (isBase64Encoded) => {
       headers: {
         'content-type': 'text/plain',
       },
-      httpMethod: 'POST',
       isBase64Encoded,
-      multiValueHeaders: {},
-      multiValueQueryStringParameters: {},
-      path: '/',
+      rawPath: '/',
       pathParameters: {},
       queryStringParameters: {},
       requestContext: {} as any,
-      resource: '',
       stageVariables: {},
+      rawQueryString: '',
+      routeKey: '$default',
+      version: '2.0',
     })
 
     expect(standardBody).toBe('foo')
@@ -131,16 +126,15 @@ describe.each([true, false])('toStandardBody: base64=%s', (isBase64Encoded) => {
       headers: {
         'content-type': res.headers.get('content-type')!,
       },
-      httpMethod: 'POST',
       isBase64Encoded: true,
-      multiValueHeaders: {},
-      multiValueQueryStringParameters: {},
-      path: '/',
+      rawPath: '/',
       pathParameters: {},
       queryStringParameters: {},
       requestContext: {} as any,
-      resource: '',
       stageVariables: {},
+      rawQueryString: '',
+      routeKey: '$default',
+      version: '2.0',
     })
 
     expect(standardBody).toBeInstanceOf(FormData)
@@ -150,21 +144,20 @@ describe.each([true, false])('toStandardBody: base64=%s', (isBase64Encoded) => {
 
   it('form-data (empty)', async () => {
     await expect(toStandardBody({
-      body: null,
+      body: undefined,
       headers: {
         'content-type': 'multipart/form-data; boundary=foo',
       },
-      httpMethod: 'POST',
-      isBase64Encoded: true,
-      multiValueHeaders: {},
-      multiValueQueryStringParameters: {},
-      path: '/',
+      isBase64Encoded,
+      rawPath: '/',
       pathParameters: {},
       queryStringParameters: {},
       requestContext: {} as any,
-      resource: '',
       stageVariables: {},
-    })).rejects.toThrow('Failed to parse body as FormData')
+      rawQueryString: '',
+      routeKey: '$default',
+      version: '2.0',
+    })).rejects.toThrow('Failed to parse body as FormData.')
   })
 
   it('url-search-params', async () => {
@@ -173,16 +166,15 @@ describe.each([true, false])('toStandardBody: base64=%s', (isBase64Encoded) => {
       headers: {
         'content-type': 'application/x-www-form-urlencoded',
       },
-      httpMethod: 'POST',
       isBase64Encoded,
-      multiValueHeaders: {},
-      multiValueQueryStringParameters: {},
-      path: '/',
+      rawPath: '/',
       pathParameters: {},
       queryStringParameters: {},
       requestContext: {} as any,
-      resource: '',
       stageVariables: {},
+      rawQueryString: '',
+      routeKey: '$default',
+      version: '2.0',
     })
 
     expect(standardBody).toEqual(new URLSearchParams('foo=bar&bar=baz'))
@@ -190,20 +182,19 @@ describe.each([true, false])('toStandardBody: base64=%s', (isBase64Encoded) => {
 
   it('url-search-params (empty)', async () => {
     const standardBody: any = await toStandardBody({
-      body: null,
+      body: undefined,
       headers: {
         'content-type': 'application/x-www-form-urlencoded',
       },
-      httpMethod: 'POST',
       isBase64Encoded,
-      multiValueHeaders: {},
-      multiValueQueryStringParameters: {},
-      path: '/',
+      rawPath: '/',
       pathParameters: {},
       queryStringParameters: {},
       requestContext: {} as any,
-      resource: '',
       stageVariables: {},
+      rawQueryString: '',
+      routeKey: '$default',
+      version: '2.0',
     })
 
     expect(standardBody).toEqual(new URLSearchParams())
@@ -215,16 +206,15 @@ describe.each([true, false])('toStandardBody: base64=%s', (isBase64Encoded) => {
       headers: {
         'content-type': 'application/pdf',
       },
-      httpMethod: 'POST',
       isBase64Encoded,
-      multiValueHeaders: {},
-      multiValueQueryStringParameters: {},
-      path: '/',
+      rawPath: '/',
       pathParameters: {},
       queryStringParameters: {},
       requestContext: {} as any,
-      resource: '',
       stageVariables: {},
+      rawQueryString: '',
+      routeKey: '$default',
+      version: '2.0',
     })
 
     expect(standardBody).toBeInstanceOf(File)
@@ -237,20 +227,19 @@ describe.each([true, false])('toStandardBody: base64=%s', (isBase64Encoded) => {
 
   it('blob (empty)', async () => {
     const standardBody: any = await toStandardBody({
-      body: null,
+      body: undefined,
       headers: {
         'content-type': 'application/pdf',
       },
-      httpMethod: 'POST',
       isBase64Encoded,
-      multiValueHeaders: {},
-      multiValueQueryStringParameters: {},
-      path: '/',
+      rawPath: '/',
       pathParameters: {},
       queryStringParameters: {},
       requestContext: {} as any,
-      resource: '',
       stageVariables: {},
+      rawQueryString: '',
+      routeKey: '$default',
+      version: '2.0',
     })
 
     expect(standardBody).toBeInstanceOf(File)
@@ -270,16 +259,15 @@ describe.each([true, false])('toStandardBody: base64=%s', (isBase64Encoded) => {
         'content-type': 'application/json',
         'content-disposition': 'attachment; filename="foo.pdf"',
       },
-      httpMethod: 'POST',
       isBase64Encoded,
-      multiValueHeaders: {},
-      multiValueQueryStringParameters: {},
-      path: '/',
+      rawPath: '/',
       pathParameters: {},
       queryStringParameters: {},
       requestContext: {} as any,
-      resource: '',
       stageVariables: {},
+      rawQueryString: '',
+      routeKey: '$default',
+      version: '2.0',
     })
 
     expect(standardBody).toBeInstanceOf(File)
@@ -300,16 +288,15 @@ describe.each([true, false])('toStandardBody: base64=%s', (isBase64Encoded) => {
         'content-type': 'application/json',
         'content-disposition': 'attachment',
       },
-      httpMethod: 'POST',
       isBase64Encoded,
-      multiValueHeaders: {},
-      multiValueQueryStringParameters: {},
-      path: '/',
+      rawPath: '/',
       pathParameters: {},
       queryStringParameters: {},
       requestContext: {} as any,
-      resource: '',
       stageVariables: {},
+      rawQueryString: '',
+      routeKey: '$default',
+      version: '2.0',
     })
 
     expect(standardBody).toBeInstanceOf(File)
@@ -329,16 +316,15 @@ describe.each([true, false])('toStandardBody: base64=%s', (isBase64Encoded) => {
       headers: {
         'content-disposition': 'attachment',
       },
-      httpMethod: 'POST',
       isBase64Encoded,
-      multiValueHeaders: {},
-      multiValueQueryStringParameters: {},
-      path: '/',
+      rawPath: '/',
       pathParameters: {},
       queryStringParameters: {},
       requestContext: {} as any,
-      resource: '',
       stageVariables: {},
+      rawQueryString: '',
+      routeKey: '$default',
+      version: '2.0',
     })
 
     expect(standardBody).toBeInstanceOf(File)
@@ -390,7 +376,7 @@ describe('toLambdaBody', () => {
     })
 
     const response = new Response(body, {
-      headers,
+      headers: headers as Record<string, string>,
     })
     const resForm = await response.formData()
 
@@ -426,7 +412,7 @@ describe('toLambdaBody', () => {
     expect(generateContentDispositionSpy).toHaveBeenCalledWith('blob')
 
     const response = new Response(body, {
-      headers,
+      headers: headers as Record<string, string>,
     })
     const resBlob = await response.blob()
 
@@ -452,7 +438,7 @@ describe('toLambdaBody', () => {
     expect(generateContentDispositionSpy).toHaveBeenCalledWith('foo.pdf')
 
     const response = new Response(body, {
-      headers,
+      headers: headers as Record<string, string>,
     })
     const resBlob = await response.blob()
 
@@ -476,7 +462,7 @@ describe('toLambdaBody', () => {
     expect(generateContentDispositionSpy).toHaveBeenCalledTimes(0)
 
     const response = new Response(body, {
-      headers,
+      headers: headers as Record<string, string>,
     })
     const resBlob = await response.blob()
 

--- a/packages/standard-server-aws-lambda/src/body.ts
+++ b/packages/standard-server-aws-lambda/src/body.ts
@@ -1,13 +1,13 @@
 import type { StandardBody, StandardHeaders } from '@orpc/standard-server'
-import type { APIGatewayEvent } from 'aws-lambda'
 import type { ToEventStreamOptions } from './event-iterator'
+import type { APIGatewayProxyEvent } from './types'
 import { Buffer } from 'node:buffer'
 import { Readable } from 'node:stream'
 import { isAsyncIteratorObject, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
 import { flattenHeader, generateContentDisposition, getFilenameFromContentDisposition } from '@orpc/standard-server'
 import { toEventIterator, toEventStream } from './event-iterator'
 
-export async function toStandardBody(event: APIGatewayEvent): Promise<StandardBody> {
+export async function toStandardBody(event: APIGatewayProxyEvent): Promise<StandardBody> {
   const contentType = event.headers['content-type'] ?? flattenHeader(event.multiValueHeaders['content-type'])
   const contentDisposition = event.headers['content-disposition'] ?? flattenHeader(event.multiValueHeaders['content-disposition'])
 

--- a/packages/standard-server-aws-lambda/src/body.ts
+++ b/packages/standard-server-aws-lambda/src/body.ts
@@ -1,0 +1,65 @@
+import type { StandardBody } from '@orpc/standard-server'
+import type { APIGatewayEvent } from 'aws-lambda'
+import { Buffer } from 'node:buffer'
+import { parseEmptyableJSON } from '@orpc/shared'
+import { flattenHeader, getFilenameFromContentDisposition } from '@orpc/standard-server'
+import { toEventIterator } from './event-iterator'
+
+export async function toStandardBody(event: APIGatewayEvent): Promise<StandardBody> {
+  if (event.httpMethod === 'GET' || event.httpMethod === 'HEAD' || event.body === null) {
+    return undefined
+  }
+
+  const contentType = event.headers['content-type'] ?? flattenHeader(event.multiValueHeaders['content-type'])
+  const contentDisposition = event.headers['content-disposition'] ?? flattenHeader(event.multiValueHeaders['content-disposition'])
+
+  if (typeof contentDisposition === 'string') {
+    const fileName = getFilenameFromContentDisposition(contentDisposition) ?? 'blob'
+
+    return _parseAsFile(event.body, event.isBase64Encoded, fileName, contentType ?? '')
+  }
+
+  if (!contentType || contentType.startsWith('application/json')) {
+    const text = _parseAsString(event.body, event.isBase64Encoded)
+    return parseEmptyableJSON(text)
+  }
+
+  if (contentType.startsWith('multipart/form-data')) {
+    return _parseAsFormData(event.body, event.isBase64Encoded, contentType)
+  }
+
+  if (contentType.startsWith('application/x-www-form-urlencoded')) {
+    const text = _parseAsString(event.body, event.isBase64Encoded)
+    return new URLSearchParams(text)
+  }
+
+  if (contentType.startsWith('text/event-stream')) {
+    return toEventIterator(_parseAsString(event.body, event.isBase64Encoded))
+  }
+
+  if (contentType.startsWith('text/plain')) {
+    return _parseAsString(event.body, event.isBase64Encoded)
+  }
+
+  return _parseAsFile(event.body, event.isBase64Encoded, 'blob', contentType)
+}
+
+function _parseAsFile(body: string, isBase64Encoded: boolean, fileName: string, contentType: string): File {
+  const blobPart = isBase64Encoded ? Buffer.from(body, 'base64') : body
+  return new File([blobPart], fileName, { type: contentType })
+}
+
+function _parseAsString(body: string, isBase64Encoded: boolean): string {
+  return isBase64Encoded ? Buffer.from(body, 'base64').toString() : body
+}
+
+function _parseAsFormData(body: string, isBase64Encoded: boolean, contentType: string): Promise<FormData> {
+  const blobPart = isBase64Encoded ? Buffer.from(body, 'base64') : body
+  const response = new Response(blobPart, {
+    headers: {
+      'content-type': contentType,
+    },
+  })
+
+  return response.formData()
+}

--- a/packages/standard-server-aws-lambda/src/body.ts
+++ b/packages/standard-server-aws-lambda/src/body.ts
@@ -101,11 +101,11 @@ function _parseAsFile(body: string | null, isBase64Encoded: boolean, fileName: s
 }
 
 function _parseAsString(body: string | null, isBase64Encoded: boolean): string | null {
-  return isBase64Encoded && typeof body === 'string' ? Buffer.from(body, 'base64').toString() : body
+  return isBase64Encoded && body !== null ? Buffer.from(body, 'base64').toString() : body
 }
 
-function _parseAsFormData(body: string, isBase64Encoded: boolean, contentType: string): Promise<FormData> {
-  const blobPart = isBase64Encoded ? Buffer.from(body, 'base64') : body
+function _parseAsFormData(body: string | null, isBase64Encoded: boolean, contentType: string): Promise<FormData> {
+  const blobPart = isBase64Encoded && body !== null ? Buffer.from(body, 'base64') : body
   const response = new Response(blobPart, {
     headers: {
       'content-type': contentType,

--- a/packages/standard-server-aws-lambda/src/event-iterator.test.ts
+++ b/packages/standard-server-aws-lambda/src/event-iterator.test.ts
@@ -1,0 +1,299 @@
+import { Readable } from 'node:stream'
+import { isAsyncIteratorObject } from '@orpc/shared'
+import { ErrorEvent, getEventMeta, withEventMeta } from '@orpc/standard-server'
+import { toEventIterator, toEventStream } from './event-iterator'
+
+describe('toEventIterator', () => {
+  it('with done event', async () => {
+    const generator = toEventIterator(
+      'event: message\ndata: {"order": 1}\nid: id-1\nretry: 10000\n\n'
+      + 'event: message\ndata: {"order": 2}\nid: id-2\n\n'
+      + ': ping\n\n'
+      + 'event: done\ndata: {"order": 3}\nid: id-3\nretry: 30000\n\n',
+    )
+    expect(generator).toSatisfy(isAsyncIteratorObject)
+
+    expect(await generator.next()).toSatisfy(({ done, value }) => {
+      expect(done).toEqual(false)
+      expect(value).toEqual({ order: 1 })
+      expect(getEventMeta(value)).toEqual(expect.objectContaining({ id: 'id-1', retry: 10000 }))
+
+      return true
+    })
+
+    expect(await generator.next()).toSatisfy(({ done, value }) => {
+      expect(done).toEqual(false)
+      expect(value).toEqual({ order: 2 })
+      expect(getEventMeta(value)).toEqual(expect.objectContaining({ id: 'id-2', retry: undefined }))
+
+      return true
+    })
+
+    expect(await generator.next()).toSatisfy(({ done, value }) => {
+      expect(done).toEqual(true)
+      expect(value).toEqual({ order: 3 })
+      expect(getEventMeta(value)).toEqual(expect.objectContaining({ id: 'id-3', retry: 30000 }))
+
+      return true
+    })
+  })
+
+  it('without dont event', async () => {
+    const generator = toEventIterator(
+      'event: message\ndata: {"order": 1}\nid: id-1\nretry: 10000\n\n'
+      + 'event: message\ndata: {"order": 2}\nid: id-2\n\n'
+      + ': ping\n\n',
+    )
+    expect(generator).toSatisfy(isAsyncIteratorObject)
+
+    expect(await generator.next()).toSatisfy(({ done, value }) => {
+      expect(done).toEqual(false)
+      expect(value).toEqual({ order: 1 })
+      expect(getEventMeta(value)).toEqual(expect.objectContaining({ id: 'id-1', retry: 10000 }))
+
+      return true
+    })
+
+    expect(await generator.next()).toSatisfy(({ done, value }) => {
+      expect(done).toEqual(false)
+      expect(value).toEqual({ order: 2 })
+      expect(getEventMeta(value)).toEqual(expect.objectContaining({ id: 'id-2', retry: undefined }))
+
+      return true
+    })
+
+    expect(await generator.next()).toSatisfy(({ done, value }) => {
+      expect(done).toEqual(true)
+      expect(value).toEqual(undefined)
+      expect(getEventMeta(value)).toEqual(undefined)
+
+      return true
+    })
+  })
+
+  it('with error event', async () => {
+    const generator = toEventIterator(
+      'event: message\ndata: {"order": 1}\nid: id-1\nretry: 10000\n\n'
+      + 'event: message\ndata: {"order": 2}\nid: id-2\n\n'
+      + ': ping\n\n'
+      + 'event: error\ndata: {"order": 3}\nid: id-3\nretry: 30000\n\n',
+    )
+    expect(generator).toSatisfy(isAsyncIteratorObject)
+
+    expect(await generator.next()).toSatisfy(({ done, value }) => {
+      expect(done).toEqual(false)
+      expect(value).toEqual({ order: 1 })
+      expect(getEventMeta(value)).toEqual(expect.objectContaining({ id: 'id-1', retry: 10000 }))
+
+      return true
+    })
+
+    expect(await generator.next()).toSatisfy(({ done, value }) => {
+      expect(done).toEqual(false)
+      expect(value).toEqual({ order: 2 })
+      expect(getEventMeta(value)).toEqual(expect.objectContaining({ id: 'id-2', retry: undefined }))
+
+      return true
+    })
+
+    await expect(generator.next()).rejects.toSatisfy((error: any) => {
+      expect(error).toBeInstanceOf(ErrorEvent)
+      expect(error.data).toEqual({ order: 3 })
+      expect(getEventMeta(error)).toEqual(expect.objectContaining({ id: 'id-3', retry: 30000 }))
+
+      return true
+    })
+  })
+
+  it('with body=null', async () => {
+    const generator = toEventIterator(null)
+    expect(generator).toSatisfy(isAsyncIteratorObject)
+
+    expect(await generator.next()).toEqual({ done: true, value: undefined })
+  })
+})
+
+describe('toEventStream', () => {
+  it('with return', async () => {
+    async function* gen() {
+      yield withEventMeta({ order: 1 }, { id: 'id-1' })
+      yield withEventMeta({ order: 2 }, { retry: 20000 })
+      yield undefined
+      return withEventMeta({ order: 4 }, { id: 'id-4', retry: 40000 })
+    }
+
+    const reader = Readable.toWeb(toEventStream(gen(), {}))
+      .pipeThrough(new TextDecoderStream())
+      .getReader()
+
+    expect((await reader.read())).toEqual({ done: false, value: 'event: message\nid: id-1\ndata: {"order":1}\n\n' })
+    expect((await reader.read())).toEqual({ done: false, value: 'event: message\nretry: 20000\ndata: {"order":2}\n\n' })
+    expect((await reader.read())).toEqual({ done: false, value: 'event: message\n\n' })
+    expect((await reader.read())).toEqual({ done: false, value: 'event: done\nretry: 40000\nid: id-4\ndata: {"order":4}\n\n' })
+    expect((await reader.read())).toEqual({ done: true, value: undefined })
+  })
+
+  it('without return', async () => {
+    async function* gen() {
+      yield withEventMeta({ order: 1 }, { id: 'id-1' })
+      yield withEventMeta({ order: 2 }, { retry: 20000 })
+      yield undefined
+    }
+
+    const reader = Readable.toWeb(toEventStream(gen(), {}))
+      .pipeThrough(new TextDecoderStream())
+      .getReader()
+
+    expect((await reader.read())).toEqual({ done: false, value: 'event: message\nid: id-1\ndata: {"order":1}\n\n' })
+    expect((await reader.read())).toEqual({ done: false, value: 'event: message\nretry: 20000\ndata: {"order":2}\n\n' })
+    expect((await reader.read())).toEqual({ done: false, value: 'event: message\n\n' })
+    expect((await reader.read())).toEqual({ done: true, value: undefined })
+  })
+
+  it('with normal error', async () => {
+    async function* gen() {
+      yield withEventMeta({ order: 1 }, { id: 'id-1' })
+      yield withEventMeta({ order: 2 }, { retry: 20000 })
+      yield undefined
+      throw withEventMeta(new Error('order-4'), { id: 'id-4', retry: 40000 })
+    }
+
+    const reader = Readable.toWeb(toEventStream(gen(), {}))
+      .pipeThrough(new TextDecoderStream())
+      .getReader()
+
+    expect((await reader.read()).value).toEqual('event: message\nid: id-1\ndata: {"order":1}\n\n')
+    expect((await reader.read()).value).toEqual('event: message\nretry: 20000\ndata: {"order":2}\n\n')
+    expect((await reader.read()).value).toEqual('event: message\n\n')
+    expect((await reader.read()).value).toEqual('event: error\nretry: 40000\nid: id-4\n\n')
+    expect((await reader.read()).done).toEqual(true)
+  })
+
+  it('with ErrorEvent error', async () => {
+    async function* gen() {
+      yield withEventMeta({ order: 1 }, { id: 'id-1' })
+      yield withEventMeta({ order: 2 }, { retry: 20000 })
+      yield undefined
+      throw withEventMeta(new ErrorEvent({ data: { order: 4 } }), { id: 'id-4', retry: 40000 })
+    }
+
+    const reader = Readable.toWeb(toEventStream(gen(), {}))
+      .pipeThrough(new TextDecoderStream())
+      .getReader()
+
+    expect((await reader.read()).value).toEqual('event: message\nid: id-1\ndata: {"order":1}\n\n')
+    expect((await reader.read()).value).toEqual('event: message\nretry: 20000\ndata: {"order":2}\n\n')
+    expect((await reader.read()).value).toEqual('event: message\n\n')
+    expect((await reader.read()).value).toEqual('event: error\nretry: 40000\nid: id-4\ndata: {"order":4}\n\n')
+    expect((await reader.read()).done).toEqual(true)
+  })
+
+  it('when canceled from client - yield', async () => {
+    let hasFinally = false
+
+    async function* gen() {
+      try {
+        await new Promise(resolve => setTimeout(resolve, 100))
+        yield 1
+        await new Promise(resolve => setTimeout(resolve, 100))
+        yield 2
+      }
+      finally {
+        hasFinally = true
+      }
+    }
+
+    const stream = toEventStream(gen(), {})
+
+    const reader = Readable.toWeb(stream).getReader()
+    await reader.read()
+    await new Promise(resolve => setTimeout(resolve, 1))
+    await stream.destroy() // use stream.destroy() instead of reader.cancel() to improve node compatibility
+
+    await vi.waitFor(() => {
+      expect(hasFinally).toBe(true)
+    })
+  })
+
+  it('when canceled from client - throw', async () => {
+    let hasFinally = false
+
+    async function* gen() {
+      try {
+        await new Promise(resolve => setTimeout(resolve, 10))
+        yield 1
+        await new Promise(resolve => setTimeout(resolve, 10))
+        throw new Error('something')
+      }
+      finally {
+        hasFinally = true
+      }
+    }
+
+    const stream = toEventStream(gen(), {})
+
+    const reader = Readable.toWeb(stream).getReader()
+    await reader.read()
+    await new Promise(resolve => setTimeout(resolve, 1))
+    await stream.destroy() // use stream.destroy() instead of reader.cancel() to improve node compatibility
+
+    await vi.waitFor(() => {
+      expect(hasFinally).toBe(true)
+    })
+  })
+
+  it('keep alive', { retry: 5 }, async () => {
+    async function* gen() {
+      while (true) {
+        await new Promise(resolve => setTimeout(resolve, 100))
+        yield 'hello'
+      }
+    }
+
+    const stream = toEventStream(gen(), {
+      eventIteratorKeepAliveEnabled: true,
+      eventIteratorKeepAliveInterval: 40,
+      eventIteratorKeepAliveComment: 'ping',
+    })
+
+    const reader = Readable.toWeb(stream)
+      .pipeThrough(new TextDecoderStream())
+      .getReader()
+
+    let now = Date.now()
+    await expect(reader.read()).resolves.toEqual({ done: false, value: ': ping\n\n' })
+    await expect(reader.read()).resolves.toEqual({ done: false, value: ': ping\n\n' })
+    await expect(reader.read()).resolves.toEqual({ done: false, value: 'event: message\ndata: "hello"\n\n' })
+    expect(Date.now() - now).toBeGreaterThanOrEqual(80)
+    expect(Date.now() - now).toBeLessThan(120)
+
+    now = Date.now()
+    await expect(reader.read()).resolves.toEqual({ done: false, value: ': ping\n\n' })
+    await expect(reader.read()).resolves.toEqual({ done: false, value: ': ping\n\n' })
+    await expect(reader.read()).resolves.toEqual({ done: false, value: 'event: message\ndata: "hello"\n\n' })
+    expect(Date.now() - now).toBeGreaterThanOrEqual(80)
+    expect(Date.now() - now).toBeLessThan(120)
+  })
+})
+
+it.each([
+  [[1, 2, 3, 4, 5, 6]],
+  [[{ a: 1 }, { b: 2 }, { c: 3 }, { d: 4 }, { e: 5 }, { f: 6 }]],
+])('toEventStream + toEventIterator: %#', async (...values) => {
+  const stream = toEventStream((async function* () {
+    for (const value of values) {
+      yield value
+    }
+  })(), { eventIteratorKeepAliveInterval: 0 })
+
+  let text = ''
+  for await (const value of stream) {
+    text += value.toString()
+  }
+
+  const iterator = toEventIterator(text)
+
+  for await (const value of iterator) {
+    expect(value).toEqual(values.shift())
+  }
+})

--- a/packages/standard-server-aws-lambda/src/event-iterator.test.ts
+++ b/packages/standard-server-aws-lambda/src/event-iterator.test.ts
@@ -38,7 +38,7 @@ describe('toEventIterator', () => {
     })
   })
 
-  it('without dont event', async () => {
+  it('without done event', async () => {
     const generator = toEventIterator(
       'event: message\ndata: {"order": 1}\nid: id-1\nretry: 10000\n\n'
       + 'event: message\ndata: {"order": 2}\nid: id-2\n\n'

--- a/packages/standard-server-aws-lambda/src/event-iterator.test.ts
+++ b/packages/standard-server-aws-lambda/src/event-iterator.test.ts
@@ -105,8 +105,8 @@ describe('toEventIterator', () => {
     })
   })
 
-  it('with body=null', async () => {
-    const generator = toEventIterator(null)
+  it('with body=undefined', async () => {
+    const generator = toEventIterator(undefined)
     expect(generator).toSatisfy(isAsyncIteratorObject)
 
     expect(await generator.next()).toEqual({ done: true, value: undefined })

--- a/packages/standard-server-aws-lambda/src/event-iterator.ts
+++ b/packages/standard-server-aws-lambda/src/event-iterator.ts
@@ -3,7 +3,7 @@ import { createAsyncIteratorObject, isTypescriptObject, parseEmptyableJSON, stri
 import { encodeEventMessage, ErrorEvent, EventDecoderStream, getEventMeta, withEventMeta } from '@orpc/standard-server'
 
 export function toEventIterator(
-  body: string | null,
+  body: string | undefined,
 ): AsyncIteratorObject<unknown | void, unknown | void, void> & AsyncGenerator<unknown | void, unknown | void, void> {
   const eventStream = new ReadableStream<string>({
     pull(controller) {

--- a/packages/standard-server-aws-lambda/src/event-iterator.ts
+++ b/packages/standard-server-aws-lambda/src/event-iterator.ts
@@ -1,0 +1,154 @@
+import { Readable } from 'node:stream'
+import { createAsyncIteratorObject, isTypescriptObject, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
+import { encodeEventMessage, ErrorEvent, EventDecoderStream, getEventMeta, withEventMeta } from '@orpc/standard-server'
+
+export function toEventIterator(
+  body: string,
+): AsyncIteratorObject<unknown | void, unknown | void, void> & AsyncGenerator<unknown | void, unknown | void, void> {
+  const eventStream = new ReadableStream<string>({
+    pull(controller) {
+      controller.enqueue(body)
+      controller.close()
+    },
+  }).pipeThrough(new EventDecoderStream())
+
+  const reader = eventStream.getReader()
+
+  return createAsyncIteratorObject(async () => {
+    while (true) {
+      const { done, value } = await reader.read()
+
+      if (done) {
+        return { done: true, value: undefined }
+      }
+
+      switch (value.event) {
+        case 'message': {
+          let message = parseEmptyableJSON(value.data)
+
+          if (isTypescriptObject(message)) {
+            message = withEventMeta(message, value)
+          }
+
+          return { done: false, value: message }
+        }
+
+        case 'error': {
+          let error = new ErrorEvent({
+            data: parseEmptyableJSON(value.data),
+          })
+
+          error = withEventMeta(error, value)
+
+          throw error
+        }
+
+        case 'done': {
+          let done = parseEmptyableJSON(value.data)
+
+          if (isTypescriptObject(done)) {
+            done = withEventMeta(done, value)
+          }
+
+          return { done: true, value: done }
+        }
+      }
+    }
+  }, async () => {
+    await reader.cancel()
+  })
+}
+
+export interface ToEventStreamOptions {
+  /**
+   * If true, a ping comment is sent periodically to keep the connection alive.
+   *
+   * @default true
+   */
+  eventIteratorKeepAliveEnabled?: boolean
+
+  /**
+   * Interval (in milliseconds) between ping comments sent after the last event.
+   *
+   * @default 5000
+   */
+  eventIteratorKeepAliveInterval?: number
+
+  /**
+   * The content of the ping comment. Must not include newline characters.
+   *
+   * @default ''
+   */
+  eventIteratorKeepAliveComment?: string
+}
+
+export function toEventStream(
+  iterator: AsyncIterator<unknown | void, unknown | void, void>,
+  options: ToEventStreamOptions = {},
+): Readable {
+  const keepAliveEnabled = options.eventIteratorKeepAliveEnabled ?? true
+  const keepAliveInterval = options.eventIteratorKeepAliveInterval ?? 5000
+  const keepAliveComment = options.eventIteratorKeepAliveComment ?? ''
+
+  let cancelled = false
+  let timeout: ReturnType<typeof setInterval> | undefined
+
+  const stream = new ReadableStream<string>({
+    async pull(controller) {
+      try {
+        if (keepAliveEnabled) {
+          timeout = setInterval(() => {
+            controller.enqueue(encodeEventMessage({
+              comments: [keepAliveComment],
+            }))
+          }, keepAliveInterval)
+        }
+
+        const value = await iterator.next()
+
+        clearInterval(timeout)
+
+        if (cancelled) {
+          return
+        }
+
+        const meta = getEventMeta(value.value)
+
+        if (!value.done || value.value !== undefined || meta !== undefined) {
+          controller.enqueue(encodeEventMessage({
+            ...meta,
+            event: value.done ? 'done' : 'message',
+            data: stringifyJSON(value.value),
+          }))
+        }
+
+        if (value.done) {
+          controller.close()
+        }
+      }
+      catch (err) {
+        clearInterval(timeout)
+
+        if (cancelled) {
+          return
+        }
+
+        controller.enqueue(encodeEventMessage({
+          ...getEventMeta(err),
+          event: 'error',
+          data: err instanceof ErrorEvent ? stringifyJSON(err.data) : undefined,
+        }))
+
+        controller.close()
+      }
+    },
+    async cancel() {
+      cancelled = true
+      clearInterval(timeout)
+
+      await iterator.return?.()
+    },
+  })
+
+  return Readable.fromWeb(stream)
+}

--- a/packages/standard-server-aws-lambda/src/event-iterator.ts
+++ b/packages/standard-server-aws-lambda/src/event-iterator.ts
@@ -3,11 +3,13 @@ import { createAsyncIteratorObject, isTypescriptObject, parseEmptyableJSON, stri
 import { encodeEventMessage, ErrorEvent, EventDecoderStream, getEventMeta, withEventMeta } from '@orpc/standard-server'
 
 export function toEventIterator(
-  body: string,
+  body: string | null,
 ): AsyncIteratorObject<unknown | void, unknown | void, void> & AsyncGenerator<unknown | void, unknown | void, void> {
   const eventStream = new ReadableStream<string>({
     pull(controller) {
-      controller.enqueue(body)
+      if (typeof body === 'string') {
+        controller.enqueue(body)
+      }
       controller.close()
     },
   }).pipeThrough(new EventDecoderStream())

--- a/packages/standard-server-aws-lambda/src/headers.test.ts
+++ b/packages/standard-server-aws-lambda/src/headers.test.ts
@@ -4,12 +4,13 @@ it('toStandardHeaders', () => {
   expect(toStandardHeaders({
     'content-type': 'application/json',
     'content-length': '12',
-  }, {
-    'content-length': ['12', '34'],
-    'set-cookie': ['value1', 'value2'],
-  })).toEqual({
+    'set-cookie': 'invalid',
+  }, [
+    'value1',
+    'value2',
+  ])).toEqual({
     'content-type': 'application/json',
-    'content-length': ['12', '34'],
+    'content-length': '12',
     'set-cookie': ['value1', 'value2'],
   })
 })

--- a/packages/standard-server-aws-lambda/src/headers.test.ts
+++ b/packages/standard-server-aws-lambda/src/headers.test.ts
@@ -1,0 +1,31 @@
+import { toLambdaHeaders, toStandardHeaders } from './headers'
+
+it('toStandardHeaders', () => {
+  expect(toStandardHeaders({
+    'content-type': 'application/json',
+    'content-length': '12',
+  }, {
+    'content-length': ['12', '34'],
+    'set-cookie': ['value1', 'value2'],
+  })).toEqual({
+    'content-type': 'application/json',
+    'content-length': ['12', '34'],
+    'set-cookie': ['value1', 'value2'],
+  })
+})
+
+it('toLambdaHeaders', () => {
+  const [headers, cookies] = toLambdaHeaders({
+    'content-type': 'application/json',
+    'content-length': ['12', '34'],
+    'set-cookie': ['value1', 'value2'],
+    'x-custom-header': undefined,
+  })
+
+  expect(headers).toEqual({
+    'content-type': 'application/json',
+    'content-length': '12, 34',
+  })
+
+  expect(cookies).toEqual(['value1', 'value2'])
+})

--- a/packages/standard-server-aws-lambda/src/headers.ts
+++ b/packages/standard-server-aws-lambda/src/headers.ts
@@ -1,5 +1,5 @@
 import type { StandardHeaders } from '@orpc/standard-server'
-import type { APIGatewayProxyEventHeaders, APIGatewayProxyEventMultiValueHeaders } from 'aws-lambda'
+import type { APIGatewayProxyEventHeaders, APIGatewayProxyEventMultiValueHeaders } from './types'
 import { toArray } from '@orpc/shared'
 import { flattenHeader } from '@orpc/standard-server'
 

--- a/packages/standard-server-aws-lambda/src/headers.ts
+++ b/packages/standard-server-aws-lambda/src/headers.ts
@@ -1,15 +1,15 @@
 import type { StandardHeaders } from '@orpc/standard-server'
-import type { APIGatewayProxyEventHeaders, APIGatewayProxyEventMultiValueHeaders } from './types'
+import type { APIGatewayProxyEventHeaders } from './types'
 import { toArray } from '@orpc/shared'
 import { flattenHeader } from '@orpc/standard-server'
 
 export function toStandardHeaders(
   headers: APIGatewayProxyEventHeaders,
-  multiValueHeaders: APIGatewayProxyEventMultiValueHeaders,
+  cookies: string[] | undefined,
 ): StandardHeaders {
   return {
     ...headers,
-    ...multiValueHeaders,
+    'set-cookie': cookies,
   }
 }
 

--- a/packages/standard-server-aws-lambda/src/headers.ts
+++ b/packages/standard-server-aws-lambda/src/headers.ts
@@ -1,0 +1,28 @@
+import type { StandardHeaders } from '@orpc/standard-server'
+import type { APIGatewayProxyEventHeaders, APIGatewayProxyEventMultiValueHeaders } from 'aws-lambda'
+
+export function toStandardHeaders(
+  headers: APIGatewayProxyEventHeaders,
+  multiValueHeaders: APIGatewayProxyEventMultiValueHeaders,
+): StandardHeaders {
+  return {
+    ...headers,
+    ...multiValueHeaders,
+  }
+}
+
+export function toLambdaHeaders(standard: StandardHeaders): [headers: APIGatewayProxyEventHeaders, multiValueHeaders: APIGatewayProxyEventMultiValueHeaders] {
+  const headers: APIGatewayProxyEventHeaders = {}
+  const multiValueHeaders: APIGatewayProxyEventMultiValueHeaders = {}
+
+  for (const [key, value] of Object.entries(standard)) {
+    if (Array.isArray(value)) {
+      multiValueHeaders[key] = value
+    }
+    else {
+      headers[key] = value
+    }
+  }
+
+  return [headers, multiValueHeaders]
+}

--- a/packages/standard-server-aws-lambda/src/index.ts
+++ b/packages/standard-server-aws-lambda/src/index.ts
@@ -1,6 +1,11 @@
+import type Stream from 'node:stream'
+
 export * from './body'
 export * from './event-iterator'
 export * from './headers'
 export * from './request'
 export * from './response'
 export * from './url'
+
+export type { APIGatewayEvent } from 'aws-lambda'
+export type ResponseStream = Stream.Writable

--- a/packages/standard-server-aws-lambda/src/index.ts
+++ b/packages/standard-server-aws-lambda/src/index.ts
@@ -5,6 +5,7 @@ export * from './event-iterator'
 export * from './headers'
 export * from './request'
 export * from './response'
+export * from './signal'
 export * from './url'
 
 export type { APIGatewayEvent } from 'aws-lambda'

--- a/packages/standard-server-aws-lambda/src/index.ts
+++ b/packages/standard-server-aws-lambda/src/index.ts
@@ -1,0 +1,6 @@
+export * from './body'
+export * from './event-iterator'
+export * from './headers'
+export * from './request'
+export * from './response'
+export * from './url'

--- a/packages/standard-server-aws-lambda/src/index.ts
+++ b/packages/standard-server-aws-lambda/src/index.ts
@@ -6,7 +6,7 @@ export * from './headers'
 export * from './request'
 export * from './response'
 export * from './signal'
+export * from './types'
 export * from './url'
 
-export type { APIGatewayEvent } from 'aws-lambda'
 export type ResponseStream = Stream.Writable

--- a/packages/standard-server-aws-lambda/src/request.test.ts
+++ b/packages/standard-server-aws-lambda/src/request.test.ts
@@ -1,0 +1,97 @@
+import type { APIGatewayEvent } from 'aws-lambda'
+import { isAsyncIteratorObject } from '@orpc/shared'
+import * as Body from './body'
+import * as Headers from './headers'
+import { toStandardLazyRequest } from './request'
+
+const toStandardBodySpy = vi.spyOn(Body, 'toStandardBody')
+const toStandardHeadersSpy = vi.spyOn(Headers, 'toStandardHeaders')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('toStandardLazyRequest', () => {
+  const event: APIGatewayEvent = {
+    httpMethod: 'POST',
+    body: JSON.stringify({ foo: 'bar' }),
+    headers: {
+      'host': 'example.com',
+      'content-type': 'application/json',
+    },
+    isBase64Encoded: false,
+    multiValueHeaders: {
+      cookie: ['foo=bar', 'bar=baz'],
+    },
+    multiValueQueryStringParameters: {},
+    path: '/',
+    pathParameters: {},
+    queryStringParameters: {},
+    requestContext: {} as any,
+    resource: '',
+    stageVariables: {},
+  }
+
+  it('works', () => {
+    const standardRequest = toStandardLazyRequest(event)
+
+    expect(standardRequest.url).toEqual(new URL('https://example.com'))
+    expect(standardRequest.method).toBe('POST')
+    expect(standardRequest.signal).toBe(undefined)
+    expect(standardRequest.headers).toEqual(toStandardHeadersSpy.mock.results[0]!.value)
+    expect(standardRequest.body()).toBe(toStandardBodySpy.mock.results[0]!.value)
+
+    expect(toStandardHeadersSpy).toBeCalledTimes(1)
+    expect(toStandardHeadersSpy).toBeCalledWith(event.headers, event.multiValueHeaders)
+
+    expect(toStandardBodySpy).toBeCalledTimes(1)
+    expect(toStandardBodySpy).toBeCalledWith(event)
+  })
+
+  it('lazy headers', async () => {
+    const lazyResponse = toStandardLazyRequest(event)
+
+    expect(toStandardHeadersSpy).toBeCalledTimes(0)
+    lazyResponse.headers = { overrided: '1' }
+    expect(lazyResponse.headers).toEqual({ overrided: '1' }) // can override before access
+    expect(toStandardHeadersSpy).toBeCalledTimes(0)
+
+    const lazyResponse2 = toStandardLazyRequest(event)
+    expect(lazyResponse2.headers).toEqual(toStandardHeadersSpy.mock.results[0]!.value)
+    expect(lazyResponse2.headers).toEqual(toStandardHeadersSpy.mock.results[0]!.value) // ensure cached
+    expect(toStandardHeadersSpy).toBeCalledTimes(1)
+
+    lazyResponse2.headers = { overrided: '2' }
+    expect(lazyResponse2.headers).toEqual({ overrided: '2' }) // can override after access
+  })
+
+  it('lazy body', async () => {
+    const lazyResponse = toStandardLazyRequest(event)
+
+    expect(toStandardBodySpy).toBeCalledTimes(0)
+    const overrideBody = () => Promise.resolve('1')
+    lazyResponse.body = overrideBody
+    expect(lazyResponse.body).toBe(overrideBody)
+    expect(toStandardBodySpy).toBeCalledTimes(0)
+
+    const lazyResponse2 = toStandardLazyRequest(event)
+    expect(lazyResponse2.body()).toEqual(toStandardBodySpy.mock.results[0]!.value)
+    expect(lazyResponse2.body()).toEqual(toStandardBodySpy.mock.results[0]!.value) // ensure cached
+    expect(toStandardBodySpy).toBeCalledTimes(1)
+  })
+
+  it('with event iterator', async () => {
+    const body = await toStandardLazyRequest({
+      ...event,
+      body: 'event: message\ndata: "foo"\n\nevent: done\ndata: "bar"\n\n',
+      isBase64Encoded: false,
+      headers: {
+        'content-type': 'text/event-stream',
+      },
+    }).body() as AsyncGenerator
+
+    expect(body).toSatisfy(isAsyncIteratorObject)
+    expect(await body.next()).toEqual({ done: false, value: 'foo' })
+    expect(await body.next()).toEqual({ done: true, value: 'bar' })
+  })
+})

--- a/packages/standard-server-aws-lambda/src/request.ts
+++ b/packages/standard-server-aws-lambda/src/request.ts
@@ -1,0 +1,23 @@
+import type { StandardLazyRequest } from '@orpc/standard-server'
+import type { APIGatewayEvent } from 'aws-lambda'
+import { once } from '@orpc/shared'
+import { toStandardBody } from './body'
+import { toStandardHeaders } from './headers'
+import { toStandardUrl } from './url'
+
+export function toStandardLazyRequest(event: APIGatewayEvent): StandardLazyRequest {
+  return {
+    url: toStandardUrl(event),
+    method: event.httpMethod,
+    get headers() {
+      const headers = toStandardHeaders(event.headers, event.multiValueHeaders)
+      Object.defineProperty(this, 'headers', { value: headers, writable: true })
+      return headers
+    },
+    set headers(value) {
+      Object.defineProperty(this, 'headers', { value, writable: true })
+    },
+    signal: undefined,
+    body: once(() => toStandardBody(event)),
+  }
+}

--- a/packages/standard-server-aws-lambda/src/request.ts
+++ b/packages/standard-server-aws-lambda/src/request.ts
@@ -1,23 +1,25 @@
 import type { StandardLazyRequest } from '@orpc/standard-server'
-import type { APIGatewayProxyEvent } from './types'
+import type Stream from 'node:stream'
+import type { APIGatewayProxyEventV2 } from './types'
 import { once } from '@orpc/shared'
 import { toStandardBody } from './body'
 import { toStandardHeaders } from './headers'
+import { toAbortSignal } from './signal'
 import { toStandardUrl } from './url'
 
-export function toStandardLazyRequest(event: APIGatewayProxyEvent): StandardLazyRequest {
+export function toStandardLazyRequest(event: APIGatewayProxyEventV2, responseStream: Stream.Writable): StandardLazyRequest {
   return {
     url: toStandardUrl(event),
-    method: event.httpMethod,
+    method: event.requestContext.http.method,
     get headers() {
-      const headers = toStandardHeaders(event.headers, event.multiValueHeaders)
+      const headers = toStandardHeaders(event.headers, event.cookies)
       Object.defineProperty(this, 'headers', { value: headers, writable: true })
       return headers
     },
     set headers(value) {
       Object.defineProperty(this, 'headers', { value, writable: true })
     },
-    signal: undefined,
+    signal: toAbortSignal(responseStream),
     body: once(() => toStandardBody(event)),
   }
 }

--- a/packages/standard-server-aws-lambda/src/request.ts
+++ b/packages/standard-server-aws-lambda/src/request.ts
@@ -1,11 +1,11 @@
 import type { StandardLazyRequest } from '@orpc/standard-server'
-import type { APIGatewayEvent } from 'aws-lambda'
+import type { APIGatewayProxyEvent } from './types'
 import { once } from '@orpc/shared'
 import { toStandardBody } from './body'
 import { toStandardHeaders } from './headers'
 import { toStandardUrl } from './url'
 
-export function toStandardLazyRequest(event: APIGatewayEvent): StandardLazyRequest {
+export function toStandardLazyRequest(event: APIGatewayProxyEvent): StandardLazyRequest {
   return {
     url: toStandardUrl(event),
     method: event.httpMethod,

--- a/packages/standard-server-aws-lambda/src/response.test.ts
+++ b/packages/standard-server-aws-lambda/src/response.test.ts
@@ -1,0 +1,154 @@
+import type { StandardResponse } from '@orpc/standard-server'
+import { Buffer } from 'node:buffer'
+import Stream from 'node:stream'
+import * as Body from './body'
+import { sendStandardResponse } from './response'
+
+const toLambdaBodySpy = vi.spyOn(Body, 'toLambdaBody')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+
+  globalThis.awslambda = {
+    HttpResponseStream: {
+      from: vi.fn(() => {
+        const chunkes: any[] = []
+
+        const stream = new Stream.Writable({
+          write: (chunk, encoding, callback) => {
+            chunkes.push(chunk)
+            callback()
+          },
+        })
+
+        ;(stream as any).chunkes = chunkes
+
+        return stream
+      }),
+    },
+  } as any
+})
+
+describe('sendStandardResponse', () => {
+  it('chunked', async () => {
+    const res: StandardResponse = {
+      body: { value: 123 },
+      headers: {
+        'x-custom-header': 'custom-value',
+        'set-cookie': ['foo=bar', 'bar=baz'],
+      },
+      status: 206,
+    }
+
+    const responseStream = new Stream.Writable()
+
+    await sendStandardResponse(responseStream, res, { eventIteratorKeepAliveComment: 'test' })
+
+    expect(toLambdaBodySpy).toBeCalledTimes(1)
+    expect(toLambdaBodySpy).toBeCalledWith(res.body, res.headers, { eventIteratorKeepAliveComment: 'test' })
+
+    expect(awslambda.HttpResponseStream.from).toBeCalledTimes(1)
+    expect(awslambda.HttpResponseStream.from).toBeCalledWith(responseStream, {
+      statusCode: res.status,
+      headers: {
+        'content-type': 'application/json',
+        'x-custom-header': 'custom-value',
+      },
+      cookies: res.headers['set-cookie'],
+    })
+
+    expect(vi.mocked(awslambda.HttpResponseStream.from).mock.results[0]!.value.chunkes).toEqual([
+      Buffer.from(JSON.stringify({ value: 123 })),
+    ])
+
+    expect(vi.mocked(awslambda.HttpResponseStream.from).mock.results[0]!.value.closed).toBe(true)
+  })
+
+  it('stream', async () => {
+    const res: StandardResponse = {
+      body: (async function* () {
+        yield 'foo'
+        yield 'bar'
+      })(),
+      headers: {
+        'x-custom-header': 'custom-value',
+        'set-cookie': ['foo=bar', 'bar=baz'],
+      },
+      status: 206,
+    }
+
+    const responseStream = new Stream.Writable()
+
+    await sendStandardResponse(responseStream, res, { eventIteratorKeepAliveComment: 'test' })
+
+    expect(toLambdaBodySpy).toBeCalledTimes(1)
+    expect(toLambdaBodySpy).toBeCalledWith(res.body, res.headers, { eventIteratorKeepAliveComment: 'test' })
+
+    expect(awslambda.HttpResponseStream.from).toBeCalledTimes(1)
+    expect(awslambda.HttpResponseStream.from).toBeCalledWith(responseStream, {
+      statusCode: res.status,
+      headers: {
+        'content-type': 'text/event-stream',
+        'cache-control': 'no-cache',
+        'connection': 'keep-alive',
+        'x-custom-header': 'custom-value',
+      },
+      cookies: res.headers['set-cookie'],
+    })
+
+    expect(vi.mocked(awslambda.HttpResponseStream.from).mock.results[0]!.value.chunkes).toEqual([
+      Buffer.from('event: message\ndata: "foo"\n\n'),
+      Buffer.from('event: message\ndata: "bar"\n\n'),
+    ])
+
+    expect(vi.mocked(awslambda.HttpResponseStream.from).mock.results[0]!.value.closed).toBe(true)
+  })
+
+  it('stream error while sending', async () => {
+    let clean = false
+    const res: StandardResponse = {
+      body: (async function* () {
+        try {
+          yield 1
+          await new Promise(r => setTimeout(r, 100))
+          yield 2
+          await new Promise(r => setTimeout(r, 100))
+          yield 3
+          await new Promise(r => setTimeout(r, 100))
+          yield 4
+        }
+        finally {
+          clean = true
+        }
+      })(),
+      headers: {
+        'x-custom-header': 'custom-value',
+        'set-cookie': ['foo=bar', 'bar=baz'],
+      },
+      status: 206,
+    }
+
+    const responseStream = new Stream.Writable()
+
+    const sendPromise = sendStandardResponse(responseStream, res, { eventIteratorKeepAliveComment: 'test' })
+
+    await new Promise(r => setTimeout(r, 110))
+
+    expect(vi.mocked(awslambda.HttpResponseStream.from).mock.results[0]!.value.chunkes).toEqual([
+      Buffer.from('event: message\ndata: 1\n\n'),
+      Buffer.from('event: message\ndata: 2\n\n'),
+    ])
+
+    expect(vi.mocked(awslambda.HttpResponseStream.from).mock.results[0]!.value.closed).toBe(false)
+    expect(clean).toBe(false)
+
+    vi.mocked(awslambda.HttpResponseStream.from).mock.results[0]!.value.destroy(new Error('test'))
+
+    await new Promise(r => setTimeout(r, 110))
+
+    expect(vi.mocked(awslambda.HttpResponseStream.from).mock.results[0]!.value.closed).toBe(true)
+    expect(clean).toBe(true)
+
+    await expect(sendPromise).rejects.toThrow('test')
+  })
+})

--- a/packages/standard-server-aws-lambda/src/response.test.ts
+++ b/packages/standard-server-aws-lambda/src/response.test.ts
@@ -194,7 +194,7 @@ describe('sendStandardResponse', () => {
       await sendPromise
     })
 
-    it('without', async () => {
+    it('without error', async () => {
       let clean = false
       const res: StandardResponse = {
         body: (async function* () {

--- a/packages/standard-server-aws-lambda/src/response.ts
+++ b/packages/standard-server-aws-lambda/src/response.ts
@@ -16,13 +16,13 @@ export function sendStandardResponse(
     responseStream.once('close', resolve)
 
     const [body, standardHeaders] = toLambdaBody(standardResponse.body, standardResponse.headers, options)
-    const [headers, cookies] = toLambdaHeaders(standardHeaders)
+    const [headers, setCookies] = toLambdaHeaders(standardHeaders)
 
     // awslambda is global aws lambda global object
     ;(globalThis as any).awslambda.HttpResponseStream.from(responseStream, {
       statusCode: standardResponse.status,
       headers,
-      cookies,
+      cookies: setCookies,
     })
 
     if (body === undefined) {

--- a/packages/standard-server-aws-lambda/src/response.ts
+++ b/packages/standard-server-aws-lambda/src/response.ts
@@ -21,24 +21,20 @@ export function sendStandardResponse(
       cookies,
     })
 
-    responseStream.on('close', () => {
-      if (responseStream.errored) {
-        reject(responseStream.errored)
-      }
-      else {
-        resolve()
-      }
-    })
+    responseStream.once('error', reject)
+    responseStream.once('close', resolve)
 
     if (body === undefined || typeof body === 'string') {
       responseStream.end(body)
     }
     else {
-      responseStream.on('close', () => {
+      responseStream.once('close', () => {
         if (!body.closed) {
           body.destroy(responseStream.errored ?? undefined)
         }
       })
+
+      body.once('error', error => responseStream.destroy(error))
 
       body.pipe(responseStream)
     }

--- a/packages/standard-server-aws-lambda/src/response.ts
+++ b/packages/standard-server-aws-lambda/src/response.ts
@@ -12,21 +12,25 @@ export function sendStandardResponse(
   options: SendStandardResponseOptions = {},
 ): Promise<void> {
   return new Promise((resolve, reject) => {
+    responseStream.once('error', reject)
+    responseStream.once('close', resolve)
+
     const [body, standardHeaders] = toLambdaBody(standardResponse.body, standardResponse.headers, options)
     const [headers, cookies] = toLambdaHeaders(standardHeaders)
 
     // awslambda is global aws lambda global object
-    responseStream = (globalThis as any).awslambda.HttpResponseStream.from(responseStream, {
+    ;(globalThis as any).awslambda.HttpResponseStream.from(responseStream, {
       statusCode: standardResponse.status,
       headers,
       cookies,
     })
 
-    responseStream.once('error', reject)
-    responseStream.once('close', resolve)
-
-    if (body === undefined || typeof body === 'string') {
-      responseStream.end(body)
+    if (body === undefined) {
+      responseStream.end()
+    }
+    else if (typeof body === 'string') {
+      responseStream.write(body)
+      responseStream.end()
     }
     else {
       responseStream.once('close', () => {

--- a/packages/standard-server-aws-lambda/src/response.ts
+++ b/packages/standard-server-aws-lambda/src/response.ts
@@ -21,16 +21,22 @@ export function sendStandardResponse(
       cookies,
     })
 
-    responseStream.on('error', reject)
-    responseStream.on('finish', resolve)
+    responseStream.on('close', () => {
+      if (responseStream.errored) {
+        reject(responseStream.errored)
+      }
+      else {
+        resolve()
+      }
+    })
 
     if (body === undefined || typeof body === 'string') {
       responseStream.end(body)
     }
     else {
-      body.on('close', () => {
-        if (!responseStream.closed) {
-          responseStream.destroy(body.errored ?? undefined)
+      responseStream.on('close', () => {
+        if (!body.closed) {
+          body.destroy(responseStream.errored ?? undefined)
         }
       })
 

--- a/packages/standard-server-aws-lambda/src/response.ts
+++ b/packages/standard-server-aws-lambda/src/response.ts
@@ -15,7 +15,8 @@ export function sendStandardResponse(
     const [body, standardHeaders] = toLambdaBody(standardResponse.body, standardResponse.headers, options)
     const [headers, cookies] = toLambdaHeaders(standardHeaders)
 
-    responseStream = awslambda.HttpResponseStream.from(responseStream, {
+    // awslambda is global aws lambda global object
+    responseStream = (globalThis as any).awslambda.HttpResponseStream.from(responseStream, {
       statusCode: standardResponse.status,
       headers,
       cookies,

--- a/packages/standard-server-aws-lambda/src/response.ts
+++ b/packages/standard-server-aws-lambda/src/response.ts
@@ -1,0 +1,37 @@
+import type { StandardResponse } from '@orpc/standard-server'
+import type Stream from 'node:stream'
+import type { ToLambdaBodyOptions } from './body'
+import { toLambdaBody } from './body'
+import { toLambdaHeaders } from './headers'
+
+export interface SendStandardResponseOptions extends ToLambdaBodyOptions {}
+
+export function sendStandardResponse(
+  responseStream: Stream.Writable,
+  standardResponse: StandardResponse,
+  options: SendStandardResponseOptions = {},
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    responseStream.on('error', reject)
+    responseStream.on('finish', resolve)
+
+    const [body, standardHeaders] = toLambdaBody(standardResponse.body, standardResponse.headers, options)
+    const [headers, cookies] = toLambdaHeaders(standardHeaders)
+
+    responseStream = awslambda.HttpResponseStream.from(responseStream, {
+      statusCode: standardResponse.status,
+      headers,
+      cookies,
+    })
+
+    if (body === undefined) {
+      responseStream.end()
+    }
+    else if (typeof body === 'string') {
+      responseStream.write(body)
+    }
+    else {
+      body.pipe(responseStream)
+    }
+  })
+}

--- a/packages/standard-server-aws-lambda/src/signal.test.ts
+++ b/packages/standard-server-aws-lambda/src/signal.test.ts
@@ -38,7 +38,7 @@ describe('toAbortSignal', async () => {
 
     await vi.waitFor(() => {
       expect(signal.aborted).toEqual(true)
-      expect(signal.reason).toEqual('Error: test')
+      expect(signal.reason).toEqual(new Error('test'))
     })
   })
 
@@ -57,7 +57,7 @@ describe('toAbortSignal', async () => {
 
     await vi.waitFor(() => {
       expect(signal.aborted).toEqual(true)
-      expect(signal.reason).toEqual('Client connection prematurely closed.')
+      expect(signal.reason).toEqual(new Error('Writable stream closed before it finished writing'))
     })
   })
 })

--- a/packages/standard-server-aws-lambda/src/signal.test.ts
+++ b/packages/standard-server-aws-lambda/src/signal.test.ts
@@ -1,0 +1,63 @@
+import Stream from 'node:stream'
+import { toAbortSignal } from './signal'
+
+describe('toAbortSignal', async () => {
+  it('on success', async () => {
+    const stream = new Stream.Writable({
+      write(chunk, encoding, callback) {
+        callback()
+      },
+    })
+
+    const signal = toAbortSignal(stream)
+
+    expect(signal.aborted).toBe(false)
+
+    stream.end('test')
+
+    await new Promise(r => setTimeout(r, 100))
+
+    expect(signal.aborted).toBe(false)
+  })
+
+  it('on error', async () => {
+    const stream = new Stream.Writable({
+      write(chunk, encoding, callback) {
+        callback()
+      },
+    })
+
+    // catch error
+    stream.on('error', () => {})
+
+    const signal = toAbortSignal(stream)
+
+    expect(signal.aborted).toBe(false)
+
+    stream.destroy(new Error('test'))
+
+    await vi.waitFor(() => {
+      expect(signal.aborted).toEqual(true)
+      expect(signal.reason).toEqual('Error: test')
+    })
+  })
+
+  it('on writableFinished=false', async () => {
+    const stream = new Stream.Writable({
+      write(chunk, encoding, callback) {
+      },
+    })
+
+    const signal = toAbortSignal(stream)
+
+    expect(signal.aborted).toBe(false)
+
+    stream.write('test')
+    stream.destroy()
+
+    await vi.waitFor(() => {
+      expect(signal.aborted).toEqual(true)
+      expect(signal.reason).toEqual('Client connection prematurely closed.')
+    })
+  })
+})

--- a/packages/standard-server-aws-lambda/src/signal.ts
+++ b/packages/standard-server-aws-lambda/src/signal.ts
@@ -5,16 +5,12 @@ export function toAbortSignal(
 ): AbortSignal {
   const controller = new AbortController()
 
+  responseStream.once('error', error => controller.abort(error))
+
   responseStream.once('close', () => {
-    if (responseStream.errored) {
-      controller.abort(responseStream.errored.toString())
+    if (!responseStream.writableFinished) {
+      controller.abort(new Error('Writable stream closed before it finished writing'))
     }
-
-    else if (!responseStream.writableFinished) {
-      controller.abort('Client connection prematurely closed.')
-    }
-
-    // Not abort if success
   })
 
   return controller.signal

--- a/packages/standard-server-aws-lambda/src/signal.ts
+++ b/packages/standard-server-aws-lambda/src/signal.ts
@@ -1,0 +1,21 @@
+import type Stream from 'node:stream'
+
+export function toAbortSignal(
+  responseStream: Stream.Writable,
+): AbortSignal {
+  const controller = new AbortController()
+
+  responseStream.once('close', () => {
+    if (responseStream.errored) {
+      controller.abort(responseStream.errored.toString())
+    }
+
+    else if (!responseStream.writableFinished) {
+      controller.abort('Client connection prematurely closed.')
+    }
+
+    // Not abort if success
+  })
+
+  return controller.signal
+}

--- a/packages/standard-server-aws-lambda/src/types.test-d.ts
+++ b/packages/standard-server-aws-lambda/src/types.test-d.ts
@@ -1,0 +1,6 @@
+import type { APIGatewayEvent } from 'aws-lambda'
+import type { APIGatewayProxyEvent } from './types'
+
+it('APIGatewayProxyEvent', () => {
+  expectTypeOf<APIGatewayEvent>().toExtend<APIGatewayProxyEvent>()
+})

--- a/packages/standard-server-aws-lambda/src/types.test-d.ts
+++ b/packages/standard-server-aws-lambda/src/types.test-d.ts
@@ -1,6 +1,6 @@
-import type { APIGatewayEvent } from 'aws-lambda'
-import type { APIGatewayProxyEvent } from './types'
+import type * as awslambda from 'aws-lambda'
+import type { APIGatewayProxyEventV2 } from './types'
 
 it('APIGatewayProxyEvent', () => {
-  expectTypeOf<APIGatewayEvent>().toExtend<APIGatewayProxyEvent>()
+  expectTypeOf<awslambda.APIGatewayProxyEventV2>().toExtend<APIGatewayProxyEventV2>()
 })

--- a/packages/standard-server-aws-lambda/src/types.ts
+++ b/packages/standard-server-aws-lambda/src/types.ts
@@ -1,0 +1,42 @@
+// this is mainly copied from aws-lambda
+
+export interface APIGatewayProxyEventHeaders {
+  [name: string]: string | undefined
+}
+
+export interface APIGatewayProxyEventMultiValueHeaders {
+  [name: string]: string[] | undefined
+}
+
+export interface APIGatewayProxyEventPathParameters {
+  [name: string]: string | undefined
+}
+
+export interface APIGatewayProxyEventQueryStringParameters {
+  [name: string]: string | undefined
+}
+
+export interface APIGatewayProxyEventMultiValueQueryStringParameters {
+  [name: string]: string[] | undefined
+}
+
+export interface APIGatewayProxyEventStageVariables {
+  [name: string]: string | undefined
+}
+
+export interface APIGatewayProxyEvent {
+  body: string | null
+  headers: APIGatewayProxyEventHeaders
+  multiValueHeaders: APIGatewayProxyEventMultiValueHeaders
+  httpMethod: string
+  isBase64Encoded: boolean
+  path: string
+  pathParameters: APIGatewayProxyEventPathParameters | null
+  queryStringParameters: APIGatewayProxyEventQueryStringParameters | null
+  multiValueQueryStringParameters: APIGatewayProxyEventMultiValueQueryStringParameters | null
+  stageVariables: APIGatewayProxyEventStageVariables | null
+  requestContext: {
+    domainName?: string | undefined
+  }
+  resource: string
+}

--- a/packages/standard-server-aws-lambda/src/types.ts
+++ b/packages/standard-server-aws-lambda/src/types.ts
@@ -4,10 +4,6 @@ export interface APIGatewayProxyEventHeaders {
   [name: string]: string | undefined
 }
 
-export interface APIGatewayProxyEventMultiValueHeaders {
-  [name: string]: string[] | undefined
-}
-
 export interface APIGatewayProxyEventPathParameters {
   [name: string]: string | undefined
 }
@@ -16,27 +12,28 @@ export interface APIGatewayProxyEventQueryStringParameters {
   [name: string]: string | undefined
 }
 
-export interface APIGatewayProxyEventMultiValueQueryStringParameters {
-  [name: string]: string[] | undefined
-}
-
 export interface APIGatewayProxyEventStageVariables {
   [name: string]: string | undefined
 }
 
-export interface APIGatewayProxyEvent {
-  body: string | null
+export interface APIGatewayProxyEventV2 {
+  version: string
+  routeKey: string
+  rawPath: string
+  rawQueryString: string
+  cookies?: string[]
   headers: APIGatewayProxyEventHeaders
-  multiValueHeaders: APIGatewayProxyEventMultiValueHeaders
-  httpMethod: string
-  isBase64Encoded: boolean
-  path: string
-  pathParameters: APIGatewayProxyEventPathParameters | null
-  queryStringParameters: APIGatewayProxyEventQueryStringParameters | null
-  multiValueQueryStringParameters: APIGatewayProxyEventMultiValueQueryStringParameters | null
-  stageVariables: APIGatewayProxyEventStageVariables | null
+  queryStringParameters?: APIGatewayProxyEventQueryStringParameters
   requestContext: {
-    domainName?: string | undefined
+    domainName: string
+    http: {
+      method: string
+      path: string
+      protocol: string
+    }
   }
-  resource: string
+  body?: string
+  pathParameters?: APIGatewayProxyEventPathParameters
+  isBase64Encoded: boolean
+  stageVariables?: APIGatewayProxyEventStageVariables
 }

--- a/packages/standard-server-aws-lambda/src/url.test.ts
+++ b/packages/standard-server-aws-lambda/src/url.test.ts
@@ -1,0 +1,62 @@
+import { toStandardUrl } from './url'
+
+describe('toStandardUrl', () => {
+  it('origin', async () => {
+    expect(toStandardUrl({
+      requestContext: {
+        domainName: 'example1.com',
+      },
+      headers: {
+        host: 'example2.com',
+      },
+      multiValueHeaders: {
+        host: ['example3.com', 'example4.com'],
+      },
+      path: '/',
+    } as any).origin).toEqual('https://example1.com')
+
+    expect(toStandardUrl({
+      requestContext: {},
+      headers: {
+        host: 'example2.com',
+      },
+      multiValueHeaders: {
+        host: ['example3.com', 'example4.com'],
+      },
+      path: '/',
+    } as any).origin).toEqual('https://example2.com')
+
+    expect(toStandardUrl({
+      requestContext: {},
+      headers: {},
+      multiValueHeaders: {
+        host: ['example3.com', 'example4.com'],
+      },
+      path: '/',
+    } as any).origin).toEqual('https://example3.com')
+
+    expect(toStandardUrl({
+      requestContext: {},
+      headers: {},
+      multiValueHeaders: {},
+      path: '/',
+    } as any).origin).toEqual('https://localhost')
+  })
+
+  it('query string', async () => {
+    expect(toStandardUrl({
+      requestContext: {},
+      headers: {},
+      multiValueHeaders: {},
+      path: '/',
+      queryStringParameters: {
+        key1: 'value1',
+        key2: 'value2',
+      },
+      multiValueQueryStringParameters: {
+        key2: ['value3', 'value4'],
+        key3: ['value5', 'value6'],
+      },
+    } as any).search).toEqual('?key1=value1&key2=value2&key2=value3&key2=value4&key3=value5&key3=value6')
+  })
+})

--- a/packages/standard-server-aws-lambda/src/url.test.ts
+++ b/packages/standard-server-aws-lambda/src/url.test.ts
@@ -1,62 +1,11 @@
 import { toStandardUrl } from './url'
 
-describe('toStandardUrl', () => {
-  it('origin', async () => {
-    expect(toStandardUrl({
-      requestContext: {
-        domainName: 'example1.com',
-      },
-      headers: {
-        host: 'example2.com',
-      },
-      multiValueHeaders: {
-        host: ['example3.com', 'example4.com'],
-      },
-      path: '/',
-    } as any).origin).toEqual('https://example1.com')
-
-    expect(toStandardUrl({
-      requestContext: {},
-      headers: {
-        host: 'example2.com',
-      },
-      multiValueHeaders: {
-        host: ['example3.com', 'example4.com'],
-      },
-      path: '/',
-    } as any).origin).toEqual('https://example2.com')
-
-    expect(toStandardUrl({
-      requestContext: {},
-      headers: {},
-      multiValueHeaders: {
-        host: ['example3.com', 'example4.com'],
-      },
-      path: '/',
-    } as any).origin).toEqual('https://example3.com')
-
-    expect(toStandardUrl({
-      requestContext: {},
-      headers: {},
-      multiValueHeaders: {},
-      path: '/',
-    } as any).origin).toEqual('https://localhost')
-  })
-
-  it('query string', async () => {
-    expect(toStandardUrl({
-      requestContext: {},
-      headers: {},
-      multiValueHeaders: {},
-      path: '/',
-      queryStringParameters: {
-        key1: 'value1',
-        key2: 'value2',
-      },
-      multiValueQueryStringParameters: {
-        key2: ['value3', 'value4'],
-        key3: ['value5', 'value6'],
-      },
-    } as any).search).toEqual('?key1=value1&key2=value2&key2=value3&key2=value4&key3=value5&key3=value6')
-  })
+it('toStandardUrl', () => {
+  expect(toStandardUrl({
+    requestContext: {
+      domainName: 'example.com',
+    },
+    rawPath: '/api/planets',
+    rawQueryString: 'key1=value1&key2=value2',
+  } as any)).toEqual(new URL('https://example.com/api/planets?key1=value1&key2=value2'))
 })

--- a/packages/standard-server-aws-lambda/src/url.ts
+++ b/packages/standard-server-aws-lambda/src/url.ts
@@ -1,6 +1,6 @@
-import type { APIGatewayEvent } from 'aws-lambda'
+import type { APIGatewayProxyEvent } from './types'
 
-export function toStandardUrl(event: APIGatewayEvent): URL {
+export function toStandardUrl(event: APIGatewayProxyEvent): URL {
   const host = event.requestContext.domainName ?? event.headers.host ?? event.multiValueHeaders.host?.[0] ?? 'localhost'
   const url = new URL(`https://${host}${event.path}`)
 

--- a/packages/standard-server-aws-lambda/src/url.ts
+++ b/packages/standard-server-aws-lambda/src/url.ts
@@ -1,0 +1,29 @@
+import type { APIGatewayEvent } from 'aws-lambda'
+import { flattenHeader } from '@orpc/standard-server'
+
+export function toStandardUrl(event: APIGatewayEvent): URL {
+  const host = event.requestContext.domainName ?? event.headers.host ?? flattenHeader(event.multiValueHeaders.host) ?? 'localhost'
+  const url = new URL(`https://${host}${event.path}`)
+
+  if (event.queryStringParameters) {
+    for (const key in event.queryStringParameters) {
+      const value = event.queryStringParameters[key]
+      if (typeof value === 'string') {
+        url.searchParams.append(key, value)
+      }
+    }
+  }
+
+  if (event.multiValueQueryStringParameters) {
+    for (const key in event.multiValueQueryStringParameters) {
+      const value = event.multiValueQueryStringParameters[key]
+      if (value) {
+        for (const v of value) {
+          url.searchParams.append(key, v)
+        }
+      }
+    }
+  }
+
+  return url
+}

--- a/packages/standard-server-aws-lambda/src/url.ts
+++ b/packages/standard-server-aws-lambda/src/url.ts
@@ -1,28 +1,5 @@
-import type { APIGatewayProxyEvent } from './types'
+import type { APIGatewayProxyEventV2 } from './types'
 
-export function toStandardUrl(event: APIGatewayProxyEvent): URL {
-  const host = event.requestContext.domainName ?? event.headers.host ?? event.multiValueHeaders.host?.[0] ?? 'localhost'
-  const url = new URL(`https://${host}${event.path}`)
-
-  if (event.queryStringParameters) {
-    for (const key in event.queryStringParameters) {
-      const value = event.queryStringParameters[key]
-      if (typeof value === 'string') {
-        url.searchParams.append(key, value)
-      }
-    }
-  }
-
-  if (event.multiValueQueryStringParameters) {
-    for (const key in event.multiValueQueryStringParameters) {
-      const value = event.multiValueQueryStringParameters[key]
-      if (value) {
-        for (const v of value) {
-          url.searchParams.append(key, v)
-        }
-      }
-    }
-  }
-
-  return url
+export function toStandardUrl(event: APIGatewayProxyEventV2): URL {
+  return new URL(`https://${event.requestContext.domainName}${event.rawPath}?${event.rawQueryString}`)
 }

--- a/packages/standard-server-aws-lambda/src/url.ts
+++ b/packages/standard-server-aws-lambda/src/url.ts
@@ -1,8 +1,7 @@
 import type { APIGatewayEvent } from 'aws-lambda'
-import { flattenHeader } from '@orpc/standard-server'
 
 export function toStandardUrl(event: APIGatewayEvent): URL {
-  const host = event.requestContext.domainName ?? event.headers.host ?? flattenHeader(event.multiValueHeaders.host) ?? 'localhost'
+  const host = event.requestContext.domainName ?? event.headers.host ?? event.multiValueHeaders.host?.[0] ?? 'localhost'
   const url = new URL(`https://${host}${event.path}`)
 
   if (event.queryStringParameters) {

--- a/packages/standard-server-aws-lambda/tsconfig.json
+++ b/packages/standard-server-aws-lambda/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.lib.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "references": [
+    { "path": "../shared" }
+  ],
+  "include": ["src"],
+  "exclude": [
+    "**/*.test.*",
+    "**/*.test-d.ts",
+    "**/*.bench.*",
+    "**/__tests__/**",
+    "**/__mocks__/**",
+    "**/__snapshots__/**"
+  ]
+}

--- a/packages/standard-server-fetch/playground/event-source.ts
+++ b/packages/standard-server-fetch/playground/event-source.ts
@@ -1,45 +1,13 @@
-import { isAsyncIteratorObject } from '@orpc/shared'
-import { toStandardLazyRequest } from '../src/request'
-import { toFetchResponse } from '../src/response'
-import { serve } from '@hono/node-server'
-
-serve({
+Bun.serve({
   async fetch(request) {
-    const body = await toStandardLazyRequest(request).body()
-
-    if (isAsyncIteratorObject(body)) {
-      while (true) {
-        const value = await body.next()
-
-        console.log(value)
-
-        if (value.done) {
-          break
-        }
-      }
-    }
-
-    async function* gen() {
-      try {
-        while (true) {
-          yield `hello${Date.now()}`
-          console.log('yield')
-          await new Promise(resolve => setTimeout(resolve, 1000))
-        }
-      }
-      catch {
-        console.log('---------------------error')
-      }
-      finally {
-        console.log('---------------------done')
-      }
-    }
-
-    return toFetchResponse({
-      headers: {},
-      status: 200,
-      body: gen(),
+    console.log('fetch')
+    request.signal.addEventListener('abort', () => {
+      console.log('abort')
     })
+
+    await new Promise(r => setTimeout(r, 5000))
+
+    return new Response('success')
   },
   port: 3000,
 })

--- a/packages/standard-server-fetch/playground/event-source.ts
+++ b/packages/standard-server-fetch/playground/event-source.ts
@@ -1,13 +1,45 @@
-Bun.serve({
+import { isAsyncIteratorObject } from '@orpc/shared'
+import { toStandardLazyRequest } from '../src/request'
+import { toFetchResponse } from '../src/response'
+import { serve } from '@hono/node-server'
+
+serve({
   async fetch(request) {
-    console.log('fetch')
-    request.signal.addEventListener('abort', () => {
-      console.log('abort')
+    const body = await toStandardLazyRequest(request).body()
+
+    if (isAsyncIteratorObject(body)) {
+      while (true) {
+        const value = await body.next()
+
+        console.log(value)
+
+        if (value.done) {
+          break
+        }
+      }
+    }
+
+    async function* gen() {
+      try {
+        while (true) {
+          yield `hello${Date.now()}`
+          console.log('yield')
+          await new Promise(resolve => setTimeout(resolve, 1000))
+        }
+      }
+      catch {
+        console.log('---------------------error')
+      }
+      finally {
+        console.log('---------------------done')
+      }
+    }
+
+    return toFetchResponse({
+      headers: {},
+      status: 200,
+      body: gen(),
     })
-
-    await new Promise(r => setTimeout(r, 5000))
-
-    return new Response('success')
   },
   port: 3000,
 })

--- a/packages/standard-server-fetch/src/event-iterator.test.ts
+++ b/packages/standard-server-fetch/src/event-iterator.test.ts
@@ -42,7 +42,7 @@ describe('toEventIterator', () => {
     })
   })
 
-  it('without dont event', async () => {
+  it('without done event', async () => {
     const stream = new ReadableStream<string>({
       async pull(controller) {
         controller.enqueue(': ping\n\n')

--- a/packages/standard-server-node/src/event-iterator.test.ts
+++ b/packages/standard-server-node/src/event-iterator.test.ts
@@ -43,7 +43,7 @@ describe('toEventIterator', () => {
     })
   })
 
-  it('without dont event', async () => {
+  it('without done event', async () => {
     const stream = Readable.fromWeb(new ReadableStream<string>({
       async pull(controller) {
         controller.enqueue('event: message\ndata: {"order": 1}\nid: id-1\nretry: 10000\n\n')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -453,6 +453,19 @@ importers:
         specifier: workspace:*
         version: link:../shared
 
+  packages/standard-server-aws-lambda:
+    dependencies:
+      '@orpc/shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@orpc/standard-server':
+        specifier: workspace:*
+        version: link:../standard-server
+    devDependencies:
+      '@types/aws-lambda':
+        specifier: ^8.10.149
+        version: 8.10.149
+
   packages/standard-server-fetch:
     dependencies:
       '@orpc/shared':
@@ -4566,6 +4579,9 @@ packages:
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/aws-lambda@8.10.149':
+    resolution: {integrity: sha512-NXSZIhfJjnXqJgtS7IwutqIF/SOy1Wz5Px4gUY1RWITp3AYTyuJS4xaXr/bIJY1v15XMzrJ5soGnPM+7uigZjA==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -16537,6 +16553,8 @@ snapshots:
     optional: true
 
   '@types/aria-query@5.0.4': {}
+
+  '@types/aws-lambda@8.10.149': {}
 
   '@types/babel__core@7.20.5':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,6 +465,9 @@ importers:
       '@types/aws-lambda':
         specifier: ^8.10.149
         version: 8.10.149
+      '@types/node':
+        specifier: ^22.15.17
+        version: 22.15.21
 
   packages/standard-server-fetch:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,6 +393,9 @@ importers:
       '@orpc/standard-server':
         specifier: workspace:*
         version: link:../standard-server
+      '@orpc/standard-server-aws-lambda':
+        specifier: workspace:*
+        version: link:../standard-server-aws-lambda
       '@orpc/standard-server-fetch':
         specifier: workspace:*
         version: link:../standard-server-fetch

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     { "path": "./packages/standard-server" },
     { "path": "./packages/standard-server-fetch" },
     { "path": "./packages/standard-server-node" },
+    { "path": "./packages/standard-server-aws-lambda" },
     { "path": "./packages/standard-server-peer" }
   ],
   "include": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced AWS Lambda adapters for oRPC, enabling seamless integration with AWS Lambda for both RPC and OpenAPI endpoints.
  - Added comprehensive support for Lambda event and response handling, including streaming, headers, body conversion, and abort signal integration.
  - Provided example usage and updated documentation for deploying oRPC endpoints on AWS Lambda.
  - Added utilities for converting Lambda event bodies, headers, URLs, and requests to standardized formats and vice versa.
  - Enabled strict HTTP method enforcement in RPC handler with default GET method checking.

- **Bug Fixes**
  - None.

- **Documentation**
  - Updated and expanded documentation to cover AWS Lambda integration, usage examples, and adapter details.

- **Tests**
  - Added extensive test coverage for Lambda adapters, including body parsing and serialization, headers conversion, event streaming, request/response handling, abort signals, and type compatibility.

- **Chores**
  - Added configuration, metadata, and project references for the new AWS Lambda adapter package.
  - Added new package for standard server AWS Lambda adapter with build and type scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->