### PR TITLE
fix(tanstack-query): default enabled option not working

### DIFF
--- a/packages/react-query/src/procedure-utils.test.ts
+++ b/packages/react-query/src/procedure-utils.test.ts
@@ -33,7 +33,7 @@ describe('createProcedureUtils', () => {
     it('without skipToken', async () => {
       const options = utils.queryOptions({ input: { search: '__search__' }, context: { batch: '__batch__' } })
 
-      expect(options.enabled).toBe(true)
+      expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
@@ -72,7 +72,7 @@ describe('createProcedureUtils', () => {
         queryFnOptions: { refetchMode: 'replace' },
       })
 
-      expect(options.enabled).toBe(true)
+      expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
@@ -130,7 +130,7 @@ describe('createProcedureUtils', () => {
         initialPageParam: '__initialPageParam__',
       })
 
-      expect(options.enabled).toBe(true)
+      expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)

--- a/packages/react-query/src/procedure-utils.ts
+++ b/packages/react-query/src/procedure-utils.ts
@@ -87,14 +87,14 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
 
           return client(optionsIn.input, { signal, context: optionsIn.context })
         },
-        enabled: optionsIn.input !== skipToken,
+        enabled: optionsIn.input === skipToken ? false : undefined,
         ...optionsIn,
       }
     },
 
     experimental_streamedOptions(...[optionsIn = {} as any]) {
       return {
-        enabled: optionsIn.input !== skipToken,
+        enabled: optionsIn.input === skipToken ? false : undefined,
         queryKey: generateOperationKey(options.path, { type: 'streamed', input: optionsIn.input, fnOptions: optionsIn.queryFnOptions }),
         queryFn: streamedQuery({
           queryFn: async ({ signal }) => {
@@ -129,7 +129,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
 
           return client(optionsIn.input(pageParam as any), { signal, context: optionsIn.context as any })
         },
-        enabled: optionsIn.input !== skipToken,
+        enabled: optionsIn.input === skipToken ? false : undefined,
         ...(optionsIn as any),
       }
     },

--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -12,7 +12,7 @@ export interface QueryOptionsBase<TOutput, TError> {
   queryFn(ctx: QueryFunctionContext): Promise<TOutput>
   throwOnError?(error: TError): boolean // Help TQ infer TError
   retryDelay?: (count: number, error: TError) => number // Help TQ infer TError (suspense hooks)
-  enabled: boolean
+  enabled: boolean | undefined
 }
 
 type experimental_StreamedQueryOptions = Omit<Parameters<typeof experimental_streamedQuery>[0], 'queryFn'>
@@ -36,7 +36,7 @@ export interface InfiniteOptionsBase<TOutput, TError, TPageParam> {
   queryFn(ctx: QueryFunctionContext<QueryKey, TPageParam>): Promise<TOutput>
   throwOnError?(error: TError): boolean // Help TQ infer TError
   retryDelay?: (count: number, error: TError) => number // Help TQ infer TError (suspense hooks)
-  enabled: boolean
+  enabled: boolean | undefined
 }
 
 export type MutationOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TMutationContext>

--- a/packages/solid-query/src/procedure-utils.test.ts
+++ b/packages/solid-query/src/procedure-utils.test.ts
@@ -33,7 +33,7 @@ describe('createProcedureUtils', () => {
     it('without skipToken', async () => {
       const options = utils.queryOptions({ input: { search: '__search__' }, context: { batch: '__batch__' } })
 
-      expect(options.enabled).toBe(true)
+      expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
@@ -72,7 +72,7 @@ describe('createProcedureUtils', () => {
         queryFnOptions: { refetchMode: 'replace' },
       })
 
-      expect(options.enabled).toBe(true)
+      expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
@@ -130,7 +130,7 @@ describe('createProcedureUtils', () => {
         initialPageParam: '__initialPageParam__',
       })
 
-      expect(options.enabled).toBe(true)
+      expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)

--- a/packages/solid-query/src/procedure-utils.ts
+++ b/packages/solid-query/src/procedure-utils.ts
@@ -77,14 +77,14 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
 
           return client(optionsIn.input, { signal, context: optionsIn.context })
         },
-        enabled: optionsIn.input !== skipToken,
+        enabled: optionsIn.input === skipToken ? false : undefined,
         ...optionsIn,
       }
     },
 
     experimental_streamedOptions(...[optionsIn = {} as any]) {
       return {
-        enabled: optionsIn.input !== skipToken,
+        enabled: optionsIn.input === skipToken ? false : undefined,
         queryKey: generateOperationKey(options.path, { type: 'streamed', input: optionsIn.input, fnOptions: optionsIn.queryFnOptions }),
         queryFn: experimental_streamedQuery({
           queryFn: async ({ signal }) => {
@@ -119,7 +119,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
 
           return client(optionsIn.input(pageParam as any), { signal, context: optionsIn.context as any })
         },
-        enabled: optionsIn.input !== skipToken,
+        enabled: optionsIn.input === skipToken ? false : undefined,
         ...(optionsIn as any),
       }
     },

--- a/packages/solid-query/src/types.ts
+++ b/packages/solid-query/src/types.ts
@@ -20,7 +20,7 @@ export interface QueryOptionsBase<TOutput, TError> {
   queryFn(ctx: QueryFunctionContext): Promise<TOutput>
   throwOnError?(error: TError): boolean // Help TQ infer TError
   retryDelay?: (count: number, error: TError) => number // Help TQ infer TError (suspense hooks)
-  enabled: boolean
+  enabled: boolean | undefined
 }
 
 type experimental_StreamedQueryOptions = Omit<Parameters<typeof streamedQuery>[0]['refetchMode'], 'queryFn'>
@@ -44,7 +44,7 @@ export interface InfiniteOptionsBase<TOutput, TError, TPageParam> {
   queryFn(ctx: QueryFunctionContext<QueryKey, TPageParam>): Promise<TOutput>
   throwOnError?(error: TError): boolean // Help TQ infer TError
   retryDelay?: (count: number, error: TError) => number // Help TQ infer TError (suspense hooks)
-  enabled: boolean
+  enabled: boolean | undefined
 }
 
 export type MutationOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TMutationContext>

--- a/packages/svelte-query/src/procedure-utils.test.tsx
+++ b/packages/svelte-query/src/procedure-utils.test.tsx
@@ -33,7 +33,7 @@ describe('createProcedureUtils', () => {
     it('without skipToken', async () => {
       const options = utils.queryOptions({ input: { search: '__search__' }, context: { batch: '__batch__' } })
 
-      expect(options.enabled).toBe(true)
+      expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
@@ -72,7 +72,7 @@ describe('createProcedureUtils', () => {
         queryFnOptions: { refetchMode: 'replace' },
       })
 
-      expect(options.enabled).toBe(true)
+      expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
@@ -130,7 +130,7 @@ describe('createProcedureUtils', () => {
         initialPageParam: '__initialPageParam__',
       })
 
-      expect(options.enabled).toBe(true)
+      expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)

--- a/packages/svelte-query/src/procedure-utils.ts
+++ b/packages/svelte-query/src/procedure-utils.ts
@@ -77,14 +77,14 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
 
           return client(optionsIn.input, { signal, context: optionsIn.context })
         },
-        enabled: optionsIn.input !== skipToken,
+        enabled: optionsIn.input === skipToken ? false : undefined,
         ...optionsIn,
       }
     },
 
     experimental_streamedOptions(...[optionsIn = {} as any]) {
       return {
-        enabled: optionsIn.input !== skipToken,
+        enabled: optionsIn.input === skipToken ? false : undefined,
         queryKey: generateOperationKey(options.path, { type: 'streamed', input: optionsIn.input, fnOptions: optionsIn.queryFnOptions }),
         queryFn: experimental_streamedQuery({
           queryFn: async ({ signal }) => {
@@ -119,7 +119,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
 
           return client(optionsIn.input(pageParam as any), { signal, context: optionsIn.context as any })
         },
-        enabled: optionsIn.input !== skipToken,
+        enabled: optionsIn.input === skipToken ? false : undefined,
         ...(optionsIn as any),
       }
     },

--- a/packages/svelte-query/src/types.ts
+++ b/packages/svelte-query/src/types.ts
@@ -20,7 +20,7 @@ export interface QueryOptionsBase<TOutput, TError> {
   queryFn(ctx: QueryFunctionContext): Promise<TOutput>
   throwOnError?(error: TError): boolean // Help TQ infer TError
   retryDelay?: (count: number, error: TError) => number // Help TQ infer TError (suspense hooks)
-  enabled: boolean
+  enabled: boolean | undefined
 }
 
 type experimental_StreamedQueryOptions = Omit<Parameters<typeof experimental_streamedQuery>[0], 'queryFn'>
@@ -44,7 +44,7 @@ export interface InfiniteOptionsBase<TOutput, TError, TPageParam> {
   queryFn(ctx: QueryFunctionContext<QueryKey, TPageParam>): Promise<TOutput>
   throwOnError?(error: TError): boolean // Help TQ infer TError
   retryDelay?: (count: number, error: TError) => number // Help TQ infer TError (suspense hooks)
-  enabled: boolean
+  enabled: boolean | undefined
 }
 
 export type MutationOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TMutationContext>

--- a/packages/tanstack-query/src/procedure-utils.test-d.ts
+++ b/packages/tanstack-query/src/procedure-utils.test-d.ts
@@ -148,7 +148,7 @@ describe('ProcedureUtils', () => {
         maxPages: number
         queryFn: QueryFunction<UtilsOutput>
         throwOnError?(error: UtilsError): boolean
-        enabled: boolean
+        enabled: boolean | undefined
       }>()
     })
 
@@ -281,7 +281,7 @@ describe('ProcedureUtils', () => {
         maxPages: number
         queryFn: QueryFunction<UtilsOutput>
         throwOnError?(error: UtilsError): boolean
-        enabled: boolean
+        enabled: boolean | undefined
       }>()
     })
 
@@ -410,7 +410,7 @@ describe('ProcedureUtils', () => {
         maxPages: number
         queryFn: QueryFunction<UtilsOutput[number]>
         throwOnError?(error: UtilsError): boolean
-        enabled: boolean
+        enabled: boolean | undefined
       }>()
     })
 
@@ -661,7 +661,7 @@ describe('ProcedureUtils', () => {
         maxPages: number
         queryFn: QueryFunction<UtilsOutput>
         throwOnError?(error: UtilsError): boolean
-        enabled: boolean
+        enabled: boolean | undefined
       }>()
     })
 

--- a/packages/tanstack-query/src/procedure-utils.test.ts
+++ b/packages/tanstack-query/src/procedure-utils.test.ts
@@ -46,7 +46,7 @@ describe('createProcedureUtils', () => {
     it('without skipToken', async () => {
       const options = utils.queryOptions({ input: { search: '__search__' }, context: { batch: '__batch__' } })
 
-      expect(options.enabled).toBe(true)
+      expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
@@ -97,7 +97,7 @@ describe('createProcedureUtils', () => {
         },
       })
 
-      expect(options.enabled).toBe(true)
+      expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
@@ -182,7 +182,7 @@ describe('createProcedureUtils', () => {
         context: { batch: '__batch__' },
       })
 
-      expect(options.enabled).toBe(true)
+      expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
@@ -268,7 +268,7 @@ describe('createProcedureUtils', () => {
         initialPageParam: '__initialPageParam__',
       })
 
-      expect(options.enabled).toBe(true)
+      expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)

--- a/packages/tanstack-query/src/procedure-utils.ts
+++ b/packages/tanstack-query/src/procedure-utils.ts
@@ -184,7 +184,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
             } satisfies OperationContext,
           })
         },
-        enabled: optionsIn.input !== skipToken,
+        enabled: optionsIn.input === skipToken ? false : undefined,
         ...optionsIn,
         queryKey,
       }
@@ -200,7 +200,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
       const queryKey = utils.experimental_streamedKey(optionsIn)
 
       return {
-        enabled: optionsIn.input !== skipToken,
+        enabled: optionsIn.input === skipToken ? false : undefined,
         queryFn: experimental_streamedQuery({
           queryFn: async ({ signal }) => {
             if (optionsIn.input === skipToken) {
@@ -241,7 +241,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
       const queryKey = utils.experimental_liveKey(optionsIn)
 
       return {
-        enabled: optionsIn.input !== skipToken,
+        enabled: optionsIn.input === skipToken ? false : undefined,
         queryFn: experimental_liveQuery(async ({ signal }) => {
           if (optionsIn.input === skipToken) {
             throw new Error('queryFn should not be called with skipToken used as input')
@@ -298,7 +298,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
             } as any,
           })
         },
-        enabled: optionsIn.input !== skipToken,
+        enabled: optionsIn.input === skipToken ? false : undefined,
         ...(optionsIn as any),
         queryKey,
       }

--- a/packages/tanstack-query/src/types.ts
+++ b/packages/tanstack-query/src/types.ts
@@ -50,7 +50,7 @@ export interface QueryOptionsBase<TOutput, TError> {
   queryFn: QueryFunction<TOutput>
   throwOnError?: (error: TError) => boolean // Help TQ infer TError
   retryDelay?: (count: number, error: TError) => number // Help TQ infer TError (suspense hooks)
-  enabled: boolean
+  enabled: boolean | undefined
 }
 
 export type experimental_StreamedKeyOptions<TInput>
@@ -75,7 +75,7 @@ export interface InfiniteOptionsBase<TOutput, TError, TPageParam> {
   select?(): InfiniteData<TOutput, TPageParam> // Help TQ infer TPageParam
   throwOnError?: (error: TError) => boolean // Help TQ infer TError
   retryDelay?: (count: number, error: TError) => number // Help TQ infer TError (suspense hooks)
-  enabled: boolean
+  enabled: boolean | undefined
 }
 
 export type MutationOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TMutationContext>

--- a/packages/vue-query/src/procedure-utils.test.ts
+++ b/packages/vue-query/src/procedure-utils.test.ts
@@ -34,7 +34,7 @@ describe('createProcedureUtils', () => {
     it('without skipToken', async () => {
       const options = utils.queryOptions({ input: computed(() => ({ search: ref('__search__') })), context: { batch: '__batch__' } })
 
-      expect(options.enabled.value).toBe(true)
+      expect(options.enabled.value).toBe(undefined)
 
       expect(options.queryKey.value).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
@@ -74,7 +74,7 @@ describe('createProcedureUtils', () => {
 
       input.value = computed(() => ({ search: ref('__search__') }))
 
-      expect(options.enabled.value).toBe(true)
+      expect(options.enabled.value).toBe(undefined)
 
       expect(options.queryKey.value).toBe(generateOperationKeySpy.mock.results[1]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(2)
@@ -102,7 +102,7 @@ describe('createProcedureUtils', () => {
         },
       })
 
-      expect(options.enabled.value).toBe(true)
+      expect(options.enabled.value).toBe(undefined)
 
       expect(options.queryKey.value).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
@@ -166,7 +166,7 @@ describe('createProcedureUtils', () => {
 
       input.value = computed(() => ({ search: ref('__search__') }))
 
-      expect(options.enabled.value).toBe(true)
+      expect(options.enabled.value).toBe(undefined)
 
       expect(options.queryKey.value).toBe(generateOperationKeySpy.mock.results[1]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(2)
@@ -206,7 +206,7 @@ describe('createProcedureUtils', () => {
         initialPageParam: '__initialPageParam__',
       })
 
-      expect(options.enabled.value).toBe(true)
+      expect(options.enabled.value).toBe(undefined)
 
       expect(options.queryKey.value).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
@@ -268,7 +268,7 @@ describe('createProcedureUtils', () => {
 
       input.value = (pageParam: any) => (computed(() => ({ search: '__search__', pageParam })))
 
-      expect(options.enabled.value).toBe(true)
+      expect(options.enabled.value).toBe(undefined)
 
       expect(options.queryKey.value).toBe(generateOperationKeySpy.mock.results[1]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(2)

--- a/packages/vue-query/src/procedure-utils.ts
+++ b/packages/vue-query/src/procedure-utils.ts
@@ -81,14 +81,14 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
 
           return client(input, { signal, context: unrefDeep(optionsIn.context) })
         },
-        enabled: computed(() => unrefDeep(optionsIn.input) !== skipToken),
+        enabled: computed(() => unrefDeep(optionsIn.input) === skipToken ? false : undefined),
         ...optionsIn,
       }
     },
 
     experimental_streamedOptions(...[optionsIn = {} as any]) {
       return {
-        enabled: computed(() => unrefDeep(optionsIn.input) !== skipToken),
+        enabled: computed(() => unrefDeep(optionsIn.input) === skipToken ? false : undefined),
         queryKey: computed(() => generateOperationKey(options.path, { type: 'streamed', input: unrefDeep(optionsIn.input), fnOptions: optionsIn.queryFnOptions })),
         queryFn: experimental_streamedQuery({
           queryFn: async ({ signal }) => {
@@ -131,7 +131,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
 
           return client(unrefDeep(input(pageParam as any) as any), { signal, context: unrefDeep(optionsIn.context) as any })
         },
-        enabled: computed(() => unrefDeep(optionsIn.input) !== skipToken),
+        enabled: computed(() => unrefDeep(optionsIn.input) === skipToken ? false : undefined),
         ...(optionsIn as any),
       }
     },

--- a/packages/vue-query/src/types.ts
+++ b/packages/vue-query/src/types.ts
@@ -33,7 +33,7 @@ export interface QueryOptionsBase<TOutput, TError> {
   queryFn(ctx: QueryFunctionContext): Promise<TOutput>
   throwOnError?(error: TError): boolean // Help TQ infer TError
   retryDelay?: (count: number, error: TError) => number // Help TQ infer TError (suspense hooks)
-  enabled: ComputedRef<boolean>
+  enabled: ComputedRef<boolean | undefined>
 }
 
 type experimental_StreamedQueryOptions = Omit<Parameters<typeof experimental_streamedQuery>[0], 'queryFn'>
@@ -65,7 +65,7 @@ export interface InfiniteOptionsBase<TOutput, TError, TPageParam> {
   queryFn(ctx: QueryFunctionContext<QueryKey, TPageParam>): Promise<TOutput>
   throwOnError?(error: TError): boolean // Help TQ infer TError
   retryDelay?: (count: number, error: TError) => number // Help TQ infer TError (suspense hooks)
-  enabled: ComputedRef<boolean>
+  enabled: ComputedRef<boolean | undefined>
 }
 
 export type MutationOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TMutationContext>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated query option utilities across all supported frameworks to set the `enabled` property to `false` when using `skipToken`, and to `undefined` otherwise.
  * Adjusted type definitions so that the `enabled` property can now be `boolean` or `undefined` instead of strictly `boolean`.
* **Tests**
  * Updated test cases to expect `enabled` as `undefined` (instead of `true`) when not using `skipToken`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->