### PR TITLE
fix(client): wait until WebSocket is open before sending

### DIFF
--- a/packages/client/src/adapters/websocket/link-websocket-client.ts
+++ b/packages/client/src/adapters/websocket/link-websocket-client.ts
@@ -12,13 +12,13 @@ export class experimental_LinkWebsocketClient<T extends ClientContext> implement
 
   constructor(options: experimental_LinkWebsocketClientOptions) {
     const untilOpen = new Promise<void>((resolve) => {
-      if (options.websocket.readyState === 1) {
-        resolve()
-      }
-      else {
+      if (options.websocket.readyState === 0) { // CONNECTING
         options.websocket.addEventListener('open', () => {
           resolve()
         })
+      }
+      else {
+        resolve()
       }
     })
 

--- a/packages/client/src/adapters/websocket/link-websocket-client.ts
+++ b/packages/client/src/adapters/websocket/link-websocket-client.ts
@@ -15,7 +15,7 @@ export class experimental_LinkWebsocketClient<T extends ClientContext> implement
       if (options.websocket.readyState === 0) { // CONNECTING
         options.websocket.addEventListener('open', () => {
           resolve()
-        })
+        }, { once: true })
       }
       else {
         resolve()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured messages are only sent after the WebSocket connection is fully open, preventing premature message sending.

- **Tests**
  - Improved test coverage to verify correct message handling when the WebSocket is not yet open and after it becomes open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->