### PR TITLE
feat(server, openapi): add filter option to handlers

### DIFF
--- a/apps/content/docs/openapi/openapi-handler.md
+++ b/apps/content/docs/openapi/openapi-handler.md
@@ -90,6 +90,16 @@ export default async function fetch(request: Request) {
 }
 ```
 
+## Filtering Procedures
+
+You can filter a procedure from matching by using the `filter` option:
+
+```ts
+const handler = new OpenAPIHandler(router, {
+  filter: ({ contract, path }) => !contract['~orpc'].route.tags?.includes('internal'),
+})
+```
+
 ## Event Iterator Keep Alive
 
 To keep [Event Iterator](/docs/event-iterator) connections alive, `OpenAPIHandler` periodically sends a ping comment to the client. You can configure this behavior using the following options:

--- a/apps/content/docs/openapi/openapi-specification.md
+++ b/apps/content/docs/openapi/openapi-specification.md
@@ -151,13 +151,13 @@ const spec = await generator.generate(router, {
 
 :::
 
-## Excluding Procedures
+## Filtering Procedures
 
-You can exclude a procedure from the OpenAPI specification using the `exclude` option:
+You can filter a procedure from the OpenAPI specification using the `filter` option:
 
 ```ts
 const spec = await generator.generate(router, {
-  exclude: (procedure, path) => !!procedure['~orpc'].route.tags?.includes('admin'),
+  filter: ({ contract, path }) => !contract['~orpc'].route.tags?.includes('internal'),
 })
 ```
 

--- a/apps/content/docs/rpc-handler.md
+++ b/apps/content/docs/rpc-handler.md
@@ -73,6 +73,16 @@ export default async function fetch(request: Request) {
 }
 ```
 
+## Filtering Procedures
+
+You can filter a procedure from matching by using the `filter` option:
+
+```ts
+const handler = new RPCHandler(router, {
+  filter: ({ contract, path }) => !contract['~orpc'].route.tags?.includes('internal'),
+})
+```
+
 ## Event Iterator Keep Alive
 
 To keep [Event Iterator](/docs/event-iterator) connections alive, `RPCHandler` periodically sends a ping comment to the client. You can configure this behavior using the following options:

--- a/packages/openapi/src/adapters/standard/openapi-handler.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler.ts
@@ -1,20 +1,22 @@
 import type { StandardBracketNotationSerializerOptions, StandardOpenAPIJsonSerializerOptions } from '@orpc/openapi-client/standard'
 import type { Context, Router } from '@orpc/server'
 import type { StandardHandlerOptions } from '@orpc/server/standard'
+import type { StandardOpenAPIMatcherOptions } from './openapi-matcher'
 import { StandardBracketNotationSerializer, StandardOpenAPIJsonSerializer, StandardOpenAPISerializer } from '@orpc/openapi-client/standard'
 import { StandardHandler } from '@orpc/server/standard'
 import { StandardOpenAPICodec } from './openapi-codec'
 import { StandardOpenAPIMatcher } from './openapi-matcher'
 
 export interface StandardOpenAPIHandlerOptions<T extends Context>
-  extends StandardHandlerOptions<T>, StandardOpenAPIJsonSerializerOptions, StandardBracketNotationSerializerOptions {}
+  extends StandardHandlerOptions<T>, StandardOpenAPIJsonSerializerOptions,
+  StandardBracketNotationSerializerOptions, StandardOpenAPIMatcherOptions {}
 
 export class StandardOpenAPIHandler<T extends Context> extends StandardHandler<T> {
   constructor(router: Router<any, T>, options: NoInfer<StandardOpenAPIHandlerOptions<T>>) {
     const jsonSerializer = new StandardOpenAPIJsonSerializer(options)
     const bracketNotationSerializer = new StandardBracketNotationSerializer(options)
     const serializer = new StandardOpenAPISerializer(jsonSerializer, bracketNotationSerializer)
-    const matcher = new StandardOpenAPIMatcher()
+    const matcher = new StandardOpenAPIMatcher(options)
     const codec = new StandardOpenAPICodec(serializer)
 
     super(router, matcher, codec, options)

--- a/packages/openapi/src/adapters/standard/openapi-matcher.test.ts
+++ b/packages/openapi/src/adapters/standard/openapi-matcher.test.ts
@@ -237,4 +237,26 @@ describe('standardOpenAPIMatcher', () => {
       params: undefined,
     })
   })
+
+  it('filter procedures', async () => {
+    const rpcMatcher = new StandardOpenAPIMatcher({
+      filter: (options) => {
+        if (options.path.includes('ping')) {
+          return false
+        }
+
+        return true
+      },
+    })
+    rpcMatcher.init(router)
+
+    expect(await rpcMatcher.match('POST', '/base')).toEqual(undefined)
+    expect(await rpcMatcher.match('DELETE', '/ping/unnoq')).toEqual(undefined)
+
+    expect(await rpcMatcher.match('GET', '/pong/something')).toEqual({
+      path: ['pong'],
+      procedure: routedPong,
+      params: { pong: 'something' },
+    })
+  })
 })

--- a/packages/openapi/src/openapi-generator.ts
+++ b/packages/openapi/src/openapi-generator.ts
@@ -100,6 +100,7 @@ export class OpenAPIGenerator {
       info: options.info ?? { title: 'API Reference', version: '0.0.0' },
       openapi: '3.1.1',
       exclude: undefined,
+      filter: undefined,
       commonSchemas: undefined,
     } as OpenAPI.Document
 

--- a/packages/server/src/adapters/standard/rpc-handler.ts
+++ b/packages/server/src/adapters/standard/rpc-handler.ts
@@ -2,19 +2,21 @@ import type { StandardRPCJsonSerializerOptions } from '@orpc/client/standard'
 import type { Context } from '../../context'
 import type { Router } from '../../router'
 import type { StandardHandlerOptions } from './handler'
+import type { StandardRPCMatcherOptions } from './rpc-matcher'
 import { StandardRPCJsonSerializer, StandardRPCSerializer } from '@orpc/client/standard'
 import { StandardHandler } from './handler'
 import { StandardRPCCodec } from './rpc-codec'
 import { StandardRPCMatcher } from './rpc-matcher'
 
-export interface StandardRPCHandlerOptions<T extends Context> extends StandardHandlerOptions<T>, StandardRPCJsonSerializerOptions {
+export interface StandardRPCHandlerOptions<T extends Context>
+  extends StandardHandlerOptions<T>, StandardRPCJsonSerializerOptions, StandardRPCMatcherOptions {
 }
 
 export class StandardRPCHandler<T extends Context> extends StandardHandler<T> {
   constructor(router: Router<any, T>, options: StandardRPCHandlerOptions<T> = {}) {
     const jsonSerializer = new StandardRPCJsonSerializer(options)
     const serializer = new StandardRPCSerializer(jsonSerializer)
-    const matcher = new StandardRPCMatcher()
+    const matcher = new StandardRPCMatcher(options)
     const codec = new StandardRPCCodec(serializer)
 
     super(router, matcher, codec, options)

--- a/packages/server/src/adapters/standard/rpc-matcher.test.ts
+++ b/packages/server/src/adapters/standard/rpc-matcher.test.ts
@@ -168,4 +168,25 @@ describe('standardRPCMatcher', () => {
     expect(pingLoader).toHaveBeenCalledTimes(4)
     expect(pongLoader).toHaveBeenCalledTimes(4)
   })
+
+  it('filter procedures', async () => {
+    const rpcMatcher = new StandardRPCMatcher({
+      filter: (options) => {
+        if (options.path.includes('ping')) {
+          return false
+        }
+
+        return true
+      },
+    })
+    rpcMatcher.init(router)
+
+    expect(await rpcMatcher.match('ANYTHING', '/ping')).toEqual(undefined)
+    expect(await rpcMatcher.match('ANYTHING', '/nested/ping')).toEqual(undefined)
+
+    expect(await rpcMatcher.match('ANYTHING', '/pong')).toEqual({
+      path: ['pong'],
+      procedure: pong,
+    })
+  })
 })

--- a/packages/server/src/router-utils.ts
+++ b/packages/server/src/router-utils.ts
@@ -165,7 +165,7 @@ export interface TraverseContractProceduresOptions {
 }
 
 export interface ContractProcedureCallbackOptions {
-  contract: AnyContractProcedure
+  contract: AnyContractProcedure | AnyProcedure
   path: readonly string[]
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for filtering procedures in OpenAPI and RPC handlers, enabling selective inclusion of routes via custom filter functions.
  * Introduced a filter option in handler and generator configurations, replacing the deprecated exclude option for enhanced flexibility.

* **Documentation**
  * Updated and expanded documentation to explain the new filtering procedures feature with detailed examples.

* **Tests**
  * Added test cases confirming the filtering functionality works as intended in both OpenAPI and RPC matchers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->