### PR TITLE
feat(openapi): override operationId and spec callback for extending operations

### DIFF
--- a/apps/content/docs/openapi/openapi-specification.md
+++ b/apps/content/docs/openapi/openapi-specification.md
@@ -168,12 +168,13 @@ You can enrich your API documentation by specifying operation metadata using the
 ```ts
 const ping = os
   .route({
+    operationId: 'ping', // override auto-generated operationId
     summary: 'the summary',
     description: 'the description',
     deprecated: false,
     tags: ['tag'],
     successDescription: 'the success description',
-    spec: { // override entire auto-generated operation object
+    spec: { // override entire auto-generated operation object, can also be a callback for extending
       operationId: 'customOperationId',
       tags: ['tag'],
       summary: 'the summary',
@@ -204,11 +205,22 @@ const router = os.tag('planets').router({
 
 ### Customizing Operation Objects
 
-You can also extend the operation object using the `.spec` helper for an `error` or `middleware`:
+You can also extend the operation object by defining `route.spec` as a callback, or by using `oo.spec` in errors or middleware:
 
 ```ts
 import { oo } from '@orpc/openapi'
 
+// Using `route.spec` as a callback
+const procedure = os
+  .route({
+    spec: spec => ({
+      ...spec,
+      security: [{ 'api-key': [] }],
+    }),
+  })
+  .handler(() => 'Hello, World!')
+
+// With errors
 const base = os.errors({
   UNAUTHORIZED: oo.spec({
     data: z.any(),
@@ -217,15 +229,14 @@ const base = os.errors({
   })
 })
 
-// OR in middleware
-
+// With middleware
 const requireAuth = oo.spec(
   os.middleware(async ({ next, errors }) => {
     throw new ORPCError('UNAUTHORIZED')
     return next()
   }),
   {
-    security: [{ 'api-key': [] }]
+    security: [{ 'api-key': [] }],
   }
 )
 ```

--- a/packages/contract/src/route.ts
+++ b/packages/contract/src/route.ts
@@ -22,6 +22,14 @@ export interface Route {
   path?: HTTPPath
 
   /**
+   * The operation ID of the endpoint.
+   * This option is typically relevant when integrating with OpenAPI.
+   *
+   * @default Concatenation of router segments
+   */
+  operationId?: string
+
+  /**
    * The summary of the procedure.
    * This option is typically relevant when integrating with OpenAPI.
    *
@@ -127,7 +135,7 @@ export interface Route {
    *
    * @see {@link https://orpc.unnoq.com/docs/openapi/openapi-specification#operation-metadata Operation Metadata Docs}
    */
-  spec?: OpenAPI.OperationObject
+  spec?: OpenAPI.OperationObject | ((current: OpenAPI.OperationObject) => OpenAPI.OperationObject)
 }
 
 export function mergeRoute(a: Route, b: Route): Route {

--- a/packages/openapi/src/openapi-generator.test.ts
+++ b/packages/openapi/src/openapi-generator.test.ts
@@ -57,6 +57,7 @@ const routeTests: TestCase[] = [
   {
     name: 'metadata',
     contract: oc.route({
+      operationId: 'customOperationId',
       tags: ['planets'],
       summary: 'the summary',
       description: 'the description',
@@ -67,6 +68,7 @@ const routeTests: TestCase[] = [
     expected: {
       '/': {
         post: expect.objectContaining({
+          operationId: 'customOperationId',
           tags: ['planets'],
           summary: 'the summary',
           description: 'the description',
@@ -892,6 +894,33 @@ const customOperationTests: TestCase[] = [
           tags: ['tag'],
           summary: '__OVERRIDE__',
           security: [{ bearerAuth: [] }],
+        },
+      },
+    },
+  },
+  {
+    name: 'extend operation object',
+    contract: oc
+      .route({
+        spec: spec => ({
+          ...spec,
+          operationId: 'customOperationId',
+          summary: '__OVERRIDE__',
+        }),
+      })
+      .errors({
+        TEST: customOpenAPIOperation({}, { security: [{ bearerAuth: [] }] }),
+      })
+      .input(z.object({ id: z.string() }))
+      .output(z.object({ name: z.string() })),
+    expected: {
+      '/': {
+        post: {
+          operationId: 'customOperationId',
+          summary: '__OVERRIDE__',
+          security: [{ bearerAuth: [] }],
+          requestBody: expect.any(Object),
+          responses: expect.any(Object),
         },
       },
     },


### PR DESCRIPTION
- Allow overriding auto-generated operationId in route configuration
- Accept route.spec as callback function for extending operation objects
- Enable dynamic modification of OpenAPI operation specifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for explicitly setting an operation ID for endpoints in OpenAPI integration.
  * Enabled dynamic extension of OpenAPI operation objects using a callback function for advanced customization.

* **Documentation**
  * Enhanced OpenAPI documentation with clearer explanations and new examples for setting operation IDs and extending operation objects.

* **Tests**
  * Added new tests to verify dynamic extension and customization of OpenAPI operation objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->