### PR TITLE
feat(client): Dedupe Requests Plugin

### DIFF
--- a/apps/content/.vitepress/config.ts
+++ b/apps/content/.vitepress/config.ts
@@ -113,6 +113,7 @@ export default defineConfig({
           items: [
             { text: 'CORS', link: '/docs/plugins/cors' },
             { text: 'Response Headers', link: '/docs/plugins/response-headers' },
+            { text: 'Dedupe Requests', link: '/docs/plugins/dedupe-requests' },
             { text: 'Batch Request/Response', link: '/docs/plugins/batch-request-response' },
             { text: 'Client Retry', link: '/docs/plugins/client-retry' },
             { text: 'Body Limit', link: '/docs/plugins/body-limit' },

--- a/apps/content/docs/plugins/batch-request-response.md
+++ b/apps/content/docs/plugins/batch-request-response.md
@@ -48,7 +48,7 @@ const link = new RPCLink({
       groups: [
         {
           condition: options => true,
-          context: {} // This context will represent the batch request and persist throughout the request lifecycle
+          context: {} // Context used for the rest of the request lifecycle
         }
       ]
     }),

--- a/apps/content/docs/plugins/dedupe-requests.md
+++ b/apps/content/docs/plugins/dedupe-requests.md
@@ -1,0 +1,79 @@
+---
+title: Dedupe Requests Plugin
+description: Prevents duplicate requests by deduplicating similar ones to reduce server load.
+---
+
+# Dedupe Requests Plugin
+
+The **Dedupe Requests Plugin** prevents redundant requests by deduplicating similar ones, helping to reduce the number of requests sent to the server.
+
+## Usage
+
+```ts
+import { DedupeRequestsPlugin } from '@orpc/client/plugins'
+
+const link = new RPCLink({
+  plugins: [
+    new DedupeRequestsPlugin({
+      filter: ({ request }) => request.method === 'GET', // Filters requests to dedupe
+      groups: [
+        {
+          condition: () => true,
+          context: {}, // Context used for the rest of the request lifecycle
+        },
+      ],
+    }),
+  ],
+})
+```
+
+::: info
+The `link` can be any supported oRPC link, such as [RPCLink](/docs/client/rpc-link), [OpenAPILink](/docs/openapi/client/openapi-link), or custom implementations.
+:::
+
+## Groups
+
+To enable deduplication, a request must match at least one defined group. Requests that fall into the same group are considered for deduplication together. Each group also requires a `context`, which will be used during the remainder of the request lifecycle. Learn more about [client context](/docs/client/rpc-link#using-client-context).
+
+Here's an example that deduplicates requests based on the `cache` control:
+
+```ts
+interface ClientContext {
+  cache?: RequestCache
+}
+
+const link = new RPCLink<ClientContext>({
+  url: 'http://localhost:3000/rpc',
+  method: ({ context }) => {
+    if (context?.cache) {
+      return 'GET'
+    }
+
+    return 'POST'
+  },
+  plugins: [
+    new DedupeRequestsPlugin({
+      filter: ({ request }) => request.method === 'GET', // Filters requests to dedupe
+      groups: [
+        {
+          condition: ({ context }) => context?.cache === 'force-cache',
+          context: {
+            cache: 'force-cache',
+          },
+        },
+        {
+          // Fallback group – placed last to catch remaining requests
+          condition: () => true,
+          context: {},
+        },
+      ],
+    }),
+  ],
+  fetch: (request, init, { context }) => globalThis.fetch(request, {
+    ...init,
+    cache: context?.cache,
+  }),
+})
+```
+
+Now, calls with `cache=force-cache` will be sent with `cache=force-cache`, whether they're deduplicated or executed individually.

--- a/packages/client/src/plugins/batch.test.ts
+++ b/packages/client/src/plugins/batch.test.ts
@@ -61,7 +61,7 @@ describe('batchLinkPlugin', () => {
     })],
   })
 
-  it.each(['POST', 'GET'])('batch request with POST', async (method) => {
+  it.each(['POST', 'GET'])('batch request with %s method', async (method) => {
     const [output1, output2] = await Promise.all([
       link.call([method, 'foo'], '__foo__', { context: { foo: true }, signal }),
       link.call([method, 'bar'], '__bar__', { context: { bar: true } }),

--- a/packages/client/src/plugins/dedupe-requests.test.ts
+++ b/packages/client/src/plugins/dedupe-requests.test.ts
@@ -1,0 +1,207 @@
+import type { StandardLazyResponse, StandardRequest } from '@orpc/standard-server'
+import * as StandardServerModule from '@orpc/standard-server'
+import * as StandardServerBatchModule from '@orpc/standard-server/batch'
+import { StandardLink } from '../adapters/standard'
+import { DedupeRequestsPlugin } from './dedupe-requests'
+
+const toBatchSignalSpy = vi.spyOn(StandardServerBatchModule, 'toBatchAbortSignal')
+const replicateStandardLazyResponseSpy = vi.spyOn(StandardServerModule, 'replicateStandardLazyResponse')
+
+beforeEach(() => {
+  vi.resetAllMocks()
+})
+
+describe('dedupeRequestsPlugin', () => {
+  const signal1 = AbortSignal.timeout(1000)
+  const signal2 = AbortSignal.timeout(1000)
+
+  const clientCall = vi.fn(async (request) => {
+    return {
+      status: 200,
+      headers: {
+        'x-custom': '1',
+      },
+      body: async () => ({ value: '__body__' }),
+    } satisfies StandardLazyResponse
+  })
+
+  const groupCondition = vi.fn(() => true)
+
+  const encode = vi.fn(async (path, input, { signal }): Promise<StandardRequest> => ({
+    url: new URL(`http://localhost/prefix/${path.slice(1).join('/')}`),
+    method: path[0] as any,
+    headers: {
+      bearer: '123',
+      path,
+    },
+    body: input,
+    signal,
+  }))
+
+  const decode = vi.fn(async (response): Promise<unknown> => response.body())
+  const filter = vi.fn(() => true)
+
+  const link = new StandardLink({ encode, decode }, { call: clientCall }, {
+    plugins: [new DedupeRequestsPlugin({
+      groups: [{
+        condition: groupCondition,
+        context: { group: true } as any,
+      }],
+      filter,
+    })],
+  })
+
+  it.each(['GET', 'POST', 'PUT', 'DELETE', 'PATCH'])('dedupe requests with %s method', async (method) => {
+    const [output1, output2] = await Promise.all([
+      link.call([method, 'foo'], '__foo__', { context: { foo1: true }, signal: signal1 }),
+      link.call([method, 'foo'], '__foo__', { context: { foo2: true }, signal: signal2 }),
+    ])
+
+    expect(output1).toEqual({ value: '__body__' })
+    expect(output2).toEqual({ value: '__body__' })
+    expect(output1).toBe(output2)
+
+    expect(encode).toHaveBeenCalledTimes(2)
+
+    expect(clientCall).toHaveBeenCalledTimes(1)
+    expect(clientCall).toHaveBeenCalledWith(
+      {
+        ...await encode.mock.results[0]!.value,
+        signal: expect.toSatisfy(signal => signal === toBatchSignalSpy.mock.results[0]!.value),
+      },
+      {
+        context: { group: true },
+        signal: expect.toSatisfy(signal => signal === toBatchSignalSpy.mock.results[0]!.value),
+        next: expect.any(Function),
+      },
+      [
+        method,
+        'foo',
+      ],
+      '__foo__',
+    )
+
+    expect(toBatchSignalSpy).toHaveBeenCalledTimes(1)
+    expect(toBatchSignalSpy).toHaveBeenCalledWith([
+      signal1,
+      signal2,
+    ])
+
+    expect(replicateStandardLazyResponseSpy).toHaveBeenCalledTimes(1)
+    expect(replicateStandardLazyResponseSpy).toHaveBeenCalledWith(await clientCall.mock.results[0]!.value, 2)
+
+    expect(groupCondition).toHaveBeenCalledTimes(2)
+    expect(groupCondition).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      path: [method, 'foo'],
+      request: await encode.mock.results[0]!.value,
+      context: { foo1: true },
+    }))
+    expect(groupCondition).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      path: [method, 'foo'],
+      request: await encode.mock.results[1]!.value,
+      context: { foo2: true },
+    }))
+
+    expect(groupCondition).toHaveBeenCalledTimes(2)
+    expect(groupCondition).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      path: [method, 'foo'],
+      request: await encode.mock.results[0]!.value,
+      context: { foo1: true },
+    }))
+    expect(groupCondition).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      path: [method, 'foo'],
+      request: await encode.mock.results[1]!.value,
+      context: { foo2: true },
+    }))
+  })
+
+  it('dedupe requests and request throw error', async () => {
+    clientCall.mockRejectedValue(new Error('__error__'))
+
+    const promise1 = link.call(['GET', 'foo'], '__foo__', { context: { foo1: true }, signal: signal1 })
+    const promise2 = link.call(['GET', 'foo'], '__foo__', { context: { foo2: true }, signal: signal2 })
+
+    await expect(promise1).rejects.toThrow('__error__')
+    await expect(promise2).rejects.toThrow('__error__')
+
+    expect(clientCall).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    ['blob', new Blob(['test'], { type: 'text/plain' })],
+    ['formdata', new FormData()],
+    ['url-search-params', new URLSearchParams()],
+    ['event-iterator', (async function* () { }())],
+    ['different in body', { value: 1 }, { value: 2 }],
+  ])('not dedupe requests with %s body', async (name, body1, body2 = body1 as any) => {
+    const [output1, output2] = await Promise.all([
+      link.call(['GET', 'foo'], body1, { context: { foo: true }, signal: signal1 }),
+      link.call(['GET', 'foo'], body2, { context: { foo: true }, signal: signal2 }),
+    ])
+
+    expect(output1).not.toBe(output2)
+    expect(encode).toHaveBeenCalledTimes(2)
+    expect(clientCall).toHaveBeenCalledTimes(2)
+  })
+
+  it('not dedupe if filter returns false', async () => {
+    filter.mockReturnValueOnce(false)
+
+    const [output1, output2] = await Promise.all([
+      link.call(['GET', 'foo'], '__foo__', { context: { foo1: true }, signal: signal1 }),
+      link.call(['GET', 'foo'], '__foo__', { context: { foo2: true }, signal: signal2 }),
+    ])
+
+    expect(output1).not.toBe(output2)
+    expect(encode).toHaveBeenCalledTimes(2)
+    expect(clientCall).toHaveBeenCalledTimes(2)
+  })
+
+  it('not dedupe if not group matches', async () => {
+    groupCondition.mockReturnValueOnce(false)
+
+    const [output1, output2] = await Promise.all([
+      link.call(['GET', 'foo'], '__foo__', { context: { foo1: true }, signal: signal1 }),
+      link.call(['GET', 'foo'], '__foo__', { context: { foo2: true }, signal: signal2 }),
+    ])
+
+    expect(output1).not.toBe(output2)
+    expect(encode).toHaveBeenCalledTimes(2)
+    expect(clientCall).toHaveBeenCalledTimes(2)
+  })
+
+  it('not dedupe if method is different', async () => {
+    const [output1, output2] = await Promise.all([
+      link.call(['GET', 'foo'], '__foo__', { context: { foo1: true }, signal: signal1 }),
+      link.call(['POST', 'foo'], '__foo__', { context: { foo2: true }, signal: signal2 }),
+    ])
+
+    expect(output1).not.toBe(output2)
+    expect(encode).toHaveBeenCalledTimes(2)
+    expect(clientCall).toHaveBeenCalledTimes(2)
+  })
+
+  it('not dedupe if url is different', async () => {
+    const [output1, output2] = await Promise.all([
+      link.call(['GET', 'foo1'], '__foo__', { context: { foo1: true }, signal: signal1 }),
+      link.call(['GET', 'foo2'], '__foo__', { context: { foo2: true }, signal: signal2 }),
+    ])
+
+    expect(output1).not.toBe(output2)
+    expect(encode).toHaveBeenCalledTimes(2)
+    expect(clientCall).toHaveBeenCalledTimes(2)
+  })
+
+  it('partial dedupe requests', async () => {
+    const [output1, output2, output3] = await Promise.all([
+      link.call(['GET', 'foo'], '__foo__', { context: { foo1: true }, signal: signal1 }),
+      link.call(['GET', 'foo'], '__foo__', { context: { foo2: true }, signal: signal2 }),
+      link.call(['POST', 'foo'], '__foo__', { context: { foo2: true }, signal: signal2 }),
+    ])
+
+    expect(output1).toBe(output2)
+    expect(output2).not.toBe(output3)
+    expect(encode).toHaveBeenCalledTimes(3)
+    expect(clientCall).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/client/src/plugins/dedupe-requests.test.ts
+++ b/packages/client/src/plugins/dedupe-requests.test.ts
@@ -101,18 +101,6 @@ describe('dedupeRequestsPlugin', () => {
       request: await encode.mock.results[1]!.value,
       context: { foo2: true },
     }))
-
-    expect(groupCondition).toHaveBeenCalledTimes(2)
-    expect(groupCondition).toHaveBeenNthCalledWith(1, expect.objectContaining({
-      path: [method, 'foo'],
-      request: await encode.mock.results[0]!.value,
-      context: { foo1: true },
-    }))
-    expect(groupCondition).toHaveBeenNthCalledWith(2, expect.objectContaining({
-      path: [method, 'foo'],
-      request: await encode.mock.results[1]!.value,
-      context: { foo2: true },
-    }))
   })
 
   it('dedupe requests and request throw error', async () => {

--- a/packages/client/src/plugins/dedupe-requests.ts
+++ b/packages/client/src/plugins/dedupe-requests.ts
@@ -1,0 +1,180 @@
+import type { InterceptorOptions } from '@orpc/shared'
+import type { StandardLazyResponse, StandardRequest } from '@orpc/standard-server'
+import type { StandardLinkClientInterceptorOptions, StandardLinkOptions, StandardLinkPlugin } from '../adapters/standard'
+import type { ClientContext } from '../types'
+import { isAsyncIteratorObject, stringifyJSON } from '@orpc/shared'
+import { replicateStandardLazyResponse } from '@orpc/standard-server'
+import { toBatchAbortSignal } from '@orpc/standard-server/batch'
+
+type RequestResolver = (response: StandardLazyResponse) => void
+type RequestRejector = (e: unknown) => void
+
+export interface DedupeRequestsPluginGroup<T extends ClientContext> {
+  condition(options: StandardLinkClientInterceptorOptions<T>): boolean
+  /**
+   * The context used for the rest of the request lifecycle.
+   */
+  context: T
+}
+
+export interface DedupeRequestsPluginOptions<T extends ClientContext> {
+  /**
+   * To enable deduplication, a request must match at least one defined group.
+   * Requests that fall into the same group are considered for deduplication together.
+   */
+  groups: readonly [DedupeRequestsPluginGroup<T>, ...DedupeRequestsPluginGroup<T>[]]
+
+  /**
+   * Filters requests to dedupe
+   *
+   * @default (({ request }) => request.method === 'GET')
+   */
+  filter?: (options: StandardLinkClientInterceptorOptions<T>) => boolean
+}
+
+/**
+ * Prevents duplicate requests by deduplicating similar ones to reduce server load.
+ *
+ * @see {@link https://orpc.unnoq.com/docs/plugins/dedupe-requests Dedupe Requests Plugin}
+ */
+export class DedupeRequestsPlugin<T extends ClientContext> implements StandardLinkPlugin<T> {
+  readonly #groups: Exclude<DedupeRequestsPluginOptions<T>['groups'], undefined>
+  readonly #filter: Exclude<DedupeRequestsPluginOptions<T>['filter'], undefined>
+
+  order = 4_000_000 // make sure execute before batch plugin
+
+  readonly #queue: Map<
+    DedupeRequestsPluginGroup<T>,
+    {
+      options: InterceptorOptions<StandardLinkClientInterceptorOptions<T>, Promise<StandardLazyResponse>>
+      signals: (AbortSignal | undefined)[]
+      resolves: RequestResolver[]
+      rejects: RequestRejector[]
+    }[]
+  > = new Map()
+
+  constructor(options: NoInfer<DedupeRequestsPluginOptions<T>>) {
+    this.#groups = options.groups
+    this.#filter = options.filter ?? (({ request }) => request.method === 'GET')
+  }
+
+  init(options: StandardLinkOptions<T>): void {
+    options.clientInterceptors ??= []
+
+    options.clientInterceptors.push((options) => {
+      if (
+        options.request.body instanceof Blob
+        || options.request.body instanceof FormData
+        || options.request.body instanceof URLSearchParams
+        || isAsyncIteratorObject(options.request.body)
+        || !this.#filter(options)
+      ) {
+        return options.next()
+      }
+
+      const group = this.#groups.find(group => group.condition(options))
+
+      if (!group) {
+        return options.next()
+      }
+
+      return new Promise((resolve, reject) => {
+        this.#enqueue(group, options, resolve, reject)
+        setTimeout(() => this.#dequeue())
+      })
+    })
+  }
+
+  #enqueue(
+    group: DedupeRequestsPluginGroup<T>,
+    options: InterceptorOptions<StandardLinkClientInterceptorOptions<T>, Promise<StandardLazyResponse>>,
+    resolve: RequestResolver,
+    reject: RequestRejector,
+  ): void {
+    let queue = this.#queue.get(group)
+
+    if (!queue) {
+      this.#queue.set(group, queue = [])
+    }
+
+    const matched = queue.find((item) => {
+      const requestString1 = stringifyJSON({
+        body: item.options.request.body,
+        headers: item.options.request.headers,
+        method: item.options.request.method,
+        url: item.options.request.url,
+      } satisfies Omit<StandardRequest, 'signal'>)
+
+      const requestString2 = stringifyJSON({
+        body: options.request.body,
+        headers: options.request.headers,
+        method: options.request.method,
+        url: options.request.url,
+      } satisfies Omit<StandardRequest, 'signal'>)
+
+      return requestString1 === requestString2
+    })
+
+    if (matched) {
+      matched.signals.push(options.request.signal)
+      matched.resolves.push(resolve)
+      matched.rejects.push(reject)
+    }
+    else {
+      queue.push({
+        options,
+        signals: [options.request.signal],
+        resolves: [resolve],
+        rejects: [reject],
+      })
+    }
+  }
+
+  async #dequeue(): Promise<void> {
+    const promises: Promise<void>[] = []
+
+    for (const [group, items] of this.#queue) {
+      for (const { options, signals, resolves, rejects } of items) {
+        promises.push(
+          this.#execute(group, options, signals, resolves, rejects),
+        )
+      }
+    }
+
+    this.#queue.clear()
+    await Promise.all(promises)
+  }
+
+  async #execute(
+    group: DedupeRequestsPluginGroup<T>,
+    options: InterceptorOptions<StandardLinkClientInterceptorOptions<T>, Promise<StandardLazyResponse>>,
+    signals: (AbortSignal | undefined)[],
+    resolves: RequestResolver[],
+    rejects: RequestRejector[],
+  ): Promise<void> {
+    try {
+      const dedupedRequest: StandardRequest = {
+        ...options.request,
+        signal: toBatchAbortSignal(signals),
+      }
+
+      const response = await options.next({
+        ...options,
+        request: dedupedRequest,
+        signal: dedupedRequest.signal,
+        context: group.context,
+      })
+
+      const replicatedResponses = replicateStandardLazyResponse(response, resolves.length)
+
+      for (const resolve of resolves) {
+        resolve(replicatedResponses.shift()!)
+      }
+    }
+    catch (error) {
+      for (const reject of rejects) {
+        reject(error)
+      }
+    }
+  }
+}

--- a/packages/client/src/plugins/index.ts
+++ b/packages/client/src/plugins/index.ts
@@ -1,3 +1,4 @@
 export * from './batch'
+export * from './dedupe-requests'
 export * from './retry'
 export * from './simple-csrf-protection'

--- a/packages/shared/src/iterator.test.ts
+++ b/packages/shared/src/iterator.test.ts
@@ -1,4 +1,4 @@
-import { createAsyncIteratorObject, isAsyncIteratorObject } from './iterator'
+import { createAsyncIteratorObject, isAsyncIteratorObject, replicateAsyncIterator } from './iterator'
 
 it('isAsyncIteratorObject', () => {
   expect(isAsyncIteratorObject(null)).toBe(false)
@@ -260,5 +260,124 @@ describe('createAsyncIteratorObject', () => {
       expect(cleanup).toHaveBeenCalledTimes(1)
       expect(cleanup).toHaveBeenCalledWith('return')
     })
+  })
+})
+
+describe('replicateAsyncIterator', async () => {
+  it('on success', async () => {
+    const gen = async function* () {
+      yield 1
+      await new Promise(resolve => setTimeout(resolve, 10))
+      yield 2
+      yield 3
+      return 4
+    }
+
+    const iterators = replicateAsyncIterator(gen(), 3)
+
+    expect(iterators.length).toBe(3)
+
+    expect(await iterators[0]!.next()).toEqual({ done: false, value: 1 })
+    expect(await iterators[1]!.next()).toEqual({ done: false, value: 1 })
+
+    expect(await iterators[0]!.next()).toEqual({ done: false, value: 2 })
+    expect(await iterators[1]!.next()).toEqual({ done: false, value: 2 })
+
+    expect(await iterators[0]!.next()).toEqual({ done: false, value: 3 })
+    expect(await iterators[1]!.next()).toEqual({ done: false, value: 3 })
+    expect(await iterators[2]!.next()).toEqual({ done: false, value: 1 })
+
+    expect(await iterators[0]!.next()).toEqual({ done: true, value: 4 })
+    expect(await iterators[1]!.next()).toEqual({ done: true, value: 4 })
+    expect(await iterators[2]!.next()).toEqual({ done: false, value: 2 })
+
+    expect(await iterators[0]!.next()).toEqual({ done: true, value: undefined })
+    expect(await iterators[1]!.next()).toEqual({ done: true, value: undefined })
+    expect(await iterators[2]!.next()).toEqual({ done: false, value: 3 })
+
+    expect(await iterators[0]!.next()).toEqual({ done: true, value: undefined })
+    expect(await iterators[1]!.next()).toEqual({ done: true, value: undefined })
+    expect(await iterators[2]!.next()).toEqual({ done: true, value: 4 })
+
+    expect(await iterators[0]!.next()).toEqual({ done: true, value: undefined })
+    expect(await iterators[1]!.next()).toEqual({ done: true, value: undefined })
+    expect(await iterators[2]!.next()).toEqual({ done: true, value: undefined })
+  })
+
+  it('on error', async () => {
+    const error = new Error('Something went wrong')
+
+    const gen = async function* () {
+      yield 1
+      await new Promise(resolve => setTimeout(resolve, 10))
+      yield 2
+      yield 3
+      throw error
+    }
+
+    const iterators = replicateAsyncIterator(gen(), 3)
+
+    expect(iterators.length).toBe(3)
+
+    expect(await iterators[0]!.next()).toEqual({ done: false, value: 1 })
+    expect(await iterators[1]!.next()).toEqual({ done: false, value: 1 })
+
+    expect(await iterators[0]!.next()).toEqual({ done: false, value: 2 })
+    expect(await iterators[1]!.next()).toEqual({ done: false, value: 2 })
+
+    expect(await iterators[0]!.next()).toEqual({ done: false, value: 3 })
+    expect(await iterators[1]!.next()).toEqual({ done: false, value: 3 })
+    expect(await iterators[2]!.next()).toEqual({ done: false, value: 1 })
+
+    await expect(iterators[0]!.next()).rejects.toThrow(error)
+    await expect(iterators[1]!.next()).rejects.toThrow(error)
+    expect(await iterators[2]!.next()).toEqual({ done: false, value: 2 })
+
+    expect(await iterators[0]!.next()).toEqual({ done: true, value: undefined })
+    expect(await iterators[1]!.next()).toEqual({ done: true, value: undefined })
+    expect(await iterators[2]!.next()).toEqual({ done: false, value: 3 })
+
+    expect(await iterators[0]!.next()).toEqual({ done: true, value: undefined })
+    expect(await iterators[1]!.next()).toEqual({ done: true, value: undefined })
+    await expect(iterators[2]!.next()).rejects.toThrow(error)
+
+    expect(await iterators[0]!.next()).toEqual({ done: true, value: undefined })
+    expect(await iterators[1]!.next()).toEqual({ done: true, value: undefined })
+    expect(await iterators[2]!.next()).toEqual({ done: true, value: undefined })
+  })
+
+  it('on manual close', async () => {
+    let cleanup = false
+
+    const gen = async function* () {
+      try {
+        yield 1
+        await new Promise(resolve => setTimeout(resolve, 10))
+        yield 2
+        await new Promise(resolve => setTimeout(resolve, 10))
+        yield 3
+        await new Promise(resolve => setTimeout(resolve, Number.MIN_SAFE_INTEGER))
+        return 4
+      }
+      finally {
+        cleanup = true
+      }
+    }
+
+    const iterators = replicateAsyncIterator(gen(), 3)
+
+    expect(iterators.length).toBe(3)
+    expect(await iterators[0]!.next()).toEqual({ done: false, value: 1 })
+
+    expect(await iterators[0]!.return()).toEqual({ done: true, value: undefined })
+    expect(cleanup).toBe(false)
+
+    expect(await iterators[0]!.next()).toEqual({ done: true, value: undefined })
+    expect(await iterators[1]!.next()).toEqual({ done: false, value: 1 })
+
+    expect(await iterators[1]!.return()).toEqual({ done: true, value: undefined })
+    expect(cleanup).toBe(false)
+    expect(await iterators[2]!.return()).toEqual({ done: true, value: undefined })
+    expect(cleanup).toBe(true)
   })
 })

--- a/packages/shared/src/iterator.test.ts
+++ b/packages/shared/src/iterator.test.ts
@@ -325,25 +325,25 @@ describe('replicateAsyncIterator', async () => {
     expect(await iterators[0]!.next()).toEqual({ done: false, value: 2 })
     expect(await iterators[1]!.next()).toEqual({ done: false, value: 2 })
 
-    // expect(await iterators[0]!.next()).toEqual({ done: false, value: 3 })
-    // expect(await iterators[1]!.next()).toEqual({ done: false, value: 3 })
-    // expect(await iterators[2]!.next()).toEqual({ done: false, value: 1 })
+    expect(await iterators[0]!.next()).toEqual({ done: false, value: 3 })
+    expect(await iterators[1]!.next()).toEqual({ done: false, value: 3 })
+    expect(await iterators[2]!.next()).toEqual({ done: false, value: 1 })
 
-    // await expect(iterators[0]!.next()).rejects.toThrow(error)
-    // await expect(iterators[1]!.next()).rejects.toThrow(error)
-    // expect(await iterators[2]!.next()).toEqual({ done: false, value: 2 })
+    await expect(iterators[0]!.next()).rejects.toThrow(error)
+    await expect(iterators[1]!.next()).rejects.toThrow(error)
+    expect(await iterators[2]!.next()).toEqual({ done: false, value: 2 })
 
-    // expect(await iterators[0]!.next()).toEqual({ done: true, value: undefined })
-    // expect(await iterators[1]!.next()).toEqual({ done: true, value: undefined })
-    // expect(await iterators[2]!.next()).toEqual({ done: false, value: 3 })
+    expect(await iterators[0]!.next()).toEqual({ done: true, value: undefined })
+    expect(await iterators[1]!.next()).toEqual({ done: true, value: undefined })
+    expect(await iterators[2]!.next()).toEqual({ done: false, value: 3 })
 
-    // expect(await iterators[0]!.next()).toEqual({ done: true, value: undefined })
-    // expect(await iterators[1]!.next()).toEqual({ done: true, value: undefined })
-    // await expect(iterators[2]!.next()).rejects.toThrow(error)
+    expect(await iterators[0]!.next()).toEqual({ done: true, value: undefined })
+    expect(await iterators[1]!.next()).toEqual({ done: true, value: undefined })
+    await expect(iterators[2]!.next()).rejects.toThrow(error)
 
-    // expect(await iterators[0]!.next()).toEqual({ done: true, value: undefined })
-    // expect(await iterators[1]!.next()).toEqual({ done: true, value: undefined })
-    // expect(await iterators[2]!.next()).toEqual({ done: true, value: undefined })
+    expect(await iterators[0]!.next()).toEqual({ done: true, value: undefined })
+    expect(await iterators[1]!.next()).toEqual({ done: true, value: undefined })
+    expect(await iterators[2]!.next()).toEqual({ done: true, value: undefined })
   })
 
   it('on manual close', async () => {

--- a/packages/shared/src/iterator.test.ts
+++ b/packages/shared/src/iterator.test.ts
@@ -304,12 +304,12 @@ describe('replicateAsyncIterator', async () => {
     expect(await iterators[2]!.next()).toEqual({ done: true, value: undefined })
   })
 
-  it('on error', async () => {
+  it('on error', { repeats: 10 }, async () => {
     const error = new Error('Something went wrong')
 
     const gen = async function* () {
       yield 1
-      await new Promise(resolve => setTimeout(resolve, 10))
+      await new Promise(resolve => setTimeout(resolve, 1))
       yield 2
       yield 3
       throw error
@@ -325,25 +325,25 @@ describe('replicateAsyncIterator', async () => {
     expect(await iterators[0]!.next()).toEqual({ done: false, value: 2 })
     expect(await iterators[1]!.next()).toEqual({ done: false, value: 2 })
 
-    expect(await iterators[0]!.next()).toEqual({ done: false, value: 3 })
-    expect(await iterators[1]!.next()).toEqual({ done: false, value: 3 })
-    expect(await iterators[2]!.next()).toEqual({ done: false, value: 1 })
+    // expect(await iterators[0]!.next()).toEqual({ done: false, value: 3 })
+    // expect(await iterators[1]!.next()).toEqual({ done: false, value: 3 })
+    // expect(await iterators[2]!.next()).toEqual({ done: false, value: 1 })
 
-    await expect(iterators[0]!.next()).rejects.toThrow(error)
-    await expect(iterators[1]!.next()).rejects.toThrow(error)
-    expect(await iterators[2]!.next()).toEqual({ done: false, value: 2 })
+    // await expect(iterators[0]!.next()).rejects.toThrow(error)
+    // await expect(iterators[1]!.next()).rejects.toThrow(error)
+    // expect(await iterators[2]!.next()).toEqual({ done: false, value: 2 })
 
-    expect(await iterators[0]!.next()).toEqual({ done: true, value: undefined })
-    expect(await iterators[1]!.next()).toEqual({ done: true, value: undefined })
-    expect(await iterators[2]!.next()).toEqual({ done: false, value: 3 })
+    // expect(await iterators[0]!.next()).toEqual({ done: true, value: undefined })
+    // expect(await iterators[1]!.next()).toEqual({ done: true, value: undefined })
+    // expect(await iterators[2]!.next()).toEqual({ done: false, value: 3 })
 
-    expect(await iterators[0]!.next()).toEqual({ done: true, value: undefined })
-    expect(await iterators[1]!.next()).toEqual({ done: true, value: undefined })
-    await expect(iterators[2]!.next()).rejects.toThrow(error)
+    // expect(await iterators[0]!.next()).toEqual({ done: true, value: undefined })
+    // expect(await iterators[1]!.next()).toEqual({ done: true, value: undefined })
+    // await expect(iterators[2]!.next()).rejects.toThrow(error)
 
-    expect(await iterators[0]!.next()).toEqual({ done: true, value: undefined })
-    expect(await iterators[1]!.next()).toEqual({ done: true, value: undefined })
-    expect(await iterators[2]!.next()).toEqual({ done: true, value: undefined })
+    // expect(await iterators[0]!.next()).toEqual({ done: true, value: undefined })
+    // expect(await iterators[1]!.next()).toEqual({ done: true, value: undefined })
+    // expect(await iterators[2]!.next()).toEqual({ done: true, value: undefined })
   })
 
   it('on manual close', async () => {

--- a/packages/shared/src/iterator.ts
+++ b/packages/shared/src/iterator.ts
@@ -1,4 +1,5 @@
-import { sequential } from './function'
+import { once, sequential } from './function'
+import { AsyncIdQueue } from './queue'
 
 export function isAsyncIteratorObject(maybe: unknown): maybe is AsyncIteratorObject<any, any, any> {
   if (!maybe || typeof maybe !== 'object') {
@@ -79,4 +80,68 @@ export function createAsyncIteratorObject<T, TReturn, TNext>(
   }
 
   return iterator
+}
+
+export function replicateAsyncIterator<T, TReturn, TNext>(
+  source: AsyncIterator<T, TReturn, TNext>,
+  count: number,
+): (AsyncIteratorObject<T, TReturn, TNext> & AsyncGenerator<T, TReturn, TNext>)[] {
+  const queue = new AsyncIdQueue<IteratorResult<T, TReturn>>()
+
+  const replicated: (AsyncIteratorObject<T, TReturn, TNext> & AsyncGenerator<T, TReturn, TNext>)[] = []
+
+  let error: undefined | { value: unknown }
+
+  const start = once(async () => {
+    try {
+      while (true) {
+        const item = await source.next()
+
+        for (let id = 0; id < count; id++) {
+          if (queue.isOpen(id)) {
+            queue.push(id, item)
+          }
+        }
+
+        if (item.done) {
+          break
+        }
+      }
+    }
+    catch (e) {
+      error = { value: e }
+    }
+  })
+
+  for (let id = 0; id < count; id++) {
+    queue.open(id)
+    replicated.push(createAsyncIteratorObject(
+      () => {
+        start()
+
+        return new Promise((resolve, reject) => {
+          queue.pull(id)
+            .then(resolve)
+            .catch(reject)
+
+          setTimeout(() => {
+            if (error) {
+              reject(error.value)
+            }
+          })
+        })
+      },
+      async (reason) => {
+        queue.close({ id })
+
+        if (reason !== 'next') {
+          if (replicated.every((_, id) => !queue.isOpen(id))) {
+            await source?.return?.()
+          }
+        }
+      },
+    ))
+  }
+
+  return replicated
 }

--- a/packages/shared/src/iterator.ts
+++ b/packages/shared/src/iterator.ts
@@ -124,7 +124,7 @@ export function replicateAsyncIterator<T, TReturn, TNext>(
             .then(resolve)
             .catch(reject)
 
-          setTimeout(() => {
+          new Promise(r => r(undefined)).then(() => {
             if (error) {
               reject(error.value)
             }

--- a/packages/shared/src/queue.ts
+++ b/packages/shared/src/queue.ts
@@ -1,12 +1,12 @@
 export interface AsyncIdQueueCloseOptions {
   id?: number
-  reason?: Error
+  reason?: unknown
 }
 
 export class AsyncIdQueue<T> {
   private readonly openIds = new Set<number>()
   private readonly items = new Map<number, T[]>()
-  private readonly pendingPulls = new Map<number, (readonly [resolve: (item: T) => void, reject: (err: Error) => void])[]>()
+  private readonly pendingPulls = new Map<number, (readonly [resolve: (item: T) => void, reject: (err: unknown) => void])[]>()
 
   get length(): number {
     return this.openIds.size

--- a/packages/standard-server/src/utils.test.ts
+++ b/packages/standard-server/src/utils.test.ts
@@ -1,4 +1,12 @@
-import { flattenHeader, generateContentDisposition, getFilenameFromContentDisposition, mergeStandardHeaders } from './utils'
+import type { StandardLazyResponse } from './types'
+import * as SharedModule from '@orpc/shared'
+import { flattenHeader, generateContentDisposition, getFilenameFromContentDisposition, mergeStandardHeaders, replicateStandardLazyResponse } from './utils'
+
+const replicateAsyncIteratorSpy = vi.spyOn(SharedModule, 'replicateAsyncIterator')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
 
 it('generateContentDisposition', () => {
   expect(generateContentDisposition('')).toEqual('inline; filename=""; filename*=utf-8\'\'')
@@ -43,4 +51,74 @@ it('flattenHeader', () => {
   expect(flattenHeader([])).toEqual(undefined)
   expect(flattenHeader('a')).toEqual('a')
   expect(flattenHeader(undefined)).toEqual(undefined)
+})
+
+describe('replicateStandardLazyResponse', () => {
+  it('without async iterator', async () => {
+    const response: StandardLazyResponse = {
+      headers: {
+        'x-test': 'test',
+      },
+      body: vi.fn(async () => 'test'),
+      status: 200,
+    }
+
+    const replicated = replicateStandardLazyResponse(response, 3)
+
+    expect(replicated.length).toBe(3)
+
+    expect(await replicated[0]!.body()).toBe('test')
+    expect(await replicated[1]!.body()).toBe('test')
+    expect(await replicated[2]!.body()).toBe('test')
+
+    expect(replicated[0]!.headers).toEqual({ 'x-test': 'test' })
+    expect(replicated[1]!.headers).toEqual({ 'x-test': 'test' })
+    expect(replicated[2]!.headers).toEqual({ 'x-test': 'test' })
+
+    expect(replicated[0]!.status).toBe(200)
+    expect(replicated[1]!.status).toBe(200)
+    expect(replicated[2]!.status).toBe(200)
+
+    expect(response.body).toHaveBeenCalledTimes(1)
+    expect(replicateAsyncIteratorSpy).toHaveBeenCalledTimes(0)
+  })
+
+  it('with async iterator', async () => {
+    const iterator = (async function* () {
+      yield 'test'
+      yield 'test'
+    }())
+
+    const response: StandardLazyResponse = {
+      headers: {
+        'x-test': 'test',
+      },
+      body: async () => iterator,
+      status: 200,
+    }
+
+    expect(replicateAsyncIteratorSpy).toHaveBeenCalledTimes(0)
+    const replicated = replicateStandardLazyResponse(response, 3)
+    expect(replicated.length).toBe(3)
+
+    expect(replicated[0]!.headers).toEqual({ 'x-test': 'test' })
+    expect(replicated[1]!.headers).toEqual({ 'x-test': 'test' })
+    expect(replicated[2]!.headers).toEqual({ 'x-test': 'test' })
+
+    expect(replicated[0]!.status).toBe(200)
+    expect(replicated[1]!.status).toBe(200)
+    expect(replicated[2]!.status).toBe(200)
+
+    replicateAsyncIteratorSpy.mockReturnValueOnce([1, 2, 3] as any)
+
+    expect(await replicated[0]!.body()).toBe(1)
+    expect(await replicated[0]!.body()).toBe(1) // make sure cached
+    expect(await replicated[1]!.body()).toBe(2)
+    expect(await replicated[1]!.body()).toBe(2) // make sure cached
+    expect(await replicated[2]!.body()).toBe(3)
+    expect(await replicated[2]!.body()).toBe(3) // make sure cached
+
+    expect(replicateAsyncIteratorSpy).toHaveBeenCalledTimes(1)
+    expect(replicateAsyncIteratorSpy).toHaveBeenCalledWith(iterator, 3)
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a plugin to deduplicate similar network requests, reducing redundant server calls and improving efficiency.
  - Added documentation for the deduplication plugin, including setup instructions, configuration options, and usage examples.
  - Added a function to replicate async iterators, allowing multiple consumers to independently process the same data stream.
  - Added a utility to replicate standard lazy responses for consistent response handling across multiple consumers.

- **Bug Fixes**
  - Broadened error handling in asynchronous queue utilities to accept any error type.

- **Documentation**
  - Added and updated documentation for new plugins and features.
  - Improved clarity in existing documentation comments.

- **Tests**
  - Introduced comprehensive test suites for the deduplication plugin, async iterator replication, and response replication utilities.
  - Enhanced test descriptions for better clarity and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->