### PR TITLE
fix(openapi): tsconfig erasableSyntaxOnly option not working

### DIFF
--- a/packages/json-schema-typed/.gitignore
+++ b/packages/json-schema-typed/.gitignore
@@ -1,0 +1,26 @@
+# Hidden folders and files
+.*
+!.gitignore
+!.*.example
+
+# Common generated folders
+logs/
+node_modules/
+out/
+dist/
+dist-ssr/
+build/
+coverage/
+temp/
+
+# Common generated files
+*.log
+*.log.*
+*.tsbuildinfo
+*.vitest-temp.json
+vite.config.ts.timestamp-*
+vitest.config.ts.timestamp-*
+
+# Common manual ignore files
+*.local
+*.pem

--- a/packages/json-schema-typed/README.md
+++ b/packages/json-schema-typed/README.md
@@ -1,0 +1,76 @@
+<div align="center">
+  <image align="center" src="https://orpc.unnoq.com/logo.webp" width=280 alt="oRPC logo" />
+</div>
+
+<h1></h1>
+
+<div align="center">
+  <a href="https://codecov.io/gh/unnoq/orpc">
+    <img alt="codecov" src="https://codecov.io/gh/unnoq/orpc/branch/main/graph/badge.svg">
+  </a>
+  <a href="https://www.npmjs.com/package/@orpc/json-schema-typed">
+    <img alt="weekly downloads" src="https://img.shields.io/npm/dw/%40orpc%2Fjson-schema-typed?logo=npm" />
+  </a>
+  <a href="https://github.com/unnoq/orpc/blob/main/LICENSE">
+    <img alt="MIT License" src="https://img.shields.io/github/license/unnoq/orpc?logo=open-source-initiative" />
+  </a>
+  <a href="https://discord.gg/TXEbwRBvQn">
+    <img alt="Discord" src="https://img.shields.io/discord/1308966753044398161?color=7389D8&label&logo=discord&logoColor=ffffff" />
+  </a>
+</div>
+
+<h3 align="center">Typesafe APIs Made Simple 🪄</h3>
+
+**oRPC is a powerful combination of RPC and OpenAPI**, makes it easy to build APIs that are end-to-end type-safe and adhere to OpenAPI standards
+
+---
+
+## Highlights
+
+- **🔗 End-to-End Type Safety**: Ensure type-safe inputs, outputs, and errors from client to server.
+- **📘 First-Class OpenAPI**: Built-in support that fully adheres to the OpenAPI standard.
+- **📝 Contract-First Development**: Optionally define your API contract before implementation.
+- **⚙️ Framework Integrations**: Seamlessly integrate with TanStack Query (React, Vue, Solid, Svelte, Angular), Pinia Colada, and more.
+- **🚀 Server Actions**: Fully compatible with React Server Actions on Next.js, TanStack Start, and other platforms.
+- **🔠 Standard Schema Support**: Works out of the box with Zod, Valibot, ArkType, and other schema validators.
+- **🗃️ Native Types**: Supports native types like Date, File, Blob, BigInt, URL, and more.
+- **⏱️ Lazy Router**: Enhance cold start times with our lazy routing feature.
+- **📡 SSE & Streaming**: Enjoy full type-safe support for SSE and streaming.
+- **🌍 Multi-Runtime Support**: Fast and lightweight on Cloudflare, Deno, Bun, Node.js, and beyond.
+- **🔌 Extendability**: Easily extend functionality with plugins, middleware, and interceptors.
+- **🛡️ Reliability**: Well-tested, TypeScript-based, production-ready, and MIT licensed.
+
+## Documentation
+
+You can find the full documentation [here](https://orpc.unnoq.com).
+
+## Packages
+
+- [@orpc/contract](https://www.npmjs.com/package/@orpc/contract): Build your API contract.
+- [@orpc/server](https://www.npmjs.com/package/@orpc/server): Build your API or implement API contract.
+- [@orpc/client](https://www.npmjs.com/package/@orpc/client): Consume your API on the client with type-safety.
+- [@orpc/openapi](https://www.npmjs.com/package/@orpc/openapi): Generate OpenAPI specs and handle OpenAPI requests.
+- [@orpc/nest](https://www.npmjs.com/package/@orpc/nest): Deeply integrate oRPC with [NestJS](https://nestjs.com/).
+- [@orpc/react](https://www.npmjs.com/package/@orpc/react): Utilities for integrating oRPC with React and React Server Actions.
+- [@orpc/tanstack-query](https://www.npmjs.com/package/@orpc/tanstack-query): [TanStack Query](https://tanstack.com/query/latest) integration.
+- [@orpc/vue-colada](https://www.npmjs.com/package/@orpc/vue-colada): Integration with [Pinia Colada](https://pinia-colada.esm.dev/).
+- [@orpc/hey-api](https://www.npmjs.com/package/@orpc/hey-api): [Hey API](https://heyapi.dev/) integration.
+- [@orpc/zod](https://www.npmjs.com/package/@orpc/zod): More schemas that [Zod](https://zod.dev/) doesn't support yet.
+- [@orpc/valibot](https://www.npmjs.com/package/@orpc/valibot): OpenAPI spec generation from [Valibot](https://valibot.dev/).
+- [@orpc/arktype](https://www.npmjs.com/package/@orpc/arktype): OpenAPI spec generation from [ArkType](https://arktype.io/).
+
+## `@orpc/json-schema-typed`
+
+Re-export of [json-schema-typed](https://www.npmjs.com/package/json-schema-typed) due to the upstream issue [RemyRylan/json-schema-typed#116](https://github.com/RemyRylan/json-schema-typed/issues/116).
+
+## Sponsors
+
+<p align="center">
+  <a href="https://cdn.jsdelivr.net/gh/unnoq/unnoq/sponsors.svg">
+    <img src='https://cdn.jsdelivr.net/gh/unnoq/unnoq/sponsors.svg'/>
+  </a>
+</p>
+
+## License
+
+Distributed under the MIT License. See [LICENSE](https://github.com/unnoq/orpc/blob/main/LICENSE) for more information.

--- a/packages/json-schema-typed/build.config.ts
+++ b/packages/json-schema-typed/build.config.ts
@@ -1,0 +1,7 @@
+import { defineBuildConfig } from 'unbuild'
+
+export default defineBuildConfig({
+  rollup: {
+    inlineDependencies: ['json-schema-typed'],
+  },
+})

--- a/packages/json-schema-typed/package.json
+++ b/packages/json-schema-typed/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@orpc/json-schema-typed",
+  "type": "module",
+  "version": "0.0.0",
+  "license": "MIT",
+  "homepage": "https://orpc.unnoq.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unnoq/orpc.git",
+    "directory": "packages/json-schema-typed"
+  },
+  "keywords": [
+    "unnoq",
+    "orpc"
+  ],
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.mjs"
+      },
+      "./draft-07": {
+        "types": "./dist/draft-07.d.mts",
+        "import": "./dist/draft-07.mjs",
+        "default": "./dist/draft-07.mjs"
+      },
+      "./draft-2019-09": {
+        "types": "./dist/draft-2019-09.d.mts",
+        "import": "./dist/draft-2019-09.mjs",
+        "default": "./dist/draft-2019-09.mjs"
+      },
+      "./draft-2020-12": {
+        "types": "./dist/draft-2020-12.d.mts",
+        "import": "./dist/draft-2020-12.mjs",
+        "default": "./dist/draft-2020-12.mjs"
+      }
+    }
+  },
+  "exports": {
+    ".": "./src/index.ts",
+    "./draft-07": "./src/draft-07.ts",
+    "./draft-2019-09": "./src/draft-2019-09.ts",
+    "./draft-2020-12": "./src/draft-2020-12.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "unbuild",
+    "build:watch": "pnpm run build --watch",
+    "type:check": "tsc -b"
+  },
+  "devDependencies": {
+    "json-schema-typed": "^8.0.1"
+  }
+}

--- a/packages/json-schema-typed/src/draft-07.ts
+++ b/packages/json-schema-typed/src/draft-07.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-imports
+export * from 'json-schema-typed/draft-07'

--- a/packages/json-schema-typed/src/draft-2019-09.ts
+++ b/packages/json-schema-typed/src/draft-2019-09.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-imports
+export * from 'json-schema-typed/draft-2019-09'

--- a/packages/json-schema-typed/src/draft-2020-12.ts
+++ b/packages/json-schema-typed/src/draft-2020-12.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-imports
+export * from 'json-schema-typed/draft-2020-12'

--- a/packages/json-schema-typed/src/index.ts
+++ b/packages/json-schema-typed/src/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-restricted-imports
+export * from 'json-schema-typed'

--- a/packages/json-schema-typed/tsconfig.json
+++ b/packages/json-schema-typed/tsconfig.json
@@ -1,12 +1,5 @@
 {
   "extends": "../../tsconfig.lib.json",
-  "references": [
-    { "path": "../shared" },
-    { "path": "../server" },
-    { "path": "../openapi" },
-    { "path": "../contract" },
-    { "path": "../json-schema-typed" }
-  ],
   "include": ["src"],
   "exclude": [
     "**/*.test.*",

--- a/packages/json-schema/package.json
+++ b/packages/json-schema/package.json
@@ -35,10 +35,10 @@
   },
   "dependencies": {
     "@orpc/contract": "workspace:*",
+    "@orpc/json-schema-typed": "workspace:*",
     "@orpc/openapi": "workspace:*",
     "@orpc/server": "workspace:*",
-    "@orpc/shared": "workspace:*",
-    "json-schema-typed": "^8.0.1"
+    "@orpc/shared": "workspace:*"
   },
   "devDependencies": {
     "zod": "^4.0.14"

--- a/packages/json-schema/src/types.ts
+++ b/packages/json-schema/src/types.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-imports */
-import type * as Draft07 from 'json-schema-typed/draft-07'
-import type * as Draft2019 from 'json-schema-typed/draft-2019-09'
-import type * as Draft2020 from 'json-schema-typed/draft-2020-12'
+import type * as Draft07 from '@orpc/json-schema-typed/draft-07'
+import type * as Draft2019 from '@orpc/json-schema-typed/draft-2019-09'
+import type * as Draft2020 from '@orpc/json-schema-typed/draft-2020-12'
 
 export type JsonSchema
   = | Draft2020.JSONSchema

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -66,11 +66,11 @@
   "dependencies": {
     "@orpc/client": "workspace:*",
     "@orpc/contract": "workspace:*",
+    "@orpc/json-schema-typed": "workspace:*",
     "@orpc/openapi-client": "workspace:*",
     "@orpc/server": "workspace:*",
     "@orpc/shared": "workspace:*",
     "@orpc/standard-server": "workspace:*",
-    "json-schema-typed": "^8.0.1",
     "rou3": "^0.7.3"
   },
   "devDependencies": {

--- a/packages/openapi/src/schema.ts
+++ b/packages/openapi/src/schema.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-imports */
-import type { JSONSchema, keywords } from 'json-schema-typed/draft-2020-12'
-import { ContentEncoding as JSONSchemaContentEncoding, Format as JSONSchemaFormat, TypeName as JSONSchemaTypeName } from 'json-schema-typed/draft-2020-12'
+import type { JSONSchema, keywords } from '@orpc/json-schema-typed/draft-2020-12'
+import { ContentEncoding as JSONSchemaContentEncoding, Format as JSONSchemaFormat, TypeName as JSONSchemaTypeName } from '@orpc/json-schema-typed/draft-2020-12'
 
 export { JSONSchemaContentEncoding, JSONSchemaFormat, JSONSchemaTypeName }
 export type { JSONSchema }

--- a/packages/openapi/tsconfig.json
+++ b/packages/openapi/tsconfig.json
@@ -6,6 +6,7 @@
     { "path": "../contract" },
     { "path": "../server" },
     { "path": "../standard-server" },
+    { "path": "../json-schema-typed" },
     { "path": "../shared" }
   ],
   "include": ["src"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -318,6 +318,9 @@ importers:
       '@orpc/contract':
         specifier: workspace:*
         version: link:../contract
+      '@orpc/json-schema-typed':
+        specifier: workspace:*
+        version: link:../json-schema-typed
       '@orpc/openapi':
         specifier: workspace:*
         version: link:../openapi
@@ -327,13 +330,16 @@ importers:
       '@orpc/shared':
         specifier: workspace:*
         version: link:../shared
-      json-schema-typed:
-        specifier: ^8.0.1
-        version: 8.0.1
     devDependencies:
       zod:
         specifier: ^4.0.14
         version: 4.0.14
+
+  packages/json-schema-typed:
+    devDependencies:
+      json-schema-typed:
+        specifier: ^8.0.1
+        version: 8.0.1
 
   packages/nest:
     dependencies:
@@ -407,6 +413,9 @@ importers:
       '@orpc/contract':
         specifier: workspace:*
         version: link:../contract
+      '@orpc/json-schema-typed':
+        specifier: workspace:*
+        version: link:../json-schema-typed
       '@orpc/openapi-client':
         specifier: workspace:*
         version: link:../openapi-client
@@ -419,9 +428,6 @@ importers:
       '@orpc/standard-server':
         specifier: workspace:*
         version: link:../standard-server
-      json-schema-typed:
-        specifier: ^8.0.1
-        version: 8.0.1
       rou3:
         specifier: ^0.7.3
         version: 0.7.3


### PR DESCRIPTION
related: [RemyRylan/json-schema-typed#116](https://github.com/RemyRylan/json-schema-typed/issues/116)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the `@orpc/json-schema-typed` package, providing re-exports for multiple JSON Schema draft versions under the oRPC namespace.

* **Documentation**
  * Added a comprehensive README for `@orpc/json-schema-typed`, highlighting features, usage, and related packages.

* **Chores**
  * Updated dependencies in related packages to use `@orpc/json-schema-typed` instead of the external `json-schema-typed`.
  * Added build configuration, TypeScript setup, and `.gitignore` for the new package.
  * Updated TypeScript project references in dependent packages to include the new package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->