### PR TITLE
refactor(standard-server-peer): drop support for Blob as encoded message

### DIFF
--- a/packages/client/src/adapters/message-port/link-client.ts
+++ b/packages/client/src/adapters/message-port/link-client.ts
@@ -13,8 +13,8 @@ export class experimental_LinkMessagePortClient<T extends ClientContext> impleme
   private readonly peer: ClientPeer
 
   constructor(options: experimental_LinkMessagePortClientOptions) {
-    this.peer = new ClientPeer(async (message) => {
-      postMessagePortMessage(options.port, message instanceof Blob ? await message.arrayBuffer() : message)
+    this.peer = new ClientPeer((message) => {
+      return postMessagePortMessage(options.port, message)
     })
 
     onMessagePortMessage(options.port, async (message) => {

--- a/packages/client/src/adapters/websocket/link-websocket-client.ts
+++ b/packages/client/src/adapters/websocket/link-websocket-client.ts
@@ -27,8 +27,12 @@ export class experimental_LinkWebsocketClient<T extends ClientContext> implement
       return options.websocket.send(message)
     })
 
-    options.websocket.addEventListener('message', (event) => {
-      this.peer.message(event.data)
+    options.websocket.addEventListener('message', async (event) => {
+      const message = event.data instanceof Blob
+        ? await event.data.arrayBuffer()
+        : event.data
+
+      this.peer.message(message)
     })
 
     options.websocket.addEventListener('close', () => {

--- a/packages/server/src/adapters/bun-ws/handler.ts
+++ b/packages/server/src/adapters/bun-ws/handler.ts
@@ -26,14 +26,8 @@ export class experimental_BunWsHandler<T extends Context> {
     let peer = this.peers.get(ws)
 
     if (!peer) {
-      this.peers.set(ws, peer = new ServerPeer(async (raw) => {
-        if (raw instanceof Blob) {
-          const buffer = await raw.arrayBuffer()
-          ws.send(buffer)
-        }
-        else {
-          ws.send(raw)
-        }
+      this.peers.set(ws, peer = new ServerPeer((message) => {
+        ws.send(message)
       }))
     }
 

--- a/packages/server/src/adapters/crossws/handler.ts
+++ b/packages/server/src/adapters/crossws/handler.ts
@@ -23,14 +23,8 @@ export class experimental_CrosswsHandler<T extends Context> {
     let peer = this.peers.get(ws)
 
     if (!peer) {
-      this.peers.set(ws, peer = new ServerPeer(async (raw) => {
-        if (raw instanceof Blob) {
-          const buffer = await raw.arrayBuffer()
-          ws.send(buffer)
-        }
-        else {
-          ws.send(raw)
-        }
+      this.peers.set(ws, peer = new ServerPeer((message) => {
+        ws.send(message)
       }))
     }
 

--- a/packages/server/src/adapters/message-port/handler.ts
+++ b/packages/server/src/adapters/message-port/handler.ts
@@ -3,7 +3,7 @@ import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { Context } from '../../context'
 import type { StandardHandler } from '../standard'
 import type { FriendlyStandardHandleOptions } from '../standard/utils'
-import { onMessagePortClose, onMessagePortMessage } from '@orpc/client/message-port'
+import { onMessagePortClose, onMessagePortMessage, postMessagePortMessage } from '@orpc/client/message-port'
 import { resolveMaybeOptionalOptions } from '@orpc/shared'
 import { ServerPeer } from '@orpc/standard-server-peer'
 import { resolveFriendlyStandardHandleOptions } from '../standard/utils'
@@ -15,8 +15,8 @@ export class experimental_MessagePortHandler<T extends Context> {
   }
 
   upgrade(port: SupportedMessagePort, ...rest: MaybeOptionalOptions<Omit<FriendlyStandardHandleOptions<T>, 'prefix'>>): void {
-    const peer = new ServerPeer(async (message) => {
-      port.postMessage(message instanceof Blob ? await message.arrayBuffer() : message)
+    const peer = new ServerPeer((message) => {
+      return postMessagePortMessage(port, message)
     })
 
     onMessagePortMessage(port, async (message) => {

--- a/packages/server/src/adapters/websocket/handler.ts
+++ b/packages/server/src/adapters/websocket/handler.ts
@@ -16,7 +16,11 @@ export class experimental_WebsocketHandler<T extends Context> {
     const peer = new ServerPeer(ws.send.bind(ws))
 
     ws.addEventListener('message', async (event) => {
-      const [id, request] = await peer.message(event.data)
+      const message = event.data instanceof Blob
+        ? await event.data.arrayBuffer()
+        : event.data
+
+      const [id, request] = await peer.message(message)
 
       if (!request) {
         return

--- a/packages/server/src/adapters/websocket/rpc-handler.test.ts
+++ b/packages/server/src/adapters/websocket/rpc-handler.test.ts
@@ -42,6 +42,10 @@ describe('rpcHandler', async () => {
     }),
   }
 
+  const ping_buffer_request_message = {
+    data: new Blob([ping_request_message.data]),
+  }
+
   const not_found_request_message = {
     data: await encodeRequestMessage(19, MessageType.REQUEST, {
       url: new URL('orpc:/not-found'),
@@ -61,6 +65,21 @@ describe('rpcHandler', async () => {
     await vi.waitFor(() => expect(wss.send).toHaveBeenCalledTimes(1))
 
     const [id,, payload] = (await decodeResponseMessage(wss.send.mock.calls[0]![0]))
+
+    expect(id).toBeTypeOf('number')
+    expect(payload).toEqual({
+      status: 200,
+      headers: {},
+      body: { json: 'pong' },
+    })
+  })
+
+  it('on success with buffer data', async () => {
+    onMessage(ping_buffer_request_message)
+
+    await vi.waitFor(() => expect(wss.send).toHaveBeenCalledTimes(1))
+
+    const [id, , payload] = (await decodeResponseMessage(wss.send.mock.calls[0]![0]))
 
     expect(id).toBeTypeOf('number')
     expect(payload).toEqual({

--- a/packages/server/src/adapters/ws/handler.ts
+++ b/packages/server/src/adapters/ws/handler.ts
@@ -18,7 +18,11 @@ export class experimental_WsHandler<T extends Context> {
     const peer = new ServerPeer(ws.send.bind(ws))
 
     ws.addEventListener('message', async (event) => {
-      const [id, request] = await peer.message(new Blob(Array.isArray(event.data) ? event.data : [event.data]))
+      const message = Array.isArray(event.data)
+        ? await (new Blob(event.data)).arrayBuffer()
+        : event.data
+
+      const [id, request] = await peer.message(message)
 
       if (!request) {
         return

--- a/packages/server/src/adapters/ws/rpc-handler.test.ts
+++ b/packages/server/src/adapters/ws/rpc-handler.test.ts
@@ -43,12 +43,12 @@ describe('rpcHandler', async () => {
   }
 
   const ping_buffer_request_message = {
-    data: await encodeRequestMessage(19, MessageType.REQUEST, {
+    data: [new TextEncoder().encode(await encodeRequestMessage(19, MessageType.REQUEST, {
       url: new URL('orpc:/ping'),
       body: { json: 'input' },
       headers: {},
       method: 'POST',
-    }),
+    }) as string)],
   }
 
   const abort_message = {

--- a/packages/standard-server-peer/src/codec.test.ts
+++ b/packages/standard-server-peer/src/codec.test.ts
@@ -182,7 +182,7 @@ describe('encode/decode request message', () => {
         body: formData,
       })
 
-      expect(message).toBeInstanceOf(Blob)
+      expect(message).toBeInstanceOf(ArrayBuffer)
 
       const [id, type, payload] = await decodeRequestMessage(message)
 
@@ -216,9 +216,9 @@ describe('encode/decode request message', () => {
         body: formData,
       })
 
-      expect(message).toBeInstanceOf(Blob)
+      expect(message).toBeInstanceOf(ArrayBuffer)
 
-      const [id, type, payload] = await decodeRequestMessage(await (message as any).arrayBuffer())
+      const [id, type, payload] = await decodeRequestMessage(message)
 
       expect(id).toBe(198)
       expect(type).toBe(MessageType.REQUEST)
@@ -254,7 +254,7 @@ describe('encode/decode request message', () => {
           body: blob,
         })
 
-        expect(message).toBeInstanceOf(Blob)
+        expect(message).toBeInstanceOf(ArrayBuffer)
 
         const [id, type, payload] = await decodeRequestMessage(message)
 
@@ -287,7 +287,7 @@ describe('encode/decode request message', () => {
           body: blob,
         })
 
-        expect(message).toBeInstanceOf(Blob)
+        expect(message).toBeInstanceOf(ArrayBuffer)
 
         const [id, type, payload] = await decodeRequestMessage(message)
 
@@ -317,7 +317,7 @@ describe('encode/decode request message', () => {
           body: file,
         })
 
-        expect(message).toBeInstanceOf(Blob)
+        expect(message).toBeInstanceOf(ArrayBuffer)
 
         const [id, type, payload] = await decodeRequestMessage(message)
 
@@ -350,7 +350,7 @@ describe('encode/decode request message', () => {
           body: file,
         })
 
-        expect(message).toBeInstanceOf(Blob)
+        expect(message).toBeInstanceOf(ArrayBuffer)
 
         const [id, type, payload] = await decodeRequestMessage(message)
 
@@ -386,7 +386,7 @@ describe('encode/decode request message', () => {
       body: blob,
     })
 
-    expect(message).toBeInstanceOf(Blob)
+    expect(message).toBeInstanceOf(ArrayBuffer)
 
     const [id, type, payload] = await decodeRequestMessage(message)
 
@@ -567,7 +567,7 @@ describe('encode/decode response message', () => {
         body: formData,
       })
 
-      expect(message).toBeInstanceOf(Blob)
+      expect(message).toBeInstanceOf(ArrayBuffer)
 
       const [id, type, payload] = await decodeResponseMessage(message)
 
@@ -599,9 +599,9 @@ describe('encode/decode response message', () => {
         body: formData,
       })
 
-      expect(message).toBeInstanceOf(Blob)
+      expect(message).toBeInstanceOf(ArrayBuffer)
 
-      const [id, type, payload] = await decodeResponseMessage(await (message as any).arrayBuffer())
+      const [id, type, payload] = await decodeResponseMessage(message)
 
       expect(id).toBe(198)
       expect(type).toBe(MessageType.RESPONSE)
@@ -635,7 +635,7 @@ describe('encode/decode response message', () => {
           body: blob,
         })
 
-        expect(message).toBeInstanceOf(Blob)
+        expect(message).toBeInstanceOf(ArrayBuffer)
 
         const [id, type, payload] = await decodeResponseMessage(message)
 
@@ -666,7 +666,7 @@ describe('encode/decode response message', () => {
           body: blob,
         })
 
-        expect(message).toBeInstanceOf(Blob)
+        expect(message).toBeInstanceOf(ArrayBuffer)
 
         const [id, type, payload] = await decodeResponseMessage(message)
 
@@ -694,7 +694,7 @@ describe('encode/decode response message', () => {
           body: file,
         })
 
-        expect(message).toBeInstanceOf(Blob)
+        expect(message).toBeInstanceOf(ArrayBuffer)
 
         const [id, type, payload] = await decodeResponseMessage(message)
 
@@ -725,7 +725,7 @@ describe('encode/decode response message', () => {
           body: file,
         })
 
-        expect(message).toBeInstanceOf(Blob)
+        expect(message).toBeInstanceOf(ArrayBuffer)
 
         const [id, type, payload] = await decodeResponseMessage(message)
 
@@ -756,7 +756,7 @@ describe('encode/decode response message', () => {
       body: blob,
     })
 
-    expect(message).toBeInstanceOf(Blob)
+    expect(message).toBeInstanceOf(ArrayBuffer)
 
     const [id, type, payload] = await decodeResponseMessage(message)
 

--- a/packages/standard-server-peer/src/codec.ts
+++ b/packages/standard-server-peer/src/codec.ts
@@ -326,7 +326,7 @@ async function encodeRawMessage(data: object, blobData?: Blob): Promise<EncodedM
     new TextEncoder().encode(json),
     new Uint8Array([JSON_AND_BINARY_DELIMITER]),
     blobData,
-  ])
+  ]).arrayBuffer()
 }
 
 async function decodeRawMessage(raw: EncodedMessage): Promise<{ json: any, blobData?: ArrayBuffer }> {

--- a/packages/standard-server-peer/src/types.ts
+++ b/packages/standard-server-peer/src/types.ts
@@ -1,6 +1,6 @@
 import type { Promisable } from '@orpc/shared'
 
-export type EncodedMessage = string | ArrayBufferLike | Blob
+export type EncodedMessage = string | ArrayBufferLike
 
 export interface EncodedMessageSendFn {
   (message: EncodedMessage): Promisable<void>


### PR DESCRIPTION
- WebSocket and MessagePort do not support streaming data - only buffered - so there’s no benefit to using Blob.
- Cloudflare Worker WebSocket does not support Blob as transferable data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of binary data in WebSocket and message port communication, ensuring consistent processing of binary messages across different adapters.

- **Refactor**
  - Simplified message handling logic for both client and server, removing unnecessary asynchronous processing and special cases for Blob data.
  - Updated internal data formats to use ArrayBuffer instead of Blob for encoded messages, resulting in more consistent and efficient binary data handling.

- **Tests**
  - Updated tests to reflect changes in binary message encoding, now expecting ArrayBuffer instead of Blob.
  - Added test coverage for handling successful responses wrapped in Blob objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->