### PR TITLE
refactor: improve isAsyncIteratorObject util

### DIFF
--- a/packages/shared/src/iterator.test.ts
+++ b/packages/shared/src/iterator.test.ts
@@ -6,7 +6,7 @@ it('isAsyncIteratorObject', () => {
   expect(isAsyncIteratorObject(() => {})).toBe(false)
   expect(isAsyncIteratorObject({ [Symbol.asyncIterator]: 123 })).toBe(false)
 
-  expect(isAsyncIteratorObject({ [Symbol.asyncIterator]: () => { } })).toBe(true)
+  expect(isAsyncIteratorObject({ [Symbol.asyncIterator]: () => { } })).toBe(false)
 
   async function* gen() { }
   expect(isAsyncIteratorObject(gen())).toBe(true)

--- a/packages/shared/src/iterator.test.ts
+++ b/packages/shared/src/iterator.test.ts
@@ -7,6 +7,7 @@ it('isAsyncIteratorObject', () => {
   expect(isAsyncIteratorObject({ [Symbol.asyncIterator]: 123 })).toBe(false)
 
   expect(isAsyncIteratorObject({ [Symbol.asyncIterator]: () => { } })).toBe(false)
+  expect(isAsyncIteratorObject({ next: () => {} })).toBe(false)
 
   async function* gen() { }
   expect(isAsyncIteratorObject(gen())).toBe(true)

--- a/packages/shared/src/iterator.ts
+++ b/packages/shared/src/iterator.ts
@@ -6,7 +6,7 @@ export function isAsyncIteratorObject(maybe: unknown): maybe is AsyncIteratorObj
     return false
   }
 
-  return Symbol.asyncIterator in maybe && typeof maybe[Symbol.asyncIterator] === 'function'
+  return 'next' in maybe && typeof maybe.next === 'function' && Symbol.asyncIterator in maybe && typeof maybe[Symbol.asyncIterator] === 'function'
 }
 
 export interface AsyncIteratorClassNextFn<T, TReturn> {


### PR DESCRIPTION
Check the `next` method to distinguish AsyncIteratorObject vs AsyncIterable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of async iterator objects to ensure only objects with both a valid async iterator symbol and a `next` method are recognized.
* **Tests**
  * Updated tests to reflect the stricter criteria for identifying async iterator objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->