### PR TITLE
fix(openapi): OpenAPIGenerator make response headers optional when headers object is optional

### DIFF
--- a/packages/openapi/src/openapi-generator.test.ts
+++ b/packages/openapi/src/openapi-generator.test.ts
@@ -620,6 +620,28 @@ const successResponseTests: TestCase[] = [
     },
   },
   {
+    name: 'outputStructure=detailed + headers is optional',
+    contract: oc.route({ outputStructure: 'detailed' }).output(z.object({ headers: z.object({ 'x-custom': z.string() }).optional() })),
+    expected: {
+      '/': {
+        post: expect.objectContaining({
+          responses: {
+            200: expect.objectContaining({
+              headers: {
+                'x-custom': {
+                  required: undefined,
+                  schema: {
+                    type: 'string',
+                  },
+                },
+              },
+            }),
+          },
+        }),
+      },
+    },
+  },
+  {
     name: 'outputStructure=detailed + multiple status',
     contract: oc.route({ outputStructure: 'detailed' }).output(z.union([
       z.object({ body: z.string() }),

--- a/packages/openapi/src/openapi-generator.ts
+++ b/packages/openapi/src/openapi-generator.ts
@@ -454,7 +454,7 @@ export class OpenAPIGenerator {
             ref.responses[itemStatus].headers ??= {}
             ref.responses[itemStatus].headers[key] = {
               schema: toOpenAPISchema(headerSchema) as any,
-              required: headersSchema.required?.includes(key),
+              required: item.required?.includes('headers') && headersSchema.required?.includes(key),
             }
           }
         }


### PR DESCRIPTION
When outputStructure=detailed and headers field in output schema is optional

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of optional response headers in generated OpenAPI specifications, ensuring headers are only marked as required when appropriate.

- **Tests**
  - Added a new test case to verify correct representation of optional headers in detailed output structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->