### PR TITLE
feat(server): allow RPC calls without data

### DIFF
--- a/apps/content/docs/advanced/rpc-protocol.md
+++ b/apps/content/docs/advanced/rpc-protocol.md
@@ -12,10 +12,10 @@ The RPC protocol enables remote procedure calls over HTTP using JSON, supporting
 The procedure to call is determined by the `pathname`.
 
 ```bash
-curl https://example.com/rpc/planet/create?data={}
+curl https://example.com/rpc/planet/create
 ```
 
-This example calls the `planet.create` procedure, with `/rpc` as the prefix. `?data={}` is the minimum required to indicate a valid GET RPC request with `undefined` input.
+This example calls the `planet.create` procedure, with `/rpc` as the prefix:
 
 ```ts
 const router = {

--- a/packages/client/src/adapters/standard/rpc-serializer.test.ts
+++ b/packages/client/src/adapters/standard/rpc-serializer.test.ts
@@ -193,3 +193,8 @@ describe('standardRPCSerializer: event iterator', async () => {
     })
   })
 })
+
+it('standardRPCSerializer support deserialize undefined data', () => {
+  const serializer = new StandardRPCSerializer(new StandardRPCJsonSerializer())
+  expect(serializer.deserialize(undefined)).toEqual(undefined)
+})

--- a/packages/client/src/adapters/standard/rpc-serializer.ts
+++ b/packages/client/src/adapters/standard/rpc-serializer.ts
@@ -78,6 +78,16 @@ export class StandardRPCSerializer {
   }
 
   #deserialize(data: any): unknown {
+    /**
+     * Only deserializing undefined is supported, while the return of serialize(undefined) is always an object.
+     * This is for supporting calling RPC endpoints without arguments.
+     *
+     * @todo Consider supporting serialize(undefined) -> undefined in the future
+     */
+    if (data === undefined) {
+      return undefined
+    }
+
     if (!(data instanceof FormData)) {
       return this.jsonSerializer.deserialize(data.json, data.meta ?? [])
     }


### PR DESCRIPTION
- underline rpc serializer support deserialize `undefined` data
- any serializer should accept `undefined` as valid deserialize data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * RPC calls with no input are now handled correctly during deserialization, preventing errors when invoking endpoints without parameters.

* **Documentation**
  * Updated RPC protocol docs: clarified routing example and replaced the previous GET-parameter example with a concise router-based example.

* **Tests**
  * Added unit tests to cover deserialization of undefined input, improving confidence in behavior for parameter-less RPC endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->