### PR TITLE
feat(standard-server-peer)!: use string instead of number for unique ID

### DIFF
--- a/packages/client/src/adapters/message-port/rpc-link.test.ts
+++ b/packages/client/src/adapters/message-port/rpc-link.test.ts
@@ -34,7 +34,7 @@ describe('rpcLink', () => {
 
     const [id, , payload] = (await decodeRequestMessage(sentMessages[0]))
 
-    expect(id).toBeTypeOf('number')
+    expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
       url: new URL('orpc:/ping'),
       body: { json: 'input' },
@@ -54,7 +54,7 @@ describe('rpcLink', () => {
 
     const [id, , payload] = (await decodeRequestMessage(sentMessages[0]))
 
-    expect(id).toBeTypeOf('number')
+    expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
       url: new URL('orpc:/ping'),
       body: expect.any(FormData),

--- a/packages/client/src/adapters/websocket/rpc-link.test.ts
+++ b/packages/client/src/adapters/websocket/rpc-link.test.ts
@@ -34,7 +34,7 @@ describe('rpcLink', () => {
 
     const [id,, payload] = (await decodeRequestMessage(websocket.send.mock.calls[0]![0]))
 
-    expect(id).toBeTypeOf('number')
+    expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
       url: new URL('orpc:/ping'),
       body: { json: 'input' },
@@ -54,7 +54,7 @@ describe('rpcLink', () => {
 
     const [id, , payload] = (await decodeRequestMessage(websocket.send.mock.calls[0]![0]))
 
-    expect(id).toBeTypeOf('number')
+    expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
       url: new URL('orpc:/ping'),
       body: { json: 'input' },

--- a/packages/durable-event-iterator/src/durable-object/handler.test.ts
+++ b/packages/durable-event-iterator/src/durable-object/handler.test.ts
@@ -40,15 +40,15 @@ describe('durableEventIteratorRouter', async () => {
 
       expect(output).toBeInstanceOf(HibernationEventIterator)
 
-      output.hibernationCallback?.(123)
+      output.hibernationCallback?.('123')
 
       expect(serializeInternalAttachmentSpy).toHaveBeenCalledWith(currentWebsocket, {
-        [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]: 123,
+        [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]: '123',
       })
 
       expect(sendEventsAfterSpy).toHaveBeenCalledWith(
         currentWebsocket,
-        123,
+        '123',
         new Date((date - 1) * 1000),
       )
     })
@@ -77,15 +77,15 @@ describe('durableEventIteratorRouter', async () => {
 
       expect(output).toBeInstanceOf(HibernationEventIterator)
 
-      output.hibernationCallback?.(123)
+      output.hibernationCallback?.('123')
 
       expect(serializeInternalAttachmentSpy).toHaveBeenCalledWith(currentWebsocket, {
-        [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]: 123,
+        [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]: '123',
       })
 
       expect(sendEventsAfterSpy).toHaveBeenCalledWith(
         currentWebsocket,
-        123,
+        '123',
         '3',
       )
     })

--- a/packages/durable-event-iterator/src/durable-object/object.test.ts
+++ b/packages/durable-event-iterator/src/durable-object/object.test.ts
@@ -84,7 +84,7 @@ describe('durableEventIteratorObject', () => {
     const object = new DurableEventIteratorObject(ctx, {})
     const currentWebsocket = createCloudflareWebsocket()
 
-    const request = await encodeRequestMessage(123, MessageType.REQUEST, {
+    const request = await encodeRequestMessage('123', MessageType.REQUEST, {
       url: new URL('https://example.com'),
       headers: {
         'content-type': 'text/event-stream',

--- a/packages/durable-event-iterator/src/durable-object/websocket-manager.test.ts
+++ b/packages/durable-event-iterator/src/durable-object/websocket-manager.test.ts
@@ -25,7 +25,7 @@ describe('durableEventIteratorObjectWebsocketManager', () => {
      * Usually set hibernation happen after token payload, but this for test coverage
      */
     manager.serializeInternalAttachment(websocket, {
-      [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]: 0,
+      [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]: '0',
     })
     /**
      * Initial attachment, executed internally
@@ -41,7 +41,7 @@ describe('durableEventIteratorObjectWebsocketManager', () => {
     })
     // safely override the hibernation id
     manager.serializeInternalAttachment(websocket, {
-      [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]: 123,
+      [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]: '123',
     })
 
     manager.serializeAttachment(websocket, {
@@ -58,7 +58,7 @@ describe('durableEventIteratorObjectWebsocketManager', () => {
         iat: 1923456780,
         rpc: ['test'],
       },
-      [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]: 123,
+      [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]: '123',
       some: 'data',
     })
   })
@@ -89,7 +89,7 @@ describe('durableEventIteratorObjectWebsocketManager', () => {
         iat: 1923456780,
         rpc: ['test'],
       },
-      [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]: 123,
+      [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]: '123',
     })
 
     manager.serializeInternalAttachment(websocket2, {
@@ -107,8 +107,8 @@ describe('durableEventIteratorObjectWebsocketManager', () => {
     manager.publishEvent(wss, { test: 'event2' })
 
     expect(encodeHibernationRPCEventSpy).toHaveBeenCalledTimes(2)
-    expect(encodeHibernationRPCEventSpy).toHaveBeenNthCalledWith(1, 123, withEventMeta({ test: 'event1' }, { id: '1' }), options)
-    expect(encodeHibernationRPCEventSpy).toHaveBeenNthCalledWith(2, 123, withEventMeta({ test: 'event2' }, { id: '2' }), options)
+    expect(encodeHibernationRPCEventSpy).toHaveBeenNthCalledWith(1, '123', withEventMeta({ test: 'event1' }, { id: '1' }), options)
+    expect(encodeHibernationRPCEventSpy).toHaveBeenNthCalledWith(2, '123', withEventMeta({ test: 'event2' }, { id: '2' }), options)
 
     expect(storage.getEventsAfter('0')).toHaveLength(2)
 
@@ -138,11 +138,11 @@ describe('durableEventIteratorObjectWebsocketManager', () => {
     storage.storeEvent({ test: 'event2' })
     storage.storeEvent({ test: 'event3' })
 
-    manager.sendEventsAfter(websocket, 123, '1')
+    manager.sendEventsAfter(websocket, '123', '1')
 
     expect(encodeHibernationRPCEventSpy).toHaveBeenCalledTimes(2)
-    expect(encodeHibernationRPCEventSpy).toHaveBeenNthCalledWith(1, 123, withEventMeta({ test: 'event2' }, { id: '2' }), options)
-    expect(encodeHibernationRPCEventSpy).toHaveBeenNthCalledWith(2, 123, withEventMeta({ test: 'event3' }, { id: '3' }), options)
+    expect(encodeHibernationRPCEventSpy).toHaveBeenNthCalledWith(1, '123', withEventMeta({ test: 'event2' }, { id: '2' }), options)
+    expect(encodeHibernationRPCEventSpy).toHaveBeenNthCalledWith(2, '123', withEventMeta({ test: 'event3' }, { id: '3' }), options)
 
     expect(websocket.send).toHaveBeenCalledTimes(2)
     expect(websocket.send).toHaveBeenNthCalledWith(1, encodeHibernationRPCEventSpy.mock.results[0]!.value)

--- a/packages/durable-event-iterator/src/durable-object/websocket-manager.ts
+++ b/packages/durable-event-iterator/src/durable-object/websocket-manager.ts
@@ -14,7 +14,7 @@ export type DurableEventIteratorObjectWebsocketInternalAttachment<
   /**
    * Internal Hibernation Event Iterator ID.
    */
-  [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]?: number
+  [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]?: string
 
   /**
    * The payload of the Token used to authenticate the WebSocket connection.
@@ -67,7 +67,7 @@ export class DurableEventIteratorObjectWebsocketManager<
    */
   sendEventsAfter(
     ws: WebSocket,
-    hibernationId: number,
+    hibernationId: string,
     after: string | Date,
   ): void {
     const events = this.eventStorage.getEventsAfter(after)

--- a/packages/server/src/adapters/bun-ws/rpc-handler.test.ts
+++ b/packages/server/src/adapters/bun-ws/rpc-handler.test.ts
@@ -28,7 +28,7 @@ describe('rpcHandler', async () => {
     send: vi.fn(),
   }
 
-  const ping_request_message = await encodeRequestMessage(19, MessageType.REQUEST, {
+  const ping_request_message = await encodeRequestMessage('19', MessageType.REQUEST, {
     url: new URL('orpc:/ping'),
     body: { json: 'input' },
     headers: {},
@@ -36,7 +36,7 @@ describe('rpcHandler', async () => {
   }) as string
 
   const file_request_message = {
-    buffer: new TextEncoder().encode(await encodeRequestMessage(19, MessageType.REQUEST, {
+    buffer: new TextEncoder().encode(await encodeRequestMessage('19', MessageType.REQUEST, {
       url: new URL('orpc:/file'),
       body: { json: 'input' },
       headers: {},
@@ -44,14 +44,14 @@ describe('rpcHandler', async () => {
     }) as string),
   }
 
-  const not_found_request_message = await encodeRequestMessage(19, MessageType.REQUEST, {
+  const not_found_request_message = await encodeRequestMessage('19', MessageType.REQUEST, {
     url: new URL('orpc:/not-found'),
     body: { json: 'input' },
     headers: {},
     method: 'POST',
   }) as string
 
-  const abort_message = await encodeRequestMessage(19, MessageType.ABORT_SIGNAL, undefined) as string
+  const abort_message = await encodeRequestMessage('19', MessageType.ABORT_SIGNAL, undefined) as string
 
   it('on success', async () => {
     handler.message(wss, ping_request_message)
@@ -60,7 +60,7 @@ describe('rpcHandler', async () => {
 
     const [id,, payload] = (await decodeResponseMessage(wss.send.mock.calls[0]![0]))
 
-    expect(id).toBeTypeOf('number')
+    expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
       status: 200,
       headers: {},
@@ -74,7 +74,7 @@ describe('rpcHandler', async () => {
     await vi.waitFor(() => expect(wss.send).toHaveBeenCalledTimes(1))
     const [id, , payload] = (await decodeResponseMessage(wss.send.mock.calls[0]![0]))
 
-    expect(id).toBeTypeOf('number')
+    expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
       status: 200,
       headers: {
@@ -120,7 +120,7 @@ describe('rpcHandler', async () => {
 
     const [id,, payload] = (await decodeResponseMessage(wss.send.mock.calls[0]![0]))
 
-    expect(id).toBeTypeOf('number')
+    expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
       status: 404,
       headers: {},

--- a/packages/server/src/adapters/crossws/rpc-handler.test.ts
+++ b/packages/server/src/adapters/crossws/rpc-handler.test.ts
@@ -29,7 +29,7 @@ describe('rpcHandler', async () => {
   }
 
   const ping_request_message = {
-    rawData: await encodeRequestMessage(19, MessageType.REQUEST, {
+    rawData: await encodeRequestMessage('19', MessageType.REQUEST, {
       url: new URL('orpc:/ping'),
       body: { json: 'input' },
       headers: {},
@@ -38,7 +38,7 @@ describe('rpcHandler', async () => {
   } as any
 
   const file_request_message = {
-    rawData: new TextEncoder().encode(await encodeRequestMessage(19, MessageType.REQUEST, {
+    rawData: new TextEncoder().encode(await encodeRequestMessage('19', MessageType.REQUEST, {
       url: new URL('orpc:/file'),
       body: { json: 'input' },
       headers: {},
@@ -50,7 +50,7 @@ describe('rpcHandler', async () => {
   } as any
 
   const not_found_request_message = {
-    rawData: await encodeRequestMessage(19, MessageType.REQUEST, {
+    rawData: await encodeRequestMessage('19', MessageType.REQUEST, {
       url: new URL('orpc:/not_found'),
       body: { json: 'input' },
       headers: {},
@@ -59,7 +59,7 @@ describe('rpcHandler', async () => {
   } as any
 
   const abort_message = {
-    rawData: await encodeRequestMessage(19, MessageType.ABORT_SIGNAL, undefined),
+    rawData: await encodeRequestMessage('19', MessageType.ABORT_SIGNAL, undefined),
   } as any
 
   it('on success', async () => {
@@ -68,7 +68,7 @@ describe('rpcHandler', async () => {
     await vi.waitFor(() => expect(wss.send).toHaveBeenCalledTimes(1))
     const [id,, payload] = (await decodeResponseMessage(wss.send.mock.calls[0]![0]))
 
-    expect(id).toBeTypeOf('number')
+    expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
       status: 200,
       headers: {},
@@ -82,7 +82,7 @@ describe('rpcHandler', async () => {
     await vi.waitFor(() => expect(wss.send).toHaveBeenCalledTimes(1))
     const [id, , payload] = (await decodeResponseMessage(wss.send.mock.calls[0]![0]))
 
-    expect(id).toBeTypeOf('number')
+    expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
       status: 200,
       headers: {
@@ -128,7 +128,7 @@ describe('rpcHandler', async () => {
 
     const [id,, payload] = (await decodeResponseMessage(wss.send.mock.calls[0]![0]))
 
-    expect(id).toBeTypeOf('number')
+    expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
       status: 404,
       headers: {},

--- a/packages/server/src/adapters/message-port/rpc-handler.test.ts
+++ b/packages/server/src/adapters/message-port/rpc-handler.test.ts
@@ -40,28 +40,28 @@ describe('rpcHandler', async () => {
     handler.upgrade(serverPort)
   })
 
-  const ping_request_message = await encodeRequestMessage(19, MessageType.REQUEST, {
+  const ping_request_message = await encodeRequestMessage('19', MessageType.REQUEST, {
     url: new URL('orpc:/ping'),
     body: { json: 'input' },
     headers: {},
     method: 'POST',
   })
 
-  const file_request_message = new TextEncoder().encode(await encodeRequestMessage(19, MessageType.REQUEST, {
+  const file_request_message = new TextEncoder().encode(await encodeRequestMessage('19', MessageType.REQUEST, {
     url: new URL('orpc:/file'),
     body: { json: 'input' },
     headers: {},
     method: 'POST',
   }) as string)
 
-  const not_found_request_message = await encodeRequestMessage(19, MessageType.REQUEST, {
+  const not_found_request_message = await encodeRequestMessage('19', MessageType.REQUEST, {
     url: new URL('orpc:/not-found'),
     body: { json: 'input' },
     headers: {},
     method: 'POST',
   })
 
-  const abort_message = await encodeRequestMessage(19, MessageType.ABORT_SIGNAL, undefined)
+  const abort_message = await encodeRequestMessage('19', MessageType.ABORT_SIGNAL, undefined)
 
   it('on success', async () => {
     clientPort.postMessage(ping_request_message)
@@ -70,7 +70,7 @@ describe('rpcHandler', async () => {
 
     const [id,, payload] = (await decodeResponseMessage(sentMessages[0]))
 
-    expect(id).toBeTypeOf('number')
+    expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
       status: 200,
       headers: {},
@@ -85,7 +85,7 @@ describe('rpcHandler', async () => {
 
     const [id, , payload] = (await decodeResponseMessage(sentMessages[0]))
 
-    expect(id).toBeTypeOf('number')
+    expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
       status: 200,
       headers: {
@@ -131,7 +131,7 @@ describe('rpcHandler', async () => {
 
     const [id,, payload] = (await decodeResponseMessage(sentMessages[0]))
 
-    expect(id).toBeTypeOf('number')
+    expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
       status: 404,
       headers: {},

--- a/packages/server/src/adapters/websocket/rpc-handler.test.ts
+++ b/packages/server/src/adapters/websocket/rpc-handler.test.ts
@@ -34,7 +34,7 @@ describe('rpcHandler', async () => {
   handler.upgrade(wss)
 
   const ping_request_message = {
-    data: await encodeRequestMessage(19, MessageType.REQUEST, {
+    data: await encodeRequestMessage('19', MessageType.REQUEST, {
       url: new URL('orpc:/ping'),
       body: { json: 'input' },
       headers: {},
@@ -47,7 +47,7 @@ describe('rpcHandler', async () => {
   }
 
   const not_found_request_message = {
-    data: await encodeRequestMessage(19, MessageType.REQUEST, {
+    data: await encodeRequestMessage('19', MessageType.REQUEST, {
       url: new URL('orpc:/not-found'),
       body: { json: 'input' },
       headers: {},
@@ -56,7 +56,7 @@ describe('rpcHandler', async () => {
   }
 
   const abort_message = {
-    data: await encodeRequestMessage(19, MessageType.ABORT_SIGNAL, undefined),
+    data: await encodeRequestMessage('19', MessageType.ABORT_SIGNAL, undefined),
   }
 
   it('on success', async () => {
@@ -66,7 +66,7 @@ describe('rpcHandler', async () => {
 
     const [id,, payload] = (await decodeResponseMessage(wss.send.mock.calls[0]![0]))
 
-    expect(id).toBeTypeOf('number')
+    expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
       status: 200,
       headers: {},
@@ -81,7 +81,7 @@ describe('rpcHandler', async () => {
 
     const [id, , payload] = (await decodeResponseMessage(wss.send.mock.calls[0]![0]))
 
-    expect(id).toBeTypeOf('number')
+    expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
       status: 200,
       headers: {},
@@ -91,7 +91,7 @@ describe('rpcHandler', async () => {
 
   it('on abort signal', async () => {
     onMessage({
-      data: await encodeRequestMessage(19, MessageType.REQUEST, {
+      data: await encodeRequestMessage('19', MessageType.REQUEST, {
         url: new URL('orpc:/ping'),
         body: { json: 'input' },
         headers: {},
@@ -129,7 +129,7 @@ describe('rpcHandler', async () => {
     await vi.waitFor(() => expect(wss.send).toHaveBeenCalledTimes(1))
     const [id,, payload] = (await decodeResponseMessage(wss.send.mock.calls[0]![0]))
 
-    expect(id).toBeTypeOf('number')
+    expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
       status: 404,
       headers: {},

--- a/packages/server/src/adapters/ws/rpc-handler.test.ts
+++ b/packages/server/src/adapters/ws/rpc-handler.test.ts
@@ -34,7 +34,7 @@ describe('rpcHandler', async () => {
   handler.upgrade(wss)
 
   const ping_request_message = {
-    data: await encodeRequestMessage(19, MessageType.REQUEST, {
+    data: await encodeRequestMessage('19', MessageType.REQUEST, {
       url: new URL('orpc:/ping'),
       body: { json: 'input' },
       headers: {},
@@ -43,7 +43,7 @@ describe('rpcHandler', async () => {
   }
 
   const ping_buffer_request_message = {
-    data: [new TextEncoder().encode(await encodeRequestMessage(19, MessageType.REQUEST, {
+    data: [new TextEncoder().encode(await encodeRequestMessage('19', MessageType.REQUEST, {
       url: new URL('orpc:/ping'),
       body: { json: 'input' },
       headers: {},
@@ -52,11 +52,11 @@ describe('rpcHandler', async () => {
   }
 
   const abort_message = {
-    data: await encodeRequestMessage(19, MessageType.ABORT_SIGNAL, undefined),
+    data: await encodeRequestMessage('19', MessageType.ABORT_SIGNAL, undefined),
   }
 
   const not_found_request_message = {
-    data: await encodeRequestMessage(19, MessageType.REQUEST, {
+    data: await encodeRequestMessage('19', MessageType.REQUEST, {
       url: new URL('orpc:/not-found'),
       body: { json: 'input' },
       headers: {},
@@ -71,7 +71,7 @@ describe('rpcHandler', async () => {
 
     const [id,, payload] = (await decodeResponseMessage(wss.send.mock.calls[0]![0]))
 
-    expect(id).toBeTypeOf('number')
+    expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
       status: 200,
       headers: {},
@@ -85,7 +85,7 @@ describe('rpcHandler', async () => {
     await vi.waitFor(() => expect(wss.send).toHaveBeenCalledTimes(1))
     const [id, , payload] = (await decodeResponseMessage(wss.send.mock.calls[0]![0]))
 
-    expect(id).toBeTypeOf('number')
+    expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
       status: 200,
       headers: {},
@@ -126,7 +126,7 @@ describe('rpcHandler', async () => {
     await vi.waitFor(() => expect(wss.send).toHaveBeenCalledTimes(1))
     const [id,, payload] = (await decodeResponseMessage(wss.send.mock.calls[0]![0]))
 
-    expect(id).toBeTypeOf('number')
+    expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
       status: 404,
       headers: {},

--- a/packages/server/src/hibernation/event-iterator.test.ts
+++ b/packages/server/src/hibernation/event-iterator.test.ts
@@ -22,7 +22,7 @@ const serializer = new StandardRPCSerializer(new StandardRPCJsonSerializer({
 
 describe('encodeHibernationRPCEvent', () => {
   it('message without meta', async () => {
-    const id = 39483
+    const id = '39483'
     const planet = 'hello world'
     const encoded = encodeHibernationRPCEvent(id, planet, {
       customJsonSerializers: [planetSerializer],
@@ -34,7 +34,7 @@ describe('encodeHibernationRPCEvent', () => {
   })
 
   it('message with meta', async () => {
-    const id = 39483
+    const id = '39483'
     const planet = withEventMeta(new Planet('Earth', 12345), { retry: 400 })
     const encoded = encodeHibernationRPCEvent(id, planet, {
       customJsonSerializers: [planetSerializer],
@@ -46,7 +46,7 @@ describe('encodeHibernationRPCEvent', () => {
   })
 
   it('done', async () => {
-    const id = 39483
+    const id = '39483'
     const planet = withEventMeta(new Planet('Earth', 12345), { retry: 400 })
     const encoded = encodeHibernationRPCEvent(id, planet, {
       customJsonSerializers: [planetSerializer],
@@ -59,7 +59,7 @@ describe('encodeHibernationRPCEvent', () => {
   })
 
   it('error', async () => {
-    const id = 39483
+    const id = '39483'
     const planet = withEventMeta(new ORPCError('BAD_GATEWAY', { data: '__TEST__' }), { retry: 400 })
     const encoded = encodeHibernationRPCEvent(id, planet, {
       customJsonSerializers: [planetSerializer],

--- a/packages/server/src/hibernation/event-iterator.ts
+++ b/packages/server/src/hibernation/event-iterator.ts
@@ -24,7 +24,7 @@ export interface experimental_EncodeHibernationRPCEventOptions extends StandardR
  * @see {@link https://orpc.unnoq.com/docs/plugins/hibernation Hibernation Plugin}
  */
 export function experimental_encodeHibernationRPCEvent(
-  id: number,
+  id: string,
   payload: unknown,
   options: experimental_EncodeHibernationRPCEventOptions = {},
 ): string {

--- a/packages/shared/src/id.test.ts
+++ b/packages/shared/src/id.test.ts
@@ -3,13 +3,7 @@ import { SequentialIdGenerator } from './id'
 it('sequentialIdGenerator', () => {
   const idGenerator = new SequentialIdGenerator()
 
-  expect(idGenerator.generate()).toBe(0)
-  expect(idGenerator.generate()).toBe(1)
-  expect(idGenerator.generate()).toBe(2)
-
-  ;(idGenerator as any).nextId = Number.MAX_SAFE_INTEGER
-
-  expect(idGenerator.generate()).toBe(Number.MAX_SAFE_INTEGER)
-  expect(idGenerator.generate()).toBe(0)
-  expect(idGenerator.generate()).toBe(1)
+  expect(idGenerator.generate()).toBe('0')
+  expect(idGenerator.generate()).toBe('1')
+  expect(idGenerator.generate()).toBe('2')
 })

--- a/packages/shared/src/id.test.ts
+++ b/packages/shared/src/id.test.ts
@@ -1,9 +1,30 @@
 import { SequentialIdGenerator } from './id'
 
-it('sequentialIdGenerator', () => {
-  const idGenerator = new SequentialIdGenerator()
+describe('sequentialIdGenerator', () => {
+  it('unique and increase', () => {
+    const idGenerator = new SequentialIdGenerator()
 
-  expect(idGenerator.generate()).toBe('0')
-  expect(idGenerator.generate()).toBe('1')
-  expect(idGenerator.generate()).toBe('2')
+    expect(idGenerator.generate()).toBe('0')
+    expect(idGenerator.generate()).toBe('1')
+    expect(idGenerator.generate()).toBe('2')
+    expect(idGenerator.generate()).toBe('3')
+
+    for (let i = 4; i < 1000; i++) {
+      expect(idGenerator.generate()).toBe(i.toString(32))
+    }
+  })
+
+  it('large range', () => {
+    const idGenerator = new SequentialIdGenerator()
+    const generatedIds = new Set<string>()
+
+    const size = 100_000
+
+    for (let i = 0; i < size; i++) {
+      const id = idGenerator.generate()
+      generatedIds.add(id)
+    }
+
+    expect(generatedIds.size).toBe(size)
+  })
 })

--- a/packages/shared/src/id.ts
+++ b/packages/shared/src/id.ts
@@ -1,12 +1,9 @@
 export class SequentialIdGenerator {
-  private nextId = 0
+  private index = BigInt(0)
 
-  generate(): number {
-    if (this.nextId === Number.MAX_SAFE_INTEGER) {
-      this.nextId = 0
-      return Number.MAX_SAFE_INTEGER
-    }
-
-    return this.nextId++
+  generate(): string {
+    const id = this.index.toString(32)
+    this.index++
+    return id
   }
 }

--- a/packages/shared/src/iterator.ts
+++ b/packages/shared/src/iterator.ts
@@ -111,8 +111,8 @@ export function replicateAsyncIterator<T, TReturn, TNext>(
         const item = await source.next()
 
         for (let id = 0; id < count; id++) {
-          if (queue.isOpen(id)) {
-            queue.push(id, item)
+          if (queue.isOpen(id.toString())) {
+            queue.push(id.toString(), item)
           }
         }
 
@@ -127,13 +127,13 @@ export function replicateAsyncIterator<T, TReturn, TNext>(
   })
 
   for (let id = 0; id < count; id++) {
-    queue.open(id)
+    queue.open(id.toString())
     replicated.push(new AsyncIteratorClass(
       () => {
         start()
 
         return new Promise((resolve, reject) => {
-          queue.pull(id)
+          queue.pull(id.toString())
             .then(resolve)
             .catch(reject)
 
@@ -145,10 +145,10 @@ export function replicateAsyncIterator<T, TReturn, TNext>(
         })
       },
       async (reason) => {
-        queue.close({ id })
+        queue.close({ id: id.toString() })
 
         if (reason !== 'next') {
-          if (replicated.every((_, id) => !queue.isOpen(id))) {
+          if (replicated.every((_, id) => !queue.isOpen(id.toString()))) {
             await source?.return?.()
           }
         }

--- a/packages/shared/src/queue.test.ts
+++ b/packages/shared/src/queue.test.ts
@@ -2,8 +2,8 @@ import { AsyncIdQueue } from './queue'
 
 describe('asyncIdQueue', () => {
   let queue: AsyncIdQueue<string>
-  const queueId1 = 1
-  const queueId2 = 2
+  const queueId1 = '1'
+  const queueId2 = '2'
 
   beforeEach(() => {
     queue = new AsyncIdQueue<string>()
@@ -103,33 +103,33 @@ describe('asyncIdQueue', () => {
   })
 
   it('close, isOpen, length', async () => {
-    expect(queue.isOpen(1)).toBe(false)
+    expect(queue.isOpen('1')).toBe(false)
 
-    queue.open(1)
-    expect(queue.isOpen(1)).toBe(true)
+    queue.open('1')
+    expect(queue.isOpen('1')).toBe(true)
     expect(queue.length).toBe(1)
 
-    queue.open(2)
-    expect(queue.isOpen(2)).toBe(true)
+    queue.open('2')
+    expect(queue.isOpen('2')).toBe(true)
     expect(queue.length).toBe(2)
 
-    queue.open(3)
-    expect(queue.isOpen(3)).toBe(true)
+    queue.open('3')
+    expect(queue.isOpen('3')).toBe(true)
     expect(queue.length).toBe(3)
 
-    expect(queue.isOpen(1)).toBe(true)
-    expect(queue.isOpen(2)).toBe(true)
-    expect(queue.isOpen(3)).toBe(true)
+    expect(queue.isOpen('1')).toBe(true)
+    expect(queue.isOpen('2')).toBe(true)
+    expect(queue.isOpen('3')).toBe(true)
 
-    queue.close({ id: 1 })
-    expect(queue.isOpen(1)).toBe(false)
-    expect(queue.isOpen(2)).toBe(true)
-    expect(queue.isOpen(3)).toBe(true)
+    queue.close({ id: '1' })
+    expect(queue.isOpen('1')).toBe(false)
+    expect(queue.isOpen('2')).toBe(true)
+    expect(queue.isOpen('3')).toBe(true)
 
     queue.close()
 
-    expect(queue.isOpen(1)).toBe(false)
-    expect(queue.isOpen(2)).toBe(false)
-    expect(queue.isOpen(3)).toBe(false)
+    expect(queue.isOpen('1')).toBe(false)
+    expect(queue.isOpen('2')).toBe(false)
+    expect(queue.isOpen('3')).toBe(false)
   })
 })

--- a/packages/shared/src/queue.ts
+++ b/packages/shared/src/queue.ts
@@ -1,26 +1,26 @@
 export interface AsyncIdQueueCloseOptions {
-  id?: number
+  id?: string
   reason?: unknown
 }
 
 export class AsyncIdQueue<T> {
-  private readonly openIds = new Set<number>()
-  private readonly items = new Map<number, T[]>()
-  private readonly pendingPulls = new Map<number, (readonly [resolve: (item: T) => void, reject: (err: unknown) => void])[]>()
+  private readonly openIds = new Set<string>()
+  private readonly items = new Map<string, T[]>()
+  private readonly pendingPulls = new Map<string, (readonly [resolve: (item: T) => void, reject: (err: unknown) => void])[]>()
 
   get length(): number {
     return this.openIds.size
   }
 
-  open(id: number): void {
+  open(id: string): void {
     this.openIds.add(id)
   }
 
-  isOpen(id: number): boolean {
+  isOpen(id: string): boolean {
     return this.openIds.has(id)
   }
 
-  push(id: number, item: T): void {
+  push(id: string, item: T): void {
     this.assertOpen(id)
 
     const pending = this.pendingPulls.get(id)
@@ -44,7 +44,7 @@ export class AsyncIdQueue<T> {
     }
   }
 
-  async pull(id: number): Promise<T> {
+  async pull(id: string): Promise<T> {
     this.assertOpen(id)
 
     const items = this.items.get(id)
@@ -96,7 +96,7 @@ export class AsyncIdQueue<T> {
     this.items.delete(id)
   }
 
-  assertOpen(id: number): void {
+  assertOpen(id: string): void {
     if (!this.isOpen(id)) {
       throw new Error(`[AsyncIdQueue] Cannot access queue[${id}] because it is not open or aborted.`)
     }

--- a/packages/standard-server-peer/src/client.test.ts
+++ b/packages/standard-server-peer/src/client.test.ts
@@ -38,9 +38,9 @@ describe('clientPeer', () => {
     expect(peer.request(baseRequest)).resolves.toEqual(baseResponse)
 
     await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
-    expect(await decodeRequestMessage(send.mock.calls[0]![0])).toEqual([0, MessageType.REQUEST, baseRequest])
+    expect(await decodeRequestMessage(send.mock.calls[0]![0])).toEqual(['0', MessageType.REQUEST, baseRequest])
 
-    peer.message(await encodeResponseMessage(0, MessageType.RESPONSE, baseResponse))
+    peer.message(await encodeResponseMessage('0', MessageType.RESPONSE, baseResponse))
   })
 
   it('multiple simple request/response', async () => {
@@ -48,11 +48,11 @@ describe('clientPeer', () => {
     expect(peer.request({ ...baseRequest, body: '__SECOND__' })).resolves.toEqual({ ...baseResponse, body: '__SECOND__' })
 
     await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(2))
-    expect(await decodeRequestMessage(send.mock.calls[0]![0])).toEqual([0, MessageType.REQUEST, baseRequest])
-    expect(await decodeRequestMessage(send.mock.calls[1]![0])).toEqual([1, MessageType.REQUEST, { ...baseRequest, body: '__SECOND__' }])
+    expect(await decodeRequestMessage(send.mock.calls[0]![0])).toEqual(['0', MessageType.REQUEST, baseRequest])
+    expect(await decodeRequestMessage(send.mock.calls[1]![0])).toEqual(['1', MessageType.REQUEST, { ...baseRequest, body: '__SECOND__' }])
 
-    peer.message(await encodeResponseMessage(0, MessageType.RESPONSE, baseResponse))
-    peer.message(await encodeResponseMessage(1, MessageType.RESPONSE, { ...baseResponse, body: '__SECOND__' }))
+    peer.message(await encodeResponseMessage('0', MessageType.RESPONSE, baseResponse))
+    peer.message(await encodeResponseMessage('1', MessageType.RESPONSE, { ...baseResponse, body: '__SECOND__' }))
   })
 
   describe('request', () => {
@@ -69,7 +69,7 @@ describe('clientPeer', () => {
       await expect(peer.request(request)).rejects.toThrow('This operation was aborted')
       expect(send).toHaveBeenCalledTimes(0)
 
-      await peer.message(await encodeResponseMessage(0, MessageType.RESPONSE, baseResponse))
+      await peer.message(await encodeResponseMessage('0', MessageType.RESPONSE, baseResponse))
     })
 
     it('signal', async () => {
@@ -90,10 +90,10 @@ describe('clientPeer', () => {
       controller.abort()
 
       await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(2))
-      expect(await decodeRequestMessage(send.mock.calls[0]![0])).toEqual([0, MessageType.REQUEST, baseRequest])
-      expect(await decodeRequestMessage(send.mock.calls[1]![0])).toEqual([0, MessageType.ABORT_SIGNAL, undefined])
+      expect(await decodeRequestMessage(send.mock.calls[0]![0])).toEqual(['0', MessageType.REQUEST, baseRequest])
+      expect(await decodeRequestMessage(send.mock.calls[1]![0])).toEqual(['0', MessageType.ABORT_SIGNAL, undefined])
 
-      await peer.message(await encodeResponseMessage(0, MessageType.RESPONSE, baseResponse))
+      await peer.message(await encodeResponseMessage('0', MessageType.RESPONSE, baseResponse))
     })
 
     it('signal 2', async () => {
@@ -112,13 +112,13 @@ describe('clientPeer', () => {
       expect(peer.request(request)).rejects.toThrow('This operation was aborted')
 
       await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
-      expect(await decodeRequestMessage(send.mock.calls[0]![0])).toEqual([0, MessageType.REQUEST, baseRequest])
+      expect(await decodeRequestMessage(send.mock.calls[0]![0])).toEqual(['0', MessageType.REQUEST, baseRequest])
 
       controller.abort()
       await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(2))
-      expect(await decodeRequestMessage(send.mock.calls[1]![0])).toEqual([0, MessageType.ABORT_SIGNAL, undefined])
+      expect(await decodeRequestMessage(send.mock.calls[1]![0])).toEqual(['0', MessageType.ABORT_SIGNAL, undefined])
 
-      await peer.message(await encodeResponseMessage(0, MessageType.RESPONSE, baseResponse))
+      await peer.message(await encodeResponseMessage('0', MessageType.RESPONSE, baseResponse))
     })
 
     it('iterator', async () => {
@@ -134,12 +134,12 @@ describe('clientPeer', () => {
 
       await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(4))
       expect(await decodeRequestMessage(send.mock.calls[0]![0]))
-        .toEqual([0, MessageType.REQUEST, { ...request, body: undefined, headers: { ...request.headers, 'content-type': 'text/event-stream' } }])
-      expect(await decodeRequestMessage(send.mock.calls[1]![0])).toEqual([0, MessageType.EVENT_ITERATOR, { event: 'message', data: 'hello' }])
-      expect(await decodeRequestMessage(send.mock.calls[2]![0])).toEqual([0, MessageType.EVENT_ITERATOR, { event: 'message', data: { hello2: true }, meta: { id: 'id-1' } }])
-      expect(await decodeRequestMessage(send.mock.calls[3]![0])).toEqual([0, MessageType.EVENT_ITERATOR, { event: 'done' }])
+        .toEqual(['0', MessageType.REQUEST, { ...request, body: undefined, headers: { ...request.headers, 'content-type': 'text/event-stream' } }])
+      expect(await decodeRequestMessage(send.mock.calls[1]![0])).toEqual(['0', MessageType.EVENT_ITERATOR, { event: 'message', data: 'hello' }])
+      expect(await decodeRequestMessage(send.mock.calls[2]![0])).toEqual(['0', MessageType.EVENT_ITERATOR, { event: 'message', data: { hello2: true }, meta: { id: 'id-1' } }])
+      expect(await decodeRequestMessage(send.mock.calls[3]![0])).toEqual(['0', MessageType.EVENT_ITERATOR, { event: 'done' }])
 
-      peer.message(await encodeResponseMessage(0, MessageType.RESPONSE, baseResponse))
+      peer.message(await encodeResponseMessage('0', MessageType.RESPONSE, baseResponse))
     })
 
     it('iterator and server abort while sending', async () => {
@@ -169,14 +169,14 @@ describe('clientPeer', () => {
       expect(yieldFn).toHaveBeenCalledTimes(1)
       expect(isFinallyCalled).toBe(false)
 
-      await peer.message(await encodeResponseMessage(0, MessageType.ABORT_SIGNAL, undefined))
+      await peer.message(await encodeResponseMessage('0', MessageType.ABORT_SIGNAL, undefined))
       await new Promise(resolve => setTimeout(resolve, 20))
 
       expect(send).toHaveBeenCalledTimes(2)
       expect(yieldFn).toHaveBeenCalledTimes(2)
       expect(isFinallyCalled).toBe(true)
 
-      await peer.message(await encodeResponseMessage(0, MessageType.RESPONSE, baseResponse))
+      await peer.message(await encodeResponseMessage('0', MessageType.RESPONSE, baseResponse))
       await new Promise(resolve => setTimeout(resolve, 20))
 
       expect(send).toHaveBeenCalledTimes(2)
@@ -194,7 +194,7 @@ describe('clientPeer', () => {
 
       await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
       expect(await decodeRequestMessage(send.mock.calls[0]![0]))
-        .toEqual([0, MessageType.REQUEST, {
+        .toEqual(['0', MessageType.REQUEST, {
           ...request,
           headers: {
             ...request.headers,
@@ -203,7 +203,7 @@ describe('clientPeer', () => {
           },
         }])
 
-      peer.message(await encodeResponseMessage(0, MessageType.RESPONSE, baseResponse))
+      peer.message(await encodeResponseMessage('0', MessageType.RESPONSE, baseResponse))
     })
 
     it('form data', async () => {
@@ -220,7 +220,7 @@ describe('clientPeer', () => {
 
       await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
       expect(await decodeRequestMessage(send.mock.calls[0]![0]))
-        .toEqual([0, MessageType.REQUEST, {
+        .toEqual(['0', MessageType.REQUEST, {
           ...request,
           headers: {
             ...request.headers,
@@ -228,7 +228,7 @@ describe('clientPeer', () => {
           },
         }])
 
-      peer.message(await encodeResponseMessage(0, MessageType.RESPONSE, baseResponse))
+      peer.message(await encodeResponseMessage('0', MessageType.RESPONSE, baseResponse))
     })
 
     it('throw if can not send', async () => {
@@ -307,10 +307,10 @@ describe('clientPeer', () => {
 
       await new Promise(resolve => setTimeout(resolve, 0))
 
-      peer.message(await encodeResponseMessage(0, MessageType.RESPONSE, response))
-      peer.message(await encodeResponseMessage(0, MessageType.EVENT_ITERATOR, { event: 'message', data: 'hello' }))
-      peer.message(await encodeResponseMessage(0, MessageType.EVENT_ITERATOR, { event: 'message', data: { hello2: true }, meta: { id: 'id-1' } }))
-      peer.message(await encodeResponseMessage(0, MessageType.EVENT_ITERATOR, { event: 'done', data: 'hello3' }))
+      peer.message(await encodeResponseMessage('0', MessageType.RESPONSE, response))
+      peer.message(await encodeResponseMessage('0', MessageType.EVENT_ITERATOR, { event: 'message', data: 'hello' }))
+      peer.message(await encodeResponseMessage('0', MessageType.EVENT_ITERATOR, { event: 'message', data: { hello2: true }, meta: { id: 'id-1' } }))
+      peer.message(await encodeResponseMessage('0', MessageType.EVENT_ITERATOR, { event: 'done', data: 'hello3' }))
 
       const result = await responsePromise
 
@@ -359,8 +359,8 @@ describe('clientPeer', () => {
 
       await new Promise(resolve => setTimeout(resolve, 0))
 
-      peer.message(await encodeResponseMessage(0, MessageType.RESPONSE, response))
-      peer.message(await encodeResponseMessage(0, MessageType.EVENT_ITERATOR, { event: 'message', data: 'hello' }))
+      peer.message(await encodeResponseMessage('0', MessageType.RESPONSE, response))
+      peer.message(await encodeResponseMessage('0', MessageType.EVENT_ITERATOR, { event: 'message', data: 'hello' }))
 
       const result = await responsePromise
 
@@ -385,7 +385,7 @@ describe('clientPeer', () => {
       expect(await iterator.next()).toEqual({ done: true, value: undefined })
 
       expect(send).toHaveBeenCalledTimes(2)
-      expect(await decodeRequestMessage(send.mock.calls[1]![0])).toEqual([0, MessageType.ABORT_SIGNAL, undefined])
+      expect(await decodeRequestMessage(send.mock.calls[1]![0])).toEqual(['0', MessageType.ABORT_SIGNAL, undefined])
     })
 
     it('iterator and server success response while sending', async () => {
@@ -415,7 +415,7 @@ describe('clientPeer', () => {
       expect(yieldFn).toHaveBeenCalledTimes(1)
       expect(isFinallyCalled).toBe(false)
 
-      await peer.message(await encodeResponseMessage(0, MessageType.RESPONSE, baseResponse))
+      await peer.message(await encodeResponseMessage('0', MessageType.RESPONSE, baseResponse))
       await new Promise(resolve => setTimeout(resolve, 20))
 
       expect(send).toHaveBeenCalledTimes(2)
@@ -451,7 +451,7 @@ describe('clientPeer', () => {
       const [response] = await Promise.all([
         peer.request(request),
         new Promise(resolve => setTimeout(resolve, 0))
-          .then(async () => peer.message(await encodeResponseMessage(0, MessageType.RESPONSE, { ...baseResponse, body: (async function* () { })() }))),
+          .then(async () => peer.message(await encodeResponseMessage('0', MessageType.RESPONSE, { ...baseResponse, body: (async function* () { })() }))),
       ])
 
       const iterator = response.body as AsyncGenerator
@@ -466,7 +466,7 @@ describe('clientPeer', () => {
       expect(yieldFn).toHaveBeenCalledTimes(2)
       expect(isFinallyCalled).toBe(false)
 
-      await peer.message(await encodeResponseMessage(0, MessageType.EVENT_ITERATOR, { event: 'done', data: 'hello' }))
+      await peer.message(await encodeResponseMessage('0', MessageType.EVENT_ITERATOR, { event: 'done', data: 'hello' }))
       await iterator.next()
       await new Promise(resolve => setTimeout(resolve, 10))
 
@@ -496,7 +496,7 @@ describe('clientPeer', () => {
         },
       })
 
-      peer.message(await encodeResponseMessage(0, MessageType.RESPONSE, response))
+      peer.message(await encodeResponseMessage('0', MessageType.RESPONSE, response))
     })
 
     it('form data', async () => {
@@ -517,7 +517,7 @@ describe('clientPeer', () => {
         },
       })
 
-      peer.message(await encodeResponseMessage(0, MessageType.RESPONSE, response))
+      peer.message(await encodeResponseMessage('0', MessageType.RESPONSE, response))
     })
   })
 

--- a/packages/standard-server-peer/src/client.ts
+++ b/packages/standard-server-peer/src/client.ts
@@ -20,7 +20,7 @@ export class ClientPeer {
 
   private readonly responseQueue = new AsyncIdQueue<StandardResponse>()
   private readonly serverEventIteratorQueue = new AsyncIdQueue<EventIteratorPayload>()
-  private readonly serverControllers = new Map<number, AbortController>()
+  private readonly serverControllers = new Map<string, AbortController>()
 
   private readonly send: (...args: Parameters<typeof encodeRequestMessage>) => Promise<void>
 
@@ -43,7 +43,7 @@ export class ClientPeer {
     ) / 3
   }
 
-  open(id: number): AbortController {
+  open(id: string): AbortController {
     this.serverEventIteratorQueue.open(id)
     this.responseQueue.open(id)
     const controller = new AbortController()

--- a/packages/standard-server-peer/src/codec.test.ts
+++ b/packages/standard-server-peer/src/codec.test.ts
@@ -9,19 +9,19 @@ for (let i = 0; i < 300000; i++) {
 
 describe('encode/decode request message', () => {
   it('abort signal', async () => {
-    const message = await encodeRequestMessage(198, MessageType.ABORT_SIGNAL, undefined)
+    const message = await encodeRequestMessage('198', MessageType.ABORT_SIGNAL, undefined)
 
     expect(message).toBeTypeOf('string')
 
     const [id, type, payload] = await decodeRequestMessage(message)
 
-    expect(id).toBe(198)
+    expect(id).toBe('198')
     expect(type).toBe(MessageType.ABORT_SIGNAL)
     expect(payload).toBeUndefined()
   })
 
   it('event iterator', async () => {
-    const message = await encodeRequestMessage(198, MessageType.EVENT_ITERATOR, {
+    const message = await encodeRequestMessage('198', MessageType.EVENT_ITERATOR, {
       event: 'message',
       data: 'hello',
       meta: {
@@ -35,7 +35,7 @@ describe('encode/decode request message', () => {
 
     const [id, type, payload] = await decodeRequestMessage(message)
 
-    expect(id).toBe(198)
+    expect(id).toBe('198')
     expect(type).toBe(MessageType.EVENT_ITERATOR)
     expect(payload).toEqual({
       event: 'message',
@@ -58,7 +58,7 @@ describe('encode/decode request message', () => {
     ['DELETE', new URL('https://example.com/api/v1/users/1'), { }],
   ] as const)('request %s', (method, url, headers) => {
     it('undefined', async () => {
-      const message = await encodeRequestMessage(198, MessageType.REQUEST, {
+      const message = await encodeRequestMessage('198', MessageType.REQUEST, {
         url,
         headers,
         method,
@@ -69,7 +69,7 @@ describe('encode/decode request message', () => {
 
       const [id, type, payload] = await decodeRequestMessage(message)
 
-      expect(id).toBe(198)
+      expect(id).toBe('198')
       expect(type).toBe(MessageType.REQUEST)
       expect(payload).toEqual({
         url,
@@ -80,7 +80,7 @@ describe('encode/decode request message', () => {
     })
 
     it('json', async () => {
-      const message = await encodeRequestMessage(198, MessageType.REQUEST, {
+      const message = await encodeRequestMessage('198', MessageType.REQUEST, {
         url,
         headers,
         method,
@@ -91,7 +91,7 @@ describe('encode/decode request message', () => {
 
       const [id, type, payload] = await decodeRequestMessage(message)
 
-      expect(id).toBe(198)
+      expect(id).toBe('198')
       expect(type).toBe(MessageType.REQUEST)
       expect(payload).toEqual({
         url,
@@ -102,7 +102,7 @@ describe('encode/decode request message', () => {
     })
 
     it('json buffer', async () => {
-      const message = await encodeRequestMessage(198, MessageType.REQUEST, {
+      const message = await encodeRequestMessage('198', MessageType.REQUEST, {
         url,
         headers,
         method,
@@ -113,7 +113,7 @@ describe('encode/decode request message', () => {
 
       const [id, type, payload] = await decodeRequestMessage(new TextEncoder().encode(message as string))
 
-      expect(id).toBe(198)
+      expect(id).toBe('198')
       expect(type).toBe(MessageType.REQUEST)
       expect(payload).toEqual({
         url,
@@ -126,7 +126,7 @@ describe('encode/decode request message', () => {
     it('urlSearchParams', async () => {
       const query = new URLSearchParams('a=1&b=2')
 
-      const message = await encodeRequestMessage(198, MessageType.REQUEST, {
+      const message = await encodeRequestMessage('198', MessageType.REQUEST, {
         url,
         headers,
         method,
@@ -137,7 +137,7 @@ describe('encode/decode request message', () => {
 
       const [id, type, payload] = await decodeRequestMessage(message)
 
-      expect(id).toBe(198)
+      expect(id).toBe('198')
       expect(type).toBe(MessageType.REQUEST)
       expect(payload).toEqual({
         url,
@@ -148,7 +148,7 @@ describe('encode/decode request message', () => {
     })
 
     it('event iterator', async () => {
-      const message = await encodeRequestMessage(198, MessageType.REQUEST, {
+      const message = await encodeRequestMessage('198', MessageType.REQUEST, {
         url,
         method,
         headers,
@@ -159,7 +159,7 @@ describe('encode/decode request message', () => {
 
       const [id, type, payload] = await decodeRequestMessage(message)
 
-      expect(id).toBe(198)
+      expect(id).toBe('198')
       expect(type).toBe(MessageType.REQUEST)
       expect(payload).toEqual({
         url,
@@ -175,7 +175,7 @@ describe('encode/decode request message', () => {
       formData.append('b', '2')
       formData.append('file', new File(['foo'], 'some-name.pdf', { type: 'application/pdf' }))
 
-      const message = await encodeRequestMessage(198, MessageType.REQUEST, {
+      const message = await encodeRequestMessage('198', MessageType.REQUEST, {
         url,
         headers,
         method,
@@ -186,7 +186,7 @@ describe('encode/decode request message', () => {
 
       const [id, type, payload] = await decodeRequestMessage(message)
 
-      expect(id).toBe(198)
+      expect(id).toBe('198')
       expect(type).toBe(MessageType.REQUEST)
       expect(payload).toEqual({
         url,
@@ -209,7 +209,7 @@ describe('encode/decode request message', () => {
       formData.append('b', '2')
       formData.append('file', new File(['foo'], 'some-name.pdf', { type: 'application/pdf' }))
 
-      const message = await encodeRequestMessage(198, MessageType.REQUEST, {
+      const message = await encodeRequestMessage('198', MessageType.REQUEST, {
         url,
         headers,
         method,
@@ -220,7 +220,7 @@ describe('encode/decode request message', () => {
 
       const [id, type, payload] = await decodeRequestMessage(message)
 
-      expect(id).toBe(198)
+      expect(id).toBe('198')
       expect(type).toBe(MessageType.REQUEST)
       expect(payload).toEqual({
         url,
@@ -247,7 +247,7 @@ describe('encode/decode request message', () => {
       it('blob', async () => {
         const blob = new Blob(['foo'], { type: contentType })
 
-        const message = await encodeRequestMessage(198, MessageType.REQUEST, {
+        const message = await encodeRequestMessage('198', MessageType.REQUEST, {
           url,
           headers,
           method,
@@ -258,7 +258,7 @@ describe('encode/decode request message', () => {
 
         const [id, type, payload] = await decodeRequestMessage(message)
 
-        expect(id).toBe(198)
+        expect(id).toBe('198')
         expect(type).toBe(MessageType.REQUEST)
         expect(payload).toEqual({
           url,
@@ -277,7 +277,7 @@ describe('encode/decode request message', () => {
       it('blob with custom content-disposition', async () => {
         const blob = new Blob(['foo'], { type: contentType })
 
-        const message = await encodeRequestMessage(198, MessageType.REQUEST, {
+        const message = await encodeRequestMessage('198', MessageType.REQUEST, {
           url,
           headers: {
             ...headers,
@@ -291,7 +291,7 @@ describe('encode/decode request message', () => {
 
         const [id, type, payload] = await decodeRequestMessage(message)
 
-        expect(id).toBe(198)
+        expect(id).toBe('198')
         expect(type).toBe(MessageType.REQUEST)
         expect(payload).toEqual({
           url,
@@ -310,7 +310,7 @@ describe('encode/decode request message', () => {
       it('empty blob', async () => {
         const blob = new Blob([], { type: contentType })
 
-        const message = await encodeRequestMessage(198, MessageType.REQUEST, {
+        const message = await encodeRequestMessage('198', MessageType.REQUEST, {
           url,
           headers,
           method,
@@ -321,7 +321,7 @@ describe('encode/decode request message', () => {
 
         const [id, type, payload] = await decodeRequestMessage(message)
 
-        expect(id).toBe(198)
+        expect(id).toBe('198')
         expect(type).toBe(MessageType.REQUEST)
         expect(payload).toEqual({
           url,
@@ -340,7 +340,7 @@ describe('encode/decode request message', () => {
       it('file', async () => {
         const file = new File(['foo'], 'some-name.pdf', { type: contentType })
 
-        const message = await encodeRequestMessage(198, MessageType.REQUEST, {
+        const message = await encodeRequestMessage('198', MessageType.REQUEST, {
           url,
           headers,
           method,
@@ -351,7 +351,7 @@ describe('encode/decode request message', () => {
 
         const [id, type, payload] = await decodeRequestMessage(message)
 
-        expect(id).toBe(198)
+        expect(id).toBe('198')
         expect(type).toBe(MessageType.REQUEST)
         expect(payload).toEqual({
           url,
@@ -370,7 +370,7 @@ describe('encode/decode request message', () => {
       it('file with custom content-disposition', async () => {
         const file = new File(['foo'], 'some-name.pdf', { type: contentType })
 
-        const message = await encodeRequestMessage(198, MessageType.REQUEST, {
+        const message = await encodeRequestMessage('198', MessageType.REQUEST, {
           url,
           headers: {
             ...headers,
@@ -384,7 +384,7 @@ describe('encode/decode request message', () => {
 
         const [id, type, payload] = await decodeRequestMessage(message)
 
-        expect(id).toBe(198)
+        expect(id).toBe('198')
         expect(type).toBe(MessageType.REQUEST)
         expect(payload).toEqual({
           url,
@@ -403,7 +403,7 @@ describe('encode/decode request message', () => {
       it('empty file', async () => {
         const file = new File([], 'some-name.pdf', { type: contentType })
 
-        const message = await encodeRequestMessage(198, MessageType.REQUEST, {
+        const message = await encodeRequestMessage('198', MessageType.REQUEST, {
           url,
           headers,
           method,
@@ -414,7 +414,7 @@ describe('encode/decode request message', () => {
 
         const [id, type, payload] = await decodeRequestMessage(message)
 
-        expect(id).toBe(198)
+        expect(id).toBe('198')
         expect(type).toBe(MessageType.REQUEST)
         expect(payload).toEqual({
           url,
@@ -439,7 +439,7 @@ describe('encode/decode request message', () => {
     const url = new URL('https://example.com/api/v1/users/1')
     const method = 'DELETE'
 
-    const message = await encodeRequestMessage(198, MessageType.REQUEST, {
+    const message = await encodeRequestMessage('198', MessageType.REQUEST, {
       url,
       method,
       headers: MB10Headers,
@@ -450,7 +450,7 @@ describe('encode/decode request message', () => {
 
     const [id, type, payload] = await decodeRequestMessage(message)
 
-    expect(id).toBe(198)
+    expect(id).toBe('198')
     expect(type).toBe(MessageType.REQUEST)
     expect(payload).toEqual({
       url,
@@ -469,19 +469,19 @@ describe('encode/decode request message', () => {
 
 describe('encode/decode response message', () => {
   it('abort signal', async () => {
-    const message = await encodeResponseMessage(198, MessageType.ABORT_SIGNAL, undefined)
+    const message = await encodeResponseMessage('198', MessageType.ABORT_SIGNAL, undefined)
 
     expect(message).toBeTypeOf('string')
 
     const [id, type, payload] = await decodeResponseMessage(message)
 
-    expect(id).toBe(198)
+    expect(id).toBe('198')
     expect(type).toBe(MessageType.ABORT_SIGNAL)
     expect(payload).toBeUndefined()
   })
 
   it('event iterator', async () => {
-    const message = await encodeResponseMessage(198, MessageType.EVENT_ITERATOR, {
+    const message = await encodeResponseMessage('198', MessageType.EVENT_ITERATOR, {
       event: 'message',
       data: 'hello',
       meta: {
@@ -495,7 +495,7 @@ describe('encode/decode response message', () => {
 
     const [id, type, payload] = await decodeResponseMessage(message)
 
-    expect(id).toBe(198)
+    expect(id).toBe('198')
     expect(type).toBe(MessageType.EVENT_ITERATOR)
     expect(payload).toEqual({
       event: 'message',
@@ -514,7 +514,7 @@ describe('encode/decode response message', () => {
     [400, {}],
   ] as const)('response %s', (status, headers) => {
     it('undefined', async () => {
-      const message = await encodeResponseMessage(198, MessageType.RESPONSE, {
+      const message = await encodeResponseMessage('198', MessageType.RESPONSE, {
         status,
         headers,
         body: undefined,
@@ -524,7 +524,7 @@ describe('encode/decode response message', () => {
 
       const [id, type, payload] = await decodeResponseMessage(message)
 
-      expect(id).toBe(198)
+      expect(id).toBe('198')
       expect(type).toBe(MessageType.RESPONSE)
       expect(payload).toEqual({
         status,
@@ -534,7 +534,7 @@ describe('encode/decode response message', () => {
     })
 
     it('json', async () => {
-      const message = await encodeResponseMessage(198, MessageType.RESPONSE, {
+      const message = await encodeResponseMessage('198', MessageType.RESPONSE, {
         status,
         headers,
         body: { value: 1 },
@@ -544,7 +544,7 @@ describe('encode/decode response message', () => {
 
       const [id, type, payload] = await decodeResponseMessage(message)
 
-      expect(id).toBe(198)
+      expect(id).toBe('198')
       expect(type).toBe(MessageType.RESPONSE)
       expect(payload).toEqual({
         status,
@@ -554,7 +554,7 @@ describe('encode/decode response message', () => {
     })
 
     it('json buffer', async () => {
-      const message = await encodeResponseMessage(198, MessageType.RESPONSE, {
+      const message = await encodeResponseMessage('198', MessageType.RESPONSE, {
         status,
         headers,
         body: { value: 1 },
@@ -564,7 +564,7 @@ describe('encode/decode response message', () => {
 
       const [id, type, payload] = await decodeResponseMessage(new TextEncoder().encode(message as string))
 
-      expect(id).toBe(198)
+      expect(id).toBe('198')
       expect(type).toBe(MessageType.RESPONSE)
       expect(payload).toEqual({
         status,
@@ -576,7 +576,7 @@ describe('encode/decode response message', () => {
     it('urlSearchParams', async () => {
       const query = new URLSearchParams('a=1&b=2')
 
-      const message = await encodeResponseMessage(198, MessageType.RESPONSE, {
+      const message = await encodeResponseMessage('198', MessageType.RESPONSE, {
         status,
         headers,
         body: query,
@@ -586,7 +586,7 @@ describe('encode/decode response message', () => {
 
       const [id, type, payload] = await decodeResponseMessage(message)
 
-      expect(id).toBe(198)
+      expect(id).toBe('198')
       expect(type).toBe(MessageType.RESPONSE)
       expect(payload).toEqual({
         status,
@@ -596,7 +596,7 @@ describe('encode/decode response message', () => {
     })
 
     it('event iterator', async () => {
-      const message = await encodeResponseMessage(198, MessageType.RESPONSE, {
+      const message = await encodeResponseMessage('198', MessageType.RESPONSE, {
         status,
         headers,
         body: (async function* () {})(),
@@ -606,7 +606,7 @@ describe('encode/decode response message', () => {
 
       const [id, type, payload] = await decodeResponseMessage(message)
 
-      expect(id).toBe(198)
+      expect(id).toBe('198')
       expect(type).toBe(MessageType.RESPONSE)
       expect(payload).toEqual({
         status,
@@ -621,7 +621,7 @@ describe('encode/decode response message', () => {
       formData.append('b', '2')
       formData.append('file', new File(['foo'], 'some-name.pdf', { type: 'application/pdf' }))
 
-      const message = await encodeResponseMessage(198, MessageType.RESPONSE, {
+      const message = await encodeResponseMessage('198', MessageType.RESPONSE, {
         status,
         headers,
         body: formData,
@@ -631,7 +631,7 @@ describe('encode/decode response message', () => {
 
       const [id, type, payload] = await decodeResponseMessage(message)
 
-      expect(id).toBe(198)
+      expect(id).toBe('198')
       expect(type).toBe(MessageType.RESPONSE)
       expect(payload).toEqual({
         status,
@@ -653,7 +653,7 @@ describe('encode/decode response message', () => {
       formData.append('b', '2')
       formData.append('file', new File(['foo'], 'some-name.pdf', { type: 'application/pdf' }))
 
-      const message = await encodeResponseMessage(198, MessageType.RESPONSE, {
+      const message = await encodeResponseMessage('198', MessageType.RESPONSE, {
         status,
         headers,
         body: formData,
@@ -663,7 +663,7 @@ describe('encode/decode response message', () => {
 
       const [id, type, payload] = await decodeResponseMessage(message)
 
-      expect(id).toBe(198)
+      expect(id).toBe('198')
       expect(type).toBe(MessageType.RESPONSE)
       expect(payload).toEqual({
         status,
@@ -689,7 +689,7 @@ describe('encode/decode response message', () => {
       it('blob', async () => {
         const blob = new Blob(['foo'], { type: contentType })
 
-        const message = await encodeResponseMessage(198, MessageType.RESPONSE, {
+        const message = await encodeResponseMessage('198', MessageType.RESPONSE, {
           status,
           headers,
           body: blob,
@@ -699,7 +699,7 @@ describe('encode/decode response message', () => {
 
         const [id, type, payload] = await decodeResponseMessage(message)
 
-        expect(id).toBe(198)
+        expect(id).toBe('198')
         expect(type).toBe(MessageType.RESPONSE)
         expect(payload).toEqual({
           status,
@@ -717,7 +717,7 @@ describe('encode/decode response message', () => {
       it('blob with custom content-disposition', async () => {
         const blob = new Blob(['foo'], { type: contentType })
 
-        const message = await encodeResponseMessage(198, MessageType.RESPONSE, {
+        const message = await encodeResponseMessage('198', MessageType.RESPONSE, {
           status,
           headers: {
             ...headers,
@@ -730,7 +730,7 @@ describe('encode/decode response message', () => {
 
         const [id, type, payload] = await decodeResponseMessage(message)
 
-        expect(id).toBe(198)
+        expect(id).toBe('198')
         expect(type).toBe(MessageType.RESPONSE)
         expect(payload).toEqual({
           status,
@@ -748,7 +748,7 @@ describe('encode/decode response message', () => {
       it('file', async () => {
         const file = new File(['foo'], 'some-name.pdf', { type: contentType })
 
-        const message = await encodeResponseMessage(198, MessageType.RESPONSE, {
+        const message = await encodeResponseMessage('198', MessageType.RESPONSE, {
           status,
           headers,
           body: file,
@@ -758,7 +758,7 @@ describe('encode/decode response message', () => {
 
         const [id, type, payload] = await decodeResponseMessage(message)
 
-        expect(id).toBe(198)
+        expect(id).toBe('198')
         expect(type).toBe(MessageType.RESPONSE)
         expect(payload).toEqual({
           status,
@@ -776,7 +776,7 @@ describe('encode/decode response message', () => {
       it('file with custom content-disposition', async () => {
         const file = new File(['foo'], 'some-name.pdf', { type: contentType })
 
-        const message = await encodeResponseMessage(198, MessageType.RESPONSE, {
+        const message = await encodeResponseMessage('198', MessageType.RESPONSE, {
           status,
           headers: {
             ...headers,
@@ -789,7 +789,7 @@ describe('encode/decode response message', () => {
 
         const [id, type, payload] = await decodeResponseMessage(message)
 
-        expect(id).toBe(198)
+        expect(id).toBe('198')
         expect(type).toBe(MessageType.RESPONSE)
         expect(payload).toEqual({
           status,
@@ -810,7 +810,7 @@ describe('encode/decode response message', () => {
     const json = JSON.stringify(MB10Headers)
     const blob = new Blob([json], { type: 'application/pdf' })
 
-    const message = await encodeResponseMessage(198, MessageType.RESPONSE, {
+    const message = await encodeResponseMessage('198', MessageType.RESPONSE, {
       status: 203,
       headers: MB10Headers,
       body: blob,
@@ -820,7 +820,7 @@ describe('encode/decode response message', () => {
 
     const [id, type, payload] = await decodeResponseMessage(message)
 
-    expect(id).toBe(198)
+    expect(id).toBe('198')
     expect(type).toBe(MessageType.RESPONSE)
     expect(payload).toEqual({
       status: 203,

--- a/packages/standard-server-peer/src/codec.ts
+++ b/packages/standard-server-peer/src/codec.ts
@@ -31,7 +31,10 @@ export interface ResponseMessageMap {
 }
 
 interface BaseMessageFormat<P = unknown> {
-  i: number
+  /**
+   * Id that unique in client-side
+   */
+  i: string
 
   /**
    * @default REQUEST | RESPONSE
@@ -83,14 +86,14 @@ interface SerializedResponsePayload {
 }
 
 type DecodedMessageUnion<TMap extends RequestMessageMap | ResponseMessageMap> = {
-  [K in keyof TMap]: [id: number, type: K, payload: TMap[K]]
+  [K in keyof TMap]: [id: string, type: K, payload: TMap[K]]
 }[keyof TMap]
 
 export type DecodedRequestMessage = DecodedMessageUnion<RequestMessageMap>
 export type DecodedResponseMessage = DecodedMessageUnion<ResponseMessageMap>
 
 export async function encodeRequestMessage<T extends keyof RequestMessageMap>(
-  id: number,
+  id: string,
   type: T,
   payload: RequestMessageMap[T],
 ): Promise<EncodedMessage> {
@@ -138,7 +141,7 @@ export async function encodeRequestMessage<T extends keyof RequestMessageMap>(
 export async function decodeRequestMessage(raw: EncodedMessage): Promise<DecodedRequestMessage> {
   const { json: message, blobData } = await decodeRawMessage(raw)
 
-  const id: number = message.i
+  const id: string = message.i
   const type: MessageType = message.t
 
   if (type === MessageType.EVENT_ITERATOR) {
@@ -179,7 +182,7 @@ export async function decodeRequestMessage(raw: EncodedMessage): Promise<Decoded
 }
 
 export async function encodeResponseMessage<T extends keyof ResponseMessageMap>(
-  id: number,
+  id: string,
   type: T,
   payload: ResponseMessageMap[T],
 ): Promise<EncodedMessage> {
@@ -224,7 +227,7 @@ export async function encodeResponseMessage<T extends keyof ResponseMessageMap>(
 export async function decodeResponseMessage(raw: EncodedMessage): Promise<DecodedResponseMessage> {
   const { json: message, blobData } = await decodeRawMessage(raw)
 
-  const id: number = message.i
+  const id: string = message.i
   const type: MessageType | undefined = message.t
 
   if (type === MessageType.EVENT_ITERATOR) {

--- a/packages/standard-server-peer/src/codec.ts
+++ b/packages/standard-server-peer/src/codec.ts
@@ -32,7 +32,7 @@ export interface ResponseMessageMap {
 
 interface BaseMessageFormat<P = unknown> {
   /**
-   * Id that unique in client-side
+   * Client-guaranteed unique identifier
    */
   i: string
 

--- a/packages/standard-server-peer/src/event-iterator.test.ts
+++ b/packages/standard-server-peer/src/event-iterator.test.ts
@@ -7,33 +7,33 @@ describe('toEventIterator', () => {
   it('on success', async () => {
     const queue = new AsyncIdQueue<EventIteratorPayload>()
 
-    queue.open(198)
-    queue.open(199)
+    queue.open('198')
+    queue.open('199')
 
-    queue.push(198, {
+    queue.push('198', {
       event: 'message',
       data: 'hello',
     })
 
-    queue.push(199, {
+    queue.push('199', {
       event: 'message',
       data: 'hello2',
     })
 
-    queue.push(198, {
+    queue.push('198', {
       event: 'message',
       data: { hello3: true },
       meta: { id: 'id-1', retry: 2000, comments: [] },
     })
 
-    queue.push(198, {
+    queue.push('198', {
       event: 'done',
       data: { hello4: true },
       meta: { id: 'id-2', retry: 2001, comments: ['comment1', 'comment2'] },
     })
 
     const cleanup = vi.fn()
-    const iterator = toEventIterator(queue, 198, cleanup)
+    const iterator = toEventIterator(queue, '198', cleanup)
 
     await expect(iterator.next()).resolves.toSatisfy((value) => {
       expect(value.done).toBe(false)
@@ -67,33 +67,33 @@ describe('toEventIterator', () => {
   it('on error', async () => {
     const queue = new AsyncIdQueue<EventIteratorPayload>()
 
-    queue.open(198)
-    queue.open(199)
+    queue.open('198')
+    queue.open('199')
 
-    queue.push(198, {
+    queue.push('198', {
       event: 'message',
       data: 'hello',
     })
 
-    queue.push(199, {
+    queue.push('199', {
       event: 'message',
       data: 'hello2',
     })
 
-    queue.push(198, {
+    queue.push('198', {
       event: 'message',
       data: { hello3: true },
       meta: { id: 'id-1', retry: 2000, comments: [] },
     })
 
-    queue.push(198, {
+    queue.push('198', {
       event: 'error',
       data: { hello4: true },
       meta: { id: 'id-2', retry: 2001, comments: ['comment1', 'comment2'] },
     })
 
     const cleanup = vi.fn()
-    const iterator = toEventIterator(queue, 198, cleanup)
+    const iterator = toEventIterator(queue, '198', cleanup)
 
     await expect(iterator.next()).resolves.toSatisfy((value) => {
       expect(value.done).toBe(false)

--- a/packages/standard-server-peer/src/event-iterator.ts
+++ b/packages/standard-server-peer/src/event-iterator.ts
@@ -6,7 +6,7 @@ import { ErrorEvent, getEventMeta, withEventMeta } from '@orpc/standard-server'
 
 export function toEventIterator(
   queue: AsyncIdQueue<EventIteratorPayload>,
-  id: number,
+  id: string,
   cleanup: AsyncIteratorClassCleanupFn,
 ): AsyncIteratorClass<unknown> {
   return new AsyncIteratorClass(async () => {

--- a/packages/standard-server-peer/src/server.test.ts
+++ b/packages/standard-server-peer/src/server.test.ts
@@ -4,7 +4,7 @@ import { decodeResponseMessage, encodeRequestMessage, MessageType } from './code
 import { ServerPeer } from './server'
 
 describe('serverPeer', () => {
-  const REQUEST_ID = 1953
+  const REQUEST_ID = '1953'
 
   const send = vi.fn()
   let peer: ServerPeer

--- a/packages/standard-server-peer/src/server.ts
+++ b/packages/standard-server-peer/src/server.ts
@@ -18,7 +18,7 @@ export interface ServerPeerCloseOptions extends AsyncIdQueueCloseOptions {
 
 export class ServerPeer {
   private readonly clientEventIteratorQueue = new AsyncIdQueue<EventIteratorPayload>()
-  private readonly clientControllers = new Map<number, AbortController>()
+  private readonly clientControllers = new Map<string, AbortController>()
 
   private readonly send: (...args: Parameters<typeof encodeResponseMessage>) => Promise<void>
 
@@ -40,14 +40,14 @@ export class ServerPeer {
     ) / 2
   }
 
-  open(id: number): AbortController {
+  open(id: string): AbortController {
     this.clientEventIteratorQueue.open(id)
     const controller = new AbortController()
     this.clientControllers.set(id, controller)
     return controller
   }
 
-  async message(raw: EncodedMessage): Promise<[id: number, StandardRequest | undefined]> {
+  async message(raw: EncodedMessage): Promise<[id: string, StandardRequest | undefined]> {
     const [id, type, payload] = await decodeRequestMessage(raw)
 
     if (type === MessageType.ABORT_SIGNAL) {
@@ -79,7 +79,7 @@ export class ServerPeer {
     return [id, request]
   }
 
-  async response(id: number, response: StandardResponse): Promise<void> {
+  async response(id: string, response: StandardResponse): Promise<void> {
     const signal = this.clientControllers.get(id)?.signal
 
     // only send message if still open and not aborted

--- a/packages/standard-server/src/hibernation.test.ts
+++ b/packages/standard-server/src/hibernation.test.ts
@@ -8,8 +8,8 @@ it('hibernationEventIterator', async () => {
   const iterator2 = new HibernationEventIterator(callback)
   await expect(iterator2.return()).rejects.toThrowError('Cannot cleanup hibernating iterator directly')
 
-  iterator1.hibernationCallback?.(12344)
+  iterator1.hibernationCallback?.('12344')
 
-  expect(callback).toBeCalledWith(12344)
+  expect(callback).toBeCalledWith('12344')
   expect(callback).toBeCalledTimes(1)
 })

--- a/packages/standard-server/src/hibernation.ts
+++ b/packages/standard-server/src/hibernation.ts
@@ -1,7 +1,7 @@
 import { AsyncIteratorClass } from '@orpc/shared'
 
 export interface experimental_HibernationEventIteratorCallback {
-  (id: number): void
+  (id: string): void
 }
 
 export class experimental_HibernationEventIterator<T, TReturn = unknown, TNext = unknown> extends AsyncIteratorClass<T, TReturn, TNext> {


### PR DESCRIPTION
Number range has a limit. We reset when it’s reached, but it’s still more ideal if we can guarantee the ID is always unique by use string.
> This is a breaking change, but all features relies on this still experimental

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - None.

- **Refactor**
  - All internal and public APIs now use string-based identifiers instead of numeric IDs for messages, queues, and event iterators.
  - Updated all related methods, callbacks, and data structures to expect string IDs.

- **Tests**
  - Updated all test cases to use string IDs instead of numbers for request, response, and queue identifiers.

- **Documentation**
  - None.

These changes improve consistency and compatibility across the system when handling identifiers. No user-facing functionality or workflows are altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->