### PR TITLE
refactor: replace setTimeout(fn, 0) with defer util

### DIFF
--- a/packages/client/src/plugins/batch.ts
+++ b/packages/client/src/plugins/batch.ts
@@ -3,7 +3,7 @@ import type { StandardHeaders, StandardLazyResponse, StandardRequest } from '@or
 import type { BatchResponseMode } from '@orpc/standard-server/batch'
 import type { StandardLinkClientInterceptorOptions, StandardLinkOptions, StandardLinkPlugin } from '../adapters/standard'
 import type { ClientContext } from '../types'
-import { isAsyncIteratorObject, splitInHalf, toArray, value } from '@orpc/shared'
+import { defer, isAsyncIteratorObject, splitInHalf, toArray, value } from '@orpc/shared'
 import { parseBatchResponse, toBatchRequest } from '@orpc/standard-server/batch'
 
 export interface BatchLinkPluginGroup<T extends ClientContext> {
@@ -174,7 +174,7 @@ export class BatchLinkPlugin<T extends ClientContext> implements StandardLinkPlu
 
       return new Promise((resolve, reject) => {
         this.#enqueueRequest(group, options, resolve, reject)
-        setTimeout(() => this.#processPendingBatches())
+        defer(() => this.#processPendingBatches())
       })
     })
   }

--- a/packages/client/src/plugins/dedupe-requests.ts
+++ b/packages/client/src/plugins/dedupe-requests.ts
@@ -2,7 +2,7 @@ import type { InterceptorOptions } from '@orpc/shared'
 import type { StandardLazyResponse, StandardRequest } from '@orpc/standard-server'
 import type { StandardLinkClientInterceptorOptions, StandardLinkOptions, StandardLinkPlugin } from '../adapters/standard'
 import type { ClientContext } from '../types'
-import { isAsyncIteratorObject, stringifyJSON } from '@orpc/shared'
+import { defer, isAsyncIteratorObject, stringifyJSON } from '@orpc/shared'
 import { replicateStandardLazyResponse } from '@orpc/standard-server'
 import { toBatchAbortSignal } from '@orpc/standard-server/batch'
 
@@ -80,7 +80,7 @@ export class DedupeRequestsPlugin<T extends ClientContext> implements StandardLi
 
       return new Promise((resolve, reject) => {
         this.#enqueue(group, options, resolve, reject)
-        setTimeout(() => this.#dequeue())
+        defer(() => this.#dequeue())
       })
     })
   }

--- a/packages/shared/src/function.test.ts
+++ b/packages/shared/src/function.test.ts
@@ -1,4 +1,4 @@
-import { once, sequential } from './function'
+import { defer, once, sequential } from './function'
 
 it('once', () => {
   const fn = vi.fn(() => ({}))
@@ -49,5 +49,41 @@ describe('sequential', () => {
     expect(sequentialFn()).rejects.toThrow('Forced error')
     expect(sequentialFn()).resolves.toBe(2)
     expect(sequentialFn()).resolves.toBe(3)
+  })
+})
+
+describe('defer', () => {
+  it('with setTimeout', async () => {
+    const callback1 = vi.fn()
+    const callback2 = vi.fn()
+
+    defer(callback1)
+    callback2()
+
+    expect(callback1).toHaveBeenCalledTimes(0)
+
+    await new Promise(resolve => setTimeout(resolve, 100))
+
+    expect(callback1).toHaveBeenCalledTimes(1)
+    expect(callback2).toHaveBeenCalledBefore(callback1)
+  })
+
+  it('without setTimeout', async () => {
+    const originalSetTimeout = globalThis.setTimeout
+    ;(globalThis as any).setTimeout = undefined
+
+    const callback1 = vi.fn()
+    const callback2 = vi.fn()
+
+    defer(callback1)
+    globalThis.setTimeout = originalSetTimeout
+    callback2()
+
+    expect(callback1).toHaveBeenCalledTimes(0)
+
+    await new Promise(resolve => setTimeout(resolve, 100))
+
+    expect(callback1).toHaveBeenCalledTimes(1)
+    expect(callback2).toHaveBeenCalledBefore(callback1)
   })
 })

--- a/packages/shared/src/function.test.ts
+++ b/packages/shared/src/function.test.ts
@@ -69,12 +69,11 @@ describe('defer', () => {
   })
 
   it('without setTimeout', async () => {
-    const originalSetTimeout = globalThis.setTimeout
-    ;(globalThis as any).setTimeout = undefined
-
     const callback1 = vi.fn()
     const callback2 = vi.fn()
 
+    const originalSetTimeout = globalThis.setTimeout
+    ;(globalThis as any).setTimeout = undefined
     defer(callback1)
     globalThis.setTimeout = originalSetTimeout
     callback2()

--- a/packages/shared/src/function.ts
+++ b/packages/shared/src/function.ts
@@ -26,3 +26,18 @@ export function sequential<A extends any[], R>(
     })
   }
 }
+
+/**
+ * Executes the callback function after the current call stack has been cleared.
+ */
+export function defer(callback: () => void): void {
+  if (typeof setTimeout === 'function') {
+    setTimeout(callback, 0)
+  }
+  else {
+    Promise.resolve()
+      .then(() => Promise.resolve()
+        .then(() => Promise.resolve()
+          .then(callback)))
+  }
+}

--- a/packages/shared/src/function.ts
+++ b/packages/shared/src/function.ts
@@ -31,8 +31,8 @@ export function sequential<A extends any[], R>(
  * Executes the callback function after the current call stack has been cleared.
  */
 export function defer(callback: () => void): void {
-  if (typeof setTimeout === 'function') {
-    setTimeout(callback, 0)
+  if ('setTimeout' in globalThis && typeof (globalThis as any).setTimeout === 'function') {
+    (globalThis as any).setTimeout(callback, 0)
   }
   else {
     Promise.resolve()

--- a/packages/shared/src/iterator.ts
+++ b/packages/shared/src/iterator.ts
@@ -1,4 +1,4 @@
-import { once, sequential } from './function'
+import { defer, once, sequential } from './function'
 import { AsyncIdQueue } from './queue'
 
 export function isAsyncIteratorObject(maybe: unknown): maybe is AsyncIteratorObject<any, any, any> {
@@ -124,7 +124,7 @@ export function replicateAsyncIterator<T, TReturn, TNext>(
             .then(resolve)
             .catch(reject)
 
-          new Promise(r => r(undefined)).then(() => {
+          defer(() => {
             if (error) {
               reject(error.value)
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new utility function to defer execution of callbacks asynchronously, ensuring compatibility across different environments.

- **Refactor**
  - Updated internal scheduling mechanisms in batch processing and request deduplication features to use the new deferral utility for improved consistency and reliability.
  - Streamlined asynchronous handling in iterator utilities by adopting the new deferral approach.

- **Tests**
  - Added comprehensive tests to verify the behavior of the new deferral utility under various conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->