### PR TITLE
feat(openapi): parse bracket notation with same name as array

### DIFF
--- a/apps/content/docs/openapi/bracket-notation.md
+++ b/apps/content/docs/openapi/bracket-notation.md
@@ -9,9 +9,29 @@ Bracket Notation encodes structured data in formats with limited syntax, like UR
 
 ## Usage
 
-- Append `[]` **at the end** to denote an array.
-- Append `[number]` to specify an array index (missing indexes create sparse arrays).
-- Append `[key]` to denote an object property.
+1. **Same name (>=2 elements) are represented as an array.**
+
+   ```
+   color=red&color=blue → { color: ["red", "blue"] }
+   ```
+
+2. **Append `[]` at the end to denote an array.**
+
+   ```
+   color[]=red&color[]=blue → { color: ["red", "blue"] }
+   ```
+
+3. **Append `[number]` to specify an array index (missing indexes create sparse arrays).**
+
+   ```
+   color[0]=red&color[2]=blue → { color: ["red", <empty>, "blue"] }
+   ```
+
+4. **Append `[key]` to denote an object property.**
+
+   ```
+   color[red]=true&color[blue]=false → { color: { red: true, blue: false } }
+   ```
 
 ## Limitations
 

--- a/packages/openapi-client/src/adapters/standard/bracket-notation.test.ts
+++ b/packages/openapi-client/src/adapters/standard/bracket-notation.test.ts
@@ -162,16 +162,45 @@ describe('standardBracketNotationSerializer', () => {
       ])).toEqual({ '0': 1, '': 2 })
     })
 
-    it('can deserialize when conflict keys', () => {
+    it('should be an array if conflict keys', () => {
       expect(serializer.deserialize([
         ['a', 1],
         ['a', 2],
-      ])).toEqual({ a: 2 })
+      ])).toEqual({ a: [1, 2] })
 
       expect(serializer.deserialize([
         ['0', 1],
         ['0', 2],
-      ])).toEqual([2])
+      ])).toEqual([[1, 2]])
+
+      expect(serializer.deserialize([
+        ['a', 1],
+        ['a', 2],
+        ['a[2]', 3],
+      ])).toEqual({ a: [1, 2, 3] })
+
+      expect(serializer.deserialize([
+        ['0', 1],
+        ['0', 2],
+        ['0[user]', 3],
+      ])).toEqual([{
+        0: 1,
+        1: 2,
+        user: 3,
+      }])
+
+      expect(serializer.deserialize([
+        ['users[]', 1],
+        ['users[name]', 2],
+        ['users[name]', 3],
+        ['users[name]', 4],
+        ['users[]', 5],
+      ])).toEqual({
+        users: {
+          '': [1, 5],
+          'name': [2, 3, 4],
+        },
+      })
     })
 
     it('can deserialize mixed nested structures', () => {

--- a/packages/openapi-client/src/adapters/standard/bracket-notation.test.ts
+++ b/packages/openapi-client/src/adapters/standard/bracket-notation.test.ts
@@ -188,17 +188,48 @@ describe('standardBracketNotationSerializer', () => {
         1: 2,
         user: 3,
       }])
+    })
+
+    it('should be an array if [] conflict keys', () => {
+      expect(serializer.deserialize([
+        ['users[]', 1],
+        ['users[]', 2],
+        ['users[name]', 3],
+      ])).toEqual({
+        users: {
+          '': [1, 2],
+          'name': 3,
+        },
+      })
 
       expect(serializer.deserialize([
         ['users[]', 1],
-        ['users[name]', 2],
-        ['users[name]', 3],
-        ['users[name]', 4],
+        ['users[]', 2],
+        ['users[name][]', 3],
+        ['users[name][]', 4],
         ['users[]', 5],
+        ['users[name][]', 6],
       ])).toEqual({
         users: {
-          '': [1, 5],
-          'name': [2, 3, 4],
+          '': [1, 2, 5],
+          'name': [3, 4, 6],
+        },
+      })
+
+      expect(serializer.deserialize([
+        ['a[]', 1],
+        ['a[b][]', 2],
+        ['a[b][c][]', 3],
+        ['a[]', 4],
+        ['a[b][]', 5],
+        ['a[b][c][]', 6],
+      ])).toEqual({
+        a: {
+          '': [1, 4],
+          'b': {
+            '': [2, 5],
+            'c': [3, 6],
+          },
         },
       })
     })

--- a/packages/openapi-client/src/adapters/standard/bracket-notation.ts
+++ b/packages/openapi-client/src/adapters/standard/bracket-notation.ts
@@ -45,7 +45,13 @@ export class StandardBracketNotationSerializer {
 
         if (i !== segments.length - 1) {
           if (Array.isArray(currentRef[nextSegment]) && !isValidArrayIndex(segment)) {
-            currentRef[nextSegment] = { ...currentRef[nextSegment] }
+            if (arrayPushStyles.has(currentRef[nextSegment])) {
+              arrayPushStyles.delete(currentRef[nextSegment])
+              currentRef[nextSegment] = { '': currentRef[nextSegment].length === 1 ? currentRef[nextSegment][0] : currentRef[nextSegment] }
+            }
+            else {
+              currentRef[nextSegment] = { ...currentRef[nextSegment] }
+            }
           }
         }
         else {
@@ -57,7 +63,8 @@ export class StandardBracketNotationSerializer {
             }
             else {
               if (arrayPushStyles.has(currentRef[nextSegment])) {
-                currentRef[nextSegment] = { '': currentRef[nextSegment].at(-1) }
+                arrayPushStyles.delete(currentRef[nextSegment])
+                currentRef[nextSegment] = { '': currentRef[nextSegment].length === 1 ? currentRef[nextSegment][0] : currentRef[nextSegment] }
               }
 
               else if (!isValidArrayIndex(segment)) {

--- a/packages/openapi-client/src/adapters/standard/bracket-notation.ts
+++ b/packages/openapi-client/src/adapters/standard/bracket-notation.ts
@@ -71,17 +71,22 @@ export class StandardBracketNotationSerializer {
         nextSegment = segment
       })
 
-      if (Array.isArray(currentRef)) {
-        if (nextSegment === '') {
-          arrayPushStyles.add(currentRef)
-          currentRef.push(value)
-        }
-        else {
-          currentRef[Number(nextSegment)] = value
-        }
+      if (Array.isArray(currentRef) && nextSegment === '') {
+        arrayPushStyles.add(currentRef)
+        currentRef.push(value)
       }
       else {
-        currentRef[nextSegment] = value
+        if (nextSegment in currentRef) {
+          if (Array.isArray(currentRef[nextSegment])) {
+            currentRef[nextSegment].push(value)
+          }
+          else {
+            currentRef[nextSegment] = [currentRef[nextSegment], value]
+          }
+        }
+        else {
+          currentRef[nextSegment] = value
+        }
       }
     }
 

--- a/packages/openapi-client/src/adapters/standard/bracket-notation.ts
+++ b/packages/openapi-client/src/adapters/standard/bracket-notation.ts
@@ -47,10 +47,10 @@ export class StandardBracketNotationSerializer {
           if (Array.isArray(currentRef[nextSegment]) && !isValidArrayIndex(segment)) {
             if (arrayPushStyles.has(currentRef[nextSegment])) {
               arrayPushStyles.delete(currentRef[nextSegment])
-              currentRef[nextSegment] = { '': currentRef[nextSegment].length === 1 ? currentRef[nextSegment][0] : currentRef[nextSegment] }
+              currentRef[nextSegment] = pushStyleArrayToObject(currentRef[nextSegment])
             }
             else {
-              currentRef[nextSegment] = { ...currentRef[nextSegment] }
+              currentRef[nextSegment] = arrayToObject(currentRef[nextSegment])
             }
           }
         }
@@ -58,17 +58,17 @@ export class StandardBracketNotationSerializer {
           if (Array.isArray(currentRef[nextSegment])) {
             if (segment === '') {
               if (currentRef[nextSegment].length && !arrayPushStyles.has(currentRef[nextSegment])) {
-                currentRef[nextSegment] = { ...currentRef[nextSegment] }
+                currentRef[nextSegment] = arrayToObject(currentRef[nextSegment])
               }
             }
             else {
               if (arrayPushStyles.has(currentRef[nextSegment])) {
                 arrayPushStyles.delete(currentRef[nextSegment])
-                currentRef[nextSegment] = { '': currentRef[nextSegment].length === 1 ? currentRef[nextSegment][0] : currentRef[nextSegment] }
+                currentRef[nextSegment] = pushStyleArrayToObject(currentRef[nextSegment])
               }
 
               else if (!isValidArrayIndex(segment)) {
-                currentRef[nextSegment] = { ...currentRef[nextSegment] }
+                currentRef[nextSegment] = arrayToObject(currentRef[nextSegment])
               }
             }
           }
@@ -82,18 +82,16 @@ export class StandardBracketNotationSerializer {
         arrayPushStyles.add(currentRef)
         currentRef.push(value)
       }
-      else {
-        if (nextSegment in currentRef) {
-          if (Array.isArray(currentRef[nextSegment])) {
-            currentRef[nextSegment].push(value)
-          }
-          else {
-            currentRef[nextSegment] = [currentRef[nextSegment], value]
-          }
+      else if (nextSegment in currentRef) {
+        if (Array.isArray(currentRef[nextSegment])) {
+          currentRef[nextSegment].push(value)
         }
         else {
-          currentRef[nextSegment] = value
+          currentRef[nextSegment] = [currentRef[nextSegment], value]
         }
+      }
+      else {
+        currentRef[nextSegment] = value
       }
     }
 
@@ -169,4 +167,14 @@ export class StandardBracketNotationSerializer {
 
 function isValidArrayIndex(value: string): boolean {
   return /^0$|^[1-9]\d*$/.test(value)
+}
+
+function arrayToObject(array: any[]): Record<string, unknown> {
+  return { ...array }
+}
+
+function pushStyleArrayToObject(array: any[]): Record<string, unknown> {
+  return {
+    '': array.length === 1 ? array[0] : array,
+  }
 }

--- a/packages/openapi/src/openapi-generator.test.ts
+++ b/packages/openapi/src/openapi-generator.test.ts
@@ -138,7 +138,17 @@ const inputTests: TestCase[] = [
   },
   {
     name: 'query + params',
-    contract: oc.route({ path: '/planets/{id}', method: 'GET' }).input(z.object({ id: z.string(), query1: z.string(), query2: z.number().optional() })),
+    contract: oc.route({ path: '/planets/{id}', method: 'GET' }).input(
+      z.object({
+        id: z.string(),
+        query1: z.string(),
+        query2: z.number().optional(),
+        query3: z.object({
+          a: z.string(),
+        }).optional(),
+        query4: z.array(z.number()).or(z.number()),
+      }),
+    ),
     expected: {
       '/planets/{id}': {
         get: expect.objectContaining({
@@ -155,21 +165,59 @@ const inputTests: TestCase[] = [
               name: 'query1',
               in: 'query',
               required: true,
-              explode: true,
-              style: 'deepObject',
               schema: {
                 type: 'string',
               },
+              allowEmptyValue: true,
+              allowReserved: true,
             },
             {
               name: 'query2',
               in: 'query',
               required: false,
-              explode: true,
-              style: 'deepObject',
               schema: {
                 type: 'number',
               },
+              allowEmptyValue: true,
+              allowReserved: true,
+            },
+            {
+              name: 'query3',
+              in: 'query',
+              required: false,
+              schema: {
+                type: 'object',
+                properties: {
+                  a: {
+                    type: 'string',
+                  },
+                },
+                required: ['a'],
+              },
+              style: 'deepObject',
+              explode: true,
+              allowEmptyValue: true,
+              allowReserved: true,
+            },
+            {
+              name: 'query4',
+              in: 'query',
+              required: true,
+              schema: {
+                anyOf: [
+                  {
+                    type: 'array',
+                    items: {
+                      type: 'number',
+                    },
+                  },
+                  {
+                    type: 'number',
+                  },
+                ],
+              },
+              allowEmptyValue: true,
+              allowReserved: true,
             },
           ],
         }),
@@ -287,21 +335,21 @@ const inputTests: TestCase[] = [
               name: 'query1',
               in: 'query',
               required: true,
-              explode: true,
-              style: 'deepObject',
               schema: {
                 type: 'string',
               },
+              allowEmptyValue: true,
+              allowReserved: true,
             },
             {
               name: 'query2',
               in: 'query',
               required: false,
-              explode: true,
-              style: 'deepObject',
               schema: {
                 type: 'number',
               },
+              allowEmptyValue: true,
+              allowReserved: true,
             },
             {
               name: 'header1',

--- a/packages/openapi/src/openapi-utils.test.ts
+++ b/packages/openapi/src/openapi-utils.test.ts
@@ -169,9 +169,22 @@ describe('toOpenAPIParameters', () => {
     type: 'object',
     properties: {
       a: { type: 'string' },
-      b: { type: 'number' },
+      b: {
+        type: 'object',
+        properties: {
+          b1: { type: 'number' },
+          b2: { type: 'string' },
+        },
+        required: ['b1'],
+      },
+      c: {
+        oneOf: [
+          { type: 'string' },
+          { type: 'array', items: { type: 'string' } },
+        ],
+      },
     },
-    required: ['a'],
+    required: ['a', 'c'],
   }
 
   it('normal', () => {
@@ -187,7 +200,22 @@ describe('toOpenAPIParameters', () => {
       in: 'path',
       required: false,
       schema: {
-        type: 'number',
+        type: 'object',
+        properties: {
+          b1: { type: 'number' },
+          b2: { type: 'string' },
+        },
+        required: ['b1'],
+      },
+    }, {
+      name: 'c',
+      in: 'path',
+      required: true,
+      schema: {
+        oneOf: [
+          { type: 'string' },
+          { type: 'array', items: { type: 'string' } },
+        ],
       },
     }])
   })
@@ -197,11 +225,11 @@ describe('toOpenAPIParameters', () => {
       name: 'a',
       in: 'query',
       required: true,
-      explode: true,
-      style: 'deepObject',
       schema: {
         type: 'string',
       },
+      allowEmptyValue: true,
+      allowReserved: true,
     }, {
       name: 'b',
       in: 'query',
@@ -209,8 +237,27 @@ describe('toOpenAPIParameters', () => {
       explode: true,
       style: 'deepObject',
       schema: {
-        type: 'number',
+        type: 'object',
+        properties: {
+          b1: { type: 'number' },
+          b2: { type: 'string' },
+        },
+        required: ['b1'],
       },
+      allowEmptyValue: true,
+      allowReserved: true,
+    }, {
+      name: 'c',
+      in: 'query',
+      required: true,
+      schema: {
+        oneOf: [
+          { type: 'string' },
+          { type: 'array', items: { type: 'string' } },
+        ],
+      },
+      allowEmptyValue: true,
+      allowReserved: true,
     }])
   })
 })

--- a/packages/openapi/src/schema.ts
+++ b/packages/openapi/src/schema.ts
@@ -1,8 +1,8 @@
 /* eslint-disable no-restricted-imports */
 import type { JSONSchema, keywords } from 'json-schema-typed/draft-2020-12'
-import { ContentEncoding as JSONSchemaContentEncoding, Format as JSONSchemaFormat } from 'json-schema-typed/draft-2020-12'
+import { ContentEncoding as JSONSchemaContentEncoding, Format as JSONSchemaFormat, TypeName as JSONSchemaTypeName } from 'json-schema-typed/draft-2020-12'
 
-export { JSONSchemaContentEncoding, JSONSchemaFormat }
+export { JSONSchemaContentEncoding, JSONSchemaFormat, JSONSchemaTypeName }
 export type { JSONSchema }
 
 /**


### PR DESCRIPTION
- [x] Bracket Notation
- [x] OpenAPI Generator
- [x] Docs

Closes: https://github.com/unnoq/orpc/issues/518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded and clarified the documentation for bracket notation usage, providing detailed rules and examples for encoding arrays and objects in query strings and form data.

- **New Features**
  - Added utility functions for schema processing, including detection of primitive schemas and expanding arrayable schemas.
  - Exported the `JSONSchemaTypeName` type for broader schema compatibility.

- **Bug Fixes**
  - Improved deserialization logic for bracket notation to handle arrays and objects more consistently, especially with nested and conflicting keys.

- **Tests**
  - Enhanced and expanded test coverage for bracket notation deserialization, schema utilities, and OpenAPI parameter generation to support more complex and nested cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->