### PR TITLE
feat(standard-server-aws-lambda): promote to stable

### DIFF
--- a/apps/content/docs/adapters/http.md
+++ b/apps/content/docs/adapters/http.md
@@ -123,7 +123,7 @@ Deno.serve(async (request) => {
 
 ```ts [aws-lambda]
 import { APIGatewayProxyEventV2 } from 'aws-lambda'
-import { experimental_RPCHandler as RPCHandler } from '@orpc/server/aws-lambda'
+import { RPCHandler } from '@orpc/server/aws-lambda'
 
 const rpcHandler = new RPCHandler(router)
 

--- a/packages/openapi/src/adapters/aws-lambda/openapi-handler.test.ts
+++ b/packages/openapi/src/adapters/aws-lambda/openapi-handler.test.ts
@@ -1,6 +1,6 @@
 import { os } from '@orpc/server'
 import { sendStandardResponse, toStandardLazyRequest } from '@orpc/standard-server-aws-lambda'
-import { experimental_OpenAPIHandler as OpenAPIHandler } from './openapi-handler'
+import { OpenAPIHandler } from './openapi-handler'
 
 vi.mock('@orpc/standard-server-aws-lambda', () => ({
   toStandardLazyRequest: vi.fn(),

--- a/packages/openapi/src/adapters/aws-lambda/openapi-handler.ts
+++ b/packages/openapi/src/adapters/aws-lambda/openapi-handler.ts
@@ -10,7 +10,7 @@ import { StandardOpenAPIHandler } from '../standard'
  * @see {@link https://orpc.unnoq.com/docs/openapi/openapi-handler OpenAPI Handler Docs}
  * @see {@link https://orpc.unnoq.com/docs/adapters/http HTTP Adapter Docs}
  */
-export class experimental_OpenAPIHandler<T extends Context> extends AwsLambdaHandler<T> {
+export class OpenAPIHandler<T extends Context> extends AwsLambdaHandler<T> {
   constructor(router: Router<any, T>, options: NoInfer<StandardOpenAPIHandlerOptions<T> & AwsLambdaHandlerOptions> = {}) {
     super(new StandardOpenAPIHandler(router, options), options)
   }

--- a/packages/server/src/adapters/aws-lambda/rpc-handler.test.ts
+++ b/packages/server/src/adapters/aws-lambda/rpc-handler.test.ts
@@ -1,6 +1,6 @@
 import { sendStandardResponse, toStandardLazyRequest } from '@orpc/standard-server-aws-lambda'
 import { os } from '../../builder'
-import { experimental_RPCHandler as RPCHandler } from './rpc-handler'
+import { RPCHandler } from './rpc-handler'
 
 vi.mock('@orpc/standard-server-aws-lambda', () => ({
   toStandardLazyRequest: vi.fn(),

--- a/packages/server/src/adapters/aws-lambda/rpc-handler.ts
+++ b/packages/server/src/adapters/aws-lambda/rpc-handler.ts
@@ -21,7 +21,7 @@ export type RPCHandlerOptions<T extends Context> = AwsLambdaHandlerOptions & Sta
  * @see {@link https://orpc.unnoq.com/docs/rpc-handler RPC Handler Docs}
  * @see {@link https://orpc.unnoq.com/docs/adapters/http HTTP Adapter Docs}
  */
-export class experimental_RPCHandler<T extends Context> extends AwsLambdaHandler<T> {
+export class RPCHandler<T extends Context> extends AwsLambdaHandler<T> {
   constructor(router: Router<any, T>, options: NoInfer<RPCHandlerOptions<T>> = {}) {
     if (options.strictGetMethodPluginEnabled ?? true) {
       options.plugins ??= []


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the "experimental_" prefix from AWS Lambda handler class names and related imports.
  * Updated documentation to reflect the new class names.
  * No changes to functionality or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->