### PR TITLE
feat(openapi): gen spec with common schemas - `components.schemas`

### DIFF
--- a/apps/content/docs/openapi/openapi-specification.md
+++ b/apps/content/docs/openapi/openapi-specification.md
@@ -108,6 +108,42 @@ const specFromRouter = await openAPIGenerator.generate(router, {
 Features prefixed with `experimental_` are unstable and may lack some functionality.
 :::
 
+## Common Schemas
+
+Define reusable schema components that can be referenced across your OpenAPI specification:
+
+```ts
+const UserSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string().email(),
+})
+
+const PetSchema = z.object({
+  id: z.string().transform(id => Number(id)).pipe(z.number()),
+})
+
+const spec = await generator.generate(router, {
+  commonSchemas: {
+    User: {
+      schema: UserSchema,
+    },
+    InputPet: {
+      strategy: 'input',
+      schema: PetSchema,
+    },
+    OutputPet: {
+      strategy: 'output',
+      schema: PetSchema,
+    },
+  },
+})
+```
+
+:::info
+The `strategy` option determines which schema definition to use when input and output types differ (defaults to `input`). This is needed because we cannot use the same `$ref` for both input and output in this case.
+:::
+
 ## Excluding Procedures
 
 You can exclude a procedure from the OpenAPI specification using the `exclude` option:

--- a/packages/openapi/src/openapi-generator.test.ts
+++ b/packages/openapi/src/openapi-generator.test.ts
@@ -994,6 +994,10 @@ describe('openAPIGenerator', () => {
       id: z4.string().transform(v => Number(v)).pipe(z4.number().min(0).max(100)),
     })
 
+    const Cat = z4.object({
+      name: z4.string(),
+    })
+
     const DetailedStructure = z4.object({
       params: z4.object({
         pet: Pet,
@@ -1010,7 +1014,7 @@ describe('openAPIGenerator', () => {
     const spec = await generator.generate({
       user: oc.input(User).errors({ TEST: { data: User } }).output(User),
       pet: oc.input(Pet).errors({ TEST: { data: Pet } }).output(Pet),
-      iterator: oc.input(eventIterator(User, Pet)).output(eventIterator(User, Pet)),
+      iterator: oc.input(eventIterator(User, Pet)).output(eventIterator(Cat, Pet)),
       dynamicParams: oc.route({ path: '/user/{id}', method: 'POST' }).input(User),
       detailedStructure: oc.route({ path: '/detailed/{pet}', inputStructure: 'detailed', outputStructure: 'detailed' })
         .input(DetailedStructure)
@@ -1023,6 +1027,10 @@ describe('openAPIGenerator', () => {
         Pet: {
           strategy: 'output',
           schema: Pet,
+        },
+        Cat: {
+          strategy: 'output',
+          schema: Cat,
         },
         DetailedStructure: {
           strategy: 'output',
@@ -1047,6 +1055,13 @@ describe('openAPIGenerator', () => {
             id: { type: 'number', minimum: 0, maximum: 100 },
           },
           required: ['id'],
+        },
+        Cat: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+          },
+          required: ['name'],
         },
         DetailedStructure: {
           type: 'object',
@@ -1260,7 +1275,7 @@ describe('openAPIGenerator', () => {
                       type: 'object',
                       properties: {
                         event: { const: 'message' },
-                        data: { $ref: '#/components/schemas/User' },
+                        data: { $ref: '#/components/schemas/Cat' },
                         id: { type: 'string' },
                         retry: { type: 'number' },
                       },

--- a/packages/openapi/src/openapi-generator.ts
+++ b/packages/openapi/src/openapi-generator.ts
@@ -230,7 +230,15 @@ export class OpenAPIGenerator {
 
     const dynamicParams = getDynamicParams(def.route.path)?.map(v => v.name)
     const inputStructure = fallbackContractConfig('defaultInputStructure', def.route.inputStructure)
-    let [required, schema] = await this.converter.convert(def.inputSchema, { ...baseSchemaConvertOptions, strategy: 'input' })
+
+    let [required, schema] = await this.converter.convert(
+      def.inputSchema,
+      {
+        ...baseSchemaConvertOptions,
+        strategy: 'input',
+        minStructureDepthForRef: dynamicParams?.length || inputStructure === 'detailed' ? 1 : 0,
+      },
+    )
 
     if (isAnySchema(schema) && !dynamicParams?.length) {
       return
@@ -350,7 +358,14 @@ export class OpenAPIGenerator {
       return
     }
 
-    const [required, json] = await this.converter.convert(outputSchema, { ...baseSchemaConvertOptions, strategy: 'output' })
+    const [required, json] = await this.converter.convert(
+      outputSchema,
+      {
+        ...baseSchemaConvertOptions,
+        strategy: 'output',
+        minStructureDepthForRef: outputStructure === 'detailed' ? 1 : 0,
+      },
+    )
 
     if (outputStructure === 'compact') {
       ref.responses ??= {}

--- a/packages/openapi/src/openapi-utils.ts
+++ b/packages/openapi/src/openapi-utils.ts
@@ -165,3 +165,15 @@ export function toOpenAPISchema(schema: JSONSchema): OpenAPI.SchemaObject & obje
       ? { not: {} }
       : schema as OpenAPI.SchemaObject
 }
+
+const OPENAPI_JSON_SCHEMA_REF_PREFIX = /* @__PURE__ */ '#/components/schemas/'
+
+export function resolveOpenAPIJsonSchemaRef(doc: OpenAPI.Document, schema: JSONSchema): JSONSchema {
+  if (typeof schema !== 'object' || !schema.$ref?.startsWith(OPENAPI_JSON_SCHEMA_REF_PREFIX)) {
+    return schema
+  }
+
+  const name = schema.$ref.slice(OPENAPI_JSON_SCHEMA_REF_PREFIX.length)
+  const resolved = doc.components?.schemas?.[name]
+  return resolved as JSONSchema ?? schema
+}

--- a/packages/openapi/src/schema-converter.ts
+++ b/packages/openapi/src/schema-converter.ts
@@ -2,8 +2,29 @@ import type { AnySchema } from '@orpc/contract'
 import type { Promisable } from '@orpc/shared'
 import type { JSONSchema } from './schema'
 
+export interface SchemaConverterComponent {
+  allowedStrategies: SchemaConvertOptions['strategy'][]
+  schema: AnySchema
+  required: boolean
+  ref: string
+}
+
 export interface SchemaConvertOptions {
   strategy: 'input' | 'output'
+
+  /**
+   * Common components should use `$ref` to represent themselves if matched.
+   */
+  components?: SchemaConverterComponent[]
+
+  /**
+   * Minimum schema structure depth required before using `$ref` for components.
+   *
+   * For example, if set to 2, `$ref` will only be used for schemas nested at depth 2 or greater.
+   *
+   * @default 0 - No depth limit;
+   */
+  minStructureDepthForRef?: number
 }
 
 export interface SchemaConverter {

--- a/packages/zod/src/converter.components.test.ts
+++ b/packages/zod/src/converter.components.test.ts
@@ -1,0 +1,289 @@
+import { z } from 'zod'
+import { ZodToJsonSchemaConverter } from './converter'
+
+const User = z.object({
+  id: z.string(),
+  name: z.string(),
+  age: z.number().optional(),
+  get parents(): any {
+    return z.array(User).optional()
+  },
+})
+
+const Pet = z.object({
+  id: z.string(),
+  name: z.string(),
+  owner: z.lazy(() => User),
+})
+
+describe('zodToJsonSchemaConverter - components', () => {
+  const converter = new ZodToJsonSchemaConverter({ maxLazyDepth: 1 })
+
+  it.each([true, false])('works with Pet schema (required=%s)', (componentRequired) => {
+    const [required, jsonSchema] = converter.convert(
+      Pet,
+      {
+        strategy: 'input',
+        components: [
+          {
+            schema: User,
+            required: componentRequired,
+            ref: '#/components/schemas/User',
+            allowedStrategies: ['input', 'output'],
+          },
+        ],
+      },
+    )
+
+    expect(required).toBe(true)
+    expect(jsonSchema).toEqual({
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+        owner: { $ref: '#/components/schemas/User' },
+      },
+      required: componentRequired ? ['id', 'name', 'owner'] : ['id', 'name'],
+    })
+  })
+
+  describe('minStructureDepthForRef', () => {
+    it.each([true, false])('works with User schema (minStructureDepthForRef=0, required=%s)', (componentRequired) => {
+      const [required, jsonSchema] = converter.convert(
+        User,
+        {
+          strategy: 'input',
+          components: [
+            {
+              schema: User,
+              required: componentRequired,
+              ref: '#/components/schemas/User',
+              allowedStrategies: ['input', 'output'],
+            },
+          ],
+          minStructureDepthForRef: 0,
+        },
+      )
+
+      expect(required).toBe(componentRequired)
+      expect(jsonSchema).toEqual({ $ref: '#/components/schemas/User' })
+    })
+
+    it.each([true, false])('works with User schema (minStructureDepthForRef=1, strategy=input, required=%s)', (componentRequired) => {
+      const [required, jsonSchema] = converter.convert(
+        User,
+        {
+          strategy: 'input',
+          components: [
+            {
+              schema: User,
+              required: componentRequired,
+              ref: '#/components/schemas/User',
+              allowedStrategies: ['input', 'output'],
+            },
+          ],
+          minStructureDepthForRef: 1,
+        },
+      )
+
+      expect(required).toBe(true)
+      expect(jsonSchema).toEqual({
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' },
+          age: { type: 'number' },
+          parents: { type: 'array', items: componentRequired
+            ? { $ref: '#/components/schemas/User' }
+            : {
+                anyOf: [
+                  {
+                    $ref: '#/components/schemas/User',
+                  },
+                  {
+                    not: {},
+                  },
+                ],
+              } },
+        },
+        required: ['id', 'name'],
+      })
+    })
+
+    it.each([true, false])('works with User schema (minStructureDepthForRef=1, strategy=output, required=%s)', (componentRequired) => {
+      const [required, jsonSchema] = converter.convert(
+        User,
+        {
+          strategy: 'output',
+          components: [
+            {
+              schema: User,
+              required: componentRequired,
+              ref: '#/components/schemas/User',
+              allowedStrategies: ['input', 'output'],
+            },
+          ],
+          minStructureDepthForRef: 1,
+        },
+      )
+
+      expect(required).toBe(true)
+      expect(jsonSchema).toEqual({
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' },
+          age: { type: 'number' },
+          parents: {
+            type: 'array',
+            items: componentRequired
+              ? { $ref: '#/components/schemas/User' }
+              : {
+                  anyOf: [
+                    {
+                      $ref: '#/components/schemas/User',
+                    },
+                    {
+                      type: 'null',
+                    },
+                  ],
+                },
+          },
+        },
+        required: ['id', 'name'],
+      })
+    })
+
+    it('works with User schema (minStructureDepthForRef=3)', () => {
+      const [required, jsonSchema] = converter.convert(
+        User,
+        {
+          strategy: 'input',
+          components: [
+            {
+              schema: User,
+              required: true,
+              ref: '#/components/schemas/User',
+              allowedStrategies: ['input', 'output'],
+            },
+          ],
+          minStructureDepthForRef: 3,
+        },
+      )
+
+      expect(required).toBe(true)
+      expect(jsonSchema).toEqual({
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' },
+          age: { type: 'number' },
+          parents: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                name: { type: 'string' },
+                age: { type: 'number' },
+                parents: {
+                  type: 'array',
+                  items: { $ref: '#/components/schemas/User' },
+                },
+              },
+              required: ['id', 'name'],
+            },
+          },
+        },
+        required: ['id', 'name'],
+      })
+    })
+  })
+
+  it('on unsupported strategy', () => {
+    const Pet = z.object({
+      id: z.string(),
+      name: z.string(),
+    })
+
+    const [required, jsonSchema] = converter.convert(
+      Pet,
+      {
+        strategy: 'output',
+        components: [
+          {
+            schema: Pet,
+            required: true,
+            ref: '#/components/schemas/Pet',
+            allowedStrategies: ['input'],
+          },
+        ],
+      },
+    )
+
+    expect(required).toBe(true)
+    expect(jsonSchema).toEqual({
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+      },
+      required: ['id', 'name'],
+    })
+  })
+
+  it('complex case', () => {
+    const [required, jsonSchema] = converter.convert(
+      z.object({
+        users: z.array(User).optional(),
+        pets: z.array(Pet).optional(),
+        nested: z.array(z.object({
+          user: User.optional(),
+        })),
+      }).optional(),
+      {
+        strategy: 'input',
+        components: [
+          {
+            schema: User,
+            required: true,
+            ref: '#/components/schemas/User',
+            allowedStrategies: ['input', 'output'],
+          },
+          {
+            schema: Pet,
+            required: true,
+            ref: '#/components/schemas/Pet',
+            allowedStrategies: ['input', 'output'],
+          },
+        ],
+        minStructureDepthForRef: 2,
+      },
+    )
+
+    expect(required).toBe(false)
+    expect(jsonSchema).toEqual({
+      type: 'object',
+      properties: {
+        users: {
+          type: 'array',
+          items: { $ref: '#/components/schemas/User' },
+        },
+        pets: {
+          type: 'array',
+          items: { $ref: '#/components/schemas/Pet' },
+        },
+        nested: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              user: { $ref: '#/components/schemas/User' },
+            },
+          },
+        },
+      },
+      required: ['nested'],
+    })
+  })
+})

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -75,7 +75,7 @@ export interface ZodToJsonSchemaOptions {
 
 export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
   private readonly maxLazyDepth: Exclude<ZodToJsonSchemaOptions['maxLazyDepth'], undefined>
-  private readonly maxStructureDepth: Exclude<ZodToJsonSchemaOptions['maxStructureDepth'], undefined> = 100
+  private readonly maxStructureDepth: Exclude<ZodToJsonSchemaOptions['maxStructureDepth'], undefined>
   private readonly unsupportedJsonSchema: Exclude<ZodToJsonSchemaOptions['unsupportedJsonSchema'], undefined>
   private readonly anyJsonSchema: Exclude<ZodToJsonSchemaOptions['anyJsonSchema'], undefined>
 

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -41,18 +41,18 @@ import { getCustomZodDef } from './schemas/base'
 
 export interface ZodToJsonSchemaOptions {
   /**
-   * Max depth of lazy type, if it exceeds.
+   * Max depth of lazy type
    *
-   * Used `{}` when reach max depth
+   * Used `{}` when exceed max depth
    *
    * @default 3
    */
   maxLazyDepth?: number
 
   /**
-   * Max depth of nested types, if it exceeds.
+   * Max depth of nested types
    *
-   * Used anyJsonSchema (`{}`) when reach max depth
+   * Used anyJsonSchema (`{}`) when exceed max depth
    *
    * @default 10
    */
@@ -538,13 +538,15 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
       }
 
       case ZodFirstPartyTypeKind.ZodLazy: {
-        if (lazyDepth >= this.maxLazyDepth) {
+        const currentLazyDepth = lazyDepth + 1
+
+        if (currentLazyDepth > this.maxLazyDepth) {
           return [false, this.anyJsonSchema]
         }
 
         const schema_ = schema as ZodLazy<ZodTypeAny>
 
-        return this.convert(schema_._def.getter(), options, lazyDepth + 1, false, false, structureDepth)
+        return this.convert(schema_._def.getter(), options, currentLazyDepth, false, false, structureDepth)
       }
 
       case ZodFirstPartyTypeKind.ZodOptional: {

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -54,7 +54,7 @@ export interface ZodToJsonSchemaOptions {
    *
    * Used anyJsonSchema (`{}`) when reach max depth
    *
-   * @default 100
+   * @default 10
    */
   maxStructureDepth?: number
 
@@ -81,7 +81,7 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
 
   constructor(options: ZodToJsonSchemaOptions = {}) {
     this.maxLazyDepth = options.maxLazyDepth ?? 3
-    this.maxStructureDepth = options.maxStructureDepth ?? 100
+    this.maxStructureDepth = options.maxStructureDepth ?? 10
     this.unsupportedJsonSchema = options.unsupportedJsonSchema ?? { not: {} }
     this.anyJsonSchema = options.anyJsonSchema ?? {}
   }

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -33,6 +33,7 @@ import type {
   ZodUnionOptions,
 } from 'zod'
 import { JSONSchemaFormat } from '@orpc/openapi'
+import { toArray } from '@orpc/shared'
 import escapeStringRegexp from 'escape-string-regexp'
 import { ZodFirstPartyTypeKind } from 'zod'
 import { getCustomJsonSchema } from './custom-json-schema'
@@ -49,11 +50,13 @@ export interface ZodToJsonSchemaOptions {
   maxLazyDepth?: number
 
   /**
-   * The schema to be used when the Zod schema is unsupported.
+   * Max depth of nested types, if it exceeds.
    *
-   * @default { not: {} }
+   * Used anyJsonSchema (`{}`) when reach max depth
+   *
+   * @default 100
    */
-  unsupportedJsonSchema?: Exclude<JSONSchema, boolean>
+  maxStructureDepth?: number
 
   /**
    * The schema to be used to represent the any | unknown type.
@@ -61,15 +64,24 @@ export interface ZodToJsonSchemaOptions {
    * @default { }
    */
   anyJsonSchema?: Exclude<JSONSchema, boolean>
+
+  /**
+   * The schema to be used when the Zod schema is unsupported.
+   *
+   * @default { not: {} }
+   */
+  unsupportedJsonSchema?: Exclude<JSONSchema, boolean>
 }
 
 export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
   private readonly maxLazyDepth: Exclude<ZodToJsonSchemaOptions['maxLazyDepth'], undefined>
+  private readonly maxStructureDepth: Exclude<ZodToJsonSchemaOptions['maxStructureDepth'], undefined> = 100
   private readonly unsupportedJsonSchema: Exclude<ZodToJsonSchemaOptions['unsupportedJsonSchema'], undefined>
   private readonly anyJsonSchema: Exclude<ZodToJsonSchemaOptions['anyJsonSchema'], undefined>
 
   constructor(options: ZodToJsonSchemaOptions = {}) {
     this.maxLazyDepth = options.maxLazyDepth ?? 3
+    this.maxStructureDepth = options.maxStructureDepth ?? 100
     this.unsupportedJsonSchema = options.unsupportedJsonSchema ?? { not: {} }
     this.anyJsonSchema = options.anyJsonSchema ?? {}
   }
@@ -84,8 +96,23 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
     lazyDepth = 0,
     isHandledCustomJSONSchema = false,
     isHandledZodDescription = false,
+    structureDepth = 0,
   ): [required: boolean, jsonSchema: Exclude<JSONSchema, boolean>] {
     const def = (schema as ZodTypeAny)._def
+
+    if (structureDepth > this.maxStructureDepth) {
+      return [false, this.anyJsonSchema]
+    }
+
+    if (!options.minStructureDepthForRef || options.minStructureDepthForRef <= structureDepth) {
+      const components = toArray(options.components)
+
+      for (const component of components) {
+        if (component.schema === schema && component.allowedStrategies.includes(options.strategy)) {
+          return [component.required, { $ref: component.ref }]
+        }
+      }
+    }
 
     if (!isHandledZodDescription && 'description' in def && typeof def.description === 'string') {
       const [required, json] = this.convert(
@@ -94,6 +121,7 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
         lazyDepth,
         isHandledCustomJSONSchema,
         true,
+        structureDepth,
       )
 
       return [required, { ...json, description: def.description }]
@@ -109,6 +137,7 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
           lazyDepth,
           true,
           isHandledZodDescription,
+          structureDepth,
         )
 
         return [required, { ...json, ...customJSONSchema }]
@@ -320,7 +349,7 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
 
         const json: JSONSchema = { type: 'array' }
 
-        const [itemRequired, itemJson] = this.convert(def.type, options, lazyDepth, false, false)
+        const [itemRequired, itemJson] = this.convert(def.type, options, lazyDepth, false, false, structureDepth + 1)
 
         json.items = this.#toArrayItemJsonSchema(itemRequired, itemJson, options.strategy)
 
@@ -347,7 +376,7 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
         const json: JSONSchema = { type: 'array' }
 
         for (const item of schema_._def.items) {
-          const [itemRequired, itemJson] = this.convert(item, options, lazyDepth, false, false)
+          const [itemRequired, itemJson] = this.convert(item, options, lazyDepth, false, false, structureDepth + 1)
 
           prefixItems.push(
             this.#toArrayItemJsonSchema(itemRequired, itemJson, options.strategy),
@@ -359,7 +388,7 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
         }
 
         if (schema_._def.rest) {
-          const [itemRequired, itemJson] = this.convert(schema_._def.rest, options, lazyDepth, false, false)
+          const [itemRequired, itemJson] = this.convert(schema_._def.rest, options, lazyDepth, false, false, structureDepth + 1)
 
           json.items = this.#toArrayItemJsonSchema(itemRequired, itemJson, options.strategy)
         }
@@ -375,7 +404,7 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
         const required: string[] = []
 
         for (const [key, value] of Object.entries(schema_.shape)) {
-          const [itemRequired, itemJson] = this.convert(value, options, lazyDepth, false, false)
+          const [itemRequired, itemJson] = this.convert(value, options, lazyDepth, false, false, structureDepth + 1)
 
           properties[key] = itemJson
 
@@ -400,7 +429,7 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
           }
         }
         else {
-          const [_, addJson] = this.convert(schema_._def.catchall, options, lazyDepth, false, false)
+          const [_, addJson] = this.convert(schema_._def.catchall, options, lazyDepth, false, false, structureDepth + 1)
 
           json.additionalProperties = addJson
         }
@@ -413,13 +442,13 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
 
         const json: JSONSchema = { type: 'object' }
 
-        const [__, keyJson] = this.convert(schema_._def.keyType, options, lazyDepth, false, false)
+        const [__, keyJson] = this.convert(schema_._def.keyType, options, lazyDepth, false, false, structureDepth + 1)
 
         if (Object.entries(keyJson).some(([k, v]) => k !== 'type' || v !== 'string')) {
           json.propertyNames = keyJson
         }
 
-        const [_, itemJson] = this.convert(schema_._def.valueType, options, lazyDepth, false, false)
+        const [_, itemJson] = this.convert(schema_._def.valueType, options, lazyDepth, false, false, structureDepth + 1)
 
         json.additionalProperties = itemJson
 
@@ -431,7 +460,7 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
 
         const json: JSONSchema = { type: 'array', uniqueItems: true }
 
-        const [itemRequired, itemJson] = this.convert(schema_._def.valueType, options, lazyDepth, false, false)
+        const [itemRequired, itemJson] = this.convert(schema_._def.valueType, options, lazyDepth, false, false, structureDepth + 1)
 
         json.items = this.#toArrayItemJsonSchema(itemRequired, itemJson, options.strategy)
 
@@ -441,8 +470,8 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
       case ZodFirstPartyTypeKind.ZodMap: {
         const schema_ = schema as ZodMap
 
-        const [keyRequired, keyJson] = this.convert(schema_._def.keyType, options, lazyDepth, false, false)
-        const [valueRequired, valueJson] = this.convert(schema_._def.valueType, options, lazyDepth, false, false)
+        const [keyRequired, keyJson] = this.convert(schema_._def.keyType, options, lazyDepth, false, false, structureDepth + 1)
+        const [valueRequired, valueJson] = this.convert(schema_._def.valueType, options, lazyDepth, false, false, structureDepth + 1)
 
         return [true, {
           type: 'array',
@@ -468,7 +497,7 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
         let required = true
 
         for (const item of schema_._def.options) {
-          const [itemRequired, itemJson] = this.convert(item, options, lazyDepth, false, false)
+          const [itemRequired, itemJson] = this.convert(item, options, lazyDepth, false, false, structureDepth)
 
           if (!itemRequired) {
             required = false
@@ -496,7 +525,7 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
         let required: boolean = false
 
         for (const item of [schema_._def.left, schema_._def.right]) {
-          const [itemRequired, itemJson] = this.convert(item, options, lazyDepth, false, false)
+          const [itemRequired, itemJson] = this.convert(item, options, lazyDepth, false, false, structureDepth)
 
           allOf.push(itemJson)
 
@@ -515,20 +544,20 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
 
         const schema_ = schema as ZodLazy<ZodTypeAny>
 
-        return this.convert(schema_._def.getter(), options, lazyDepth + 1, false, false)
+        return this.convert(schema_._def.getter(), options, lazyDepth + 1, false, false, structureDepth)
       }
 
       case ZodFirstPartyTypeKind.ZodOptional: {
         const schema_ = schema as ZodOptional<ZodTypeAny>
 
-        const [_, inner] = this.convert(schema_._def.innerType, options, lazyDepth, false, false)
+        const [_, inner] = this.convert(schema_._def.innerType, options, lazyDepth, false, false, structureDepth)
 
         return [false, inner]
       }
 
       case ZodFirstPartyTypeKind.ZodReadonly: {
         const schema_ = schema as ZodReadonly<ZodTypeAny>
-        const [required, json] = this.convert(schema_._def.innerType, options, lazyDepth, false, false)
+        const [required, json] = this.convert(schema_._def.innerType, options, lazyDepth, false, false, structureDepth)
 
         return [required, { ...json, readOnly: true }]
       }
@@ -536,7 +565,7 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
       case ZodFirstPartyTypeKind.ZodDefault: {
         const schema_ = schema as ZodDefault<ZodTypeAny>
 
-        const [_, json] = this.convert(schema_._def.innerType, options, lazyDepth, false, false)
+        const [_, json] = this.convert(schema_._def.innerType, options, lazyDepth, false, false, structureDepth)
 
         return [false, { default: schema_._def.defaultValue(), ...json }]
       }
@@ -548,17 +577,17 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
           return [false, this.anyJsonSchema]
         }
 
-        return this.convert(schema_._def.schema, options, lazyDepth, false, false)
+        return this.convert(schema_._def.schema, options, lazyDepth, false, false, structureDepth)
       }
 
       case ZodFirstPartyTypeKind.ZodCatch: {
         const schema_ = schema as ZodCatch<ZodTypeAny>
-        return this.convert(schema_._def.innerType, options, lazyDepth, false, false)
+        return this.convert(schema_._def.innerType, options, lazyDepth, false, false, structureDepth)
       }
 
       case ZodFirstPartyTypeKind.ZodBranded: {
         const schema_ = schema as ZodBranded<ZodTypeAny, string | number | symbol>
-        return this.convert(schema_._def.type, options, lazyDepth, false, false)
+        return this.convert(schema_._def.type, options, lazyDepth, false, false, structureDepth)
       }
 
       case ZodFirstPartyTypeKind.ZodPipeline: {
@@ -570,13 +599,14 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
           lazyDepth,
           false,
           false,
+          structureDepth,
         )
       }
 
       case ZodFirstPartyTypeKind.ZodNullable: {
         const schema_ = schema as ZodNullable<ZodTypeAny>
 
-        const [required, json] = this.convert(schema_._def.innerType, options, lazyDepth, false, false)
+        const [required, json] = this.convert(schema_._def.innerType, options, lazyDepth, false, false, structureDepth)
 
         return [required, { anyOf: [{ type: 'null' }, json] }]
       }

--- a/packages/zod/src/zod4/converter.components.test.ts
+++ b/packages/zod/src/zod4/converter.components.test.ts
@@ -1,0 +1,278 @@
+import { z } from 'zod/v4'
+import { experimental_ZodToJsonSchemaConverter as ZodToJsonSchemaConverter } from './converter'
+
+const User = z.object({
+  id: z.string(),
+  name: z.string(),
+  age: z.number().optional(),
+  get parents() {
+    return z.array(User).optional()
+  },
+})
+
+const Pet = z.object({
+  id: z.string(),
+  name: z.string(),
+  owner: z.lazy(() => User),
+})
+
+describe('zodToJsonSchemaConverter - components', () => {
+  const converter = new ZodToJsonSchemaConverter({ maxLazyDepth: 1 })
+
+  it.each([true, false])('works with Pet schema (required=%s)', (componentRequired) => {
+    const [required, jsonSchema] = converter.convert(
+      Pet,
+      {
+        strategy: 'input',
+        components: [
+          {
+            schema: User,
+            required: componentRequired,
+            ref: '#/components/schemas/User',
+            allowedStrategies: ['input', 'output'],
+          },
+        ],
+      },
+    )
+
+    expect(required).toBe(true)
+    expect(jsonSchema).toEqual({
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+        owner: { $ref: '#/components/schemas/User' },
+      },
+      required: componentRequired ? ['id', 'name', 'owner'] : ['id', 'name'],
+    })
+  })
+
+  describe('minStructureDepthForRef', () => {
+    it.each([true, false])('works with User schema (minStructureDepthForRef=0, required=%s)', (componentRequired) => {
+      const [required, jsonSchema] = converter.convert(
+        User,
+        {
+          strategy: 'input',
+          components: [
+            {
+              schema: User,
+              required: componentRequired,
+              ref: '#/components/schemas/User',
+              allowedStrategies: ['input', 'output'],
+            },
+          ],
+          minStructureDepthForRef: 0,
+        },
+      )
+
+      expect(required).toBe(componentRequired)
+      expect(jsonSchema).toEqual({ $ref: '#/components/schemas/User' })
+    })
+
+    it.each([true, false])('works with User schema (minStructureDepthForRef=1, strategy=input, required=%s)', (componentRequired) => {
+      const [required, jsonSchema] = converter.convert(
+        User,
+        {
+          strategy: 'input',
+          components: [
+            {
+              schema: User,
+              required: componentRequired,
+              ref: '#/components/schemas/User',
+              allowedStrategies: ['input', 'output'],
+            },
+          ],
+          minStructureDepthForRef: 1,
+        },
+      )
+
+      expect(required).toBe(true)
+      expect(jsonSchema).toEqual({
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' },
+          age: { type: 'number' },
+          parents: { type: 'array', items: { $ref: '#/components/schemas/User' } },
+        },
+        required: ['id', 'name'],
+      })
+    })
+
+    it.each([true, false])('works with User schema (minStructureDepthForRef=1, strategy=output, required=%s)', (componentRequired) => {
+      const [required, jsonSchema] = converter.convert(
+        User,
+        {
+          strategy: 'output',
+          components: [
+            {
+              schema: User,
+              required: componentRequired,
+              ref: '#/components/schemas/User',
+              allowedStrategies: ['input', 'output'],
+            },
+          ],
+          minStructureDepthForRef: 1,
+        },
+      )
+
+      expect(required).toBe(true)
+      expect(jsonSchema).toEqual({
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' },
+          age: { type: 'number' },
+          parents: {
+            type: 'array',
+            items: componentRequired
+              ? { $ref: '#/components/schemas/User' }
+              : {
+                  anyOf: [
+                    {
+                      $ref: '#/components/schemas/User',
+                    },
+                    {
+                      type: 'null',
+                    },
+                  ],
+                },
+          },
+        },
+        required: ['id', 'name'],
+      })
+    })
+
+    it('works with User schema (minStructureDepthForRef=3)', () => {
+      const [required, jsonSchema] = converter.convert(
+        User,
+        {
+          strategy: 'input',
+          components: [
+            {
+              schema: User,
+              required: true,
+              ref: '#/components/schemas/User',
+              allowedStrategies: ['input', 'output'],
+            },
+          ],
+          minStructureDepthForRef: 3,
+        },
+      )
+
+      expect(required).toBe(true)
+      expect(jsonSchema).toEqual({
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' },
+          age: { type: 'number' },
+          parents: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'string' },
+                name: { type: 'string' },
+                age: { type: 'number' },
+                parents: {
+                  type: 'array',
+                  items: { $ref: '#/components/schemas/User' },
+                },
+              },
+              required: ['id', 'name'],
+            },
+          },
+        },
+        required: ['id', 'name'],
+      })
+    })
+  })
+
+  it('on unsupported strategy', () => {
+    const Pet = z.object({
+      id: z.string(),
+      name: z.string(),
+    })
+
+    const [required, jsonSchema] = converter.convert(
+      Pet,
+      {
+        strategy: 'output',
+        components: [
+          {
+            schema: Pet,
+            required: true,
+            ref: '#/components/schemas/Pet',
+            allowedStrategies: ['input'],
+          },
+        ],
+      },
+    )
+
+    expect(required).toBe(true)
+    expect(jsonSchema).toEqual({
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+      },
+      required: ['id', 'name'],
+    })
+  })
+
+  it('complex case', () => {
+    const [required, jsonSchema] = converter.convert(
+      z.object({
+        users: z.array(User).optional(),
+        pets: z.array(Pet).optional(),
+        nested: z.array(z.object({
+          user: User.optional(),
+        })),
+      }).optional(),
+      {
+        strategy: 'input',
+        components: [
+          {
+            schema: User,
+            required: true,
+            ref: '#/components/schemas/User',
+            allowedStrategies: ['input', 'output'],
+          },
+          {
+            schema: Pet,
+            required: true,
+            ref: '#/components/schemas/Pet',
+            allowedStrategies: ['input', 'output'],
+          },
+        ],
+        minStructureDepthForRef: 2,
+      },
+    )
+
+    expect(required).toBe(false)
+    expect(jsonSchema).toEqual({
+      type: 'object',
+      properties: {
+        users: {
+          type: 'array',
+          items: { $ref: '#/components/schemas/User' },
+        },
+        pets: {
+          type: 'array',
+          items: { $ref: '#/components/schemas/Pet' },
+        },
+        nested: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              user: { $ref: '#/components/schemas/User' },
+            },
+          },
+        },
+      },
+      required: ['nested'],
+    })
+  })
+})

--- a/packages/zod/src/zod4/converter.test.ts
+++ b/packages/zod/src/zod4/converter.test.ts
@@ -7,6 +7,31 @@ import {
 describe('zodToJsonSchemaConverter', () => {
   const converter = new ZodToJsonSchemaConverter()
 
+  it('works with recursive schemas', () => {
+    const Schema = z.object({
+      id: z.string(),
+      name: z.string(),
+      get parents() {
+        return z.array(Schema).optional()
+      },
+    })
+
+    const [required, json] = converter.convert(Schema, { strategy: 'input' })
+    expect(required).toBe(true)
+    expect(json).toEqual({
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        name: { type: 'string' },
+        parents: {
+          type: 'array',
+          items: expect.objectContaining({ type: 'object' }),
+        },
+      },
+      required: ['id', 'name'],
+    })
+  })
+
   it('.condition', async () => {
     expect(converter.condition(z.string())).toBe(true)
     expect(converter.condition(z.string().optional())).toBe(true)

--- a/packages/zod/src/zod4/converter.ts
+++ b/packages/zod/src/zod4/converter.ts
@@ -53,7 +53,7 @@ export interface experimental_ZodToJsonSchemaOptions {
    *
    * Used anyJsonSchema (`{}`) when reach max depth
    *
-   * @default 100
+   * @default 10
    */
   maxStructureDepth?: number
 
@@ -94,7 +94,7 @@ export class experimental_ZodToJsonSchemaConverter implements ConditionalSchemaC
 
   constructor(options: experimental_ZodToJsonSchemaOptions = {}) {
     this.maxLazyDepth = options.maxLazyDepth ?? 2
-    this.maxStructureDepth = options.maxStructureDepth ?? 100
+    this.maxStructureDepth = options.maxStructureDepth ?? 10
     this.anyJsonSchema = options.anyJsonSchema ?? {}
     this.unsupportedJsonSchema = options.unsupportedJsonSchema ?? { not: {} }
     this.undefinedJsonSchema = options.undefinedJsonSchema ?? { not: {} }

--- a/packages/zod/src/zod4/converter.ts
+++ b/packages/zod/src/zod4/converter.ts
@@ -40,18 +40,18 @@ import {
 
 export interface experimental_ZodToJsonSchemaOptions {
   /**
-   * Max depth of lazy type, if it exceeds.
+   * Max depth of lazy type.
    *
-   * Used anyJsonSchema (`{}`) when reach max depth
+   * Used anyJsonSchema (`{}`) when exceed max depth
    *
    * @default 2
    */
   maxLazyDepth?: number
 
   /**
-   * Max depth of nested types, if it exceeds.
+   * Max depth of nested types.
    *
-   * Used anyJsonSchema (`{}`) when reach max depth
+   * Used anyJsonSchema (`{}`) when exceed max depth
    *
    * @default 10
    */
@@ -535,11 +535,13 @@ export class experimental_ZodToJsonSchemaConverter implements ConditionalSchemaC
           case 'lazy': {
             const lazy = schema as $ZodLazy
 
-            if (lazyDepth >= this.maxLazyDepth) {
+            const currentLazyDepth = lazyDepth + 1
+
+            if (currentLazyDepth > this.maxLazyDepth) {
               return [false, this.anyJsonSchema]
             }
 
-            return this.#convert(lazy._zod.def.getter(), options, lazyDepth + 1, structureDepth)
+            return this.#convert(lazy._zod.def.getter(), options, currentLazyDepth, structureDepth)
           }
 
           default: {

--- a/packages/zod/src/zod4/converter.ts
+++ b/packages/zod/src/zod4/converter.ts
@@ -86,7 +86,7 @@ export interface experimental_ZodToJsonSchemaOptions {
 
 export class experimental_ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
   private readonly maxLazyDepth: Exclude<experimental_ZodToJsonSchemaOptions['maxLazyDepth'], undefined>
-  private readonly maxStructureDepth: Exclude<experimental_ZodToJsonSchemaOptions['maxStructureDepth'], undefined> = 100
+  private readonly maxStructureDepth: Exclude<experimental_ZodToJsonSchemaOptions['maxStructureDepth'], undefined>
   private readonly anyJsonSchema: Exclude<experimental_ZodToJsonSchemaOptions['anyJsonSchema'], undefined>
   private readonly unsupportedJsonSchema: Exclude<experimental_ZodToJsonSchemaOptions['unsupportedJsonSchema'], undefined>
   private readonly undefinedJsonSchema: Exclude<experimental_ZodToJsonSchemaOptions['undefinedJsonSchema'], undefined>

--- a/packages/zod/src/zod4/converter.ts
+++ b/packages/zod/src/zod4/converter.ts
@@ -28,7 +28,7 @@ import type {
   $ZodUnion,
 } from 'zod/v4/core'
 import { JSONSchemaContentEncoding, JSONSchemaFormat } from '@orpc/openapi'
-import { intercept } from '@orpc/shared'
+import { intercept, toArray } from '@orpc/shared'
 import {
   globalRegistry,
 } from 'zod/v4/core'
@@ -47,6 +47,15 @@ export interface experimental_ZodToJsonSchemaOptions {
    * @default 2
    */
   maxLazyDepth?: number
+
+  /**
+   * Max depth of nested types, if it exceeds.
+   *
+   * Used anyJsonSchema (`{}`) when reach max depth
+   *
+   * @default 100
+   */
+  maxStructureDepth?: number
 
   /**
    * The schema to be used to represent the any | unknown type.
@@ -77,6 +86,7 @@ export interface experimental_ZodToJsonSchemaOptions {
 
 export class experimental_ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
   private readonly maxLazyDepth: Exclude<experimental_ZodToJsonSchemaOptions['maxLazyDepth'], undefined>
+  private readonly maxStructureDepth: Exclude<experimental_ZodToJsonSchemaOptions['maxStructureDepth'], undefined> = 100
   private readonly anyJsonSchema: Exclude<experimental_ZodToJsonSchemaOptions['anyJsonSchema'], undefined>
   private readonly unsupportedJsonSchema: Exclude<experimental_ZodToJsonSchemaOptions['unsupportedJsonSchema'], undefined>
   private readonly undefinedJsonSchema: Exclude<experimental_ZodToJsonSchemaOptions['undefinedJsonSchema'], undefined>
@@ -84,6 +94,7 @@ export class experimental_ZodToJsonSchemaConverter implements ConditionalSchemaC
 
   constructor(options: experimental_ZodToJsonSchemaOptions = {}) {
     this.maxLazyDepth = options.maxLazyDepth ?? 2
+    this.maxStructureDepth = options.maxStructureDepth ?? 100
     this.anyJsonSchema = options.anyJsonSchema ?? {}
     this.unsupportedJsonSchema = options.unsupportedJsonSchema ?? { not: {} }
     this.undefinedJsonSchema = options.undefinedJsonSchema ?? { not: {} }
@@ -94,25 +105,43 @@ export class experimental_ZodToJsonSchemaConverter implements ConditionalSchemaC
     return schema !== undefined && schema['~standard'].vendor === 'zod'
   }
 
-  convert(schema: AnySchema | undefined, options: SchemaConvertOptions): [required: boolean, jsonSchema: Exclude<JSONSchema, boolean>] {
-    return this.#convert(schema as $ZodType, options, 0)
+  convert(
+    schema: AnySchema | undefined,
+    options: SchemaConvertOptions,
+  ): [required: boolean, jsonSchema: Exclude<JSONSchema, boolean>] {
+    return this.#convert(schema as $ZodType, options, 0, 0)
   }
 
   #convert(
     schema: $ZodType,
     options: SchemaConvertOptions,
     lazyDepth: number,
+    structureDepth: number,
     isHandledCustomJSONSchema: boolean = false,
   ): [required: boolean, jsonSchema: Exclude<JSONSchema, boolean>] {
     return intercept(
       this.interceptors,
       { schema, options, lazyDepth, isHandledCustomJSONSchema },
       ({ schema, options, lazyDepth, isHandledCustomJSONSchema }) => {
+        if (structureDepth > this.maxStructureDepth) {
+          return [false, this.anyJsonSchema]
+        }
+
+        if (!options.minStructureDepthForRef || options.minStructureDepthForRef <= structureDepth) {
+          const components = toArray(options.components)
+
+          for (const component of components) {
+            if (component.schema === schema && component.allowedStrategies.includes(options.strategy)) {
+              return [component.required, { $ref: component.ref }]
+            }
+          }
+        }
+
         if (!isHandledCustomJSONSchema) {
           const customJSONSchema = this.#getCustomJsonSchema(schema, options)
 
           if (customJSONSchema) {
-            const [required, json] = this.#convert(schema, options, lazyDepth, true)
+            const [required, json] = this.#convert(schema, options, lazyDepth, structureDepth, true)
 
             return [required, { ...json, ...customJSONSchema }]
           }
@@ -246,7 +275,7 @@ export class experimental_ZodToJsonSchemaConverter implements ConditionalSchemaC
               json.maxItems = maximum
             }
 
-            json.items = this.#handleArrayItemJsonSchema(this.#convert(array._zod.def.element, options, lazyDepth), options)
+            json.items = this.#handleArrayItemJsonSchema(this.#convert(array._zod.def.element, options, lazyDepth, structureDepth + 1), options)
 
             return [true, json]
           }
@@ -256,7 +285,7 @@ export class experimental_ZodToJsonSchemaConverter implements ConditionalSchemaC
             const json: JSONSchema & { required?: string[] } = { type: 'object' }
 
             for (const [key, value] of Object.entries(object._zod.def.shape)) {
-              const [itemRequired, itemJson] = this.#convert(value, options, lazyDepth)
+              const [itemRequired, itemJson] = this.#convert(value, options, lazyDepth, structureDepth + 1)
 
               json.properties ??= {}
               json.properties[key] = itemJson
@@ -272,7 +301,7 @@ export class experimental_ZodToJsonSchemaConverter implements ConditionalSchemaC
                 json.additionalProperties = false
               }
               else {
-                const [_, addJson] = this.#convert(object._zod.def.catchall, options, lazyDepth)
+                const [_, addJson] = this.#convert(object._zod.def.catchall, options, lazyDepth, structureDepth + 1)
                 json.additionalProperties = addJson
               }
             }
@@ -287,7 +316,7 @@ export class experimental_ZodToJsonSchemaConverter implements ConditionalSchemaC
             let required = true
 
             for (const item of union._zod.def.options) {
-              const [itemRequired, itemJson] = this.#convert(item, options, lazyDepth)
+              const [itemRequired, itemJson] = this.#convert(item, options, lazyDepth, structureDepth)
 
               if (!itemRequired) {
                 required = false
@@ -315,7 +344,7 @@ export class experimental_ZodToJsonSchemaConverter implements ConditionalSchemaC
             let required = false
 
             for (const item of [intersection._zod.def.left, intersection._zod.def.right]) {
-              const [itemRequired, itemJson] = this.#convert(item, options, lazyDepth)
+              const [itemRequired, itemJson] = this.#convert(item, options, lazyDepth, structureDepth)
 
               json.allOf.push(itemJson)
 
@@ -332,11 +361,11 @@ export class experimental_ZodToJsonSchemaConverter implements ConditionalSchemaC
             const json: JSONSchema & { prefixItems: JSONSchema[] } = { type: 'array', prefixItems: [] }
 
             for (const item of tuple._zod.def.items) {
-              json.prefixItems.push(this.#handleArrayItemJsonSchema(this.#convert(item, options, lazyDepth), options))
+              json.prefixItems.push(this.#handleArrayItemJsonSchema(this.#convert(item, options, lazyDepth, structureDepth + 1), options))
             }
 
             if (tuple._zod.def.rest) {
-              json.items = this.#handleArrayItemJsonSchema(this.#convert(tuple._zod.def.rest, options, lazyDepth), options)
+              json.items = this.#handleArrayItemJsonSchema(this.#convert(tuple._zod.def.rest, options, lazyDepth, structureDepth + 1), options)
             }
 
             const { minimum, maximum } = tuple._zod.bag
@@ -356,8 +385,8 @@ export class experimental_ZodToJsonSchemaConverter implements ConditionalSchemaC
             const record = schema as $ZodRecord
             const json: JSONSchema = { type: 'object' }
 
-            json.propertyNames = (this.#convert(record._zod.def.keyType, options, lazyDepth))[1]
-            json.additionalProperties = (this.#convert(record._zod.def.valueType, options, lazyDepth))[1]
+            json.propertyNames = (this.#convert(record._zod.def.keyType, options, lazyDepth, structureDepth + 1))[1]
+            json.additionalProperties = (this.#convert(record._zod.def.valueType, options, lazyDepth, structureDepth + 1))[1]
 
             return [true, json]
           }
@@ -370,8 +399,8 @@ export class experimental_ZodToJsonSchemaConverter implements ConditionalSchemaC
               items: {
                 type: 'array',
                 prefixItems: [
-                  this.#handleArrayItemJsonSchema(this.#convert(map._zod.def.keyType, options, lazyDepth), options),
-                  this.#handleArrayItemJsonSchema(this.#convert(map._zod.def.valueType, options, lazyDepth), options),
+                  this.#handleArrayItemJsonSchema(this.#convert(map._zod.def.keyType, options, lazyDepth, structureDepth + 1), options),
+                  this.#handleArrayItemJsonSchema(this.#convert(map._zod.def.valueType, options, lazyDepth, structureDepth + 1), options),
                 ],
                 maxItems: 2,
                 minItems: 2,
@@ -384,7 +413,7 @@ export class experimental_ZodToJsonSchemaConverter implements ConditionalSchemaC
             return [true, {
               type: 'array',
               uniqueItems: true,
-              items: this.#handleArrayItemJsonSchema(this.#convert(set._zod.def.valueType, options, lazyDepth), options),
+              items: this.#handleArrayItemJsonSchema(this.#convert(set._zod.def.valueType, options, lazyDepth, structureDepth + 1), options),
             }]
           }
 
@@ -442,14 +471,14 @@ export class experimental_ZodToJsonSchemaConverter implements ConditionalSchemaC
           case 'nullable': {
             const nullable = schema as $ZodNullable
 
-            const [required, json] = this.#convert(nullable._zod.def.innerType, options, lazyDepth)
+            const [required, json] = this.#convert(nullable._zod.def.innerType, options, lazyDepth, structureDepth)
 
             return [required, { anyOf: [json, { type: 'null' }] }]
           }
 
           case 'nonoptional': {
             const nonoptional = schema as $ZodNonOptional
-            const [, json] = this.#convert(nonoptional._zod.def.innerType, options, lazyDepth)
+            const [, json] = this.#convert(nonoptional._zod.def.innerType, options, lazyDepth, structureDepth)
             return [true, json]
           }
 
@@ -460,7 +489,7 @@ export class experimental_ZodToJsonSchemaConverter implements ConditionalSchemaC
           case 'default':
           case 'prefault': {
             const default_ = schema as $ZodDefault | $ZodPrefault
-            const [, json] = this.#convert(default_._zod.def.innerType, options, lazyDepth)
+            const [, json] = this.#convert(default_._zod.def.innerType, options, lazyDepth, structureDepth)
 
             return [false, {
               ...json,
@@ -470,7 +499,7 @@ export class experimental_ZodToJsonSchemaConverter implements ConditionalSchemaC
 
           case 'catch': {
             const catch_ = schema as $ZodCatch
-            return this.#convert(catch_._zod.def.innerType, options, lazyDepth)
+            return this.#convert(catch_._zod.def.innerType, options, lazyDepth, structureDepth)
           }
 
           case 'nan': {
@@ -479,12 +508,12 @@ export class experimental_ZodToJsonSchemaConverter implements ConditionalSchemaC
 
           case 'pipe': {
             const pipe = schema as $ZodPipe
-            return this.#convert(options.strategy === 'input' ? pipe._zod.def.in : pipe._zod.def.out, options, lazyDepth)
+            return this.#convert(options.strategy === 'input' ? pipe._zod.def.in : pipe._zod.def.out, options, lazyDepth, structureDepth)
           }
 
           case 'readonly': {
             const readonly_ = schema as $ZodReadonly
-            const [required, json] = this.#convert(readonly_._zod.def.innerType, options, lazyDepth)
+            const [required, json] = this.#convert(readonly_._zod.def.innerType, options, lazyDepth, structureDepth)
             return [required, { ...json, readOnly: true }]
           }
 
@@ -499,7 +528,7 @@ export class experimental_ZodToJsonSchemaConverter implements ConditionalSchemaC
 
           case 'optional': {
             const optional = schema as $ZodOptional
-            const [, json] = this.#convert(optional._zod.def.innerType, options, lazyDepth)
+            const [, json] = this.#convert(optional._zod.def.innerType, options, lazyDepth, structureDepth)
             return [false, json]
           }
 
@@ -510,11 +539,11 @@ export class experimental_ZodToJsonSchemaConverter implements ConditionalSchemaC
               return [false, this.anyJsonSchema]
             }
 
-            return this.#convert(lazy._zod.def.getter(), options, lazyDepth + 1)
+            return this.#convert(lazy._zod.def.getter(), options, lazyDepth + 1, structureDepth)
           }
 
           default: {
-            const _unsupported: 'interface' | 'int' | 'symbol' | 'promise' | 'custom' = schema._zod.def.type
+            const _unsupported: 'int' | 'symbol' | 'promise' | 'custom' = schema._zod.def.type
             return [true, this.unsupportedJsonSchema]
           }
         }

--- a/playgrounds/astro/src/pages/api/[...rest].ts
+++ b/playgrounds/astro/src/pages/api/[...rest].ts
@@ -5,6 +5,9 @@ import { ZodSmartCoercionPlugin, ZodToJsonSchemaConverter } from '@orpc/zod'
 import { OpenAPIReferencePlugin } from '@orpc/openapi/plugins'
 import { router } from '../../router'
 import type { APIRoute } from 'astro'
+import { NewUserSchema, UserSchema } from '../../schemas/user'
+import { CredentialSchema, TokenSchema } from '../../schemas/auth'
+import { NewPlanetSchema, PlanetSchema, UpdatePlanetSchema } from '../../schemas/planet'
 
 const handler = new OpenAPIHandler(router, {
   interceptors: [
@@ -22,6 +25,15 @@ const handler = new OpenAPIHandler(router, {
         info: {
           title: 'ORPC Playground',
           version: '1.0.0',
+        },
+        commonSchemas: {
+          NewUser: { schema: NewUserSchema },
+          User: { schema: UserSchema },
+          Credential: { schema: CredentialSchema },
+          TokenSchema: { schema: TokenSchema },
+          NewPlanet: { schema: NewPlanetSchema },
+          UpdatePlanet: { schema: UpdatePlanetSchema },
+          Planet: { schema: PlanetSchema },
         },
         security: [{ bearerAuth: [] }],
         components: {

--- a/playgrounds/astro/src/pages/api/[...rest].ts
+++ b/playgrounds/astro/src/pages/api/[...rest].ts
@@ -30,7 +30,7 @@ const handler = new OpenAPIHandler(router, {
           NewUser: { schema: NewUserSchema },
           User: { schema: UserSchema },
           Credential: { schema: CredentialSchema },
-          TokenSchema: { schema: TokenSchema },
+          Token: { schema: TokenSchema },
           NewPlanet: { schema: NewPlanetSchema },
           UpdatePlanet: { schema: UpdatePlanetSchema },
           Planet: { schema: PlanetSchema },

--- a/playgrounds/contract-first/src/main.ts
+++ b/playgrounds/contract-first/src/main.ts
@@ -6,6 +6,9 @@ import { ZodSmartCoercionPlugin, ZodToJsonSchemaConverter } from '@orpc/zod'
 import { router } from './router'
 import { OpenAPIReferencePlugin } from '@orpc/openapi/plugins'
 import './polyfill'
+import { NewUserSchema, UserSchema } from './schemas/user'
+import { CredentialSchema, TokenSchema } from './schemas/auth'
+import { NewPlanetSchema, PlanetSchema, UpdatePlanetSchema } from './schemas/planet'
 
 const openAPIHandler = new OpenAPIHandler(router, {
   interceptors: [
@@ -23,6 +26,15 @@ const openAPIHandler = new OpenAPIHandler(router, {
         info: {
           title: 'ORPC Playground',
           version: '1.0.0',
+        },
+        commonSchemas: {
+          NewUser: { schema: NewUserSchema },
+          User: { schema: UserSchema },
+          Credential: { schema: CredentialSchema },
+          TokenSchema: { schema: TokenSchema },
+          NewPlanet: { schema: NewPlanetSchema },
+          UpdatePlanet: { schema: UpdatePlanetSchema },
+          Planet: { schema: PlanetSchema },
         },
         security: [{ bearerAuth: [] }],
         components: {

--- a/playgrounds/contract-first/src/main.ts
+++ b/playgrounds/contract-first/src/main.ts
@@ -31,7 +31,7 @@ const openAPIHandler = new OpenAPIHandler(router, {
           NewUser: { schema: NewUserSchema },
           User: { schema: UserSchema },
           Credential: { schema: CredentialSchema },
-          TokenSchema: { schema: TokenSchema },
+          Token: { schema: TokenSchema },
           NewPlanet: { schema: NewPlanetSchema },
           UpdatePlanet: { schema: UpdatePlanetSchema },
           Planet: { schema: PlanetSchema },

--- a/playgrounds/nest/src/reference/reference.service.ts
+++ b/playgrounds/nest/src/reference/reference.service.ts
@@ -31,7 +31,7 @@ export class ReferenceService {
         NewUser: { schema: NewUserSchema },
         User: { schema: UserSchema },
         Credential: { schema: CredentialSchema },
-        TokenSchema: { schema: TokenSchema },
+        Token: { schema: TokenSchema },
         NewPlanet: { schema: NewPlanetSchema },
         UpdatePlanet: { schema: UpdatePlanetSchema },
         Planet: { schema: PlanetSchema },

--- a/playgrounds/nest/src/reference/reference.service.ts
+++ b/playgrounds/nest/src/reference/reference.service.ts
@@ -1,13 +1,15 @@
 import { OpenAPIGenerator } from '@orpc/openapi'
 import { ZodToJsonSchemaConverter } from '@orpc/zod'
 import { contract } from 'src/contract'
+import { CredentialSchema, TokenSchema } from 'src/schemas/auth'
+import { NewPlanetSchema, PlanetSchema, UpdatePlanetSchema } from 'src/schemas/planet'
+import { NewUserSchema, UserSchema } from 'src/schemas/user'
 
 export class ReferenceService {
   private readonly openapiGenerator = new OpenAPIGenerator({
     schemaConverters: [
       new ZodToJsonSchemaConverter(),
     ],
-
   })
 
   spec() {
@@ -24,6 +26,15 @@ export class ReferenceService {
             scheme: 'bearer',
           },
         },
+      },
+      commonSchemas: {
+        NewUser: { schema: NewUserSchema },
+        User: { schema: UserSchema },
+        Credential: { schema: CredentialSchema },
+        TokenSchema: { schema: TokenSchema },
+        NewPlanet: { schema: NewPlanetSchema },
+        UpdatePlanet: { schema: UpdatePlanetSchema },
+        Planet: { schema: PlanetSchema },
       },
       servers: [
         { url: 'http://localhost:3000' },

--- a/playgrounds/next/src/app/api/[[...rest]]/route.ts
+++ b/playgrounds/next/src/app/api/[[...rest]]/route.ts
@@ -4,6 +4,9 @@ import { onError } from '@orpc/server'
 import { ZodSmartCoercionPlugin, ZodToJsonSchemaConverter } from '@orpc/zod'
 import { OpenAPIReferencePlugin } from '@orpc/openapi/plugins'
 import '../../../polyfill'
+import { NewUserSchema, UserSchema } from '@/schemas/user'
+import { CredentialSchema, TokenSchema } from '@/schemas/auth'
+import { NewPlanetSchema, PlanetSchema, UpdatePlanetSchema } from '@/schemas/planet'
 
 const openAPIHandler = new OpenAPIHandler(router, {
   interceptors: [
@@ -21,6 +24,15 @@ const openAPIHandler = new OpenAPIHandler(router, {
         info: {
           title: 'ORPC Playground',
           version: '1.0.0',
+        },
+        commonSchemas: {
+          NewUser: { schema: NewUserSchema },
+          User: { schema: UserSchema },
+          Credential: { schema: CredentialSchema },
+          TokenSchema: { schema: TokenSchema },
+          NewPlanet: { schema: NewPlanetSchema },
+          UpdatePlanet: { schema: UpdatePlanetSchema },
+          Planet: { schema: PlanetSchema },
         },
         security: [{ bearerAuth: [] }],
         components: {

--- a/playgrounds/next/src/app/api/[[...rest]]/route.ts
+++ b/playgrounds/next/src/app/api/[[...rest]]/route.ts
@@ -29,7 +29,7 @@ const openAPIHandler = new OpenAPIHandler(router, {
           NewUser: { schema: NewUserSchema },
           User: { schema: UserSchema },
           Credential: { schema: CredentialSchema },
-          TokenSchema: { schema: TokenSchema },
+          Token: { schema: TokenSchema },
           NewPlanet: { schema: NewPlanetSchema },
           UpdatePlanet: { schema: UpdatePlanetSchema },
           Planet: { schema: PlanetSchema },

--- a/playgrounds/nuxt/server/routes/api/[...].ts
+++ b/playgrounds/nuxt/server/routes/api/[...].ts
@@ -3,6 +3,9 @@ import { onError } from '@orpc/server'
 import { ZodSmartCoercionPlugin, ZodToJsonSchemaConverter } from '@orpc/zod'
 import { router } from '~/server/router'
 import { OpenAPIReferencePlugin } from '@orpc/openapi/plugins'
+import { NewUserSchema, UserSchema } from '~/server/schemas/user'
+import { CredentialSchema, TokenSchema } from '~/server/schemas/auth'
+import { NewPlanetSchema, PlanetSchema, UpdatePlanetSchema } from '~/server/schemas/planet'
 
 const openAPIHandler = new OpenAPIHandler(router, {
   interceptors: [
@@ -20,6 +23,15 @@ const openAPIHandler = new OpenAPIHandler(router, {
         info: {
           title: 'ORPC Playground',
           version: '1.0.0',
+        },
+        commonSchemas: {
+          NewUser: { schema: NewUserSchema },
+          User: { schema: UserSchema },
+          Credential: { schema: CredentialSchema },
+          TokenSchema: { schema: TokenSchema },
+          NewPlanet: { schema: NewPlanetSchema },
+          UpdatePlanet: { schema: UpdatePlanetSchema },
+          Planet: { schema: PlanetSchema },
         },
         security: [{ bearerAuth: [] }],
         components: {

--- a/playgrounds/nuxt/server/routes/api/[...].ts
+++ b/playgrounds/nuxt/server/routes/api/[...].ts
@@ -28,7 +28,7 @@ const openAPIHandler = new OpenAPIHandler(router, {
           NewUser: { schema: NewUserSchema },
           User: { schema: UserSchema },
           Credential: { schema: CredentialSchema },
-          TokenSchema: { schema: TokenSchema },
+          Token: { schema: TokenSchema },
           NewPlanet: { schema: NewPlanetSchema },
           UpdatePlanet: { schema: UpdatePlanetSchema },
           Planet: { schema: PlanetSchema },

--- a/playgrounds/solid-start/src/routes/api/[...rest].ts
+++ b/playgrounds/solid-start/src/routes/api/[...rest].ts
@@ -30,7 +30,7 @@ const handler = new OpenAPIHandler(router, {
           NewUser: { schema: NewUserSchema },
           User: { schema: UserSchema },
           Credential: { schema: CredentialSchema },
-          TokenSchema: { schema: TokenSchema },
+          Token: { schema: TokenSchema },
           NewPlanet: { schema: NewPlanetSchema },
           UpdatePlanet: { schema: UpdatePlanetSchema },
           Planet: { schema: PlanetSchema },

--- a/playgrounds/solid-start/src/routes/api/[...rest].ts
+++ b/playgrounds/solid-start/src/routes/api/[...rest].ts
@@ -5,6 +5,9 @@ import { ZodSmartCoercionPlugin, ZodToJsonSchemaConverter } from '@orpc/zod'
 import { onError } from '@orpc/server'
 import { OpenAPIReferencePlugin } from '@orpc/openapi/plugins'
 import '~/polyfill'
+import { NewUserSchema, UserSchema } from '~/schemas/user'
+import { CredentialSchema, TokenSchema } from '~/schemas/auth'
+import { NewPlanetSchema, PlanetSchema, UpdatePlanetSchema } from '~/schemas/planet'
 
 const handler = new OpenAPIHandler(router, {
   interceptors: [
@@ -22,6 +25,15 @@ const handler = new OpenAPIHandler(router, {
         info: {
           title: 'ORPC Playground',
           version: '1.0.0',
+        },
+        commonSchemas: {
+          NewUser: { schema: NewUserSchema },
+          User: { schema: UserSchema },
+          Credential: { schema: CredentialSchema },
+          TokenSchema: { schema: TokenSchema },
+          NewPlanet: { schema: NewPlanetSchema },
+          UpdatePlanet: { schema: UpdatePlanetSchema },
+          Planet: { schema: PlanetSchema },
         },
         security: [{ bearerAuth: [] }],
         components: {

--- a/playgrounds/svelte-kit/src/routes/api/[...rest]/+server.ts
+++ b/playgrounds/svelte-kit/src/routes/api/[...rest]/+server.ts
@@ -30,7 +30,7 @@ const handler = new OpenAPIHandler(router, {
           NewUser: { schema: NewUserSchema },
           User: { schema: UserSchema },
           Credential: { schema: CredentialSchema },
-          TokenSchema: { schema: TokenSchema },
+          Token: { schema: TokenSchema },
           NewPlanet: { schema: NewPlanetSchema },
           UpdatePlanet: { schema: UpdatePlanetSchema },
           Planet: { schema: PlanetSchema },

--- a/playgrounds/svelte-kit/src/routes/api/[...rest]/+server.ts
+++ b/playgrounds/svelte-kit/src/routes/api/[...rest]/+server.ts
@@ -5,6 +5,9 @@ import type { RequestHandler } from '@sveltejs/kit'
 import { ZodSmartCoercionPlugin, ZodToJsonSchemaConverter } from '@orpc/zod'
 import { OpenAPIReferencePlugin } from '@orpc/openapi/plugins'
 import '../../../polyfill'
+import { NewUserSchema, UserSchema } from '../../../schemas/user'
+import { CredentialSchema, TokenSchema } from '../../../schemas/auth'
+import { NewPlanetSchema, PlanetSchema, UpdatePlanetSchema } from '../../../schemas/planet'
 
 const handler = new OpenAPIHandler(router, {
   interceptors: [
@@ -22,6 +25,15 @@ const handler = new OpenAPIHandler(router, {
         info: {
           title: 'ORPC Playground',
           version: '1.0.0',
+        },
+        commonSchemas: {
+          NewUser: { schema: NewUserSchema },
+          User: { schema: UserSchema },
+          Credential: { schema: CredentialSchema },
+          TokenSchema: { schema: TokenSchema },
+          NewPlanet: { schema: NewPlanetSchema },
+          UpdatePlanet: { schema: UpdatePlanetSchema },
+          Planet: { schema: PlanetSchema },
         },
         security: [{ bearerAuth: [] }],
         components: {

--- a/playgrounds/tanstack-start/src/routes/api/$.ts
+++ b/playgrounds/tanstack-start/src/routes/api/$.ts
@@ -31,7 +31,7 @@ const handler = new OpenAPIHandler(router, {
           NewUser: { schema: NewUserSchema },
           User: { schema: UserSchema },
           Credential: { schema: CredentialSchema },
-          TokenSchema: { schema: TokenSchema },
+          Token: { schema: TokenSchema },
           NewPlanet: { schema: NewPlanetSchema },
           UpdatePlanet: { schema: UpdatePlanetSchema },
           Planet: { schema: PlanetSchema },

--- a/playgrounds/tanstack-start/src/routes/api/$.ts
+++ b/playgrounds/tanstack-start/src/routes/api/$.ts
@@ -6,6 +6,9 @@ import { createServerFileRoute } from '@tanstack/react-start/server'
 import { router } from '~/router/index'
 import { onError } from '@orpc/server'
 import { OpenAPIReferencePlugin } from '@orpc/openapi/plugins'
+import { NewUserSchema, UserSchema } from '~/schemas/user'
+import { CredentialSchema, TokenSchema } from '~/schemas/auth'
+import { NewPlanetSchema, PlanetSchema, UpdatePlanetSchema } from '~/schemas/planet'
 
 const handler = new OpenAPIHandler(router, {
   interceptors: [
@@ -23,6 +26,15 @@ const handler = new OpenAPIHandler(router, {
         info: {
           title: 'ORPC Playground',
           version: '1.0.0',
+        },
+        commonSchemas: {
+          NewUser: { schema: NewUserSchema },
+          User: { schema: UserSchema },
+          Credential: { schema: CredentialSchema },
+          TokenSchema: { schema: TokenSchema },
+          NewPlanet: { schema: NewPlanetSchema },
+          UpdatePlanet: { schema: UpdatePlanetSchema },
+          Planet: { schema: PlanetSchema },
         },
         security: [{ bearerAuth: [] }],
         components: {


### PR DESCRIPTION
## Common Schemas

Define reusable schema components that can be referenced across your OpenAPI specification:

```ts
const UserSchema = z.object({
  id: z.string(),
  name: z.string(),
  email: z.string().email(),
})

const PetSchema = z.object({
  id: z.string().transform(id => Number(id)).pipe(z.number()),
})

const spec = await generator.generate(router, {
  commonSchemas: {
    User: {
      schema: UserSchema,
    },
    InputPet: {
      strategy: 'input',
      schema: PetSchema,
    },
    OutputPet: {
      strategy: 'output',
      schema: PetSchema,
    },
  },
})
```

The `strategy` option determines which schema definition to use when input and output types differ (defaults to `input`). This is needed because we cannot use the same `$ref` for both input and output in this case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for defining and reusing common schemas in OpenAPI specifications, enabling shared schema components to be referenced throughout API documentation.
  - Introduced options to control input/output schema strategies and recursive schema handling for improved API schema consistency.
  - Added maximum structure depth control to schema converters to prevent excessive recursion and improve performance.

- **Documentation**
  - Updated OpenAPI documentation to explain the use of common schemas and provide usage examples.

- **Tests**
  - Added comprehensive tests to validate common schema referencing, recursive schema handling, and component reuse in OpenAPI and Zod schema converters.
  - Added tests for resolving JSON Schema `$ref` references within OpenAPI documents.

- **Chores**
  - Integrated common schema registration in multiple API playgrounds, enhancing API documentation with reusable schema definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->