### PR TITLE
feat(tanstack-query): live query options

### DIFF
--- a/apps/content/docs/integrations/tanstack-query.md
+++ b/apps/content/docs/integrations/tanstack-query.md
@@ -263,12 +263,14 @@ import {
 interface ClientContext extends TanstackQueryOperationContext {
 }
 
+const GET_OPERATION_TYPE = new Set(['query', 'streamed', 'live', 'infinite'])
+
 const link = new RPCLink<ClientContext>({
   url: 'http://localhost:3000/rpc',
   method: ({ context }, path) => {
     const operationType = context[TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL]?.type
 
-    if (operationType === 'query' || operationType === 'streamed' || operationType === 'infinite') {
+    if (operationType && GET_OPERATION_TYPE.has(operationType)) {
       return 'GET'
     }
 

--- a/apps/content/docs/integrations/tanstack-query.md
+++ b/apps/content/docs/integrations/tanstack-query.md
@@ -59,6 +59,12 @@ orpc.planet.find.queryOptions({ input: { id: 123 } })
 //
 
 //
+
+//
+
+//
+
+//
 ```
 
 ::: details Avoiding Query/Mutation Key Conflicts?
@@ -91,19 +97,39 @@ const query = useQuery(orpc.planet.find.queryOptions({
 
 ## Streamed Query Options
 
-Use `.streamedOptions` to configure queries for [Event Iterator](/docs/event-iterator), which is built on top of [streamedQuery](https://tanstack.com/query/latest/docs/reference/streamedQuery). Use it with hooks like `useQuery`, `useSuspenseQuery`, or `prefetchQuery`.
+Use `.streamedOptions` to configure queries for [Event Iterator](/docs/event-iterator). This is built on [TanStack Query streamedQuery](https://tanstack.com/query/latest/docs/reference/streamedQuery) and works with hooks like `useQuery`, `useSuspenseQuery`, or `prefetchQuery`.
 
 ```ts
 const query = useQuery(orpc.streamed.experimental_streamedOptions({
   input: { id: 123 }, // Specify input if needed
   context: { cache: true }, // Provide client context if needed
-  queryFnOptions: { // Specify streamedQuery options if needed
+  queryFnOptions: { // Configure streamedQuery behavior
     refetchMode: 'reset',
     maxChunks: 3,
   }
   // additional options...
 }))
 ```
+
+::: info
+Combine with [Client Retry](/docs/plugins/client-retry#event-iterator-sse) for more reliable streaming queries.
+:::
+
+## Live Query Options
+
+Use `.liveOptions` to configure live queries for [Event Iterator](/docs/event-iterator). Unlike `.streamedOptions` which accumulates chunks, live queries replace the entire result with each new chunk received. Works with hooks like `useQuery`, `useSuspenseQuery`, or `prefetchQuery`.
+
+```ts
+const query = useQuery(orpc.live.experimental_liveOptions({
+  input: { id: 123 }, // Specify input if needed
+  context: { cache: true }, // Provide client context if needed
+  // additional options...
+}))
+```
+
+::: info
+Combine with [Client Retry](/docs/plugins/client-retry#event-iterator-sse) for more reliable live queries.
+:::
 
 ## Infinite Query Options
 

--- a/packages/tanstack-query/src/live-query.test.ts
+++ b/packages/tanstack-query/src/live-query.test.ts
@@ -1,0 +1,70 @@
+import { queryClient } from '../tests/shared'
+import { experimental_liveQuery as liveQuery } from './live-query'
+
+beforeEach(() => {
+  queryClient.clear()
+})
+
+describe('liveQuery', async () => {
+  it('works', async () => {
+    const queryFn = liveQuery(async function* () {
+      yield 1
+      await new Promise(resolve => setTimeout(resolve, 50))
+      yield 2
+      await new Promise(resolve => setTimeout(resolve, 50))
+      yield 3
+    })
+
+    const controller = new AbortController()
+
+    const resultPromise = expect(queryFn({
+      queryKey: ['live-query'],
+      signal: controller.signal,
+      client: queryClient,
+    } as any)).resolves.toEqual(3)
+
+    await vi.waitFor(() => {
+      expect(queryClient.getQueryData(['live-query'])).toEqual(1)
+    })
+
+    await vi.waitFor(() => {
+      expect(queryClient.getQueryData(['live-query'])).toEqual(2)
+    })
+
+    await resultPromise
+  })
+
+  it('on abort signal', async () => {
+    let cleanupCalled = false
+
+    const queryFn = liveQuery(async function* () {
+      try {
+        yield 1
+        await new Promise(resolve => setTimeout(resolve, 50))
+        yield 2
+        await new Promise(resolve => setTimeout(resolve, 50))
+        yield 3
+      }
+      finally {
+        cleanupCalled = true
+      }
+    })
+
+    const controller = new AbortController()
+
+    const resultPromise = expect(queryFn({
+      queryKey: ['live-query'],
+      signal: controller.signal,
+      client: queryClient,
+    } as any)).resolves.toEqual(1)
+
+    await vi.waitFor(() => {
+      expect(queryClient.getQueryData(['live-query'])).toEqual(1)
+    })
+
+    controller.abort()
+
+    await resultPromise
+    expect(cleanupCalled).toBe(true)
+  })
+})

--- a/packages/tanstack-query/src/live-query.test.ts
+++ b/packages/tanstack-query/src/live-query.test.ts
@@ -67,4 +67,18 @@ describe('liveQuery', async () => {
     await resultPromise
     expect(cleanupCalled).toBe(true)
   })
+
+  it('throw if no data yielded', async () => {
+    const queryFn = liveQuery(async function* () {
+      // No yield
+    })
+
+    await expect(queryFn({
+      queryKey: ['live-query'],
+      signal: new AbortController().signal,
+      client: queryClient,
+    } as any)).rejects.toThrowError(
+      'Live query for ["live-query"] did not yield any data. Ensure the query function returns an AsyncIterable with at least one chunk.',
+    )
+  })
 })

--- a/packages/tanstack-query/src/live-query.ts
+++ b/packages/tanstack-query/src/live-query.ts
@@ -1,5 +1,6 @@
 import type { Promisable } from '@orpc/shared'
 import type { QueryFunction, QueryFunctionContext, QueryKey } from '@tanstack/query-core'
+import { stringifyJSON } from '@orpc/shared'
 
 export function experimental_liveQuery<
   TQueryFnData = unknown,
@@ -11,15 +12,23 @@ export function experimental_liveQuery<
 ): QueryFunction<TQueryFnData, TQueryKey> {
   return async (context) => {
     const stream = await queryFn(context)
+    let last: { chunk: TQueryFnData } | undefined
 
     for await (const chunk of stream) {
       if (context.signal.aborted) {
         break
       }
 
+      last = { chunk }
       context.client.setQueryData<TQueryFnData>(context.queryKey, chunk)
     }
 
-    return context.client.getQueryData(context.queryKey)!
+    if (!last) {
+      throw new Error(
+        `Live query for ${stringifyJSON(context.queryKey)} did not yield any data. Ensure the query function returns an AsyncIterable with at least one chunk.`,
+      )
+    }
+
+    return last.chunk
   }
 }

--- a/packages/tanstack-query/src/live-query.ts
+++ b/packages/tanstack-query/src/live-query.ts
@@ -1,0 +1,25 @@
+import type { Promisable } from '@orpc/shared'
+import type { QueryFunction, QueryFunctionContext, QueryKey } from '@tanstack/query-core'
+
+export function experimental_liveQuery<
+  TQueryFnData = unknown,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  queryFn: (
+    context: QueryFunctionContext<TQueryKey>,
+  ) => Promisable<AsyncIterable<TQueryFnData>>,
+): QueryFunction<TQueryFnData, TQueryKey> {
+  return async (context) => {
+    const stream = await queryFn(context)
+
+    for await (const chunk of stream) {
+      if (context.signal.aborted) {
+        break
+      }
+
+      context.client.setQueryData<TQueryFnData>(context.queryKey, chunk)
+    }
+
+    return context.client.getQueryData(context.queryKey)!
+  }
+}

--- a/packages/tanstack-query/src/procedure-utils.angular.test-d.ts
+++ b/packages/tanstack-query/src/procedure-utils.angular.test-d.ts
@@ -158,6 +158,72 @@ describe('ProcedureUtils', () => {
     })
   })
 
+  describe('.liveOptions', () => {
+    describe('injectQuery', () => {
+      it('without args', () => {
+        const query = injectQuery(() => streamUtils.experimental_liveOptions())
+        expectTypeOf(query.data()).toEqualTypeOf<UtilsOutput[number] | undefined>()
+        expectTypeOf(query.error()).toEqualTypeOf<UtilsError | null>()
+      })
+
+      it('can infer errors inside options', () => {
+        const query = injectQuery(() => streamUtils.experimental_liveOptions({
+          throwOnError(error) {
+            expectTypeOf(error).toEqualTypeOf<UtilsError>()
+            return false
+          },
+        }))
+        expectTypeOf(query.data()).toEqualTypeOf<UtilsOutput[number] | undefined>()
+        expectTypeOf(query.error()).toEqualTypeOf<UtilsError | null>()
+      })
+
+      it('with initial data & select', () => {
+        const query = injectQuery(() => streamUtils.experimental_liveOptions({
+          select: data => ({ mapped: data }),
+          initialData: { title: 'title' },
+        }))
+
+        expectTypeOf(query.data()).toEqualTypeOf<{ mapped: UtilsOutput[number] }>()
+        expectTypeOf(query.error()).toEqualTypeOf<UtilsError | null>()
+      })
+    })
+
+    it('injectQueries', () => {
+      const queries = injectQueries({
+        queries: signal([
+          streamUtils.experimental_liveOptions(),
+          streamUtils.experimental_liveOptions({
+            input: { search: 'search' },
+            context: { batch: true },
+          }),
+          streamUtils.experimental_liveOptions({
+            select: data => ({ mapped: data }),
+          }),
+        ]),
+      })
+
+      // @ts-expect-error - TODO: fix this, injectQueries not working
+      expectTypeOf(queries()[0].data).toEqualTypeOf<UtilsOutput[number] | undefined>()
+      // @ts-expect-error - TODO: fix this, injectQueries not work at all
+      expectTypeOf(queries()[1].data).toEqualTypeOf<UtilsOutput[number] | undefined>()
+      expectTypeOf(queries()[2].data).toEqualTypeOf<{ mapped: UtilsOutput[number] } | undefined>()
+
+      // @ts-expect-error - TODO: fix this, injectQueries not work at all
+      expectTypeOf(queries()[0].error).toEqualTypeOf<null | UtilsError>()
+      // @ts-expect-error - TODO: fix this, injectQueries not work at all
+      expectTypeOf(queries()[1].error).toEqualTypeOf<null | UtilsError>()
+      expectTypeOf(queries()[2].error).toEqualTypeOf<null | UtilsError>()
+    })
+
+    it('fetchQuery', () => {
+      expectTypeOf(
+        queryClient.fetchQuery(streamUtils.experimental_liveOptions()),
+      ).toEqualTypeOf<
+        Promise<UtilsOutput[number]>
+      >()
+    })
+  })
+
   describe('.infiniteOptions', () => {
     const getNextPageParam: GetNextPageParamFunction<number, UtilsOutput> = () => 1
     const initialPageParam = 1

--- a/packages/tanstack-query/src/procedure-utils.react.test-d.ts
+++ b/packages/tanstack-query/src/procedure-utils.react.test-d.ts
@@ -253,6 +253,120 @@ describe('ProcedureUtils', () => {
     })
   })
 
+  describe('.liveOptions', () => {
+    describe('useQuery', () => {
+      it('without args', () => {
+        const query = useQuery(streamUtils.experimental_liveOptions())
+        expectTypeOf(query.data).toEqualTypeOf<UtilsOutput[number] | undefined>()
+        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+      })
+
+      it('can infer errors inside options', () => {
+        const query = useQuery(streamUtils.experimental_liveOptions({
+          throwOnError(error) {
+            expectTypeOf(error).toEqualTypeOf<UtilsError>()
+            return false
+          },
+        }))
+        expectTypeOf(query.data).toEqualTypeOf<UtilsOutput[number] | undefined>()
+        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+      })
+
+      it('with initial data & select', () => {
+        const query = useQuery(streamUtils.experimental_liveOptions({
+          select: data => ({ mapped: data }),
+          initialData: { title: 'title' },
+        }))
+
+        expectTypeOf(query.data).toEqualTypeOf<{ mapped: UtilsOutput[number] }>()
+        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+      })
+    })
+
+    describe('useSuspenseQuery', () => {
+      it('without args', () => {
+        const query = useSuspenseQuery(streamUtils.experimental_liveOptions())
+        expectTypeOf(query.data).toEqualTypeOf<UtilsOutput[number]>()
+        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+      })
+
+      it('can infer errors inside options', () => {
+        const query = useSuspenseQuery(streamUtils.experimental_liveOptions({
+          throwOnError(error) {
+            expectTypeOf(error).toEqualTypeOf<UtilsError>()
+            return false
+          },
+        }))
+
+        expectTypeOf(query.data).toEqualTypeOf<UtilsOutput[number]>()
+        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+      })
+
+      it('with select', () => {
+        const query = useSuspenseQuery(streamUtils.experimental_liveOptions({
+          select: data => ({ mapped: data }),
+        }))
+
+        expectTypeOf(query.data).toEqualTypeOf<{ mapped: UtilsOutput[number] }>()
+        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+      })
+    })
+
+    it('useQueries', () => {
+      const queries = useQueries({
+        queries: [
+          streamUtils.experimental_liveOptions(),
+          streamUtils.experimental_liveOptions({
+            input: { search: 'search' },
+            context: { batch: true },
+          }),
+          streamUtils.experimental_liveOptions({
+            select: data => ({ mapped: data }),
+          }),
+        ],
+      })
+
+      expectTypeOf(queries[0].data).toEqualTypeOf<UtilsOutput[number] | undefined>()
+      expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput[number] | undefined>()
+      expectTypeOf(queries[2].data).toEqualTypeOf<{ mapped: UtilsOutput[number] } | undefined>()
+
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | UtilsError>()
+      expectTypeOf(queries[1].error).toEqualTypeOf<null | UtilsError>()
+      expectTypeOf(queries[2].error).toEqualTypeOf<null | UtilsError>()
+    })
+
+    it('useSuspenseQueries', () => {
+      const queries = useSuspenseQueries({
+        queries: [
+          streamUtils.experimental_liveOptions(),
+          streamUtils.experimental_liveOptions({
+            input: { search: 'search' },
+            context: { batch: true },
+          }),
+          streamUtils.experimental_liveOptions({
+            select: data => ({ mapped: data }),
+          }),
+        ],
+      })
+
+      expectTypeOf(queries[0].data).toEqualTypeOf<UtilsOutput[number]>()
+      expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput[number]>()
+      expectTypeOf(queries[2].data).toEqualTypeOf<{ mapped: UtilsOutput[number] }>()
+
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | UtilsError>()
+      expectTypeOf(queries[1].error).toEqualTypeOf<null | UtilsError>()
+      expectTypeOf(queries[2].error).toEqualTypeOf<null | UtilsError>()
+    })
+
+    it('fetchQuery', () => {
+      expectTypeOf(
+        queryClient.fetchQuery(streamUtils.experimental_liveOptions()),
+      ).toEqualTypeOf<
+        Promise<UtilsOutput[number]>
+      >()
+    })
+  })
+
   describe('.infiniteOptions', () => {
     const getNextPageParam: GetNextPageParamFunction<number, UtilsOutput> = () => 1
     const initialPageParam = 1

--- a/packages/tanstack-query/src/procedure-utils.solid.test-d.ts
+++ b/packages/tanstack-query/src/procedure-utils.solid.test-d.ts
@@ -149,6 +149,68 @@ describe('ProcedureUtils', () => {
     })
   })
 
+  describe('.liveOptions', () => {
+    describe('useQuery', () => {
+      it('without args', () => {
+        const query = useQuery(() => streamUtils.experimental_liveOptions())
+        expectTypeOf(query.data).toEqualTypeOf<UtilsOutput[number] | undefined>()
+        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+      })
+
+      it('can infer errors inside options', () => {
+        const query = useQuery(() => streamUtils.experimental_liveOptions({
+          throwOnError(error) {
+            expectTypeOf(error).toEqualTypeOf<UtilsError>()
+            return false
+          },
+        }))
+        expectTypeOf(query.data).toEqualTypeOf<UtilsOutput[number] | undefined>()
+        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+      })
+
+      it('with initial data & select', () => {
+        const query = useQuery(() => streamUtils.experimental_liveOptions({
+          select: data => ({ mapped: data }),
+          initialData: { title: 'title' },
+        }))
+
+        expectTypeOf(query.data).toEqualTypeOf<{ mapped: UtilsOutput[number] }>()
+        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+      })
+    })
+
+    it('useQueries', () => {
+      const queries = useQueries(() => ({
+        queries: [
+          streamUtils.experimental_liveOptions(),
+          streamUtils.experimental_liveOptions({
+            input: { search: 'search' },
+            context: { batch: true },
+          }),
+          streamUtils.experimental_liveOptions({
+            select: data => ({ mapped: data }),
+          }),
+        ],
+      }))
+
+      expectTypeOf(queries[0].data).toEqualTypeOf<UtilsOutput[number] | undefined>()
+      expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput[number] | undefined>()
+      expectTypeOf(queries[2].data).toEqualTypeOf<{ mapped: UtilsOutput[number] } | undefined>()
+
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | UtilsError>()
+      expectTypeOf(queries[1].error).toEqualTypeOf<null | UtilsError>()
+      expectTypeOf(queries[2].error).toEqualTypeOf<null | UtilsError>()
+    })
+
+    it('fetchQuery', () => {
+      expectTypeOf(
+        queryClient.fetchQuery(streamUtils.experimental_liveOptions()),
+      ).toEqualTypeOf<
+        Promise<UtilsOutput[number]>
+      >()
+    })
+  })
+
   describe('.infiniteOptions', () => {
     const getNextPageParam: GetNextPageParamFunction<number, UtilsOutput> = () => 1
     const initialPageParam = 1

--- a/packages/tanstack-query/src/procedure-utils.svelte.test-d.ts
+++ b/packages/tanstack-query/src/procedure-utils.svelte.test-d.ts
@@ -150,6 +150,68 @@ describe('ProcedureUtils', () => {
     })
   })
 
+  describe('.liveOptions', () => {
+    describe('createQuery', () => {
+      it('without args', () => {
+        const query = createQuery(streamUtils.experimental_liveOptions())
+        expectTypeOf(get(query).data).toEqualTypeOf<UtilsOutput[number] | undefined>()
+        expectTypeOf(get(query).error).toEqualTypeOf<UtilsError | null>()
+      })
+
+      it('can infer errors inside options', () => {
+        const query = createQuery(streamUtils.experimental_liveOptions({
+          throwOnError(error) {
+            expectTypeOf(error).toEqualTypeOf<UtilsError>()
+            return false
+          },
+        }))
+        expectTypeOf(get(query).data).toEqualTypeOf<UtilsOutput[number] | undefined>()
+        expectTypeOf(get(query).error).toEqualTypeOf<UtilsError | null>()
+      })
+
+      it('with initial data & select', () => {
+        const query = createQuery(streamUtils.experimental_liveOptions({
+          select: data => ({ mapped: data }),
+          initialData: { title: 'title' },
+        }))
+
+        expectTypeOf(get(query).data).toEqualTypeOf<{ mapped: UtilsOutput[number] }>()
+        expectTypeOf(get(query).error).toEqualTypeOf<UtilsError | null>()
+      })
+    })
+
+    it('createQueries', () => {
+      const queries = createQueries({
+        queries: [
+          streamUtils.experimental_liveOptions(),
+          streamUtils.experimental_liveOptions({
+            input: { search: 'search' },
+            context: { batch: true },
+          }),
+          streamUtils.experimental_liveOptions({
+            select: data => ({ mapped: data }),
+          }),
+        ],
+      })
+
+      expectTypeOf(get(queries)[0].data).toEqualTypeOf<UtilsOutput[number] | undefined>()
+      expectTypeOf(get(queries)[1].data).toEqualTypeOf<UtilsOutput[number] | undefined>()
+      expectTypeOf(get(queries)[2].data).toEqualTypeOf<{ mapped: UtilsOutput[number] } | undefined>()
+
+      expectTypeOf(get(queries)[0].error).toEqualTypeOf<null | UtilsError>()
+      expectTypeOf(get(queries)[1].error).toEqualTypeOf<null | UtilsError>()
+      expectTypeOf(get(queries)[2].error).toEqualTypeOf<null | UtilsError>()
+    })
+
+    it('fetchQuery', () => {
+      expectTypeOf(
+        queryClient.fetchQuery(streamUtils.experimental_liveOptions()),
+      ).toEqualTypeOf<
+        Promise<UtilsOutput[number]>
+      >()
+    })
+  })
+
   describe('.infiniteOptions', () => {
     const getNextPageParam: GetNextPageParamFunction<number, UtilsOutput> = () => 1
     const initialPageParam = 1

--- a/packages/tanstack-query/src/procedure-utils.test-d.ts
+++ b/packages/tanstack-query/src/procedure-utils.test-d.ts
@@ -396,12 +396,12 @@ describe('ProcedureUtils', () => {
       expectTypeOf(streamUtils.experimental_liveOptions()).toExtend<QueryObserverOptions<UtilsOutput[number], UtilsError>>()
     })
 
-    it('return invalid streamed options if output is not an async iterable', () => {
+    it('return invalid streamed live if output is not an async iterable', () => {
       expectTypeOf(optionalUtils.experimental_liveOptions().queryFn)
         .toEqualTypeOf<QueryFunction<never>>()
     })
 
-    it('allow extend and override streamed options', () => {
+    it('allow extend and override live options', () => {
       expectTypeOf(streamUtils.experimental_liveOptions({
         queryKey: ['1'], // override
         maxPages: 1, // extend
@@ -414,7 +414,7 @@ describe('ProcedureUtils', () => {
       }>()
     })
 
-    it('can change streamed data by define select', () => {
+    it('can change live data by define select', () => {
       expectTypeOf(streamUtils.experimental_liveOptions({
         select: mapped => ({ mapped }),
       })).toExtend<QueryObserverOptions<UtilsOutput[number], UtilsError, { mapped: UtilsOutput[number] }>>()

--- a/packages/tanstack-query/src/procedure-utils.test-d.ts
+++ b/packages/tanstack-query/src/procedure-utils.test-d.ts
@@ -298,6 +298,135 @@ describe('ProcedureUtils', () => {
     })
   })
 
+  describe('.liveKey', () => {
+    it('should handle optional `input` correctly', () => {
+      optionalUtils.experimental_liveKey()
+      optionalUtils.experimental_liveKey({})
+      optionalUtils.experimental_liveKey({ input: { search: 'search' } })
+    })
+
+    it('should handle required `input` correctly', () => {
+      // @ts-expect-error - `input` is required
+      requiredUtils.experimental_liveKey()
+    })
+
+    it('should infer types for `input` correctly', () => {
+      optionalUtils.experimental_liveKey({ input: { cursor: 1 } })
+      // @ts-expect-error - Should error on invalid input type
+      optionalUtils.experimental_liveKey({ input: { cursor: 'invalid' } })
+
+      requiredUtils.experimental_liveKey({ input: 'input' })
+      // @ts-expect-error - Should error on invalid input type
+      requiredUtils.experimental_liveKey({ input: 123 })
+    })
+
+    it('allow use skipToken as input', () => {
+      optionalUtils.experimental_liveKey({ input: condition ? skipToken : { search: 'search' } })
+      // @ts-expect-error - invalid input type
+      optionalUtils.experimental_liveKey({ input: condition ? skipToken : { cursor: 'invalid' } })
+
+      requiredUtils.experimental_liveKey({ input: condition ? skipToken : 'input' })
+      // @ts-expect-error - invalid input type
+      requiredUtils.experimental_liveKey({ input: condition ? skipToken : 123 })
+    })
+
+    it('allow override query key', () => {
+      optionalUtils.experimental_liveKey({ queryKey: ['1'] })
+      // @ts-expect-error - invalid query key type
+      optionalUtils.experimental_liveKey({ queryKey: 1 })
+    })
+
+    it('return valid query key', () => {
+      expectTypeOf(optionalUtils.experimental_liveKey()).toExtend<QueryKey>()
+      expectTypeOf(optionalUtils.experimental_liveKey({
+        input: { search: 'search' },
+      })).toExtend<QueryKey>()
+    })
+
+    it('.getQueryState is typed correctly', () => {
+      const state = queryClient.getQueryState(streamUtils.experimental_liveKey())
+      expectTypeOf(state?.data).toEqualTypeOf<UtilsOutput[number] | undefined>()
+      expectTypeOf(state?.error).toEqualTypeOf<UtilsError | null | undefined>()
+    })
+  })
+
+  describe('.liveOptions', () => {
+    it('should handle optional `context` and `input` correctly', () => {
+      streamUtils.experimental_liveOptions()
+      streamUtils.experimental_liveOptions({ context: { batch: true } })
+      streamUtils.experimental_liveOptions({ input: { search: 'search' } })
+    })
+
+    it('should handle required `context` and `input` correctly', () => {
+      // @ts-expect-error - `input` and `context` are required
+      requiredUtils.experimental_liveOptions()
+      // @ts-expect-error - `input` is required
+      requiredUtils.experimental_liveOptions({ context: { batch: true } })
+      // @ts-expect-error - `context` is required
+      requiredUtils.experimental_liveOptions({ input: 'input' })
+    })
+
+    it('should infer types for `input` and `context` correctly', () => {
+      streamUtils.experimental_liveOptions({ input: { cursor: 1 } })
+      // @ts-expect-error - Should error on invalid input type
+      streamUtils.experimental_liveOptions({ input: { cursor: 'invalid' } })
+
+      streamUtils.experimental_liveOptions({ context: { batch: true } })
+      // @ts-expect-error - Should error on invalid context type
+      streamUtils.experimental_liveOptions({ context: { batch: 'invalid' } })
+
+      requiredUtils.experimental_liveOptions({ input: 'input', context: { batch: true } })
+      // @ts-expect-error - Should error on invalid input type
+      requiredUtils.experimental_liveOptions({ input: 123, context: { batch: true } })
+      // @ts-expect-error - Should error on invalid context type
+      requiredUtils.experimental_liveOptions({ input: 'input', context: { batch: 'invalid' } })
+    })
+
+    it('allow use skipToken as input', () => {
+      streamUtils.experimental_liveOptions({ input: condition ? skipToken : { search: 'search' } })
+      // @ts-expect-error - invalid input type
+      streamUtils.experimental_liveOptions({ input: condition ? skipToken : { cursor: 'invalid' } })
+
+      requiredUtils.experimental_liveOptions({ input: condition ? skipToken : 'input', context: { batch: true } })
+      // @ts-expect-error - invalid input type
+      requiredUtils.experimental_liveOptions({ input: condition ? skipToken : 123, context: { batch: true } })
+    })
+
+    it('return valid streamed options', () => {
+      expectTypeOf(streamUtils.experimental_liveOptions()).toExtend<QueryObserverOptions<UtilsOutput[number], UtilsError>>()
+    })
+
+    it('return invalid streamed options if output is not an async iterable', () => {
+      expectTypeOf(optionalUtils.experimental_liveOptions().queryFn)
+        .toEqualTypeOf<QueryFunction<never>>()
+    })
+
+    it('allow extend and override streamed options', () => {
+      expectTypeOf(streamUtils.experimental_liveOptions({
+        queryKey: ['1'], // override
+        maxPages: 1, // extend
+      })).toExtend<{
+        queryKey: string[]
+        maxPages: number
+        queryFn: QueryFunction<UtilsOutput[number]>
+        throwOnError?(error: UtilsError): boolean
+        enabled: boolean
+      }>()
+    })
+
+    it('can change streamed data by define select', () => {
+      expectTypeOf(streamUtils.experimental_liveOptions({
+        select: mapped => ({ mapped }),
+      })).toExtend<QueryObserverOptions<UtilsOutput[number], UtilsError, { mapped: UtilsOutput[number] }>>()
+    })
+
+    it('.getQueryState is typed correctly', () => {
+      const state = queryClient.getQueryState(streamUtils.experimental_liveOptions().queryKey)
+      expectTypeOf(state?.data).toEqualTypeOf<UtilsOutput[number] | undefined>()
+      expectTypeOf(state?.error).toEqualTypeOf<UtilsError | null | undefined>()
+    })
+  })
+
   describe('.infiniteKey', () => {
     const initialPageParam = 1
 

--- a/packages/tanstack-query/src/procedure-utils.ts
+++ b/packages/tanstack-query/src/procedure-utils.ts
@@ -66,8 +66,9 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
   ): DataTag<QueryKey, experimental_StreamedQueryOutput<TOutput>, TError>
 
   /**
-   * Generate [Event Iterator](https://orpc.unnoq.com/docs/event-iterator) options used for useQuery/useSuspenseQuery/prefetchQuery/...
-   * Built on top of [steamedQuery](https://tanstack.com/query/latest/docs/reference/streamedQuery)
+   * Configure queries for [Event Iterator](https://orpc.unnoq.com/docs/event-iterator).
+   * This is built on [TanStack Query streamedQuery](https://tanstack.com/query/latest/docs/reference/streamedQuery)
+   * and works with hooks like `useQuery`, `useSuspenseQuery`, or `prefetchQuery`.
    *
    * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#streamed-query-options Tanstack Streamed Query Options Utility Docs}
    */
@@ -78,7 +79,7 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
   ): NoInfer<U & Omit<StreamedOptionsBase<experimental_StreamedQueryOutput<TOutput>, TError>, keyof U>>
 
   /**
-   * Generate a **full matching** key for Live Query Options.
+   * Generate a **full matching** key for [Live Query Options](https://orpc.unnoq.com/docs/integrations/tanstack-query#live-query-options).
    *
    * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#query-mutation-key Tanstack Query/Mutation Key Docs}
    */
@@ -89,10 +90,11 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
   ): DataTag<QueryKey, experimental_LiveQueryOutput<TOutput>, TError>
 
   /**
-   * Generate live options used for useQuery/useSuspenseQuery/prefetchQuery/...
-   * The procedure must return an [Event Iterator](https://orpc.unnoq.com/docs/event-iterator).
+   * Configure live queries for [Event Iterator](https://orpc.unnoq.com/docs/event-iterator).
+   * Unlike `.streamedOptions` which accumulates chunks, live queries replace the entire result with each new chunk received.
+   * Works with hooks like `useQuery`, `useSuspenseQuery`, or `prefetchQuery`.
    *
-   * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#live-options Tanstack Live Query Options Utility Docs}
+   * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#live-query-options Tanstack Live Query Options Utility Docs}
    */
   experimental_liveOptions<U, USelectData = experimental_LiveQueryOutput<TOutput>>(
     ...rest: MaybeOptionalOptions<

--- a/packages/tanstack-query/src/types.ts
+++ b/packages/tanstack-query/src/types.ts
@@ -13,10 +13,11 @@ import type {
 } from '@tanstack/query-core'
 
 export type experimental_StreamedQueryOutput<TOutput> = TOutput extends AsyncIterable<infer U> ? U[] : never
+export type experimental_LiveQueryOutput<TOutput> = TOutput extends AsyncIterable<infer U> ? U : never
 
 type experimental_StreamedQueryOptions = Omit<Parameters<typeof experimental_streamedQuery>[0], 'queryFn'>
 
-export type OperationType = 'query' | 'streamed' | 'infinite' | 'mutation'
+export type OperationType = 'query' | 'streamed' | 'live' | 'infinite' | 'mutation'
 
 export type OperationKeyOptions<TType extends OperationType, TInput> = {
   type?: TType

--- a/packages/tanstack-query/tests/live-query.test.tsx
+++ b/packages/tanstack-query/tests/live-query.test.tsx
@@ -1,0 +1,40 @@
+import { useQuery } from '@tanstack/react-query'
+import { renderHook } from '@testing-library/react'
+import { act } from 'react'
+import { experimental_liveQuery as liveQuery } from '../src/live-query'
+import { queryClient } from './shared'
+
+it('liveQuery', async () => {
+  const { result } = renderHook(() => useQuery({
+    queryKey: ['live-query'],
+    queryFn: liveQuery(async function* () {
+      yield 1
+      await new Promise(resolve => setTimeout(resolve, 50))
+      yield 2
+      await new Promise(resolve => setTimeout(resolve, 50))
+      yield 3
+    }),
+  }, queryClient))
+
+  expect(result.current.isLoading).toBe(true)
+
+  await act(async () => {
+    await vi.waitFor(() => expect(result.current.data).toEqual(1))
+  })
+
+  await act(async () => {
+    await vi.waitFor(() => expect(result.current.data).toEqual(2))
+  })
+
+  await act(async () => {
+    await vi.waitFor(() => expect(result.current.data).toEqual(3))
+  })
+
+  act(() => {
+    result.current.refetch()
+  })
+
+  await act(async () => {
+    await vi.waitFor(() => expect(result.current.data).toEqual(1))
+  })
+})


### PR DESCRIPTION
Use `.liveOptions` to configure live queries for Event Iterator. Unlike `.streamedOptions` which accumulates chunks, live queries replace the entire result with each new chunk received

```ts
const query = useQuery(orpc.live.experimental_liveOptions({
  input: { id: 123 }, // Specify input if needed
  context: { cache: true }, // Provide client context if needed
  // additional options...
}))
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced experimental support for "live queries," enabling real-time data updates that replace the entire result with each new chunk.
  * Added new utility methods for generating live query keys and options, compatible with popular query hooks (e.g., useQuery, prefetchQuery).
  * Enhanced documentation with detailed explanations and examples for live queries.

* **Bug Fixes**
  * Improved error handling for invalid or unsupported live query outputs.

* **Tests**
  * Added comprehensive test suites for live query utilities across React, Solid, Svelte, Vue, and Angular integrations, ensuring correct behavior and type inference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->