### PR TITLE
fix(contract): eventIterator should cleanup on validation failure

### DIFF
--- a/packages/client/src/event-iterator.ts
+++ b/packages/client/src/event-iterator.ts
@@ -35,9 +35,7 @@ export function mapEventIterator<TYield, TReturn, TNext, TMap = TYield | TReturn
 
       throw mappedError
     }
-  }, async (reason) => {
-    if (reason !== 'next') {
-      await iterator.return?.()
-    }
+  }, async () => {
+    await iterator.return?.()
   })
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup handling for async generators when errors occur during value mapping or validation, ensuring proper cancellation and resource release.

* **Tests**
  * Added test cases to verify that cleanup logic runs correctly when errors are thrown in value mapping or when validation fails in async generators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->