### PR TITLE
fix(openapi): support strict object schema for dynamic params

### DIFF
--- a/packages/openapi/src/schema-utils.test.ts
+++ b/packages/openapi/src/schema-utils.test.ts
@@ -78,6 +78,40 @@ describe('separateObjectSchema', () => {
     })
   })
 
+  it('can separate if contains additionalProperties', () => {
+    const schema: ObjectSchema = {
+      type: 'object',
+      description: 'description',
+      properties: {
+        a: { type: 'string' },
+        b: { type: 'string' },
+      },
+      required: ['a'],
+      additionalProperties: true,
+    }
+
+    const [matched, rest] = separateObjectSchema(schema, ['a'])
+
+    expect(matched).toEqual({
+      type: 'object',
+      description: 'description',
+      properties: {
+        a: { type: 'string' },
+      },
+      required: ['a'],
+      additionalProperties: true,
+    })
+    expect(rest).toEqual({
+      type: 'object',
+      description: 'description',
+      properties: {
+        b: { type: 'string' },
+      },
+      required: [],
+      additionalProperties: true,
+    })
+  })
+
   it('not separate when contain not allow keyword', () => {
     const schema: ObjectSchema = {
       type: 'object',

--- a/packages/openapi/src/schema-utils.ts
+++ b/packages/openapi/src/schema-utils.ts
@@ -35,7 +35,7 @@ export function isAnySchema(schema: JSONSchema): boolean {
  * @internal
  */
 export function separateObjectSchema(schema: ObjectSchema, separatedProperties: string[]): [matched: ObjectSchema, rest: ObjectSchema] {
-  if (Object.keys(schema).some(k => k !== 'type' && k !== 'properties' && k !== 'required' && LOGIC_KEYWORDS.includes(k))) {
+  if (Object.keys(schema).some(k => k !== 'type' && k !== 'properties' && k !== 'required' && k !== 'additionalProperties' && LOGIC_KEYWORDS.includes(k))) {
     return [{ type: 'object' }, schema]
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of object schemas with the `additionalProperties` attribute, ensuring correct separation of properties while preserving the `additionalProperties` flag.

* **Tests**
  * Added a new test case to verify correct behavior when separating object schemas that include `additionalProperties: true`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->