### PR TITLE
feat(client, server): support buffered mode in batch plugin

### DIFF
--- a/apps/content/.vitepress/config.ts
+++ b/apps/content/.vitepress/config.ts
@@ -114,7 +114,7 @@ export default defineConfig({
             { text: 'CORS', link: '/docs/plugins/cors' },
             { text: 'Response Headers', link: '/docs/plugins/response-headers' },
             { text: 'Dedupe Requests', link: '/docs/plugins/dedupe-requests' },
-            { text: 'Batch Request/Response', link: '/docs/plugins/batch-request-response' },
+            { text: 'Batch Requests', link: '/docs/plugins/batch-requests' },
             { text: 'Client Retry', link: '/docs/plugins/client-retry' },
             { text: 'Body Limit', link: '/docs/plugins/body-limit' },
             { text: 'Simple CSRF Protection', link: '/docs/plugins/simple-csrf-protection' },

--- a/apps/content/docs/comparison.md
+++ b/apps/content/docs/comparison.md
@@ -34,7 +34,7 @@ This comparison table helps you understand how oRPC differs from other popular T
 | Streaming response (SSE)                       | [1](/docs/event-iterator)                                                                    | ✅   | ✅   | 🛑      |
 | Standard Schema (Zod, Valibot, ArkType, ...)   |                                                                                              | ✅   | ✅   | 🛑      |
 | Built-in Plugins (CORS, CSRF, Retry, ...)      |                                                                                              | ✅   | 🛑   | 🛑      |
-| Batch Request/Response                         | [1](/docs/plugins/batch-request-response)                                                    | ✅   | ✅   | 🛑      |
+| Batch Requests                                 | [1](/docs/plugins/batch-requests)                                                            | ✅   | ✅   | 🛑      |
 | WebSockets                                     | [1](/docs/adapters/websocket)                                                                | ✅   | ✅   | 🛑      |
 | Nest.js integration                            | [1](/docs/openapi/integrations/implement-contract-in-nest)                                   | ✅   | 🟡   | ✅      |
 | Message Port (Electron, Browser, Workers, ...) | [1](/docs/adapters/message-port)                                                             | ✅   | 🟡   | 🛑      |

--- a/apps/content/docs/plugins/batch-requests.md
+++ b/apps/content/docs/plugins/batch-requests.md
@@ -60,7 +60,7 @@ The `link` can be any supported oRPC link, such as [RPCLink](/docs/client/rpc-li
 
 By default, the plugin uses `streaming` mode, which sends responses asynchronously as they arrive. This ensures that no single request blocks others, allowing for faster and more efficient batching.
 
-If your environment does not support streaming responses such as some serverless platforms or older browsers you can switch to `buffered` mode. In this mode, all responses are collected before being sent together.
+If your environment does not support streaming responses, such as some serverless platforms or older browsers you can switch to `buffered` mode. In this mode, all responses are collected before being sent together.
 
 ```ts
 const link = new RPCLink({

--- a/apps/content/docs/plugins/batch-requests.md
+++ b/apps/content/docs/plugins/batch-requests.md
@@ -7,10 +7,6 @@ description: A plugin for oRPC to batch requests and responses.
 
 The **Batch Requests Plugin** allows you to combine multiple requests and responses into a single batch, reducing the overhead of sending each one separately.
 
-:::info
-The **Batch Plugin** streams responses asynchronously so that no individual request blocks another, ensuring all responses are handled independently for faster, more efficient batching.
-:::
-
 ## Setup
 
 This plugin requires configuration on both the server and client sides.
@@ -59,6 +55,29 @@ const link = new RPCLink({
 ::: info
 The `link` can be any supported oRPC link, such as [RPCLink](/docs/client/rpc-link), [OpenAPILink](/docs/openapi/client/openapi-link), or custom implementations.
 :::
+
+## Batch Mode
+
+By default, the plugin uses `streaming` mode, which sends responses asynchronously as they arrive. This ensures that no single request blocks others, allowing for faster and more efficient batching.
+
+If your environment does not support streaming responses such as some serverless platforms or older browsers you can switch to `buffered` mode. In this mode, all responses are collected before being sent together.
+
+```ts
+const link = new RPCLink({
+  url: 'https://api.example.com/rpc',
+  plugins: [
+    new BatchLinkPlugin({
+      mode: typeof window === 'undefined' ? 'buffered' : 'streaming', // [!code highlight]
+      groups: [
+        {
+          condition: options => true,
+          context: {}
+        }
+      ]
+    }),
+  ],
+})
+```
 
 ## Limitations
 

--- a/apps/content/docs/plugins/batch-requests.md
+++ b/apps/content/docs/plugins/batch-requests.md
@@ -1,11 +1,11 @@
 ---
-title: Batch Request/Response Plugin
+title: Batch Requests Plugin
 description: A plugin for oRPC to batch requests and responses.
 ---
 
-# Batch Request/Response Plugin
+# Batch Requests Plugin
 
-The **Batch Request/Response Plugin** allows you to combine multiple requests and responses into a single batch, reducing the overhead of sending each one separately.
+The **Batch Requests Plugin** allows you to combine multiple requests and responses into a single batch, reducing the overhead of sending each one separately.
 
 :::info
 The **Batch Plugin** streams responses asynchronously so that no individual request blocks another, ensuring all responses are handled independently for faster, more efficient batching.

--- a/packages/client/src/plugins/batch.ts
+++ b/packages/client/src/plugins/batch.ts
@@ -1,5 +1,6 @@
 import type { InterceptorOptions, Promisable, Value } from '@orpc/shared'
 import type { StandardHeaders, StandardLazyResponse, StandardRequest } from '@orpc/standard-server'
+import type { BatchResponseMode } from '@orpc/standard-server/batch'
 import type { StandardLinkClientInterceptorOptions, StandardLinkOptions, StandardLinkPlugin } from '../adapters/standard'
 import type { ClientContext } from '../types'
 import { isAsyncIteratorObject, splitInHalf, toArray, value } from '@orpc/shared'
@@ -27,7 +28,7 @@ export interface BatchLinkPluginOptions<T extends ClientContext> {
    *
    * @default 'streaming'
    */
-  mode?: Value<'streaming' | 'buffered', [readonly [StandardLinkClientInterceptorOptions<T>, ...StandardLinkClientInterceptorOptions<T>[]]]>
+  mode?: Value<BatchResponseMode, [readonly [StandardLinkClientInterceptorOptions<T>, ...StandardLinkClientInterceptorOptions<T>[]]]>
 
   /**
    * Defines the URL to use for the batch request.

--- a/packages/client/src/plugins/batch.ts
+++ b/packages/client/src/plugins/batch.ts
@@ -66,10 +66,10 @@ export interface BatchLinkPluginOptions<T extends ClientContext> {
 }
 
 /**
- * The Batch Request/Response Plugin allows you to combine multiple requests and responses into a single batch,
+ * The Batch Requests Plugin allows you to combine multiple requests and responses into a single batch,
  * reducing the overhead of sending each one separately.
  *
- * @see {@link https://orpc.unnoq.com/docs/plugins/batch-request-response Batch Request/Response Plugin Docs}
+ * @see {@link https://orpc.unnoq.com/docs/plugins/batch-requests Batch Requests Plugin Docs}
  */
 export class BatchLinkPlugin<T extends ClientContext> implements StandardLinkPlugin<T> {
   private readonly groups: Exclude<BatchLinkPluginOptions<T>['groups'], undefined>

--- a/packages/server/src/plugins/batch.ts
+++ b/packages/server/src/plugins/batch.ts
@@ -38,10 +38,10 @@ export interface BatchHandlerOptions<T extends Context> {
 }
 
 /**
- * The Batch Request/Response Plugin allows you to combine multiple requests and responses into a single batch,
+ * The Batch Requests Plugin allows you to combine multiple requests and responses into a single batch,
  * reducing the overhead of sending each one separately.
  *
- * @see {@link https://orpc.unnoq.com/docs/plugins/batch-request-response Batch Request/Response Plugin Docs}
+ * @see {@link https://orpc.unnoq.com/docs/plugins/batch-requests Batch Requests Plugin Docs}
  */
 export class BatchHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   private readonly maxSize: Exclude<BatchHandlerOptions<T>['maxSize'], undefined>

--- a/packages/standard-server/src/batch/response.test.ts
+++ b/packages/standard-server/src/batch/response.test.ts
@@ -30,6 +30,32 @@ describe.each(['streaming', 'buffered'] as const)('toBatchResponse & parseBatchR
   })
 })
 
+describe('toBatchResponse', () => {
+  it('use streaming mode by default', async () => {
+    const response = await toBatchResponse({
+      status: 207,
+      headers: { 'x-custom': 'value' },
+      body: (async function* () {})(),
+    })
+
+    expect(response.body).toSatisfy(isAsyncIteratorObject)
+  })
+
+  it('on buffered mode error', async () => {
+    await expect(
+      toBatchResponse({
+        mode: 'buffered',
+        status: 207,
+        headers: { 'x-custom': 'value' },
+        body: (async function* () {
+          yield { index: 0, status: 200, headers: { 'x-custom': 'value' }, body: 'yielded1' }
+          throw new Error('__TEST__')
+        })(),
+      }),
+    ).rejects.toThrow('__TEST__')
+  })
+})
+
 describe('parseBatchResponse', () => {
   it('throw on invalid batch body', () => {
     expect(

--- a/packages/standard-server/src/batch/response.test.ts
+++ b/packages/standard-server/src/batch/response.test.ts
@@ -40,6 +40,23 @@ describe('toBatchResponse', () => {
 
     expect(response.body).toSatisfy(isAsyncIteratorObject)
   })
+
+  it('body is array if mode is buffered', async () => {
+    const response = await toBatchResponse({
+      mode: 'buffered',
+      status: 207,
+      headers: { 'x-custom': 'value' },
+      body: (async function* () {
+        yield { index: 0, status: 200, headers: {}, body: 'test1' }
+        yield { index: 1, status: 207, headers: { 'x-custom': 'value2' }, body: 'test2' }
+      })(),
+    })
+
+    expect(response.body).toEqual([
+      { index: 0, status: 200, body: 'test1' },
+      { index: 1, headers: { 'x-custom': 'value2' }, body: 'test2' },
+    ])
+  })
 })
 
 describe('parseBatchResponse', () => {

--- a/packages/standard-server/src/batch/response.test.ts
+++ b/packages/standard-server/src/batch/response.test.ts
@@ -2,12 +2,13 @@ import type { BatchResponseBodyItem } from './response'
 import { isAsyncIteratorObject } from '@orpc/shared'
 import { parseBatchResponse, toBatchResponse } from './response'
 
-describe('toBatchResponse & parseBatchResponse', () => {
+describe.each(['streaming', 'buffered'] as const)('toBatchResponse & parseBatchResponse with %s mode', (mode) => {
   const r1: BatchResponseBodyItem = { index: 0, status: 200, headers: { }, body: 'test1' }
   const r2: BatchResponseBodyItem = { index: 1, status: 207, headers: { 'x-custom': 'value2' }, body: 'test2' }
 
   it('success', async () => {
-    const response = toBatchResponse({
+    const response = await toBatchResponse({
+      mode,
       status: 207,
       headers: { 'x-custom': 'value' },
       body: (async function* () {
@@ -40,8 +41,9 @@ describe('parseBatchResponse', () => {
     ).toThrow('Invalid batch response')
   })
 
-  it('throw on invalid batch item', async () => {
-    const parsed = parseBatchResponse(toBatchResponse({
+  it.each(['streaming', 'buffered'] as const)('throw on invalid batch body with %s mode', async (mode) => {
+    const parsed = parseBatchResponse(await toBatchResponse({
+      mode,
       status: 207,
       headers: { 'x-custom': 'value' },
       body: (async function* () {

--- a/packages/standard-server/src/batch/response.test.ts
+++ b/packages/standard-server/src/batch/response.test.ts
@@ -40,20 +40,6 @@ describe('toBatchResponse', () => {
 
     expect(response.body).toSatisfy(isAsyncIteratorObject)
   })
-
-  it('on buffered mode error', async () => {
-    await expect(
-      toBatchResponse({
-        mode: 'buffered',
-        status: 207,
-        headers: { 'x-custom': 'value' },
-        body: (async function* () {
-          yield { index: 0, status: 200, headers: { 'x-custom': 'value' }, body: 'yielded1' }
-          throw new Error('__TEST__')
-        })(),
-      }),
-    ).rejects.toThrow('__TEST__')
-  })
 })
 
 describe('parseBatchResponse', () => {

--- a/packages/standard-server/src/batch/response.ts
+++ b/packages/standard-server/src/batch/response.ts
@@ -30,23 +30,23 @@ export function toBatchResponse(options: ToBatchResponseOptions): Promisable<Sta
   if (mode === 'buffered') {
     // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve, reject) => {
-      const body: Partial<BatchResponseBodyItem>[] = []
-
       try {
+        const body: Partial<BatchResponseBodyItem>[] = []
+
         for await (const item of options.body) {
           body.push(minifyResponseItem(item))
         }
-      }
-      catch (e) {
-        reject(e)
-      }
-      finally {
+
         resolve({
           headers: options.headers,
           status: options.status,
           body,
         })
-
+      }
+      catch (e) {
+        reject(e)
+      }
+      finally {
         await options.body.return?.()
       }
     })

--- a/packages/standard-server/src/batch/response.ts
+++ b/packages/standard-server/src/batch/response.ts
@@ -28,8 +28,7 @@ export function toBatchResponse(options: ToBatchResponseOptions): Promisable<Sta
   }
 
   if (mode === 'buffered') {
-    // eslint-disable-next-line no-async-promise-executor
-    return new Promise(async (resolve, reject) => {
+    return (async () => {
       try {
         const body: Partial<BatchResponseBodyItem>[] = []
 
@@ -37,19 +36,16 @@ export function toBatchResponse(options: ToBatchResponseOptions): Promisable<Sta
           body.push(minifyResponseItem(item))
         }
 
-        resolve({
+        return {
           headers: options.headers,
           status: options.status,
           body,
-        })
-      }
-      catch (e) {
-        reject(e)
+        }
       }
       finally {
         await options.body.return?.()
       }
-    })
+    })()
   }
 
   return {

--- a/packages/standard-server/src/batch/response.ts
+++ b/packages/standard-server/src/batch/response.ts
@@ -2,6 +2,8 @@ import type { Promisable } from '@orpc/shared'
 import type { StandardHeaders, StandardResponse } from '../types'
 import { isAsyncIteratorObject, isObject } from '@orpc/shared'
 
+export type BatchResponseMode = 'streaming' | 'buffered'
+
 export interface BatchResponseBodyItem extends StandardResponse {
   index: number
 }
@@ -12,7 +14,7 @@ export interface ToBatchResponseOptions extends StandardResponse {
   /**
    * @default 'streaming'
    */
-  mode?: 'streaming' | 'buffered'
+  mode?: BatchResponseMode
 }
 
 export function toBatchResponse(options: ToBatchResponseOptions): Promisable<StandardResponse> {

--- a/packages/standard-server/src/batch/response.ts
+++ b/packages/standard-server/src/batch/response.ts
@@ -1,3 +1,4 @@
+import type { Promisable } from '@orpc/shared'
 import type { StandardHeaders, StandardResponse } from '../types'
 import { isAsyncIteratorObject, isObject } from '@orpc/shared'
 
@@ -7,11 +8,53 @@ export interface BatchResponseBodyItem extends StandardResponse {
 
 export interface ToBatchResponseOptions extends StandardResponse {
   body: AsyncIteratorObject<BatchResponseBodyItem>
+
+  /**
+   * @default 'streaming'
+   */
+  mode?: 'streaming' | 'buffered'
 }
 
-export function toBatchResponse(options: ToBatchResponseOptions): StandardResponse {
+export function toBatchResponse(options: ToBatchResponseOptions): Promisable<StandardResponse> {
+  const mode = options.mode ?? 'streaming'
+
+  const minifyResponseItem = (item: BatchResponseBodyItem): Partial<BatchResponseBodyItem> => {
+    return {
+      index: item.index,
+      status: item.status === options.status ? undefined : item.status,
+      headers: Object.keys(item.headers).length ? item.headers : undefined,
+      body: item.body,
+    }
+  }
+
+  if (mode === 'buffered') {
+    // eslint-disable-next-line no-async-promise-executor
+    return new Promise(async (resolve, reject) => {
+      const body: Partial<BatchResponseBodyItem>[] = []
+
+      try {
+        for await (const item of options.body) {
+          body.push(minifyResponseItem(item))
+        }
+      }
+      catch (e) {
+        reject(e)
+      }
+      finally {
+        resolve({
+          headers: options.headers,
+          status: options.status,
+          body,
+        })
+
+        await options.body.return?.()
+      }
+    })
+  }
+
   return {
-    ...options,
+    headers: options.headers,
+    status: options.status,
     body: (async function* () {
       try {
         for await (const item of options.body) {
@@ -24,7 +67,7 @@ export function toBatchResponse(options: ToBatchResponseOptions): StandardRespon
         }
       }
       finally {
-        options.body.return?.()
+        await options.body.return?.()
       }
     })(),
   }
@@ -33,31 +76,33 @@ export function toBatchResponse(options: ToBatchResponseOptions): StandardRespon
 export function parseBatchResponse(response: StandardResponse): AsyncGenerator<BatchResponseBodyItem> {
   const body = response.body
 
-  if (!isAsyncIteratorObject(body)) {
-    throw new TypeError('Invalid batch response', {
-      cause: response,
-    })
+  if (isAsyncIteratorObject(body) || Array.isArray(body)) {
+    return (async function* () {
+      try {
+        for await (const item of body) {
+          if (!isObject(item) || !('index' in item) || typeof item.index !== 'number') {
+            throw new TypeError('Invalid batch response', {
+              cause: item,
+            })
+          }
+
+          yield {
+            index: item.index as number,
+            status: item.status as undefined | number ?? response.status,
+            headers: item.headers as undefined | StandardHeaders ?? {},
+            body: item.body,
+          } satisfies BatchResponseBodyItem
+        }
+      }
+      finally {
+        if (isAsyncIteratorObject(body)) {
+          await body.return?.()
+        }
+      }
+    })()
   }
 
-  return (async function* () {
-    try {
-      for await (const item of body) {
-        if (!isObject(item) || !('index' in item) || typeof item.index !== 'number') {
-          throw new TypeError('Invalid batch response', {
-            cause: item,
-          })
-        }
-
-        yield {
-          index: item.index as number,
-          status: item.status as undefined | number ?? response.status,
-          headers: item.headers as undefined | StandardHeaders ?? {},
-          body: item.body,
-        } satisfies BatchResponseBodyItem
-      }
-    }
-    finally {
-      await body.return?.()
-    }
-  })()
+  throw new TypeError('Invalid batch response', {
+    cause: response,
+  })
 }

--- a/packages/standard-server/src/batch/response.ts
+++ b/packages/standard-server/src/batch/response.ts
@@ -83,7 +83,7 @@ export function parseBatchResponse(response: StandardResponse): AsyncGenerator<B
           }
 
           yield {
-            index: item.index as number,
+            index: item.index,
             status: item.status as undefined | number ?? response.status,
             headers: item.headers as undefined | StandardHeaders ?? {},
             body: item.body,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configurable batch response modes: "streaming" (default) and "buffered" for environments without streaming support.
  - Documentation updated with detailed explanations and configuration examples for batch modes.

- **Bug Fixes**
  - Enhanced validation and error handling for batch responses across both modes.

- **Tests**
  - Extended test coverage to include buffered mode scenarios and updated existing tests for streaming mode.

- **Documentation**
  - Renamed "Batch Request/Response Plugin" to "Batch Requests Plugin" and updated related links and labels for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->