### PR TITLE
feat(standard-server): allow cache event iterator response

### DIFF
--- a/packages/standard-server-aws-lambda/src/response.test.ts
+++ b/packages/standard-server-aws-lambda/src/response.test.ts
@@ -124,8 +124,6 @@ describe('sendStandardResponse', () => {
       statusCode: res.status,
       headers: {
         'content-type': 'text/event-stream',
-        'cache-control': 'no-cache',
-        'connection': 'keep-alive',
         'x-custom-header': 'custom-value',
       },
       cookies: res.headers['set-cookie'],

--- a/packages/standard-server-fetch/src/body.test.ts
+++ b/packages/standard-server-fetch/src/body.test.ts
@@ -290,8 +290,6 @@ describe('toFetchBody', () => {
 
     expect(body).toBeInstanceOf(ReadableStream)
     expect([...headers]).toEqual([
-      ['cache-control', 'no-cache'],
-      ['connection', 'keep-alive'],
       ['content-type', 'text/event-stream'],
       ['x-custom-header', 'custom-value'],
     ])

--- a/packages/standard-server-fetch/src/body.ts
+++ b/packages/standard-server-fetch/src/body.ts
@@ -87,8 +87,6 @@ export function toFetchBody(
 
   if (isAsyncIteratorObject(body)) {
     headers.set('content-type', 'text/event-stream')
-    headers.set('cache-control', 'no-cache')
-    headers.set('connection', 'keep-alive')
 
     return toEventStream(body, options)
   }

--- a/packages/standard-server-node/src/body.test.ts
+++ b/packages/standard-server-node/src/body.test.ts
@@ -348,8 +348,6 @@ describe('toNodeHttpBody', () => {
     expect(body).toBeInstanceOf(Readable)
     expect(headers).toEqual({
       'content-type': 'text/event-stream',
-      'cache-control': 'no-cache',
-      'connection': 'keep-alive',
       'x-custom-header': 'custom-value',
     })
 

--- a/packages/standard-server-node/src/body.ts
+++ b/packages/standard-server-node/src/body.ts
@@ -86,8 +86,6 @@ export function toNodeHttpBody(
 
   if (isAsyncIteratorObject(body)) {
     headers['content-type'] = 'text/event-stream'
-    headers['cache-control'] = 'no-cache'
-    headers.connection = 'keep-alive'
 
     return toEventStream(body, options)
   }

--- a/packages/standard-server-node/src/response.test.ts
+++ b/packages/standard-server-node/src/response.test.ts
@@ -145,8 +145,6 @@ describe('sendStandardResponse', () => {
 
     expect(toNodeHttpBodySpy).toBeCalledTimes(1)
     expect(toNodeHttpBodySpy).toBeCalledWith(generator, {
-      'connection': 'keep-alive',
-      'cache-control': 'no-cache',
       'content-type': 'text/event-stream',
       'x-custom-header': 'custom-value',
     }, options)
@@ -156,8 +154,6 @@ describe('sendStandardResponse', () => {
 
     expect(res.status).toBe(207)
     expect(res.headers).toMatchObject({
-      'connection': 'keep-alive',
-      'cache-control': 'no-cache',
       'content-type': 'text/event-stream',
       'x-custom-header': 'custom-value',
     })


### PR DESCRIPTION
Remove `cache-control: no-cache` header in event iterator response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Removed the automatic addition of "cache-control: no-cache" and "connection: keep-alive" headers for streamed responses. Only the "content-type: text/event-stream" header is now set for these responses.
- **Tests**
  - Updated tests to reflect the removal of the "cache-control" and "connection" headers in streamed response scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->