### PR TITLE
refactor: `createAsyncIteratorObject` -> `AsyncIteratorClass` for extendability

### DIFF
--- a/packages/client/src/event-iterator.test.ts
+++ b/packages/client/src/event-iterator.test.ts
@@ -152,11 +152,7 @@ describe('mapEventIterator', () => {
     })
 
     await mapped.next()
-    const error = new Error('TEST')
-    await expect(mapped.throw(new Error('TEST'))).rejects.toEqual({ mapped: error })
-
-    expect(map).toHaveBeenCalledTimes(2)
-
+    await expect(mapped.throw(new Error('TEST'))).rejects.toThrow()
     expect(finished).toBe(true)
   })
 })

--- a/packages/client/src/event-iterator.ts
+++ b/packages/client/src/event-iterator.ts
@@ -35,7 +35,9 @@ export function mapEventIterator<TYield, TReturn, TNext, TMap = TYield | TReturn
 
       throw mappedError
     }
-  }, async () => {
-    await iterator.return?.()
+  }, async (reason) => {
+    if (reason !== 'next') {
+      await iterator.return?.()
+    }
   })
 }

--- a/packages/shared/src/event-publisher.ts
+++ b/packages/shared/src/event-publisher.ts
@@ -1,4 +1,4 @@
-import { createAsyncIteratorObject } from './iterator'
+import { AsyncIteratorClass } from './iterator'
 
 export interface EventPublisherOptions {
   /**
@@ -130,7 +130,7 @@ export class EventPublisher<T extends Record<PropertyKey, any>> {
 
     signal?.addEventListener('abort', abortListener, { once: true })
 
-    return createAsyncIteratorObject(async () => {
+    return new AsyncIteratorClass(async () => {
       if (signal?.aborted) {
         throw signal.reason
       }

--- a/packages/shared/src/iterator.test.ts
+++ b/packages/shared/src/iterator.test.ts
@@ -1,4 +1,4 @@
-import { createAsyncIteratorObject, isAsyncIteratorObject, replicateAsyncIterator } from './iterator'
+import { AsyncIteratorClass, isAsyncIteratorObject, replicateAsyncIterator } from './iterator'
 
 it('isAsyncIteratorObject', () => {
   expect(isAsyncIteratorObject(null)).toBe(false)
@@ -15,7 +15,7 @@ it('isAsyncIteratorObject', () => {
   expect(isAsyncIteratorObject(gen2())).toBe(false)
 })
 
-describe('createAsyncIteratorObject', () => {
+describe('asyncIteratorClass', () => {
   const next = vi.fn()
   const cleanup = vi.fn()
   let iterator: AsyncGenerator
@@ -23,7 +23,7 @@ describe('createAsyncIteratorObject', () => {
   beforeEach(() => {
     next.mockReset()
     cleanup.mockReset()
-    iterator = createAsyncIteratorObject(next, cleanup)
+    iterator = new AsyncIteratorClass(next, cleanup)
   })
 
   afterEach(async () => {
@@ -157,28 +157,6 @@ describe('createAsyncIteratorObject', () => {
   describe('dispose()', () => {
     it('should implement Symbol.asyncDispose', async () => {
       expect(typeof (iterator as any)[Symbol.asyncDispose]).toBe('function')
-
-      await iterator.return(undefined)
-    })
-
-    it('should fallback to random symbol if Symbol.asyncDispose is not available', async () => {
-      const OriginalSymbol = globalThis.Symbol
-      const fallbackSymbol = Symbol.for('asyncDispose')
-
-      globalThis.Symbol = {
-        for: (name: string) => {
-          expect(name).toBe('asyncDispose')
-          return fallbackSymbol
-        },
-      } as any
-
-      const fallback = createAsyncIteratorObject(() => {
-        throw new Error('Should not be called')
-      }, async () => {})
-
-      expect(typeof (fallback as any)[fallbackSymbol]).toBe('function')
-
-      globalThis.Symbol = OriginalSymbol
 
       await iterator.return(undefined)
     })

--- a/packages/shared/src/iterator.ts
+++ b/packages/shared/src/iterator.ts
@@ -1,7 +1,7 @@
 import { defer, once, sequential } from './function'
 import { AsyncIdQueue } from './queue'
 
-export function isAsyncIteratorObject(maybe: unknown): maybe is AsyncIteratorClass<any, any, any> {
+export function isAsyncIteratorObject(maybe: unknown): maybe is AsyncIteratorObject<any, any, any> {
   if (!maybe || typeof maybe !== 'object') {
     return false
   }

--- a/packages/standard-server-fetch/src/event-iterator.ts
+++ b/packages/standard-server-fetch/src/event-iterator.ts
@@ -1,4 +1,4 @@
-import { createAsyncIteratorObject, isTypescriptObject, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
+import { AsyncIteratorClass, isTypescriptObject, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
 import {
   encodeEventMessage,
   ErrorEvent,
@@ -9,14 +9,14 @@ import {
 
 export function toEventIterator(
   stream: ReadableStream<Uint8Array> | null,
-): AsyncIteratorObject<unknown | void, unknown | void, void> & AsyncGenerator<unknown | void, unknown | void, void> {
+): AsyncIteratorClass<unknown> {
   const eventStream = stream
     ?.pipeThrough(new TextDecoderStream())
     .pipeThrough(new EventDecoderStream())
 
   const reader = eventStream?.getReader()
 
-  return createAsyncIteratorObject(async () => {
+  return new AsyncIteratorClass(async () => {
     while (true) {
       if (reader === undefined) {
         return { done: true, value: undefined }

--- a/packages/standard-server-peer/src/event-iterator.ts
+++ b/packages/standard-server-peer/src/event-iterator.ts
@@ -1,15 +1,15 @@
-import type { CreateAsyncIteratorObjectCleanupFn } from '@orpc/shared'
+import type { AsyncIteratorClassCleanupFn } from '@orpc/shared'
 import type { AsyncIdQueue } from '../../shared/src/queue'
 import type { EventIteratorPayload } from './codec'
-import { createAsyncIteratorObject, isTypescriptObject } from '@orpc/shared'
+import { AsyncIteratorClass, isTypescriptObject } from '@orpc/shared'
 import { ErrorEvent, getEventMeta, withEventMeta } from '@orpc/standard-server'
 
 export function toEventIterator(
   queue: AsyncIdQueue<EventIteratorPayload>,
   id: number,
-  cleanup: CreateAsyncIteratorObjectCleanupFn,
-): AsyncGenerator {
-  return createAsyncIteratorObject(async () => {
+  cleanup: AsyncIteratorClassCleanupFn,
+): AsyncIteratorClass<unknown> {
+  return new AsyncIteratorClass(async () => {
     const item = await queue.pull(id)
 
     switch (item.event) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Introduced a dedicated class to manage async iteration, enhancing encapsulation and maintainability.
  - Updated multiple modules to utilize the new async iterator class for handling event streams and iterators.
  - Modified function signatures to return the new async iterator class type.

- **Tests**
  - Revised test suites to accommodate the new async iterator class.
  - Removed a test concerning a deprecated async disposal symbol fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->