### PR TITLE
feat(tanstack-query): `.queryKey`, `.streamedKey`, `.infiniteKey`, `.mutationKey`

### DIFF
--- a/apps/content/docs/integrations/tanstack-query.md
+++ b/apps/content/docs/integrations/tanstack-query.md
@@ -139,7 +139,7 @@ mutation.mutate({ name: 'Earth' })
 
 oRPC provides a set of helper methods to generate keys for queries and mutations:
 
-- `.key`: Generate a **partial matching** key for action like revalidating queries, checking mutation status, etc.
+- `.key`: Generate a **partial matching** key for actions like revalidating queries, checking mutation status, etc.
 - `.queryKey`: Generate a **full matching** key for [Query Options](#query-options).
 - `.streamedKey`: Generate a **full matching** key for [Streamed Query Options](#streamed-query-options).
 - `.infiniteKey`: Generate a **full matching** key for [Infinite Query Options](#infinite-query-options).

--- a/apps/content/docs/integrations/tanstack-query.md
+++ b/apps/content/docs/integrations/tanstack-query.md
@@ -137,11 +137,13 @@ mutation.mutate({ name: 'Earth' })
 
 ## Query/Mutation Key
 
-Use `.key` to generate a `QueryKey` or `MutationKey`. This is useful for tasks such as revalidating queries, checking mutation status, etc.
+oRPC provides a set of helper methods to generate keys for queries and mutations:
 
-::: warning
-For exact key matching (e.g. setting or updating specific query data), you should use methods like `.queryOptions(...).queryKey`, `.infiniteOptions(...).queryKey`, etc.
-:::
+- `.key`: Generate a **partial matching** key for action like revalidating queries, checking mutation status, etc.
+- `.queryKey`: Generate a **full matching** key for [Query Options](#query-options).
+- `.streamedKey`: Generate a **full matching** key for [Streamed Query Options](#streamed-query-options).
+- `.infiniteKey`: Generate a **full matching** key for [Infinite Query Options](#infinite-query-options).
+- `.mutationKey`: Generate a **full matching** key for [Mutation Options](#mutation-options).
 
 ```ts
 const queryClient = useQueryClient()
@@ -159,6 +161,11 @@ queryClient.invalidateQueries({
 // Invalidate the planet find query with id 123
 queryClient.invalidateQueries({
   queryKey: orpc.planet.find.key({ input: { id: 123 } })
+})
+
+// Update the planet find query with id 123
+queryClient.setQueryData(orpc.planet.find.queryKey({ input: { id: 123 } }), (old) => {
+  return { ...old, id: 123, name: 'Earth' }
 })
 ```
 

--- a/packages/tanstack-query/src/general-utils.ts
+++ b/packages/tanstack-query/src/general-utils.ts
@@ -6,9 +6,9 @@ import { generateOperationKey } from './key'
  */
 export interface GeneralUtils<TInput> {
   /**
-   * Generate a query/mutation key for checking status, invalidate, set, get, etc.
+   * Generate a **partial matching** key for actions like revalidating queries, checking mutation status, etc.
    *
-   * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query-old/basic#query-mutation-key Tanstack Query/Mutation Key Docs}
+   * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#query-mutation-key Tanstack Query/Mutation Key Docs}
    */
   key<TType extends OperationType>(options?: OperationKeyOptions<TType, TInput>): OperationKey<TType, TInput>
 }

--- a/packages/tanstack-query/src/procedure-utils.test-d.ts
+++ b/packages/tanstack-query/src/procedure-utils.test-d.ts
@@ -157,6 +157,12 @@ describe('ProcedureUtils', () => {
         select: mapped => ({ mapped }),
       })).toExtend<QueryObserverOptions<UtilsOutput, UtilsError, { mapped: UtilsOutput }>>()
     })
+
+    it('.getQueryState is typed correctly', () => {
+      const state = queryClient.getQueryState(optionalUtils.queryOptions().queryKey)
+      expectTypeOf(state?.data).toEqualTypeOf<UtilsOutput | undefined>()
+      expectTypeOf(state?.error).toEqualTypeOf<UtilsError | null | undefined>()
+    })
   })
 
   describe('.streamedKey', () => {
@@ -283,6 +289,12 @@ describe('ProcedureUtils', () => {
       expectTypeOf(streamUtils.experimental_streamedOptions({
         select: mapped => ({ mapped }),
       })).toExtend<QueryObserverOptions<UtilsOutput, UtilsError, { mapped: UtilsOutput }>>()
+    })
+
+    it('.getQueryState is typed correctly', () => {
+      const state = queryClient.getQueryState(streamUtils.experimental_streamedOptions().queryKey)
+      expectTypeOf(state?.data).toEqualTypeOf<UtilsOutput | undefined>()
+      expectTypeOf(state?.error).toEqualTypeOf<UtilsError | null | undefined>()
     })
   })
 
@@ -531,6 +543,17 @@ describe('ProcedureUtils', () => {
         initialPageParam,
         select: mapped => ({ mapped }),
       })).toExtend<InfiniteQueryObserverOptions<UtilsOutput, UtilsError, { mapped: InfiniteData<UtilsOutput, number> }, QueryKey, number>>()
+    })
+
+    it('.getQueryState is typed correctly', () => {
+      const state = queryClient.getQueryState(optionalUtils.infiniteOptions({
+        input: () => ({}),
+        getNextPageParam,
+        initialPageParam,
+      }).queryKey)
+
+      expectTypeOf(state?.data).toEqualTypeOf<InfiniteData<UtilsOutput, number> | undefined>()
+      expectTypeOf(state?.error).toEqualTypeOf<UtilsError | null | undefined>()
     })
   })
 

--- a/packages/tanstack-query/src/procedure-utils.test-d.ts
+++ b/packages/tanstack-query/src/procedure-utils.test-d.ts
@@ -3,12 +3,14 @@ import type { ErrorFromErrorMap } from '@orpc/contract'
 import type { GetNextPageParamFunction, InfiniteData, InfiniteQueryObserverOptions, MutationObserverOptions, QueryFunction, QueryKey, QueryObserverOptions } from '@tanstack/query-core'
 import type { baseErrorMap } from '../../contract/tests/shared'
 import type { ProcedureUtils } from './procedure-utils'
-import { skipToken } from '@tanstack/query-core'
+import { QueryClient, skipToken } from '@tanstack/query-core'
 
 describe('ProcedureUtils', () => {
   type UtilsInput = { search?: string, cursor?: number } | undefined
   type UtilsOutput = { title: string }[]
   type UtilsError = ErrorFromErrorMap<typeof baseErrorMap>
+
+  const queryClient = new QueryClient()
 
   const condition = {} as boolean
 
@@ -37,6 +39,56 @@ describe('ProcedureUtils', () => {
     expectTypeOf(optionalUtils.call).toEqualTypeOf<
       Client<{ batch?: boolean }, UtilsInput, UtilsOutput, UtilsError>
     >()
+  })
+
+  describe('.queryKey', () => {
+    it('should handle optional `input` correctly', () => {
+      optionalUtils.queryKey()
+      optionalUtils.queryKey({ })
+      optionalUtils.queryKey({ input: { search: 'search' } })
+    })
+
+    it('should handle required `input` correctly', () => {
+      // @ts-expect-error - `input` is required
+      requiredUtils.queryKey()
+    })
+
+    it('should infer types for `input` correctly', () => {
+      optionalUtils.queryKey({ input: { cursor: 1 } })
+      // @ts-expect-error - Should error on invalid input type
+      optionalUtils.queryKey({ input: { cursor: 'invalid' } })
+
+      requiredUtils.queryKey({ input: 'input' })
+      // @ts-expect-error - Should error on invalid input type
+      requiredUtils.queryKey({ input: 123 })
+    })
+
+    it('allow use skipToken as input', () => {
+      optionalUtils.queryKey({ input: condition ? skipToken : { search: 'search' } })
+      // @ts-expect-error - invalid input type
+      optionalUtils.queryKey({ input: condition ? skipToken : { cursor: 'invalid' } })
+
+      requiredUtils.queryKey({ input: condition ? skipToken : 'input' })
+      // @ts-expect-error - invalid input type
+      requiredUtils.queryKey({ input: condition ? skipToken : 123 })
+    })
+
+    it('allow override query key', () => {
+      optionalUtils.queryKey({ queryKey: ['1'] })
+      // @ts-expect-error - invalid query key type
+      optionalUtils.queryKey({ queryKey: 1 })
+    })
+
+    it('return valid query key', () => {
+      expectTypeOf(optionalUtils.queryKey()).toExtend<QueryKey>()
+      expectTypeOf(optionalUtils.queryKey({ input: { search: 'search' } })).toExtend<QueryKey>()
+    })
+
+    it('.getQueryState is typed correctly', () => {
+      const state = queryClient.getQueryState(optionalUtils.queryKey())
+      expectTypeOf(state?.data).toEqualTypeOf<UtilsOutput | undefined>()
+      expectTypeOf(state?.error).toEqualTypeOf<UtilsError | null | undefined>()
+    })
   })
 
   describe('.queryOptions', () => {
@@ -104,6 +156,62 @@ describe('ProcedureUtils', () => {
       expectTypeOf(optionalUtils.queryOptions({
         select: mapped => ({ mapped }),
       })).toExtend<QueryObserverOptions<UtilsOutput, UtilsError, { mapped: UtilsOutput }>>()
+    })
+  })
+
+  describe('.streamedKey', () => {
+    it('should handle optional `input` correctly', () => {
+      optionalUtils.experimental_streamedKey()
+      optionalUtils.experimental_streamedKey({})
+      optionalUtils.experimental_streamedKey({ input: { search: 'search' } })
+    })
+
+    it('should handle required `input` correctly', () => {
+      // @ts-expect-error - `input` is required
+      requiredUtils.experimental_streamedKey()
+    })
+
+    it('should infer types for `input` correctly', () => {
+      optionalUtils.experimental_streamedKey({ input: { cursor: 1 } })
+      // @ts-expect-error - Should error on invalid input type
+      optionalUtils.experimental_streamedKey({ input: { cursor: 'invalid' } })
+
+      requiredUtils.experimental_streamedKey({ input: 'input' })
+      // @ts-expect-error - Should error on invalid input type
+      requiredUtils.experimental_streamedKey({ input: 123 })
+    })
+
+    it('allow use skipToken as input', () => {
+      optionalUtils.experimental_streamedKey({ input: condition ? skipToken : { search: 'search' } })
+      // @ts-expect-error - invalid input type
+      optionalUtils.experimental_streamedKey({ input: condition ? skipToken : { cursor: 'invalid' } })
+
+      requiredUtils.experimental_streamedKey({ input: condition ? skipToken : 'input' })
+      // @ts-expect-error - invalid input type
+      requiredUtils.experimental_streamedKey({ input: condition ? skipToken : 123 })
+    })
+
+    it('allow override query key', () => {
+      optionalUtils.experimental_streamedKey({ queryKey: ['1'] })
+      // @ts-expect-error - invalid query key type
+      optionalUtils.experimental_streamedKey({ queryKey: 1 })
+    })
+
+    it('return valid query key', () => {
+      expectTypeOf(optionalUtils.experimental_streamedKey()).toExtend<QueryKey>()
+      expectTypeOf(optionalUtils.experimental_streamedKey({
+        input: { search: 'search' },
+        queryFnOptions: {
+          maxChunks: 1,
+          refetchMode: 'replace',
+        },
+      })).toExtend<QueryKey>()
+    })
+
+    it('.getQueryState is typed correctly', () => {
+      const state = queryClient.getQueryState(streamUtils.experimental_streamedKey())
+      expectTypeOf(state?.data).toEqualTypeOf<UtilsOutput | undefined>()
+      expectTypeOf(state?.error).toEqualTypeOf<UtilsError | null | undefined>()
     })
   })
 
@@ -175,6 +283,104 @@ describe('ProcedureUtils', () => {
       expectTypeOf(streamUtils.experimental_streamedOptions({
         select: mapped => ({ mapped }),
       })).toExtend<QueryObserverOptions<UtilsOutput, UtilsError, { mapped: UtilsOutput }>>()
+    })
+  })
+
+  describe('.infiniteKey', () => {
+    const initialPageParam = 1
+
+    it('should infer types for `input` correctly', () => {
+      optionalUtils.infiniteKey({
+        input: () => ({}),
+        initialPageParam,
+      })
+      optionalUtils.infiniteKey({
+        // @ts-expect-error - Should error on invalid input type
+        input: () => ({ cursor: 'invalid' }),
+        initialPageParam,
+      })
+    })
+
+    it('allow use skipToken as input', () => {
+      optionalUtils.infiniteKey({
+        input: condition ? skipToken : () => ({}),
+        initialPageParam,
+      })
+      optionalUtils.infiniteKey({
+        // @ts-expect-error - invalid input type
+        input: condition ? skipToken : () => ({ cursor: 'invalid' }),
+        initialPageParam,
+      })
+    })
+
+    it('should infer `pageParam` type correctly', () => {
+      optionalUtils.infiniteKey({
+        input: (pageParam) => {
+          expectTypeOf(pageParam).toEqualTypeOf<number>()
+          return { cursor: pageParam }
+        },
+        initialPageParam,
+      })
+
+      optionalUtils.infiniteKey({
+        input: condition
+          ? skipToken
+          : (pageParam) => {
+              expectTypeOf(pageParam).toEqualTypeOf<number>()
+              return { cursor: pageParam }
+            },
+        initialPageParam,
+      })
+    })
+
+    it('should error on conflicting `pageParam` types', () => {
+      optionalUtils.infiniteKey({
+        input: (pageParam: number | undefined) => {
+          return { cursor: pageParam }
+        },
+        initialPageParam,
+      })
+
+      optionalUtils.infiniteKey({
+        input: condition
+          ? skipToken
+          : (pageParam: number) => {
+              return { cursor: pageParam }
+            },
+        // @ts-expect-error - conflict pageParam type
+        initialPageParam: undefined,
+      })
+    })
+
+    it('allow override query key', () => {
+      optionalUtils.infiniteKey({
+        input: () => ({}),
+        initialPageParam,
+        queryKey: ['1'],
+      })
+      optionalUtils.infiniteKey({
+        input: () => ({}),
+        initialPageParam,
+        // @ts-expect-error - invalid query key type
+        queryKey: 1,
+      })
+    })
+
+    it('return valid query key', () => {
+      expectTypeOf(optionalUtils.infiniteKey({
+        input: () => ({}),
+        initialPageParam,
+      })).toExtend<QueryKey>()
+    })
+
+    it('.getQueryState is typed correctly', () => {
+      const state = queryClient.getQueryState(optionalUtils.infiniteKey({
+        input: () => ({}),
+        initialPageParam,
+      }))
+
+      expectTypeOf(state?.data).toEqualTypeOf<InfiniteData<UtilsOutput, number> | undefined>()
+      expectTypeOf(state?.error).toEqualTypeOf<UtilsError | null | undefined>()
     })
   })
 
@@ -325,6 +531,26 @@ describe('ProcedureUtils', () => {
         initialPageParam,
         select: mapped => ({ mapped }),
       })).toExtend<InfiniteQueryObserverOptions<UtilsOutput, UtilsError, { mapped: InfiniteData<UtilsOutput, number> }, QueryKey, number>>()
+    })
+  })
+
+  describe('.mutationKey', () => {
+    it('should optional arguments', () => {
+      optionalUtils.mutationKey()
+    })
+
+    it('allow override query key', () => {
+      optionalUtils.mutationKey({
+        mutationKey: ['1'],
+      })
+      optionalUtils.mutationKey({
+        // @ts-expect-error - invalid query key type
+        mutationKey: 1,
+      })
+    })
+
+    it('return valid query key', () => {
+      expectTypeOf(optionalUtils.mutationKey()).toExtend<QueryKey>()
     })
   })
 

--- a/packages/tanstack-query/src/procedure-utils.test.ts
+++ b/packages/tanstack-query/src/procedure-utils.test.ts
@@ -30,6 +30,15 @@ describe('createProcedureUtils', () => {
     expect(utils.call).toBe(client)
   })
 
+  it('.queryKey', () => {
+    expect(utils.queryKey({ input: { search: '__search__' } })).toBe(generateOperationKeySpy.mock.results[0]!.value)
+    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+    expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'query', input: { search: '__search__' } })
+
+    expect(utils.queryKey({ queryKey: ['1'] })).toEqual(['1'])
+    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+  })
+
   describe('.queryOptions', () => {
     it('without skipToken', async () => {
       const options = utils.queryOptions({ input: { search: '__search__' }, context: { batch: '__batch__' } })
@@ -64,6 +73,15 @@ describe('createProcedureUtils', () => {
       expect(() => options.queryFn!({ signal } as any)).toThrow('queryFn should not be called with skipToken used as input')
       expect(client).toHaveBeenCalledTimes(0)
     })
+  })
+
+  it('.streamedKey', () => {
+    expect(utils.experimental_streamedKey({ input: { search: '__search__' } })).toBe(generateOperationKeySpy.mock.results[0]!.value)
+    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+    expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'streamed', input: { search: '__search__' } })
+
+    expect(utils.experimental_streamedKey({ queryKey: ['1'] })).toEqual(['1'])
+    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
   })
 
   describe('.streamedOptions', () => {
@@ -145,6 +163,15 @@ describe('createProcedureUtils', () => {
     })
   })
 
+  it('.infiniteKey', () => {
+    expect(utils.infiniteKey({ input: pageParam => ({ search: '__search__', pageParam }), initialPageParam: '__initialPageParam__' })).toBe(generateOperationKeySpy.mock.results[0]!.value)
+    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+    expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'infinite', input: { search: '__search__', pageParam: '__initialPageParam__' } })
+
+    expect(utils.infiniteKey({ input: () => ({}), initialPageParam: 0, queryKey: ['1'] })).toEqual(['1'])
+    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+  })
+
   describe('.infiniteOptions', () => {
     it('without skipToken', async () => {
       const getNextPageParam = vi.fn()
@@ -205,6 +232,15 @@ describe('createProcedureUtils', () => {
       expect(() => options.queryFn!({ signal, pageParam: '__pageParam__' } as any)).toThrow('queryFn should not be called with skipToken used as input')
       expect(client).toHaveBeenCalledTimes(0)
     })
+  })
+
+  it('.mutationKey', () => {
+    expect(utils.mutationKey()).toBe(generateOperationKeySpy.mock.results[0]!.value)
+    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+    expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'mutation' })
+
+    expect(utils.mutationKey({ mutationKey: ['1'] })).toEqual(['1'])
+    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
   })
 
   it('.mutationOptions', async () => {

--- a/packages/tanstack-query/src/procedure-utils.ts
+++ b/packages/tanstack-query/src/procedure-utils.ts
@@ -31,7 +31,9 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
   call: Client<TClientContext, TInput, TOutput, TError>
 
   /**
-   * Generate the key used for query options
+   * Generate a **full matching** key for [Query Options](https://orpc.unnoq.com/docs/integrations/tanstack-query#query-options).
+   *
+   * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#query-mutation-key Tanstack Query/Mutation Key Docs}
    */
   queryKey(
     ...rest: MaybeOptionalOptions<
@@ -51,7 +53,9 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
   ): NoInfer<U & Omit<QueryOptionsBase<TOutput, TError>, keyof U>>
 
   /**
-   * Generate the key used for streamed options
+   * Generate a **full matching** key for [Streamed Query Options](https://orpc.unnoq.com/docs/integrations/tanstack-query#streamed-query-options).
+   *
+   * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#query-mutation-key Tanstack Query/Mutation Key Docs}
    */
   experimental_streamedKey(
     ...rest: MaybeOptionalOptions<
@@ -72,7 +76,9 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
   ): NoInfer<U & Omit<StreamedOptionsBase<experimental_StreamedQueryOutput<TOutput>, TError>, keyof U>>
 
   /**
-   * Generate the key used for infinite options
+   * Generate a **full matching** key for [Infinite Query Options](https://orpc.unnoq.com/docs/integrations/tanstack-query#infinite-query-options).
+   *
+   * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#query-mutation-key Tanstack Query/Mutation Key Docs}
    */
   infiniteKey<UPageParam>(
     options: Pick<
@@ -91,7 +97,9 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
   ): NoInfer<U & Omit<InfiniteOptionsBase<TOutput, TError, UPageParam>, keyof U>>
 
   /**
-   * Generate the key used for mutation options
+   * Generate a **full matching** key for [Mutation Options](https://orpc.unnoq.com/docs/integrations/tanstack-query#mutation-options).
+   *
+   * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#query-mutation-key Tanstack Query/Mutation Key Docs}
    */
   mutationKey(
     options?: Pick<

--- a/packages/tanstack-query/src/types.ts
+++ b/packages/tanstack-query/src/types.ts
@@ -1,6 +1,7 @@
 import type { ClientContext } from '@orpc/client'
 import type { PartialDeep, SetOptional } from '@orpc/shared'
 import type {
+  DataTag,
   experimental_streamedQuery,
   InfiniteData,
   InfiniteQueryObserverOptions,
@@ -44,7 +45,7 @@ export type QueryOptionsIn<TClientContext extends ClientContext, TInput, TOutput
   & Omit<QueryObserverOptions<TOutput, TError, TSelectData>, 'queryKey'>
 
 export interface QueryOptionsBase<TOutput, TError> {
-  queryKey: QueryKey
+  queryKey: DataTag<QueryKey, TOutput, TError>
   queryFn: QueryFunction<TOutput>
   throwOnError?: (error: TError) => boolean // Help TQ infer TError
   retryDelay?: (count: number, error: TError) => number // Help TQ infer TError (suspense hooks)
@@ -68,7 +69,7 @@ export type InfiniteOptionsIn<TClientContext extends ClientContext, TInput, TOut
   & SetOptional<InfiniteQueryObserverOptions<TOutput, TError, TSelectData, QueryKey, TPageParam>, 'queryKey'>
 
 export interface InfiniteOptionsBase<TOutput, TError, TPageParam> {
-  queryKey: QueryKey
+  queryKey: DataTag<QueryKey, InfiniteData<TOutput, TPageParam>, TError>
   queryFn: QueryFunction<TOutput, QueryKey, TPageParam>
   select?(): InfiniteData<TOutput, TPageParam> // Help TQ infer TPageParam
   throwOnError?: (error: TError) => boolean // Help TQ infer TError

--- a/packages/tanstack-query/src/types.ts
+++ b/packages/tanstack-query/src/types.ts
@@ -34,10 +34,14 @@ export interface OperationContext {
   }
 }
 
+export type QueryKeyOptions<TInput> =
+  & (undefined extends TInput ? { input?: TInput | SkipToken } : { input: TInput | SkipToken })
+  & { queryKey?: QueryKey }
+
 export type QueryOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TSelectData> =
-    & (undefined extends TInput ? { input?: TInput | SkipToken } : { input: TInput | SkipToken })
-    & (Record<never, never> extends TClientContext ? { context?: TClientContext } : { context: TClientContext })
-    & SetOptional<QueryObserverOptions<TOutput, TError, TSelectData>, 'queryKey'>
+  & QueryKeyOptions<TInput>
+  & (Record<never, never> extends TClientContext ? { context?: TClientContext } : { context: TClientContext })
+  & Omit<QueryObserverOptions<TOutput, TError, TSelectData>, 'queryKey'>
 
 export interface QueryOptionsBase<TOutput, TError> {
   queryKey: QueryKey
@@ -46,6 +50,10 @@ export interface QueryOptionsBase<TOutput, TError> {
   retryDelay?: (count: number, error: TError) => number // Help TQ infer TError (suspense hooks)
   enabled: boolean
 }
+
+export type experimental_StreamedKeyOptions<TInput> =
+  & QueryKeyOptions<TInput>
+  & { queryFnOptions?: experimental_StreamedQueryOptions }
 
 export type experimental_StreamedOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TSelectData> =
   & QueryOptionsIn<TClientContext, TInput, TOutput, TError, TSelectData>

--- a/packages/tanstack-query/tests/e2e.test-d.ts
+++ b/packages/tanstack-query/tests/e2e.test-d.ts
@@ -19,6 +19,16 @@ it('.call', () => {
   expectTypeOf(orpc.ping.call).toEqualTypeOf(client.ping)
 })
 
+it('.queryKey', () => {
+  const state = queryClient.getQueryState(orpc.ping.queryKey({ input: { input: 123 } }))
+
+  expectTypeOf(state?.data).toEqualTypeOf<{ output: string } | undefined>()
+
+  if (isDefinedError(state?.error) && state.error.code === 'BASE') {
+    expectTypeOf(state.error.data).toEqualTypeOf<{ output: string }>()
+  }
+})
+
 describe('.queryOptions', () => {
   it('useQuery', () => {
     const query = useQuery(orpc.ping.queryOptions({
@@ -169,6 +179,16 @@ describe('.queryOptions', () => {
   })
 })
 
+it('.streamedKey', () => {
+  const state = queryClient.getQueryState(streamedOrpc.streamed.experimental_streamedKey({ input: { input: 123 } }))
+
+  expectTypeOf(state?.data).toEqualTypeOf<{ output: string }[] | undefined>()
+
+  if (isDefinedError(state?.error) && state.error.code === 'OVERRIDE') {
+    expectTypeOf(state.error.data).toEqualTypeOf<unknown>()
+  }
+})
+
 describe('.streamedOptions', () => {
   it('useQuery', () => {
     const query = useQuery(streamedOrpc.streamed.experimental_streamedOptions({
@@ -317,6 +337,16 @@ describe('.streamedOptions', () => {
 
     expectTypeOf(query).toEqualTypeOf<{ output: string }[]>()
   })
+})
+
+it('.infiniteKey', () => {
+  const state = queryClient.getQueryState(orpc.nested.ping.infiniteKey({ input: input => ({ input }), initialPageParam: 1 }))
+
+  expectTypeOf(state?.data).toEqualTypeOf<InfiniteData<{ output: string }, number> | undefined>()
+
+  if (isDefinedError(state?.error) && state.error.code === 'OVERRIDE') {
+    expectTypeOf(state.error.data).toEqualTypeOf<unknown>()
+  }
 })
 
 describe('.infiniteOptions', () => {

--- a/packages/tanstack-query/tests/e2e.test.tsx
+++ b/packages/tanstack-query/tests/e2e.test.tsx
@@ -34,7 +34,7 @@ it('case: with useQuery', async () => {
   })
 
   expect(
-    queryClient.getQueryData(orpc.nested.ping.key({ input: { input: 123 }, type: 'query' })),
+    queryClient.getQueryData(orpc.nested.ping.queryKey({ input: { input: 123 } })),
   ).toEqual({ output: '123' })
 
   pingHandler.mockRejectedValueOnce(new ORPCError('OVERRIDE'))
@@ -87,7 +87,7 @@ it('case: with streamed/useQuery', async () => {
   })
 
   expect(
-    queryClient.getQueryData(streamedOrpc.streamed.key({ input: { input: 2 }, type: 'streamed', fnOptions: { refetchMode: 'append', maxChunks: 3 } })),
+    queryClient.getQueryData(streamedOrpc.streamed.experimental_streamedKey({ input: { input: 2 }, queryFnOptions: { refetchMode: 'append', maxChunks: 3 } })),
   ).toEqual([{ output: '0' }, { output: '1' }])
 
   // make sure refetch mode works
@@ -150,7 +150,7 @@ it('case: with useInfiniteQuery', async () => {
   }))
 
   expect(
-    queryClient.getQueryData(orpc.nested.ping.key({ input: { input: 1 }, type: 'infinite' })),
+    queryClient.getQueryData(orpc.nested.ping.infiniteKey({ input: input => ({ input }), initialPageParam: 1 })),
   ).toEqual({
     pageParams: [1],
     pages: [


### PR DESCRIPTION
Fixes #620, #517

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced dedicated methods for generating query, streamed query, infinite query, and mutation keys within the procedure utilities, making key management more flexible and explicit.

- **Documentation**
  - Updated the Tanstack Query integration guide to clarify key generation methods and provide detailed usage examples.
  - Enhanced documentation comments to better distinguish partial matching keys from full matching keys.

- **Tests**
  - Added comprehensive unit and type-checking tests for the new key generation utilities and their integration with query state retrieval.
  - Extended end-to-end tests to verify type correctness of query state accessors for various key types.
  - Updated test usage to adopt new key-generating methods for improved clarity.

- **Refactor**
  - Centralized and streamlined key generation logic for improved consistency and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->