### PR TITLE
fix(tanstack-query): client context should include inside query/mutation keys

### DIFF
--- a/packages/tanstack-query/src/key.test.ts
+++ b/packages/tanstack-query/src/key.test.ts
@@ -8,4 +8,6 @@ it('generateOperationKey', () => {
     .toEqual([['planet', 'find'], { type: 'query', input: { id: 1 } }])
   expect(generateOperationKey(['planet', 'stream'], { type: 'streamed', input: { cursor: 0 }, fnOptions: { refetchMode: 'append' } }))
     .toEqual([['planet', 'stream'], { type: 'streamed', input: { cursor: 0 }, fnOptions: { refetchMode: 'append' } }])
+  expect(generateOperationKey(['planet', 'find'], { type: 'query', input: { id: 1 }, context: { cache: true } }))
+    .toEqual([['planet', 'find'], { type: 'query', input: { id: 1 }, context: { cache: true } }])
 })

--- a/packages/tanstack-query/src/key.ts
+++ b/packages/tanstack-query/src/key.ts
@@ -1,12 +1,17 @@
+import type { ClientContext } from '@orpc/client'
 import type { OperationKey, OperationKeyOptions, OperationType } from './types'
 
-export function generateOperationKey<TType extends OperationType, TInput>(
+/**
+ * @todo move TClientContext to second position + remove default in next major version
+ */
+export function generateOperationKey<TType extends OperationType, TInput, TClientContext extends ClientContext = ClientContext>(
   path: readonly string[],
-  state: OperationKeyOptions<TType, TInput> = {},
-): OperationKey<TType, TInput> {
+  state: OperationKeyOptions<TType, TInput, TClientContext> = {},
+): OperationKey<TType, TInput, TClientContext> {
   return [path, {
-    ...state.input !== undefined ? { input: state.input } : {},
     ...state.type !== undefined ? { type: state.type } : {},
+    ...state.context !== undefined ? { context: state.context } : {},
     ...state.fnOptions !== undefined ? { fnOptions: state.fnOptions } : {},
+    ...state.input !== undefined ? { input: state.input } : {},
   } as any]
 }

--- a/packages/tanstack-query/src/procedure-utils.test.ts
+++ b/packages/tanstack-query/src/procedure-utils.test.ts
@@ -50,7 +50,7 @@ describe('createProcedureUtils', () => {
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
-      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'query', input: { search: '__search__' } })
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'query', context: { batch: '__batch__' }, input: { search: '__search__' } })
 
       client.mockResolvedValueOnce('__output__')
       await expect(options.queryFn!({ signal } as any)).resolves.toEqual('__output__')
@@ -71,7 +71,7 @@ describe('createProcedureUtils', () => {
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
-      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'query', input: skipToken })
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'query', context: { batch: '__batch__' }, input: skipToken })
 
       expect(() => options.queryFn!({ signal } as any)).toThrow('queryFn should not be called with skipToken used as input')
       expect(client).toHaveBeenCalledTimes(0)
@@ -103,6 +103,7 @@ describe('createProcedureUtils', () => {
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
       expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], {
         type: 'streamed',
+        context: { batch: '__batch__' },
         input: { search: '__search__' },
         fnOptions: {
           refetchMode: 'replace',
@@ -144,7 +145,7 @@ describe('createProcedureUtils', () => {
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
-      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'streamed', input: skipToken })
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'streamed', context: { batch: '__batch__' }, input: skipToken })
 
       await expect(options.queryFn!({ signal, client: queryClient } as any)).rejects.toThrow('queryFn should not be called with skipToken used as input')
       expect(client).toHaveBeenCalledTimes(0)
@@ -188,6 +189,7 @@ describe('createProcedureUtils', () => {
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
       expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], {
         type: 'live',
+        context: { batch: '__batch__' },
         input: { search: '__search__' },
       })
 
@@ -223,7 +225,7 @@ describe('createProcedureUtils', () => {
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
-      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'live', input: skipToken })
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'live', context: { batch: '__batch__' }, input: skipToken })
 
       await expect(options.queryFn!({ signal, client: queryClient } as any)).rejects.toThrow('queryFn should not be called with skipToken used as input')
       expect(client).toHaveBeenCalledTimes(0)
@@ -272,7 +274,7 @@ describe('createProcedureUtils', () => {
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
-      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'infinite', input: { search: '__search__', pageParam: '__initialPageParam__' } })
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'infinite', context: { batch: '__batch__' }, input: { search: '__search__', pageParam: '__initialPageParam__' } })
 
       expect(options.initialPageParam).toEqual('__initialPageParam__')
       expect(options.getNextPageParam).toBe(getNextPageParam)
@@ -309,7 +311,7 @@ describe('createProcedureUtils', () => {
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
-      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'infinite', input: skipToken })
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'infinite', context: { batch: '__batch__' }, input: skipToken })
 
       expect(options.initialPageParam).toEqual('__initialPageParam__')
       expect(options.getNextPageParam).toBe(getNextPageParam)
@@ -335,7 +337,7 @@ describe('createProcedureUtils', () => {
 
     expect(options.mutationKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
     expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
-    expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'mutation' })
+    expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'mutation', context: { batch: '__batch__' } })
 
     client.mockResolvedValueOnce('__output__')
     await expect(options.mutationFn!('__input__')).resolves.toEqual('__output__')


### PR DESCRIPTION
Queries have different client context can behave differently, so we should treat them as separate queries

E.g. one infinite retry request, and one normal request can be dedupe into one by tanstack query, while they should behave differently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for passing and typing a `context` object in key generation utilities, allowing more flexible client context handling across queries, mutations, and related operations.

* **Bug Fixes**
  * Updated tests to verify correct handling and propagation of the `context` object in key generation.

* **Refactor**
  * Improved type definitions for operation key options to consistently include client context typing.
  * Updated utility method signatures to require or support the `context` property where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->