### PR TITLE
fix: EventPublisher should throw immediately if signal is aborted

### DIFF
--- a/packages/shared/src/event-publisher.test.ts
+++ b/packages/shared/src/event-publisher.test.ts
@@ -239,16 +239,11 @@ describe('eventPublisher', () => {
       expect(pub.size).toEqual(2) // iterator1 was unsubscribed
     })
 
-    it('throw right away if signal aborted', async () => {
+    it('throw immediately if signal aborted', () => {
       controller3.abort()
       const payloads: any[] = []
 
-      await expect(async () => {
-        for await (const payload of iterator3) {
-          payloads.push(payload)
-        }
-      },
-      ).rejects.toThrow(controller3.signal.reason)
+      expect(() => pub.subscribe('event3', { signal: controller3.signal })).toThrow(controller3.signal.reason)
     })
 
     it('throw if signal aborted while awaiting next', async () => {

--- a/packages/shared/src/event-publisher.ts
+++ b/packages/shared/src/event-publisher.ts
@@ -103,6 +103,8 @@ export class EventPublisher<T extends Record<PropertyKey, any>> {
     const signal = listenerOrOptions?.signal
     const maxBufferedEvents = listenerOrOptions?.maxBufferedEvents ?? this.#maxBufferedEvents
 
+    signal?.throwIfAborted()
+
     const bufferedEvents: T[K][] = []
     const pullResolvers: [(result: IteratorResult<T[K]>) => void, (error: Error) => void][] = []
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of aborted operations to ensure immediate feedback if an operation is started with an already-aborted signal.

- **Tests**
  - Updated tests to verify that operations throw immediately when initiated with an aborted signal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->