### PR TITLE
feat(trpc): stable tRPC to oRPC router

### DIFF
--- a/apps/content/docs/openapi/integrations/trpc.md
+++ b/apps/content/docs/openapi/integrations/trpc.md
@@ -38,10 +38,7 @@ deno install npm:@orpc/trpc@latest
 By converting a [tRPC router](https://trpc.io/docs/server/routers) to an [oRPC router](/docs/router), you can utilize most oRPC features, including OpenAPI specification generation and request handling.
 
 ```ts
-import {
-  experimental_ORPCMeta as ORPCMeta,
-  experimental_toORPCRouter as toORPCRouter
-} from '@orpc/trpc'
+import { ORPCMeta, toORPCRouter } from '@orpc/trpc'
 
 export const t = initTRPC.context<Context>().meta<ORPCMeta>().create()
 

--- a/packages/trpc/src/to-orpc-router.test-d.ts
+++ b/packages/trpc/src/to-orpc-router.test-d.ts
@@ -3,7 +3,7 @@ import type { AsyncIteratorClass } from '@orpc/shared'
 import type { inferRouterContext } from '@trpc/server'
 import type { inferRouterMeta, TrackedData } from '@trpc/server/unstable-core-do-not-import'
 import type { TRPCContext, TRPCMeta, trpcRouter } from '../tests/shared'
-import type { experimental_ToORPCRouterResult as ToORPCRouterResult } from './to-orpc-router'
+import type { ToORPCRouterResult } from './to-orpc-router'
 
 it('ToORPCRouterResult', () => {
   const orpcRouter = {} as ToORPCRouterResult<

--- a/packages/trpc/src/to-orpc-router.test.ts
+++ b/packages/trpc/src/to-orpc-router.test.ts
@@ -4,7 +4,7 @@ import { tracked, TRPCError } from '@trpc/server'
 import * as z from 'zod'
 import { inputSchema, outputSchema } from '../../contract/tests/shared'
 import { t, trpcRouter } from '../tests/shared'
-import { experimental_toORPCRouter as toORPCRouter } from './to-orpc-router'
+import { toORPCRouter } from './to-orpc-router'
 
 beforeEach(() => {
   vi.clearAllMocks()

--- a/packages/trpc/src/to-orpc-router.ts
+++ b/packages/trpc/src/to-orpc-router.ts
@@ -7,16 +7,16 @@ import { get, isObject, isTypescriptObject } from '@orpc/shared'
 import { isTrackedEnvelope, TRPCError } from '@trpc/server'
 import { getHTTPStatusCodeFromError, isAsyncIterable } from '@trpc/server/unstable-core-do-not-import'
 
-export interface experimental_ORPCMeta {
+export interface ORPCMeta {
   route?: ORPC.Route
 }
 
-export type experimental_ToORPCOutput<T>
+export type ToORPCOutput<T>
   = T extends AsyncIterable<infer TData, infer TReturn, infer TNext>
     ? AsyncIteratorClass<TData, TReturn, TNext>
     : T
 
-export type experimental_ToORPCRouterResult<TContext extends ORPC.Context, TMeta extends ORPC.Meta, TRecord extends Record<string, any>>
+export type ToORPCRouterResult<TContext extends ORPC.Context, TMeta extends ORPC.Meta, TRecord extends Record<string, any>>
     = {
       [K in keyof TRecord]:
       TRecord[K] extends AnyProcedure
@@ -24,12 +24,12 @@ export type experimental_ToORPCRouterResult<TContext extends ORPC.Context, TMeta
           TContext,
           object,
           ORPC.Schema<TRecord[K]['_def']['$types']['input'], unknown>,
-          ORPC.Schema<unknown, experimental_ToORPCOutput<TRecord[K]['_def']['$types']['output']>>,
+          ORPC.Schema<unknown, ToORPCOutput<TRecord[K]['_def']['$types']['output']>>,
           object,
           TMeta
         >
         : TRecord[K] extends Record<string, any>
-          ? experimental_ToORPCRouterResult<TContext, TMeta, TRecord[K]>
+          ? ToORPCRouterResult<TContext, TMeta, TRecord[K]>
           : never
     }
 
@@ -38,9 +38,9 @@ export type experimental_ToORPCRouterResult<TContext extends ORPC.Context, TMeta
  *
  * @warning You should set the `meta` type to `ORPCMeta` when creating your tRPC builder, to ensure OpenAPI features work correctly.
  */
-export function experimental_toORPCRouter<T extends AnyRouter>(
+export function toORPCRouter<T extends AnyRouter>(
   router: T,
-): experimental_ToORPCRouterResult<
+): ToORPCRouterResult<
     inferRouterContext<T>,
     inferRouterMeta<T>,
     T['_def']['record']
@@ -61,7 +61,7 @@ function lazyToORPCRouter(lazies: AnyRouter['_def']['lazy']) {
 
     orpcRouter[key] = ORPC.createAccessibleLazyRouter(ORPC.lazy(async () => {
       const router = await item.ref()
-      return { default: experimental_toORPCRouter(router) }
+      return { default: toORPCRouter(router) }
     }))
   }
 

--- a/packages/trpc/tests/shared.ts
+++ b/packages/trpc/tests/shared.ts
@@ -1,4 +1,4 @@
-import type { experimental_ORPCMeta as ORPCMeta } from '../src/to-orpc-router'
+import type { ORPCMeta } from '../src/to-orpc-router'
 import { initTRPC, lazy, tracked, TRPCError } from '@trpc/server'
 import { z } from 'zod/v4'
 import { inputSchema, outputSchema } from '../../contract/tests/shared'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated naming of several types and functions by removing the "experimental_" prefix, reflecting their stable status. All references and imports have been adjusted accordingly. No changes to functionality or test logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->