### PR TITLE
feat(trpc): support event iterator for toORPCRouter

### DIFF
--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -38,6 +38,7 @@
     "@trpc/server": ">=11.4.2"
   },
   "dependencies": {
+    "@orpc/client": "workspace:*",
     "@orpc/server": "workspace:*",
     "@orpc/shared": "workspace:*"
   },

--- a/packages/trpc/src/to-orpc-router.test-d.ts
+++ b/packages/trpc/src/to-orpc-router.test-d.ts
@@ -1,6 +1,6 @@
 import type { ContractRouter, InferRouterInitialContext, Procedure, Router, Schema } from '@orpc/server'
 import type { inferRouterContext } from '@trpc/server'
-import type { inferRouterMeta } from '@trpc/server/unstable-core-do-not-import'
+import type { inferRouterMeta, TrackedData } from '@trpc/server/unstable-core-do-not-import'
 import type { TRPCContext, TRPCMeta, trpcRouter } from '../tests/shared'
 import type { experimental_ToORPCRouterResult as ToORPCRouterResult } from './to-orpc-router'
 
@@ -24,7 +24,7 @@ it('ToORPCRouterResult', () => {
   >()
 
   expectTypeOf(orpcRouter.subscribe).toEqualTypeOf<
-    Procedure<TRPCContext, object, Schema<{ u: string }, unknown>, Schema<unknown, AsyncIterable<string, void, any>>, object, TRPCMeta>
+    Procedure<TRPCContext, object, Schema<{ u: string }, unknown>, Schema<unknown, AsyncIteratorObject<'pong' | TrackedData<{ order: number }>, void, any>>, object, TRPCMeta>
   >()
 
   expectTypeOf(orpcRouter.nested).toEqualTypeOf<
@@ -35,7 +35,7 @@ it('ToORPCRouterResult', () => {
 
   expectTypeOf(orpcRouter.lazy).toEqualTypeOf<
     {
-      subscribe: Procedure<TRPCContext, object, Schema<void, unknown>, Schema<unknown, AsyncIterable<string, void, any>>, object, TRPCMeta>
+      subscribe: Procedure<TRPCContext, object, Schema<void, unknown>, Schema<unknown, AsyncIteratorObject<string, void, any>>, object, TRPCMeta>
       lazy: {
         throw: Procedure<TRPCContext, object, Schema<{ input: number }, unknown>, Schema<unknown, { output: string }>, object, TRPCMeta>
       }

--- a/packages/trpc/src/to-orpc-router.test-d.ts
+++ b/packages/trpc/src/to-orpc-router.test-d.ts
@@ -1,4 +1,5 @@
 import type { ContractRouter, InferRouterInitialContext, Procedure, Router, Schema } from '@orpc/server'
+import type { AsyncIteratorClass } from '@orpc/shared'
 import type { inferRouterContext } from '@trpc/server'
 import type { inferRouterMeta, TrackedData } from '@trpc/server/unstable-core-do-not-import'
 import type { TRPCContext, TRPCMeta, trpcRouter } from '../tests/shared'
@@ -24,7 +25,7 @@ it('ToORPCRouterResult', () => {
   >()
 
   expectTypeOf(orpcRouter.subscribe).toEqualTypeOf<
-    Procedure<TRPCContext, object, Schema<{ u: string }, unknown>, Schema<unknown, AsyncIteratorObject<'pong' | TrackedData<{ order: number }>, void, any>>, object, TRPCMeta>
+    Procedure<TRPCContext, object, Schema<{ u: string }, unknown>, Schema<unknown, AsyncIteratorClass<'pong' | TrackedData<{ order: number }>, void, any>>, object, TRPCMeta>
   >()
 
   expectTypeOf(orpcRouter.nested).toEqualTypeOf<
@@ -35,7 +36,7 @@ it('ToORPCRouterResult', () => {
 
   expectTypeOf(orpcRouter.lazy).toEqualTypeOf<
     {
-      subscribe: Procedure<TRPCContext, object, Schema<void, unknown>, Schema<unknown, AsyncIteratorObject<string, void, any>>, object, TRPCMeta>
+      subscribe: Procedure<TRPCContext, object, Schema<void, unknown>, Schema<unknown, AsyncIteratorClass<string, void, any>>, object, TRPCMeta>
       lazy: {
         throw: Procedure<TRPCContext, object, Schema<{ input: number }, unknown>, Schema<unknown, { output: string }>, object, TRPCMeta>
       }

--- a/packages/trpc/src/to-orpc-router.test.ts
+++ b/packages/trpc/src/to-orpc-router.test.ts
@@ -1,8 +1,14 @@
 import { call, createRouterClient, isProcedure, ORPCError, unlazy } from '@orpc/server'
 import { isAsyncIteratorObject } from '@orpc/shared'
+import { tracked } from '@trpc/server'
+import { z } from 'zod'
 import { inputSchema, outputSchema } from '../../contract/tests/shared'
-import { trpcRouter } from '../tests/shared'
+import { t, trpcRouter } from '../tests/shared'
 import { experimental_toORPCRouter as toORPCRouter } from './to-orpc-router'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
 
 describe('toORPCRouter', async () => {
   const orpcRouter = toORPCRouter(trpcRouter)
@@ -71,6 +77,42 @@ describe('toORPCRouter', async () => {
       ).rejects.toSatisfy((err: any) => {
         return err instanceof ORPCError && err.message === 'lazy.lazy.throw'
       })
+    })
+  })
+
+  describe('event iterators', () => {
+    const trackedSubscription = vi.fn(async function* () {
+      yield { order: 1 }
+      yield tracked('id-2', { order: 2 })
+    })
+
+    const trpcRouter = t.router({
+      tracked: t.procedure
+        .input(z.any())
+        .subscription(trackedSubscription),
+      unsupportedTracked: t.procedure
+        .subscription(async function* () {
+          yield tracked('id-1', 1)
+        }),
+    })
+
+    const orpcRouter = toORPCRouter(trpcRouter)
+
+    it('lastEventId', async () => {
+      await call(orpcRouter.tracked, { u: 'u' }, { lastEventId: 'id-1', context: { a: 'test' } })
+      expect(trackedSubscription).toHaveBeenNthCalledWith(1, expect.objectContaining({
+        input: { u: 'u', lastEventId: 'id-1' },
+      }))
+
+      await call(orpcRouter.tracked, undefined, { lastEventId: 'id-2', context: { a: 'test' } })
+      expect(trackedSubscription).toHaveBeenNthCalledWith(2, expect.objectContaining({
+        input: { lastEventId: 'id-2' },
+      }))
+
+      await call(orpcRouter.tracked, 1234, { lastEventId: 'id-3', context: { a: 'test' } })
+      expect(trackedSubscription).toHaveBeenNthCalledWith(3, expect.objectContaining({
+        input: 1234,
+      }))
     })
   })
 })

--- a/packages/trpc/src/to-orpc-router.ts
+++ b/packages/trpc/src/to-orpc-router.ts
@@ -120,7 +120,7 @@ function toORPCProcedure(procedure: AnyProcedure) {
                 return ORPC.withEventMeta({
                   id,
                   data,
-                } as TrackedData<unknown>, {
+                } satisfies TrackedData<unknown>, {
                   id,
                 })
               }

--- a/packages/trpc/src/to-orpc-router.ts
+++ b/packages/trpc/src/to-orpc-router.ts
@@ -1,3 +1,4 @@
+import type { AsyncIteratorClass } from '@orpc/shared'
 import type { AnyProcedure, AnyRouter, inferRouterContext } from '@trpc/server'
 import type { inferRouterMeta, Parser, TrackedData } from '@trpc/server/unstable-core-do-not-import'
 import { mapEventIterator } from '@orpc/client'
@@ -12,7 +13,7 @@ export interface experimental_ORPCMeta extends ORPC.Route {
 
 export type experimental_ToORPCOutput<T>
   = T extends AsyncIterable<infer TData, infer TReturn, infer TNext>
-    ? AsyncIteratorObject<TData, TReturn, TNext>
+    ? AsyncIteratorClass<TData, TReturn, TNext>
     : T
 
 export type experimental_ToORPCRouterResult<TContext extends ORPC.Context, TMeta extends ORPC.Meta, TRecord extends Record<string, any>>

--- a/packages/trpc/tests/shared.ts
+++ b/packages/trpc/tests/shared.ts
@@ -1,5 +1,5 @@
 import type { experimental_ORPCMeta as ORPCMeta } from '../src/to-orpc-router'
-import { initTRPC, lazy, TRPCError } from '@trpc/server'
+import { initTRPC, lazy, tracked, TRPCError } from '@trpc/server'
 import { z } from 'zod/v4'
 import { inputSchema, outputSchema } from '../../contract/tests/shared'
 
@@ -34,6 +34,8 @@ export const trpcRouter = t.router({
     .input(z.object({ u: z.string() }))
     .subscription(async function* () {
       yield 'pong'
+      yield tracked('id-1', { order: 1 })
+      yield tracked('id-2', { order: 2 })
     }),
 
   nested: {

--- a/packages/trpc/tsconfig.json
+++ b/packages/trpc/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.lib.json",
   "references": [
     { "path": "../server" },
+    { "path": "../client" },
     { "path": "../shared" }
   ],
   "include": ["src"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -664,6 +664,9 @@ importers:
 
   packages/trpc:
     dependencies:
+      '@orpc/client':
+        specifier: workspace:*
+        version: link:../client
       '@orpc/server':
         specifier: workspace:*
         version: link:../server


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for async iterable outputs in procedures, enabling streaming events with event metadata.
  * Subscription procedures can now accept and utilize a `lastEventId` parameter for event streaming.

* **Tests**
  * Introduced new tests to verify event iterator behavior, including event metadata and cleanup logic in subscriptions.
  * Enhanced test data to yield tracked events with identifiers and metadata.

* **Chores**
  * Updated dependencies and TypeScript project references to include the client package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->