### PR TITLE
refactor(server): improve naming & types for hibernation apis

### DIFF
--- a/packages/durable-event-iterator/src/durable-object/handler.test.ts
+++ b/packages/durable-event-iterator/src/durable-object/handler.test.ts
@@ -40,7 +40,7 @@ describe('durableEventIteratorRouter', async () => {
 
       expect(output).toBeInstanceOf(HibernationEventIterator)
 
-      output.hibernationCallback?.(123)
+      output.hibernationCallback(123)
 
       expect(serializeInternalAttachmentSpy).toHaveBeenCalledWith(currentWebsocket, {
         [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]: 123,
@@ -77,7 +77,7 @@ describe('durableEventIteratorRouter', async () => {
 
       expect(output).toBeInstanceOf(HibernationEventIterator)
 
-      output.hibernationCallback?.(123)
+      output.hibernationCallback(123)
 
       expect(serializeInternalAttachmentSpy).toHaveBeenCalledWith(currentWebsocket, {
         [DURABLE_EVENT_ITERATOR_HIBERNATION_ID_KEY]: 123,

--- a/packages/server/src/hibernation/plugin.ts
+++ b/packages/server/src/hibernation/plugin.ts
@@ -3,7 +3,7 @@ import type { Context } from '../context'
 import type { Router } from '../router'
 import { experimental_HibernationEventIterator } from '@orpc/standard-server'
 
-export interface experimental_HibernationContext {
+export interface experimental_HibernationPluginContext {
   iterator?: experimental_HibernationEventIterator<any>
 }
 
@@ -13,7 +13,7 @@ export interface experimental_HibernationContext {
  * @see {@link https://orpc.unnoq.com/docs/plugins/hibernation Hibernation Plugin}
  */
 export class experimental_HibernationPlugin<T extends Context> implements StandardHandlerPlugin<T> {
-  readonly HIBERNATION_CONTEXT_SYMBOL = Symbol('HIBERNATION_CONTEXT')
+  readonly CONTEXT_SYMBOL = Symbol('ORPC_HIBERNATION_CONTEXT')
 
   order = 2_000_000 // make sure execute after the batch plugin
 
@@ -22,12 +22,12 @@ export class experimental_HibernationPlugin<T extends Context> implements Standa
     options.clientInterceptors ??= []
 
     options.interceptors.unshift(async (options) => {
-      const hibernationContext: experimental_HibernationContext = {}
+      const hibernationContext: experimental_HibernationPluginContext = {}
 
       const result = await options.next({
         ...options,
         context: {
-          [this.HIBERNATION_CONTEXT_SYMBOL]: hibernationContext,
+          [this.CONTEXT_SYMBOL]: hibernationContext,
           ...options.context,
         },
       })
@@ -46,7 +46,7 @@ export class experimental_HibernationPlugin<T extends Context> implements Standa
     })
 
     options.clientInterceptors.unshift(async (options) => {
-      const hibernationContext = options.context[this.HIBERNATION_CONTEXT_SYMBOL] as experimental_HibernationContext | undefined
+      const hibernationContext = options.context[this.CONTEXT_SYMBOL] as experimental_HibernationPluginContext | undefined
 
       if (!hibernationContext) {
         throw new TypeError('[HibernationPlugin] Hibernation context has been corrupted or modified by another plugin or interceptor')

--- a/packages/shared/src/object.ts
+++ b/packages/shared/src/object.ts
@@ -88,3 +88,37 @@ export const NullProtoObj = /* @__PURE__ */ (() => {
   Object.freeze(e.prototype)
   return e
 })() as unknown as ({ new<T extends Record<PropertyKey, unknown>>(): T })
+
+/**
+ * Temporary omit properties from an object using a proxy.
+ */
+export function proxyOmit<T extends object, K extends PropertyKey>(
+  obj: T,
+  ...keys: K[]
+): Omit<T, K> {
+  return new Proxy(obj, {
+    get(target, prop) {
+      if (keys.includes(prop as K)) {
+        return undefined
+      }
+
+      const val = Reflect.get(target, prop)
+
+      /**
+       * This is needed for proxy async iterators to work correctly.
+       */
+      if (typeof val === 'function') {
+        return val.bind(target)
+      }
+
+      return val
+    },
+    has(target, prop) {
+      if (keys.includes(prop as K)) {
+        return false
+      }
+
+      return Reflect.has(target, prop)
+    },
+  })
+}

--- a/packages/standard-server-peer/src/server.ts
+++ b/packages/standard-server-peer/src/server.ts
@@ -91,7 +91,7 @@ export class ServerPeer {
       .then(async () => {
         if (!signal.aborted && isAsyncIteratorObject(response.body)) {
           if (response.body instanceof experimental_HibernationEventIterator) {
-            response.body.hibernationCallback?.(id)
+            response.body.hibernationCallback(id)
           }
           else {
             await resolveEventIterator(response.body, async (payload) => {

--- a/packages/standard-server/src/hibernation.test.ts
+++ b/packages/standard-server/src/hibernation.test.ts
@@ -8,7 +8,7 @@ it('hibernationEventIterator', async () => {
   const iterator2 = new HibernationEventIterator(callback)
   await expect(iterator2.return()).rejects.toThrowError('Cannot cleanup hibernating iterator directly')
 
-  iterator1.hibernationCallback?.(12344)
+  iterator1.hibernationCallback(12344)
 
   expect(callback).toBeCalledWith(12344)
   expect(callback).toBeCalledTimes(1)

--- a/packages/standard-server/src/hibernation.ts
+++ b/packages/standard-server/src/hibernation.ts
@@ -1,4 +1,4 @@
-import { AsyncIteratorClass } from '@orpc/shared'
+import { AsyncIteratorClass, proxyOmit } from '@orpc/shared'
 
 export interface experimental_HibernationEventIteratorCallback {
   (id: string): void
@@ -23,6 +23,7 @@ export class experimental_HibernationEventIterator<T, TReturn = unknown, TNext =
     onfulfilled?: ((value: AsyncIteratorClass<T, TReturn, TNext>) => TResult1 | PromiseLike<TResult1>) | null | undefined,
     onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined,
   ): PromiseLike<TResult1 | TResult2> {
-    return Promise.resolve(this).then(onfulfilled, onrejected)
+    // Prevent recursively .then invoke by proxy omit
+    return Promise.resolve(proxyOmit(this, 'then') as unknown as AsyncIteratorClass<T, TReturn, TNext>).then(onfulfilled, onrejected)
   }
 }

--- a/packages/standard-server/src/hibernation.ts
+++ b/packages/standard-server/src/hibernation.ts
@@ -4,14 +4,11 @@ export interface experimental_HibernationEventIteratorCallback {
   (id: number): void
 }
 
-export class experimental_HibernationEventIterator<T, TReturn = unknown, TNext = unknown> extends AsyncIteratorClass<T, TReturn, TNext> {
-  /**
-   * this property is not transferred to the client, so it should be optional for type safety
-   */
-  public readonly hibernationCallback?: experimental_HibernationEventIteratorCallback
-
+export class experimental_HibernationEventIterator<T, TReturn = unknown, TNext = unknown>
+  extends AsyncIteratorClass<T, TReturn, TNext>
+  implements PromiseLike<AsyncIteratorClass<T, TReturn, TNext>> {
   constructor(
-    hibernationCallback: experimental_HibernationEventIteratorCallback,
+    public readonly hibernationCallback: experimental_HibernationEventIteratorCallback,
   ) {
     super(async () => {
       throw new Error('Cannot iterate over hibernating iterator directly')
@@ -20,7 +17,12 @@ export class experimental_HibernationEventIterator<T, TReturn = unknown, TNext =
         throw new Error('Cannot cleanup hibernating iterator directly')
       }
     })
+  }
 
-    this.hibernationCallback = hibernationCallback
+  then<TResult1 = AsyncIteratorClass<T, TReturn, TNext>, TResult2 = never>(
+    onfulfilled?: ((value: AsyncIteratorClass<T, TReturn, TNext>) => TResult1 | PromiseLike<TResult1>) | null | undefined,
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | null | undefined,
+  ): PromiseLike<TResult1 | TResult2> {
+    return Promise.resolve(this).then(onfulfilled, onrejected)
   }
 }


### PR DESCRIPTION
refactor(standard-server): distinguish server/client HibernationEventIterator type by defining .then

The client `await` the result, so the reflected result type will be more accurate by utilize .then

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Instances of hibernation event iterators can now be used with promise-like behavior, supporting the use of `.then()`.
	- Added a function to selectively hide specified properties on objects, enhancing flexibility in object handling.

- **Refactor**
	- The hibernation callback is now always required and invoked directly, simplifying usage.
	- Interface and property names related to hibernation context have been updated for consistency and clarity.

- **Tests**
	- Added tests verifying the behavior of the new property-omitting function on plain objects and asynchronous iterator instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->