### PR TITLE
fix(server): remove requirement to match status for type-safe errors

### DIFF
--- a/apps/content/docs/advanced/validation-errors.md
+++ b/apps/content/docs/advanced/validation-errors.md
@@ -112,6 +112,7 @@ import type { ZodIssue } from 'zod'
 
 const base = os.errors({
   INPUT_VALIDATION_FAILED: {
+    status: 422,
     data: z.object({
       formErrors: z.array(z.string()),
       fieldErrors: z.record(z.string(), z.array(z.string()).optional()),
@@ -135,7 +136,6 @@ const handler = new RPCHandler({ example }, {
         const zodError = new ZodError(error.cause.issues as ZodIssue[])
 
         throw new ORPCError('INPUT_VALIDATION_FAILED', {
-          status: 422,
           data: zodError.flatten(),
           cause: error.cause,
         })

--- a/packages/server/src/error.ts
+++ b/packages/server/src/error.ts
@@ -1,7 +1,7 @@
 import type { ORPCErrorCode, ORPCErrorOptions } from '@orpc/client'
 import type { ErrorMap, ErrorMapItem, InferSchemaInput } from '@orpc/contract'
 import type { MaybeOptionalOptions } from '@orpc/shared'
-import { fallbackORPCErrorStatus, ORPCError } from '@orpc/client'
+import { ORPCError } from '@orpc/client'
 
 export type ORPCErrorConstructorMapItemOptions<TData> = Omit<ORPCErrorOptions<TData>, 'defined' | 'status'>
 
@@ -49,7 +49,7 @@ export async function validateORPCError(map: ErrorMap, error: ORPCError<any, any
   const { code, status, message, data, cause, defined } = error
   const config = map?.[error.code]
 
-  if (!config || fallbackORPCErrorStatus(error.code, config.status) !== error.status) {
+  if (!config) {
     return defined
       ? new ORPCError(code, { defined: false, status, message, data, cause })
       : error


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect that the HTTP status code 422 for input validation errors is now centrally defined in the error declaration.

* **Refactor**
  * Simplified error status handling by centralizing the status code assignment and removing redundant status checks in error validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->