### PR TITLE
chore: improve stringifyJSON in case toJSON exists

### DIFF
--- a/packages/shared/src/json.test-d.ts
+++ b/packages/shared/src/json.test-d.ts
@@ -3,4 +3,5 @@ import { stringifyJSON } from './json'
 it('stringifyJSON', () => {
   expectTypeOf(stringifyJSON(undefined)).toEqualTypeOf<string | undefined>()
   expectTypeOf(stringifyJSON({})).toEqualTypeOf<string>()
+  expectTypeOf(stringifyJSON({ toJSON: () => undefined })).toEqualTypeOf<undefined | string>()
 })

--- a/packages/shared/src/json.test.ts
+++ b/packages/shared/src/json.test.ts
@@ -10,6 +10,7 @@ it('parseEmptyableJSON', () => {
 
 it('stringifyJSON', () => {
   expect(stringifyJSON(undefined)).toBeUndefined()
+  expect(stringifyJSON({ toJSON: () => undefined })).toBeUndefined()
   expect(stringifyJSON({})).toEqual('{}')
   expect(stringifyJSON({ foo: 'bar' })).toEqual('{"foo":"bar"}')
 })

--- a/packages/shared/src/json.ts
+++ b/packages/shared/src/json.ts
@@ -6,7 +6,7 @@ export function parseEmptyableJSON(text: string | null | undefined): unknown {
   return JSON.parse(text)
 }
 
-export function stringifyJSON<T>(value: T): undefined extends T ? undefined | string : string {
+export function stringifyJSON<T>(value: T | { toJSON(): T }): undefined extends T ? undefined | string : string {
   // eslint-disable-next-line ban/ban
   return JSON.stringify(value)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced support for objects with custom `toJSON` methods in JSON stringification.
- **Tests**
  - Added new test cases to verify correct handling of objects with `toJSON` methods returning `undefined`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->