### PR TITLE
fix(json-schema): enhance array to map coercion to handle unique keys

### DIFF
--- a/apps/content/docs/openapi/plugins/smart-coercion.md
+++ b/apps/content/docs/openapi/plugins/smart-coercion.md
@@ -150,6 +150,6 @@ This is particularly useful for [Bracket Notation](/docs/openapi/bracket-notatio
 
 ### Array → Map
 
-Support arrays of key-value pairs:
+Support arrays of key-value pairs with **unique keys**:
 
 - `[['key1', 'value1'], ['key2', 'value2']]` → `new Map([['key1', 'value1'], ['key2', 'value2']])`

--- a/packages/json-schema/src/coercer.test.ts
+++ b/packages/json-schema/src/coercer.test.ts
@@ -75,6 +75,11 @@ describe('jsonSchemaCoercer', () => {
       { 'type': 'array', 'items': { type: 'array', prefixItems: [{ type: 'number' }, { type: 'boolean' }] }, 'x-native-type': 'map' } as any,
       ['1'],
     )).toEqual(['1'])
+
+    expect(coercer.coerce(
+      { 'type': 'array', 'items': { type: 'array', prefixItems: [{ type: 'number' }, { type: 'boolean' }] }, 'x-native-type': 'map' } as any,
+      [['1', 'true'], ['duplicate', 'false'], ['duplicate', 'true']],
+    )).toEqual([[1, true], ['duplicate', false], ['duplicate', true]])
   })
 
   it('can coerce enum/const values', () => {

--- a/packages/json-schema/src/coercer.test.ts
+++ b/packages/json-schema/src/coercer.test.ts
@@ -78,8 +78,8 @@ describe('jsonSchemaCoercer', () => {
 
     expect(coercer.coerce(
       { 'type': 'array', 'items': { type: 'array', prefixItems: [{ type: 'number' }, { type: 'boolean' }] }, 'x-native-type': 'map' } as any,
-      [['1', 'true'], ['duplicate', 'false'], ['duplicate', 'true']],
-    )).toEqual([[1, true], ['duplicate', false], ['duplicate', true]])
+      [['1', 'true'], ['2', 'false'], ['1', 'false']],
+    )).toEqual([[1, true], [2, false], [1, false]])
   })
 
   it('can coerce enum/const values', () => {

--- a/packages/json-schema/src/coercer.ts
+++ b/packages/json-schema/src/coercer.ts
@@ -419,6 +419,12 @@ export class experimental_JsonSchemaCoercer {
       return value
     }
 
-    return new Map(value as [unknown, unknown][])
+    const result = new Map(value as [unknown, unknown][])
+
+    if (result.size !== value.length) {
+      return value
+    }
+
+    return result
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of array-to-Map conversions to ensure only arrays with unique keys are converted to Maps; arrays with duplicate keys are now preserved as arrays.

* **Documentation**
  * Updated documentation to clarify that arrays of key-value pairs must have unique keys for conversion to a Map.

* **Tests**
  * Added test cases to verify correct behavior when coercing arrays with duplicate keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->