### PR TITLE
refactor: use NullProtoObj to avoid prototype pollution when creating objects with dynamic keys

### DIFF
--- a/packages/openapi-client/src/adapters/standard/bracket-notation.ts
+++ b/packages/openapi-client/src/adapters/standard/bracket-notation.ts
@@ -1,5 +1,5 @@
 import type { Segment } from '@orpc/shared'
-import { isObject } from '@orpc/shared'
+import { isObject, NullProtoObj } from '@orpc/shared'
 
 export type StandardBracketNotationSerialized = [string, unknown][]
 
@@ -170,11 +170,19 @@ function isValidArrayIndex(value: string): boolean {
 }
 
 function arrayToObject(array: any[]): Record<string, unknown> {
-  return { ...array }
+  const obj = new NullProtoObj()
+
+  array.forEach((item, i) => {
+    obj[i] = item
+  })
+
+  return obj
 }
 
 function pushStyleArrayToObject(array: any[]): Record<string, unknown> {
-  return {
-    '': array.length === 1 ? array[0] : array,
-  }
+  const obj = new NullProtoObj()
+
+  obj[''] = array.length === 1 ? array[0] : array
+
+  return obj
 }

--- a/packages/openapi-client/src/adapters/standard/openapi-serializer.test.ts
+++ b/packages/openapi-client/src/adapters/standard/openapi-serializer.test.ts
@@ -1,4 +1,5 @@
 import { ORPCError } from '@orpc/contract'
+import { isObject } from '@orpc/shared'
 import { ErrorEvent, getEventMeta, withEventMeta } from '@orpc/standard-server'
 import { StandardBracketNotationSerializer } from './bracket-notation'
 import { StandardOpenAPIJsonSerializer } from './openapi-json-serializer'
@@ -251,7 +252,7 @@ describe('standardOpenAPIJsonSerializer', () => {
 
       const deserialized = openapiSerializer.deserialize(serialized)
 
-      expect(deserialized).toBeInstanceOf(Object)
+      expect(deserialized).toSatisfy(isObject)
       expect(deserialized).toEqual({
         date: data.date.toString(),
         number: data.number.toString(),
@@ -280,7 +281,7 @@ describe('standardOpenAPIJsonSerializer', () => {
 
       const deserialized = openapiSerializer.deserialize(serialized)
 
-      expect(deserialized).toBeInstanceOf(Object)
+      expect(deserialized).toSatisfy(isObject)
       expect(deserialized).toEqual(data)
     })
 

--- a/packages/server/src/adapters/standard/rpc-matcher.ts
+++ b/packages/server/src/adapters/standard/rpc-matcher.ts
@@ -5,6 +5,7 @@ import type { AnyRouter } from '../../router'
 import type { LazyTraverseContractProceduresOptions } from '../../router-utils'
 import type { StandardMatcher, StandardMatchResult } from './types'
 import { toHttpPath } from '@orpc/client/standard'
+import { NullProtoObj } from '@orpc/shared'
 import { unlazy } from '../../lazy'
 import { isProcedure } from '../../procedure'
 import { createContractedProcedure } from '../../procedure-utils'
@@ -19,7 +20,7 @@ export class StandardRPCMatcher implements StandardMatcher {
       procedure: AnyProcedure | undefined
       router: AnyRouter
     }
-  > = {}
+  > = new NullProtoObj()
 
   private pendingRouters: (LazyTraverseContractProceduresOptions & { httpPathPrefix: HTTPPath }) [] = []
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -36,5 +36,10 @@
   "dependencies": {
     "radash": "^12.1.0",
     "type-fest": "^4.39.1"
+  },
+  "devDependencies": {
+    "arktype": "2.1.20",
+    "valibot": "^1.1.0",
+    "zod": "^3.25.23"
   }
 }

--- a/packages/shared/src/object.ts
+++ b/packages/shared/src/object.ts
@@ -81,3 +81,10 @@ export function isPropertyKey(value: unknown): value is PropertyKey {
   const type = typeof value
   return type === 'string' || type === 'number' || type === 'symbol'
 }
+
+export const NullProtoObj = /* @__PURE__ */ (() => {
+  const e = function () { }
+  e.prototype = Object.create(null)
+  Object.freeze(e.prototype)
+  return e
+})() as unknown as ({ new<T extends Record<PropertyKey, unknown>>(): T })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -452,6 +452,16 @@ importers:
       type-fest:
         specifier: ^4.39.1
         version: 4.41.0
+    devDependencies:
+      arktype:
+        specifier: 2.1.20
+        version: 2.1.20
+      valibot:
+        specifier: ^1.1.0
+        version: 1.1.0(typescript@5.8.3)
+      zod:
+        specifier: ^3.25.23
+        version: 3.25.23
 
   packages/solid-query:
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new object type with no prototype, enhancing security and compatibility with validation libraries.
- **Tests**
  - Added tests to verify the behavior and compatibility of the new object type with popular validation libraries.
- **Chores**
  - Added new development dependencies for validation libraries.
- **Bug Fixes**
  - Improved object creation methods to prevent prototype pollution and ensure consistent object behavior across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->