### PR TITLE
feat(zod): support  zod v4 and v3 SchemaConverter use in parallel

### DIFF
--- a/packages/zod/src/converter.test.ts
+++ b/packages/zod/src/converter.test.ts
@@ -492,8 +492,10 @@ it('zodToJsonSchemaConverter.condition', async () => {
   expect(converter.condition(z.string())).toBe(true)
   expect(converter.condition(z.string().optional())).toBe(true)
 
-  const v = await import('valibot')
+  const z4 = await import('zod/v4')
+  expect(converter.condition(z4.string())).toBe(false)
 
+  const v = await import('valibot')
   expect(converter.condition(v.string())).toBe(false)
 })
 

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -88,7 +88,7 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
   }
 
   condition(schema: AnySchema | undefined): boolean {
-    return schema !== undefined && schema['~standard'].vendor === 'zod'
+    return schema !== undefined && schema['~standard'].vendor === 'zod' && !('_zod' in schema) // < zod4
   }
 
   convert(

--- a/packages/zod/src/zod4/converter.test.ts
+++ b/packages/zod/src/zod4/converter.test.ts
@@ -36,8 +36,10 @@ describe('zodToJsonSchemaConverter', () => {
     expect(converter.condition(z.string())).toBe(true)
     expect(converter.condition(z.string().optional())).toBe(true)
 
-    const v = await import('valibot')
+    const z3 = await import('zod/v3')
+    expect(converter.condition(z3.string())).toBe(false)
 
+    const v = await import('valibot')
     expect(converter.condition(v.string())).toBe(false)
   })
 

--- a/packages/zod/src/zod4/converter.ts
+++ b/packages/zod/src/zod4/converter.ts
@@ -103,7 +103,7 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
   }
 
   condition(schema: AnySchema | undefined): boolean {
-    return schema !== undefined && schema['~standard'].vendor === 'zod'
+    return schema !== undefined && schema['~standard'].vendor === 'zod' && '_zod' in schema // >= zod4
   }
 
   convert(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version detection for Zod schemas, ensuring converters correctly distinguish between Zod v3 and v4+ schemas.
  * Updated tests to verify accurate handling of different Zod versions and maintain compatibility with other schema libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->