### PR TITLE
feat(openapi): add array index limit to bracket notation for security

### DIFF
--- a/packages/openapi-client/src/adapters/standard/bracket-notation.test.ts
+++ b/packages/openapi-client/src/adapters/standard/bracket-notation.test.ts
@@ -246,31 +246,31 @@ describe('standardBracketNotationSerializer', () => {
     it('limits array indices to maxArrayIndex', () => {
       expect(serializer.deserialize([
         ['arr[1]', 1],
-        ['arr[10000]', 2],
-        ['arr[10001]', 3],
-      ])).toEqual({ arr: { 1: 1, 10000: 2, 10001: 3 } })
+        ['arr[9999]', 2],
+        ['arr[10000]', 3],
+      ])).toEqual({ arr: { 1: 1, 9999: 2, 10000: 3 } })
 
       expect(serializer.deserialize([
-        ['arr[10000]', 3],
+        ['arr[9999]', 3],
       ])).toEqual({ arr: (() => {
         const arr = []
-        arr[10000] = 3
+        arr[9999] = 3
         return arr
       })() })
 
       expect(serializer.deserialize([
-        ['arr[10001]', 3],
-      ])).toEqual({ arr: { 10001: 3 } })
+        ['arr[10000]', 3],
+      ])).toEqual({ arr: { 10000: 3 } })
 
       // if not use index, we still can exceed maxArrayIndex
       expect(serializer.deserialize([
-        ['arr[10000]', 3],
+        ['arr[9999]', 3],
         ['arr', 4],
       ])).toEqual({
         arr: (() => {
           const arr = []
-          arr[10000] = 3
-          arr[10001] = 4
+          arr[9999] = 3
+          arr[10000] = 4
           return arr
         })(),
       })

--- a/packages/openapi-client/src/adapters/standard/bracket-notation.test.ts
+++ b/packages/openapi-client/src/adapters/standard/bracket-notation.test.ts
@@ -242,6 +242,39 @@ describe('standardBracketNotationSerializer', () => {
         ['a[c][1][f]', 4],
       ])).toEqual({ a: { b: 1, c: [2, { d: 3, f: 4 }] } })
     })
+
+    it('limits array indices to maxArrayIndex', () => {
+      expect(serializer.deserialize([
+        ['arr[1]', 1],
+        ['arr[10000]', 2],
+        ['arr[10001]', 3],
+      ])).toEqual({ arr: { 1: 1, 10000: 2, 10001: 3 } })
+
+      expect(serializer.deserialize([
+        ['arr[10000]', 3],
+      ])).toEqual({ arr: (() => {
+        const arr = []
+        arr[10000] = 3
+        return arr
+      })() })
+
+      expect(serializer.deserialize([
+        ['arr[10001]', 3],
+      ])).toEqual({ arr: { 10001: 3 } })
+
+      // if not use index, we still can exceed maxArrayIndex
+      expect(serializer.deserialize([
+        ['arr[10000]', 3],
+        ['arr', 4],
+      ])).toEqual({
+        arr: (() => {
+          const arr = []
+          arr[10000] = 3
+          arr[10001] = 4
+          return arr
+        })(),
+      })
+    })
   })
 
   it.each([

--- a/packages/openapi-client/src/adapters/standard/bracket-notation.ts
+++ b/packages/openapi-client/src/adapters/standard/bracket-notation.ts
@@ -14,7 +14,7 @@ export interface StandardBracketNotationSerializerOptions {
    * downstream code might inadvertently convert these sparse arrays to dense arrays,
    * potentially creating millions of undefined elements and causing memory issues.
    *
-   * @default 10_000
+   * @default 9_999 (array with 10,000 elements)
    */
   maxBracketNotationArrayIndex?: number
 }
@@ -23,7 +23,7 @@ export class StandardBracketNotationSerializer {
   private readonly maxArrayIndex: number
 
   constructor(options: StandardBracketNotationSerializerOptions = {}) {
-    this.maxArrayIndex = options.maxBracketNotationArrayIndex ?? 10_000
+    this.maxArrayIndex = options.maxBracketNotationArrayIndex ?? 9_999
   }
 
   serialize(data: unknown, segments: Segment[] = [], result: StandardBracketNotationSerialized = []): StandardBracketNotationSerialized {

--- a/packages/openapi-client/src/adapters/standard/bracket-notation.ts
+++ b/packages/openapi-client/src/adapters/standard/bracket-notation.ts
@@ -14,6 +14,7 @@ export interface StandardBracketNotationSerializerOptions {
    * downstream code might inadvertently convert these sparse arrays to dense arrays,
    * potentially creating millions of undefined elements and causing memory issues.
    *
+   * @note Only applies to deserialization.
    * @default 9_999 (array with 10,000 elements)
    */
   maxBracketNotationArrayIndex?: number

--- a/packages/openapi-client/src/adapters/standard/bracket-notation.ts
+++ b/packages/openapi-client/src/adapters/standard/bracket-notation.ts
@@ -3,7 +3,29 @@ import { isObject, NullProtoObj } from '@orpc/shared'
 
 export type StandardBracketNotationSerialized = [string, unknown][]
 
+export interface StandardBracketNotationSerializerOptions {
+  /**
+   * Maximum allowed array index for bracket notation deserialization.
+   *
+   * This helps protect against memory exhaustion attacks where malicious input
+   * uses extremely large array indices (e.g., `?arr[4294967296]=value`).
+   *
+   * While bracket notation creates sparse arrays that handle large indices efficiently,
+   * downstream code might inadvertently convert these sparse arrays to dense arrays,
+   * potentially creating millions of undefined elements and causing memory issues.
+   *
+   * @default 10_000
+   */
+  maxBracketNotationArrayIndex?: number
+}
+
 export class StandardBracketNotationSerializer {
+  private readonly maxArrayIndex: number
+
+  constructor(options: StandardBracketNotationSerializerOptions = {}) {
+    this.maxArrayIndex = options.maxBracketNotationArrayIndex ?? 10_000
+  }
+
   serialize(data: unknown, segments: Segment[] = [], result: StandardBracketNotationSerialized = []): StandardBracketNotationSerialized {
     if (Array.isArray(data)) {
       data.forEach((item, i) => {
@@ -44,7 +66,7 @@ export class StandardBracketNotationSerializer {
         }
 
         if (i !== segments.length - 1) {
-          if (Array.isArray(currentRef[nextSegment]) && !isValidArrayIndex(segment)) {
+          if (Array.isArray(currentRef[nextSegment]) && !isValidArrayIndex(segment, this.maxArrayIndex)) {
             if (arrayPushStyles.has(currentRef[nextSegment])) {
               arrayPushStyles.delete(currentRef[nextSegment])
               currentRef[nextSegment] = pushStyleArrayToObject(currentRef[nextSegment])
@@ -67,7 +89,7 @@ export class StandardBracketNotationSerializer {
                 currentRef[nextSegment] = pushStyleArrayToObject(currentRef[nextSegment])
               }
 
-              else if (!isValidArrayIndex(segment)) {
+              else if (!isValidArrayIndex(segment, this.maxArrayIndex)) {
                 currentRef[nextSegment] = arrayToObject(currentRef[nextSegment])
               }
             }
@@ -165,8 +187,8 @@ export class StandardBracketNotationSerializer {
   }
 }
 
-function isValidArrayIndex(value: string): boolean {
-  return /^0$|^[1-9]\d*$/.test(value)
+function isValidArrayIndex(value: string, maxIndex: number): boolean {
+  return /^0$|^[1-9]\d*$/.test(value) && Number(value) <= maxIndex
 }
 
 function arrayToObject(array: any[]): Record<string, unknown> {

--- a/packages/openapi-client/src/adapters/standard/openapi-link.ts
+++ b/packages/openapi-client/src/adapters/standard/openapi-link.ts
@@ -15,7 +15,8 @@ export interface StandardOpenAPILinkOptions<T extends ClientContext>
 export class StandardOpenAPILink<T extends ClientContext> extends StandardLink<T> {
   constructor(contract: AnyContractRouter, linkClient: StandardLinkClient<T>, options: StandardOpenAPILinkOptions<T>) {
     const jsonSerializer = new StandardOpenAPIJsonSerializer(options)
-    const bracketNotationSerializer = new StandardBracketNotationSerializer()
+    // Server response is trustable so we can extend the maximum array index to maximum JavaScript array length
+    const bracketNotationSerializer = new StandardBracketNotationSerializer({ maxBracketNotationArrayIndex: 4_294_967_295 })
     const serializer = new StandardOpenAPISerializer(jsonSerializer, bracketNotationSerializer)
     const linkCodec = new StandardOpenapiLinkCodec(contract, serializer, options)
 

--- a/packages/openapi-client/src/adapters/standard/openapi-link.ts
+++ b/packages/openapi-client/src/adapters/standard/openapi-link.ts
@@ -15,7 +15,7 @@ export interface StandardOpenAPILinkOptions<T extends ClientContext>
 export class StandardOpenAPILink<T extends ClientContext> extends StandardLink<T> {
   constructor(contract: AnyContractRouter, linkClient: StandardLinkClient<T>, options: StandardOpenAPILinkOptions<T>) {
     const jsonSerializer = new StandardOpenAPIJsonSerializer(options)
-    // Server response is trustable, so we can use the maximum possible array index.
+    // Server response is trusted, so we can use the maximum possible array index.
     const bracketNotationSerializer = new StandardBracketNotationSerializer({ maxBracketNotationArrayIndex: 4_294_967_294 })
     const serializer = new StandardOpenAPISerializer(jsonSerializer, bracketNotationSerializer)
     const linkCodec = new StandardOpenapiLinkCodec(contract, serializer, options)

--- a/packages/openapi-client/src/adapters/standard/openapi-link.ts
+++ b/packages/openapi-client/src/adapters/standard/openapi-link.ts
@@ -15,8 +15,8 @@ export interface StandardOpenAPILinkOptions<T extends ClientContext>
 export class StandardOpenAPILink<T extends ClientContext> extends StandardLink<T> {
   constructor(contract: AnyContractRouter, linkClient: StandardLinkClient<T>, options: StandardOpenAPILinkOptions<T>) {
     const jsonSerializer = new StandardOpenAPIJsonSerializer(options)
-    // Server response is trustable so we can extend the maximum array index to maximum JavaScript array length
-    const bracketNotationSerializer = new StandardBracketNotationSerializer({ maxBracketNotationArrayIndex: 4_294_967_295 })
+    // Server response is trustable, so we can use the maximum possible array index.
+    const bracketNotationSerializer = new StandardBracketNotationSerializer({ maxBracketNotationArrayIndex: 4_294_967_294 })
     const serializer = new StandardOpenAPISerializer(jsonSerializer, bracketNotationSerializer)
     const linkCodec = new StandardOpenapiLinkCodec(contract, serializer, options)
 

--- a/packages/openapi/src/adapters/standard/openapi-handler.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler.ts
@@ -1,4 +1,4 @@
-import type { StandardOpenAPIJsonSerializerOptions } from '@orpc/openapi-client/standard'
+import type { StandardBracketNotationSerializerOptions, StandardOpenAPIJsonSerializerOptions } from '@orpc/openapi-client/standard'
 import type { Context, Router } from '@orpc/server'
 import type { StandardHandlerOptions } from '@orpc/server/standard'
 import { StandardBracketNotationSerializer, StandardOpenAPIJsonSerializer, StandardOpenAPISerializer } from '@orpc/openapi-client/standard'
@@ -7,12 +7,12 @@ import { StandardOpenAPICodec } from './openapi-codec'
 import { StandardOpenAPIMatcher } from './openapi-matcher'
 
 export interface StandardOpenAPIHandlerOptions<T extends Context>
-  extends StandardHandlerOptions<T>, StandardOpenAPIJsonSerializerOptions {}
+  extends StandardHandlerOptions<T>, StandardOpenAPIJsonSerializerOptions, StandardBracketNotationSerializerOptions {}
 
 export class StandardOpenAPIHandler<T extends Context> extends StandardHandler<T> {
   constructor(router: Router<any, T>, options: NoInfer<StandardOpenAPIHandlerOptions<T>>) {
     const jsonSerializer = new StandardOpenAPIJsonSerializer(options)
-    const bracketNotationSerializer = new StandardBracketNotationSerializer()
+    const bracketNotationSerializer = new StandardBracketNotationSerializer(options)
     const serializer = new StandardOpenAPISerializer(jsonSerializer, bracketNotationSerializer)
     const matcher = new StandardOpenAPIMatcher()
     const codec = new StandardOpenAPICodec(serializer)


### PR DESCRIPTION
Add configurable `maxBracketNotationArrayIndex` option (default: 9,999) to `StandardBracketNotationSerializer` to prevent memory exhaustion attacks from malicious inputs with extremely large array indices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configuration for maximum allowed array index in bracket notation deserialization, enhancing control over large arrays.
* **Bug Fixes**
  * Improved deserialization to correctly handle large array indices, preventing oversized sparse arrays.
* **Tests**
  * Added tests verifying behavior of array indices near and beyond the maximum threshold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->