### PR TITLE
feat(server): Compression Plugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
           - '@antfu/eslint-config'
           - 'eslint-plugin-*'
           - '@hey-api/*'
+          - compression # inline dependency
         update-types:
           - minor
           - patch

--- a/apps/content/.vitepress/config.ts
+++ b/apps/content/.vitepress/config.ts
@@ -141,6 +141,7 @@ export default withMermaid(defineConfig({
             { text: 'Dedupe Requests', link: '/docs/plugins/dedupe-requests' },
             { text: 'Batch Requests', link: '/docs/plugins/batch-requests' },
             { text: 'Client Retry', link: '/docs/plugins/client-retry' },
+            { text: 'Compression', link: '/docs/plugins/compression' },
             { text: 'Body Limit', link: '/docs/plugins/body-limit' },
             { text: 'Simple CSRF Protection', link: '/docs/plugins/simple-csrf-protection' },
             { text: 'Strict GET method', link: '/docs/plugins/strict-get-method' },

--- a/apps/content/docs/plugins/body-limit.md
+++ b/apps/content/docs/plugins/body-limit.md
@@ -29,3 +29,7 @@ const handler = new RPCHandler(router, {
   ],
 })
 ```
+
+::: info
+The `handler` can be any supported oRPC handler, such as [RPCHandler](/docs/rpc-handler), [OpenAPIHandler](/docs/openapi/openapi-handler), or another custom handler.
+:::

--- a/apps/content/docs/plugins/compression.md
+++ b/apps/content/docs/plugins/compression.md
@@ -1,6 +1,6 @@
 ---
 title: Compression Plugin
-description: A plugin for oRPC that compresses request and response bodies.
+description: A plugin for oRPC that compresses response bodies.
 ---
 
 # Compression Plugin

--- a/apps/content/docs/plugins/compression.md
+++ b/apps/content/docs/plugins/compression.md
@@ -13,6 +13,7 @@ Depending on your adapter, import the corresponding plugin:
 
 ```ts
 import { CompressionPlugin } from '@orpc/server/node'
+import { CompressionPlugin } from '@orpc/server/fetch'
 ```
 
 ## Setup

--- a/apps/content/docs/plugins/compression.md
+++ b/apps/content/docs/plugins/compression.md
@@ -1,0 +1,32 @@
+---
+title: Compression Plugin
+description: A plugin for oRPC that compresses request and response bodies.
+---
+
+# Compression Plugin
+
+The **Compression Plugin** compresses response bodies to reduce bandwidth usage and improve performance.
+
+## Import
+
+Depending on your adapter, import the corresponding plugin:
+
+```ts
+import { CompressionPlugin } from '@orpc/server/node'
+```
+
+## Setup
+
+Add the plugin to your handler configuration:
+
+```ts
+const handler = new RPCHandler(router, {
+  plugins: [
+    new CompressionPlugin(),
+  ],
+})
+```
+
+::: info
+The `handler` can be any supported oRPC handler, such as [RPCHandler](/docs/rpc-handler), [OpenAPIHandler](/docs/openapi/openapi-handler), or another custom handler.
+:::

--- a/packages/server/build.config.ts
+++ b/packages/server/build.config.ts
@@ -1,0 +1,5 @@
+import { defineBuildConfig } from 'unbuild'
+
+export default defineBuildConfig({
+  failOnWarn: false,
+})

--- a/packages/server/build.config.ts
+++ b/packages/server/build.config.ts
@@ -1,5 +1,9 @@
 import { defineBuildConfig } from 'unbuild'
 
 export default defineBuildConfig({
+  /**
+   * Disable warnings as errors because we need to inline the `compression` package,
+   * which is not ESModule-friendly.
+   */
   failOnWarn: false,
 })

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -132,6 +132,8 @@
     "@orpc/standard-server-fetch": "workspace:*",
     "@orpc/standard-server-node": "workspace:*",
     "@orpc/standard-server-peer": "workspace:*",
+    "@types/compression": "^1.8.1",
+    "compression": "^1.8.1",
     "cookie": "^1.0.2"
   },
   "devDependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -132,12 +132,12 @@
     "@orpc/standard-server-fetch": "workspace:*",
     "@orpc/standard-server-node": "workspace:*",
     "@orpc/standard-server-peer": "workspace:*",
-    "@types/compression": "^1.8.1",
-    "compression": "^1.8.1",
     "cookie": "^1.0.2"
   },
   "devDependencies": {
+    "@types/compression": "^1.8.1",
     "@types/ws": "^8.18.1",
+    "compression": "^1.8.1",
     "crossws": "^0.4.1",
     "next": "^15.4.5",
     "supertest": "^7.1.4",

--- a/packages/server/src/adapters/fetch/compression-plugin.test.ts
+++ b/packages/server/src/adapters/fetch/compression-plugin.test.ts
@@ -515,6 +515,6 @@ describe('compressionPlugin', () => {
     await expect(response?.text()).resolves.toContain(largeText)
     expect(response?.headers.has('content-encoding')).toBe(false)
 
-    expect(filter).toHaveBeenCalledWith(response, expect.any(Request))
+    expect(filter).toHaveBeenCalledWith(expect.any(Request), response)
   })
 })

--- a/packages/server/src/adapters/fetch/compression-plugin.test.ts
+++ b/packages/server/src/adapters/fetch/compression-plugin.test.ts
@@ -1,0 +1,520 @@
+import { os } from '../../builder'
+import { CompressionPlugin } from './compression-plugin'
+import { RPCHandler } from './rpc-handler'
+
+describe('compressionPlugin', () => {
+  const largeText = 'x'.repeat(2000) // 2KB of text, above default threshold
+  const smallText = 'small response' // Small text, below threshold
+
+  it('should not compress response when no accept-encoding header', async () => {
+    const handler = new RPCHandler(os.handler(() => 'output'), {
+      plugins: [
+        new CompressionPlugin(),
+      ],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({}),
+    }))
+
+    await expect(response?.text()).resolves.toContain('output')
+    expect(response?.headers.has('content-encoding')).toBe(false)
+    expect(response?.status).toBe(200)
+  })
+
+  it('should compress response with gzip when client accepts it', async () => {
+    const handler = new RPCHandler(os.handler(() => 'output'), {
+      plugins: [
+        new CompressionPlugin(),
+      ],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'accept-encoding': 'gzip, deflate',
+      },
+      body: JSON.stringify({}),
+    }))
+
+    expect(response?.headers.get('content-encoding')).toBe('gzip')
+    expect(response?.status).toBe(200)
+
+    // Verify the response can be decompressed
+    const decompressed = response?.body?.pipeThrough(new DecompressionStream('gzip'))
+    const text = await new Response(decompressed).text()
+    expect(text).toContain('output')
+  })
+
+  it('should compress response with deflate when client accepts it', async () => {
+    const handler = new RPCHandler(os.handler(() => largeText), {
+      plugins: [
+        new CompressionPlugin(),
+      ],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'accept-encoding': 'deflate',
+      },
+      body: JSON.stringify({}),
+    }))
+
+    expect(response?.headers.get('content-encoding')).toBe('deflate')
+    expect(response?.status).toBe(200)
+
+    // Verify the response can be decompressed
+    const decompressed = response?.body?.pipeThrough(new DecompressionStream('deflate'))
+    const text = await new Response(decompressed).text()
+    expect(text).toContain(largeText)
+  })
+
+  it('should prefer gzip over deflate when both are supported', async () => {
+    const handler = new RPCHandler(os.handler(() => largeText), {
+      plugins: [
+        new CompressionPlugin(),
+      ],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'accept-encoding': 'deflate, gzip',
+      },
+      body: JSON.stringify({}),
+    }))
+
+    expect(response?.headers.get('content-encoding')).toBe('gzip')
+  })
+
+  it('should respect custom encoding order', async () => {
+    const handler = new RPCHandler(os.handler(() => largeText), {
+      plugins: [
+        new CompressionPlugin({ encodings: ['deflate', 'gzip'] }),
+      ],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'accept-encoding': 'gzip, deflate',
+      },
+      body: JSON.stringify({}),
+    }))
+
+    expect(response?.headers.get('content-encoding')).toBe('deflate')
+  })
+
+  it('should not compress response below threshold', async () => {
+    const handler = new RPCHandler(os.handler(() => 'output'), {
+      plugins: [
+        new CompressionPlugin({ threshold: 1024 }),
+      ],
+      interceptors: [
+        async (options) => {
+          const result = await options.next()
+
+          if (!result.matched) {
+            return result
+          }
+
+          return {
+            ...result,
+            response: {
+              ...result.response,
+              body: new Blob([smallText], { type: 'text/plain' }),
+            },
+          }
+        },
+      ],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'accept-encoding': 'gzip',
+        'content-length': smallText.length.toString(),
+      },
+      body: JSON.stringify({}),
+    }))
+
+    await expect(response?.text()).resolves.toContain(smallText)
+    expect(response?.headers.has('content-encoding')).toBe(false)
+  })
+
+  it('should compress response above custom threshold', async () => {
+    const handler = new RPCHandler(os.handler(() => 'output'), {
+      strictGetMethodPluginEnabled: false,
+      plugins: [
+        new CompressionPlugin({ threshold: 1024 }),
+      ],
+      interceptors: [
+        async (options) => {
+          const result = await options.next()
+
+          if (!result.matched) {
+            return result
+          }
+
+          return {
+            ...result,
+            response: {
+              ...result.response,
+              body: new Blob([largeText], { type: 'text/plain' }),
+            },
+          }
+        },
+      ],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'accept-encoding': 'gzip',
+      },
+      body: JSON.stringify({}),
+    }))
+
+    expect(response?.headers.get('content-encoding')).toBe('gzip')
+  })
+
+  it('should not compress when response already has content-encoding', async () => {
+    const handler = new RPCHandler(os.handler(() => 'output'), {
+      strictGetMethodPluginEnabled: false,
+      plugins: [
+        new CompressionPlugin(),
+      ],
+      interceptors: [
+        async (options) => {
+          const result = await options.next()
+
+          if (!result.matched) {
+            return result
+          }
+
+          return {
+            ...result,
+            response: {
+              ...result.response,
+              headers: {
+                ...result.response.headers,
+                'content-encoding': 'br',
+              },
+              body: new Blob([largeText], { type: 'text/plain' }),
+            },
+          }
+        },
+      ],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'accept-encoding': 'gzip',
+      },
+      body: JSON.stringify({}),
+    }))
+
+    await expect(response?.text()).resolves.toBe(largeText)
+    expect(response?.headers.get('content-encoding')).toBe('br')
+  })
+
+  it('should not compress when response has transfer-encoding', async () => {
+    const handler = new RPCHandler(os.handler(() => 'output'), {
+      strictGetMethodPluginEnabled: false,
+      plugins: [
+        new CompressionPlugin(),
+      ],
+      interceptors: [
+        async (options) => {
+          const result = await options.next()
+
+          if (!result.matched) {
+            return result
+          }
+
+          return {
+            ...result,
+            response: {
+              ...result.response,
+              headers: {
+                ...result.response.headers,
+                'transfer-encoding': 'chunked',
+              },
+              body: new Blob([largeText], { type: 'text/plain' }),
+            },
+          }
+        },
+      ],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'accept-encoding': 'gzip',
+      },
+      body: JSON.stringify({}),
+    }))
+
+    await expect(response?.text()).resolves.toBe(largeText)
+    expect(response?.headers.has('content-encoding')).toBe(false)
+  })
+
+  it('should not compress when response has no body', async () => {
+    const handler = new RPCHandler(os.handler(() => 'output'), {
+      strictGetMethodPluginEnabled: false,
+      plugins: [
+        new CompressionPlugin(),
+      ],
+      interceptors: [
+        async (options) => {
+          const result = await options.next()
+
+          if (!result.matched) {
+            return result
+          }
+
+          return {
+            ...result,
+            response: {
+              ...result.response,
+              status: 204,
+              body: undefined,
+            },
+          }
+        },
+      ],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'accept-encoding': 'gzip',
+      },
+      body: JSON.stringify({}),
+    }))
+
+    expect(response?.body).toBe(null)
+    expect(response?.headers.has('content-encoding')).toBe(false)
+    expect(response?.status).toBe(204)
+  })
+
+  it('should not compress non-compressible content types', async () => {
+    const handler = new RPCHandler(os.handler(() => 'output'), {
+      plugins: [
+        new CompressionPlugin(),
+      ],
+      interceptors: [
+        async (options) => {
+          const result = await options.next()
+
+          if (!result.matched) {
+            return result
+          }
+
+          return {
+            ...result,
+            response: {
+              ...result.response,
+              body: new Blob([largeText], { type: 'image/jpeg' }),
+            },
+          }
+        },
+      ],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'accept-encoding': 'gzip',
+      },
+      body: JSON.stringify({}),
+    }))
+
+    await expect(response?.text()).resolves.toBe(largeText)
+    expect(response?.headers.has('content-encoding')).toBe(false)
+  })
+
+  it.each([
+    'text/plain',
+    'text/html',
+    'application/json',
+    'application/javascript',
+    'application/xml',
+    'font/otf',
+    'application/vnd.ms-fontobject',
+  ])('should compress compressible content types: %s', async (contentType) => {
+    const handler = new RPCHandler(os.handler(() => 'output'), {
+      plugins: [
+        new CompressionPlugin(),
+      ],
+      interceptors: [
+        async (options) => {
+          const result = await options.next()
+
+          if (!result.matched) {
+            return result
+          }
+
+          return {
+            ...result,
+            response: {
+              ...result.response,
+              body: new Blob([largeText], { type: contentType }),
+            },
+          }
+        },
+      ],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'accept-encoding': 'gzip',
+      },
+      body: JSON.stringify({}),
+    }))
+
+    expect(response?.headers.get('content-encoding')).toBe('gzip')
+    expect(response?.headers.get('content-type')).toBe(contentType)
+    expect(response?.headers.get('content-length')).toBeNull() // CompressionStream changes content length
+  })
+
+  it('should not compress when cache-control has no-transform', async () => {
+    const handler = new RPCHandler(os.handler(() => 'output'), {
+      plugins: [
+        new CompressionPlugin(),
+      ],
+      interceptors: [
+        async (options) => {
+          const result = await options.next()
+
+          if (!result.matched) {
+            return result
+          }
+
+          return {
+            ...result,
+            response: {
+              ...result.response,
+              headers: {
+                ...result.response.headers,
+                'cache-control': 'no-cache, no-transform, max-age=0',
+              },
+              body: new Blob([largeText], { type: 'text/plain' }),
+            },
+          }
+        },
+      ],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'accept-encoding': 'gzip',
+      },
+      body: JSON.stringify({}),
+    }))
+
+    await expect(response?.text()).resolves.toBe(largeText)
+    expect(response?.headers.has('content-encoding')).toBe(false)
+  })
+
+  it('should compress when response has unknown content-length', async () => {
+    const handler = new RPCHandler(os.handler(() => largeText), {
+      plugins: [
+        new CompressionPlugin({ threshold: 1024 }),
+      ],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'accept-encoding': 'gzip',
+      },
+      body: JSON.stringify({}),
+    }))
+
+    expect(response?.headers.get('content-encoding')).toBe('gzip')
+  })
+
+  it('should not compress when no matching encoding is found', async () => {
+    const handler = new RPCHandler(os.handler(() => largeText), {
+      strictGetMethodPluginEnabled: false,
+      plugins: [
+        new CompressionPlugin({ encodings: ['gzip'] }),
+      ],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'accept-encoding': 'br, compress',
+      },
+      body: JSON.stringify({}),
+    }))
+
+    await expect(response?.text()).resolves.toContain(largeText)
+    expect(response?.headers.has('content-encoding')).toBe(false)
+  })
+
+  it('should handle non-matched routes without compression', async () => {
+    const handler = new RPCHandler(os.handler(() => 'ping'), {
+      strictGetMethodPluginEnabled: false,
+      plugins: [
+        new CompressionPlugin(),
+      ],
+    })
+
+    // Simulate a non-matched route by using a request that doesn't match
+    const { matched, response } = await handler.handle(new Request('https://example.com/nonexistent'))
+
+    expect(matched).toBe(false)
+    expect(response).toBeUndefined()
+  })
+
+  it('should not compress when custom filter returns false', async () => {
+    const filter = vi.fn(() => false)
+
+    const handler = new RPCHandler(os.handler(() => largeText), {
+      plugins: [
+        new CompressionPlugin({
+          filter,
+        }),
+      ],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'accept-encoding': 'gzip',
+      },
+      body: JSON.stringify({}),
+    }))
+
+    await expect(response?.text()).resolves.toContain(largeText)
+    expect(response?.headers.has('content-encoding')).toBe(false)
+
+    expect(filter).toHaveBeenCalledWith(response, expect.any(Request))
+  })
+})

--- a/packages/server/src/adapters/fetch/compression-plugin.ts
+++ b/packages/server/src/adapters/fetch/compression-plugin.ts
@@ -82,7 +82,11 @@ export class CompressionPlugin<T extends Context> implements FetchHandlerPlugin<
         return result
       }
 
-      const acceptEncoding = options.request.headers.get('accept-encoding')
+      const acceptEncoding = options.request.headers
+        .get('accept-encoding')
+        ?.split(',')
+        .map(enc => enc.trim().split(';')[0]!)
+
       const encoding = this.encodings.find(enc => acceptEncoding?.includes(enc))
 
       if (!response.body || encoding === undefined) {

--- a/packages/server/src/adapters/fetch/compression-plugin.ts
+++ b/packages/server/src/adapters/fetch/compression-plugin.ts
@@ -32,7 +32,7 @@ export interface CompressionPluginOptions {
    * This function is called in addition to the default compression checks
    * and allows for custom compression logic based on the request and response.
    */
-  filter?: (response: Response, request: Request) => boolean
+  filter?: (request: Request, response: Response) => boolean
 }
 
 /**
@@ -93,7 +93,7 @@ export class CompressionPlugin<T extends Context> implements FetchHandlerPlugin<
         return result
       }
 
-      if (this.filter && !this.filter(response, options.request)) {
+      if (this.filter && !this.filter(options.request, response)) {
         return result
       }
 

--- a/packages/server/src/adapters/fetch/compression-plugin.ts
+++ b/packages/server/src/adapters/fetch/compression-plugin.ts
@@ -1,0 +1,132 @@
+/**
+ * This plugin is heavily inspired by the [Hono Compression Plugin](https://github.com/honojs/hono/blob/main/src/middleware/compress/index.ts)
+ */
+
+import type { Context } from '../../context'
+import type { FetchHandlerOptions } from './handler'
+import type { FetchHandlerPlugin } from './plugin'
+
+const ORDERED_SUPPORTED_ENCODINGS = ['gzip', 'deflate'] as const
+
+export interface CompressionPluginOptions {
+  /**
+   * The compression schemes to use for response compression.
+   * Schemes are prioritized by their order in this array and
+   * only applied if the client supports them.
+   *
+   * @default ['gzip', 'deflate']
+   */
+  encodings?: readonly (typeof ORDERED_SUPPORTED_ENCODINGS)[number][]
+
+  /**
+   * The minimum response size in bytes required to trigger compression.
+   * Responses smaller than this threshold will not be compressed to avoid overhead.
+   * If the response size cannot be determined, compression will still be applied.
+   *
+   * @default 1024 (1KB)
+   */
+  threshold?: number
+
+  /**
+   * A filter function to determine if a response should be compressed.
+   * This function is called in addition to the default compression checks
+   * and allows for custom compression logic based on the request and response.
+   */
+  filter?: (response: Response, request: Request) => boolean
+}
+
+/**
+ * The Compression Plugin adds response compression to the Fetch Server.
+ * Build on top of [CompressionStream](https://developer.mozilla.org/en-US/docs/Web/API/CompressionStream)
+ * You might need to polyfill it if your environment does not support it.
+ *
+ * @see {@link https://orpc.unnoq.com/docs/plugins/compression Compression Plugin Docs}
+ */
+export class CompressionPlugin<T extends Context> implements FetchHandlerPlugin<T> {
+  private readonly encodings: Exclude<CompressionPluginOptions['encodings'], undefined>
+  private readonly threshold: Exclude<CompressionPluginOptions['threshold'], undefined>
+  private readonly filter: CompressionPluginOptions['filter']
+
+  constructor(options: CompressionPluginOptions = {}) {
+    this.encodings = options.encodings ?? ORDERED_SUPPORTED_ENCODINGS
+    this.threshold = options.threshold ?? 1024
+    this.filter = options.filter
+  }
+
+  initRuntimeAdapter(options: FetchHandlerOptions<T>): void {
+    options.adapterInterceptors ??= []
+
+    /**
+     * use `unshift` to ensure this runs before user-defined adapter interceptors
+     */
+    options.adapterInterceptors.unshift(async (options) => {
+      const result = await options.next()
+
+      if (!result.matched) {
+        return result
+      }
+
+      const response = result.response
+
+      if (
+        response.headers.has('content-encoding') // already encoded
+        || response.headers.has('transfer-encoding') // already encoded or chunked
+        || !isCompressibleContentType(response.headers.get('content-type')) // not compressible
+        || isNoTransformCacheControl(response.headers.get('cache-control')) // no-transform directive
+      ) {
+        return result
+      }
+
+      const contentLength = response.headers.get('content-length')
+      if (contentLength && Number(contentLength) < this.threshold) {
+        return result
+      }
+
+      const acceptEncoding = options.request.headers.get('accept-encoding')
+      const encoding = this.encodings.find(enc => acceptEncoding?.includes(enc))
+
+      if (!response.body || encoding === undefined) {
+        return result
+      }
+
+      if (this.filter && !this.filter(response, options.request)) {
+        return result
+      }
+
+      const compressedBody = response.body.pipeThrough(new CompressionStream(encoding))
+      const compressedHeaders = new Headers(response.headers)
+      compressedHeaders.delete('content-length') // CompressionStream will change the content length
+      compressedHeaders.set('content-encoding', encoding)
+
+      return {
+        ...result,
+        response: new Response(compressedBody, {
+          ...response,
+          headers: compressedHeaders,
+        }),
+      }
+    })
+  }
+}
+
+/**
+ * https://github.com/honojs/hono/blob/main/src/utils/compress.ts#L9
+ */
+const COMPRESSIBLE_CONTENT_TYPE_REGEX = /^\s*(?:text\/(?!event-stream(?:[;\s]|$))[^;\s]+|application\/(?:javascript|json|xml|xml-dtd|ecmascript|dart|postscript|rtf|tar|toml|vnd\.dart|vnd\.ms-fontobject|vnd\.ms-opentype|wasm|x-httpd-php|x-javascript|x-ns-proxy-autoconfig|x-sh|x-tar|x-virtualbox-hdd|x-virtualbox-ova|x-virtualbox-ovf|x-virtualbox-vbox|x-virtualbox-vdi|x-virtualbox-vhd|x-virtualbox-vmdk|x-www-form-urlencoded)|font\/(?:otf|ttf)|image\/(?:bmp|vnd\.adobe\.photoshop|vnd\.microsoft\.icon|vnd\.ms-dds|x-icon|x-ms-bmp)|message\/rfc822|model\/gltf-binary|x-shader\/x-fragment|x-shader\/x-vertex|[^;\s]+?\+(?:json|text|xml|yaml))(?:[;\s]|$)/i
+function isCompressibleContentType(contentType: string | null): boolean {
+  if (contentType === null) {
+    return false
+  }
+  return COMPRESSIBLE_CONTENT_TYPE_REGEX.test(contentType)
+}
+
+/**
+ * https://github.com/honojs/hono/blob/main/src/middleware/compress/index.ts#L10
+ */
+const CACHE_CONTROL_NO_TRANSFORM_REGEX = /(?:^|,)\s*no-transform\s*(?:,|$)/i
+function isNoTransformCacheControl(cacheControl: string | null): boolean {
+  if (cacheControl === null) {
+    return false
+  }
+  return CACHE_CONTROL_NO_TRANSFORM_REGEX.test(cacheControl)
+}

--- a/packages/server/src/adapters/fetch/index.ts
+++ b/packages/server/src/adapters/fetch/index.ts
@@ -1,4 +1,5 @@
 export * from './body-limit-plugin'
+export * from './compression-plugin'
 export * from './handler'
 export * from './plugin'
 export * from './rpc-handler'

--- a/packages/server/src/adapters/node/compression-plugin.test.ts
+++ b/packages/server/src/adapters/node/compression-plugin.test.ts
@@ -1,0 +1,140 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import request from 'supertest'
+import { os } from '../../builder'
+import { CompressionPlugin } from './compression-plugin'
+import { RPCHandler } from './rpc-handler'
+
+describe('compressionPlugin', () => {
+  const output = 'x'.repeat(1024) // Large enough to trigger compression
+
+  it('should compress response when accept-encoding includes gzip', async () => {
+    const res = await request(async (req: IncomingMessage, res: ServerResponse) => {
+      const handler = new RPCHandler(os.handler(() => output), {
+        plugins: [
+          new CompressionPlugin(),
+        ],
+      })
+
+      await handler.handle(req, res)
+    })
+      .post('/')
+      .set('accept-encoding', 'gzip, deflate')
+      .send({ input: 'test' })
+
+    expect(res.status).toBe(200)
+    expect(res.headers['content-encoding']).toBe('gzip')
+    // Just check that we get a response, not trying to decompress for now
+    expect(res.body).toBeDefined()
+  })
+
+  it('should not compress response when accept-encoding does not include compression', async () => {
+    const res = await request(async (req: IncomingMessage, res: ServerResponse) => {
+      const handler = new RPCHandler(os.handler(() => output), {
+        plugins: [
+          new CompressionPlugin(),
+        ],
+      })
+
+      await handler.handle(req, res)
+    })
+      .post('/')
+      .set('accept-encoding', 'identity')
+      .send({ input: 'test' })
+
+    expect(res.status).toBe(200)
+    expect(res.headers['content-encoding']).toBeUndefined()
+    expect(res.text).toContain(output)
+  })
+
+  it('should not compress responses if not satisfying filter', async () => {
+    const res = await request(async (req: IncomingMessage, res: ServerResponse) => {
+      const handler = new RPCHandler(os.handler(() => output), {
+        plugins: [
+          new CompressionPlugin({
+            filter: () => false, // Disable compression entirely for this test
+          }),
+        ],
+      })
+
+      await handler.handle(req, res)
+    })
+      .post('/')
+      .set('accept-encoding', 'gzip, deflate')
+      .send({ input: 'test' })
+
+    expect(res.status).toBe(200)
+    expect(res.headers['content-encoding']).toBeUndefined()
+    expect(res.text).toContain(output)
+  })
+
+  it('should work with deflate compression', async () => {
+    const res = await request(async (req: IncomingMessage, res: ServerResponse) => {
+      const handler = new RPCHandler(os.handler(() => output), {
+        plugins: [
+          new CompressionPlugin(),
+        ],
+      })
+
+      await handler.handle(req, res)
+    })
+      .post('/')
+      .set('accept-encoding', 'deflate')
+      .send({ input: 'test' })
+
+    expect(res.status).toBe(200)
+    expect(res.headers['content-encoding']).toBe('deflate')
+  })
+
+  it('should throw if rootInterceptor throws', async () => {
+    const res = await request(async (req: IncomingMessage, res: ServerResponse) => {
+      const rootInterceptors: any[] = []
+      const handler = new RPCHandler(os.handler(() => output), {
+        plugins: [
+          new CompressionPlugin(),
+        ],
+        rootInterceptors,
+      })
+
+      // ensure rootInterceptor run after CompressionPlugin
+      rootInterceptors.push(async () => {
+        throw new Error('Test error')
+      })
+
+      await expect(handler.handle(req, res)).rejects.toThrow('Test error')
+
+      res.statusCode = 500
+      res.end()
+    })
+      .post('/')
+      .set('accept-encoding', 'gzip, deflate')
+      .send({ input: 'test' })
+
+    expect(res.status).toBe(500)
+    expect(res.headers['content-encoding']).toBeUndefined()
+  })
+
+  it('should throw if compression options throw', async () => {
+    const res = await request(async (req: IncomingMessage, res: ServerResponse) => {
+      const handler = new RPCHandler(os.handler(() => output), {
+        plugins: [
+          new CompressionPlugin({
+            filter: () => {
+              throw new Error('Test error')
+            },
+          }),
+        ],
+      })
+
+      await expect(handler.handle(req, res)).rejects.toThrow('Test error')
+
+      res.statusCode = 500
+      res.end()
+    })
+      .post('/')
+      .set('accept-encoding', 'gzip, deflate')
+      .send({ input: 'test' })
+
+    expect(res.status).toBe(500)
+    expect(res.headers['content-encoding']).toBeUndefined()
+  })
+})

--- a/packages/server/src/adapters/node/compression-plugin.test.ts
+++ b/packages/server/src/adapters/node/compression-plugin.test.ts
@@ -87,17 +87,15 @@ describe('compressionPlugin', () => {
 
   it('should throw if rootInterceptor throws', async () => {
     const res = await request(async (req: IncomingMessage, res: ServerResponse) => {
-      const rootInterceptors: any[] = []
       const handler = new RPCHandler(os.handler(() => output), {
         plugins: [
           new CompressionPlugin(),
         ],
-        rootInterceptors,
-      })
-
-      // ensure rootInterceptor run after CompressionPlugin
-      rootInterceptors.push(async () => {
-        throw new Error('Test error')
+        rootInterceptors: [
+          async () => {
+            throw new Error('Test error')
+          },
+        ],
       })
 
       await expect(handler.handle(req, res)).rejects.toThrow('Test error')

--- a/packages/server/src/adapters/node/compression-plugin.ts
+++ b/packages/server/src/adapters/node/compression-plugin.ts
@@ -19,7 +19,11 @@ export class CompressionPlugin<T extends Context> implements NodeHttpHandlerPlug
 
   initRuntimeAdapter(options: NodeHttpHandlerOptions<T>): void {
     options.adapterInterceptors ??= []
-    options.adapterInterceptors.push(async (options) => {
+
+    /**
+     * use `unshift` to ensure this runs before user-defined adapter interceptors
+     */
+    options.adapterInterceptors.unshift(async (options) => {
       let resolve: (value: Awaited<ReturnType<typeof options.next>>) => void
       let reject: (reason?: any) => void
       const promise = new Promise<Awaited<ReturnType<typeof options.next>>>((res, rej) => {

--- a/packages/server/src/adapters/node/compression-plugin.ts
+++ b/packages/server/src/adapters/node/compression-plugin.ts
@@ -31,6 +31,7 @@ export class CompressionPlugin<T extends Context> implements NodeHttpHandlerPlug
        * These methods are proxied by the compression handler, so we need to
        * store the original methods to call them after compression is done
        * to prevent side effects to other code outside of this plugin.
+       * https://github.com/expressjs/compression/blob/master/index.js#L97-L153
        */
       const originalWrite = options.response.write
       const originalEnd = options.response.end

--- a/packages/server/src/adapters/node/compression-plugin.ts
+++ b/packages/server/src/adapters/node/compression-plugin.ts
@@ -1,0 +1,68 @@
+import type { Context } from '../../context'
+import type { NodeHttpHandlerOptions } from './handler'
+import type { NodeHttpHandlerPlugin } from './plugin'
+import compression from 'compression'
+
+export interface CompressionPluginOptions extends compression.CompressionOptions {
+}
+/**
+ * The Compression Plugin adds response compression to the Node.js HTTP Server.
+ *
+ * @see {@link https://orpc.unnoq.com/docs/plugins/compression Compression Plugin Docs}
+ */
+export class CompressionPlugin<T extends Context> implements NodeHttpHandlerPlugin<T> {
+  private readonly compressionHandler: ReturnType<typeof compression>
+
+  constructor(options: CompressionPluginOptions = {}) {
+    this.compressionHandler = compression(options)
+  }
+
+  initRuntimeAdapter(options: NodeHttpHandlerOptions<T>): void {
+    options.adapterInterceptors ??= []
+    options.adapterInterceptors.push(async (options) => {
+      let resolve: (value: Awaited<ReturnType<typeof options.next>>) => void
+      let reject: (reason?: any) => void
+      const promise = new Promise<Awaited<ReturnType<typeof options.next>>>((res, rej) => {
+        resolve = res
+        reject = rej
+      })
+
+      /**
+       * These methods are proxied by the compression handler, so we need to
+       * store the original methods to call them after compression is done
+       * to prevent side effects to other code outside of this plugin.
+       */
+      const originalWrite = options.response.write
+      const originalEnd = options.response.end
+      const originalOn = options.response.on
+
+      this.compressionHandler(
+        options.request as any,
+        options.response as any,
+        async (err) => {
+          /* v8 ignore next 3 - this never happen in realtime: https://github.com/expressjs/compression/blob/master/index.js#L243 */
+          if (err) {
+            reject(err)
+          }
+          else {
+            try {
+              resolve(await options.next())
+            }
+            catch (error) {
+              reject(error)
+            }
+          }
+        },
+      )
+
+      try {
+        return await promise
+      }
+      finally {
+        options.response.write = originalWrite
+        options.response.end = originalEnd
+        options.response.on = originalOn
+      }
+    })
+  }
+}

--- a/packages/server/src/adapters/node/index.ts
+++ b/packages/server/src/adapters/node/index.ts
@@ -1,4 +1,5 @@
 export * from './body-limit-plugin'
+export * from './compression-plugin'
 export * from './handler'
 export * from './plugin'
 export * from './rpc-handler'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -559,6 +559,12 @@ importers:
       '@orpc/standard-server-peer':
         specifier: workspace:*
         version: link:../standard-server-peer
+      '@types/compression':
+        specifier: ^1.8.1
+        version: 1.8.1
+      compression:
+        specifier: ^1.8.1
+        version: 1.8.1
       cookie:
         specifier: ^1.0.2
         version: 1.0.2
@@ -5976,6 +5982,9 @@ packages:
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
+  '@types/compression@1.8.1':
+    resolution: {integrity: sha512-kCFuWS0ebDbmxs0AXYn6e2r2nrGAb5KwQhknjSPSPgJcGd8+HVSILlUyFhGqML2gk39HcG7D1ydW9/qpYkN00Q==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
@@ -7737,6 +7746,14 @@ packages:
   compress-commons@6.0.2:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
     engines: {node: '>= 14'}
+
+  compressible@2.0.18:
+    resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
+    engines: {node: '>= 0.6'}
+
+  compression@1.8.1:
+    resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
+    engines: {node: '>= 0.8.0'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -11201,6 +11218,10 @@ packages:
 
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  on-headers@1.1.0:
+    resolution: {integrity: sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==}
     engines: {node: '>= 0.8'}
 
   once@1.4.0:
@@ -19849,6 +19870,11 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
 
+  '@types/compression@1.8.1':
+    dependencies:
+      '@types/express': 5.0.3
+      '@types/node': 22.17.0
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 22.17.0
@@ -22206,6 +22232,22 @@ snapshots:
       is-stream: 2.0.1
       normalize-path: 3.0.0
       readable-stream: 4.7.0
+
+  compressible@2.0.18:
+    dependencies:
+      mime-db: 1.54.0
+
+  compression@1.8.1:
+    dependencies:
+      bytes: 3.1.2
+      compressible: 2.0.18
+      debug: 2.6.9
+      negotiator: 0.6.4
+      on-headers: 1.1.0
+      safe-buffer: 5.2.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   concat-map@0.0.1: {}
 
@@ -26475,6 +26517,8 @@ snapshots:
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
+
+  on-headers@1.1.0: {}
 
   once@1.4.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -559,19 +559,19 @@ importers:
       '@orpc/standard-server-peer':
         specifier: workspace:*
         version: link:../standard-server-peer
-      '@types/compression':
-        specifier: ^1.8.1
-        version: 1.8.1
-      compression:
-        specifier: ^1.8.1
-        version: 1.8.1
       cookie:
         specifier: ^1.0.2
         version: 1.0.2
     devDependencies:
+      '@types/compression':
+        specifier: ^1.8.1
+        version: 1.8.1
       '@types/ws':
         specifier: ^8.18.1
         version: 8.18.1
+      compression:
+        specifier: ^1.8.1
+        version: 1.8.1
       crossws:
         specifier: ^0.4.1
         version: 0.4.1


### PR DESCRIPTION
```ts
const handler = new RPCHandler(router, {
  plugins: [
    new CompressionPlugin(),
  ],
})
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a Compression Plugin for Fetch and Node adapters: configurable encodings, threshold, and filter; automatically compresses compatible responses and respects cache-control no-transform.

- Documentation
  - Added Compression Plugin docs and sidebar entry.
  - Clarified Body Limit example supports any compatible handler.

- Tests
  - Added comprehensive Fetch and Node tests covering encodings, thresholds, filters, headers, and error scenarios.

- Chores
  - Updated Dependabot to exclude the compression package.
  - Added compression dev-dependencies and relaxed server build warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->