### PR TITLE
fix(tanstack-query): exactOptionalPropertyTypes

### DIFF
--- a/packages/react-query/src/procedure-utils.test.ts
+++ b/packages/react-query/src/procedure-utils.test.ts
@@ -33,6 +33,7 @@ describe('createProcedureUtils', () => {
     it('without skipToken', async () => {
       const options = utils.queryOptions({ input: { search: '__search__' }, context: { batch: '__batch__' } })
 
+      expect('enabled' in options).toBe(false)
       expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
@@ -72,6 +73,7 @@ describe('createProcedureUtils', () => {
         queryFnOptions: { refetchMode: 'replace' },
       })
 
+      expect('enabled' in options).toBe(false)
       expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
@@ -130,6 +132,7 @@ describe('createProcedureUtils', () => {
         initialPageParam: '__initialPageParam__',
       })
 
+      expect('enabled' in options).toBe(false)
       expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)

--- a/packages/react-query/src/procedure-utils.ts
+++ b/packages/react-query/src/procedure-utils.ts
@@ -87,14 +87,13 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
 
           return client(optionsIn.input, { signal, context: optionsIn.context })
         },
-        enabled: optionsIn.input === skipToken ? false : undefined,
+        ...optionsIn.input === skipToken ? { enabled: false } : {},
         ...optionsIn,
       }
     },
 
     experimental_streamedOptions(...[optionsIn = {} as any]) {
       return {
-        enabled: optionsIn.input === skipToken ? false : undefined,
         queryKey: generateOperationKey(options.path, { type: 'streamed', input: optionsIn.input, fnOptions: optionsIn.queryFnOptions }),
         queryFn: streamedQuery({
           queryFn: async ({ signal }) => {
@@ -112,6 +111,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
           },
           ...optionsIn.queryFnOptions,
         }),
+        ...optionsIn.input === skipToken ? { enabled: false } : {},
         ...optionsIn,
       }
     },
@@ -129,7 +129,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
 
           return client(optionsIn.input(pageParam as any), { signal, context: optionsIn.context as any })
         },
-        enabled: optionsIn.input === skipToken ? false : undefined,
+        ...optionsIn.input === skipToken ? { enabled: false } : {},
         ...(optionsIn as any),
       }
     },

--- a/packages/react-query/src/types.ts
+++ b/packages/react-query/src/types.ts
@@ -12,7 +12,7 @@ export interface QueryOptionsBase<TOutput, TError> {
   queryFn(ctx: QueryFunctionContext): Promise<TOutput>
   throwOnError?(error: TError): boolean // Help TQ infer TError
   retryDelay?: (count: number, error: TError) => number // Help TQ infer TError (suspense hooks)
-  enabled: boolean | undefined
+  enabled?: boolean
 }
 
 type experimental_StreamedQueryOptions = Omit<Parameters<typeof experimental_streamedQuery>[0], 'queryFn'>
@@ -36,7 +36,7 @@ export interface InfiniteOptionsBase<TOutput, TError, TPageParam> {
   queryFn(ctx: QueryFunctionContext<QueryKey, TPageParam>): Promise<TOutput>
   throwOnError?(error: TError): boolean // Help TQ infer TError
   retryDelay?: (count: number, error: TError) => number // Help TQ infer TError (suspense hooks)
-  enabled: boolean | undefined
+  enabled?: boolean
 }
 
 export type MutationOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TMutationContext>

--- a/packages/solid-query/src/procedure-utils.test.ts
+++ b/packages/solid-query/src/procedure-utils.test.ts
@@ -33,6 +33,7 @@ describe('createProcedureUtils', () => {
     it('without skipToken', async () => {
       const options = utils.queryOptions({ input: { search: '__search__' }, context: { batch: '__batch__' } })
 
+      expect('enabled' in options).toBe(false)
       expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
@@ -72,6 +73,7 @@ describe('createProcedureUtils', () => {
         queryFnOptions: { refetchMode: 'replace' },
       })
 
+      expect('enabled' in options).toBe(false)
       expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
@@ -130,6 +132,7 @@ describe('createProcedureUtils', () => {
         initialPageParam: '__initialPageParam__',
       })
 
+      expect('enabled' in options).toBe(false)
       expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)

--- a/packages/solid-query/src/procedure-utils.ts
+++ b/packages/solid-query/src/procedure-utils.ts
@@ -77,14 +77,13 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
 
           return client(optionsIn.input, { signal, context: optionsIn.context })
         },
-        enabled: optionsIn.input === skipToken ? false : undefined,
+        ...optionsIn.input === skipToken ? { enabled: false } : {},
         ...optionsIn,
       }
     },
 
     experimental_streamedOptions(...[optionsIn = {} as any]) {
       return {
-        enabled: optionsIn.input === skipToken ? false : undefined,
         queryKey: generateOperationKey(options.path, { type: 'streamed', input: optionsIn.input, fnOptions: optionsIn.queryFnOptions }),
         queryFn: experimental_streamedQuery({
           queryFn: async ({ signal }) => {
@@ -102,6 +101,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
           },
           ...optionsIn.queryFnOptions,
         }),
+        ...optionsIn.input === skipToken ? { enabled: false } : {},
         ...optionsIn,
       }
     },
@@ -119,7 +119,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
 
           return client(optionsIn.input(pageParam as any), { signal, context: optionsIn.context as any })
         },
-        enabled: optionsIn.input === skipToken ? false : undefined,
+        ...optionsIn.input === skipToken ? { enabled: false } : {},
         ...(optionsIn as any),
       }
     },

--- a/packages/solid-query/src/types.ts
+++ b/packages/solid-query/src/types.ts
@@ -23,7 +23,7 @@ export interface QueryOptionsBase<TOutput, TError> {
   enabled?: boolean
 }
 
-type experimental_StreamedQueryOptions = Omit<Parameters<typeof streamedQuery>[0]['refetchMode'], 'queryFn'>
+type experimental_StreamedQueryOptions = Omit<Parameters<typeof streamedQuery>[0], 'queryFn'>
 
 export type experimental_InferStreamedOutput<TOutput> = TOutput extends AsyncIterable<infer U> ? U[] : never
 

--- a/packages/solid-query/src/types.ts
+++ b/packages/solid-query/src/types.ts
@@ -20,7 +20,7 @@ export interface QueryOptionsBase<TOutput, TError> {
   queryFn(ctx: QueryFunctionContext): Promise<TOutput>
   throwOnError?(error: TError): boolean // Help TQ infer TError
   retryDelay?: (count: number, error: TError) => number // Help TQ infer TError (suspense hooks)
-  enabled: boolean | undefined
+  enabled?: boolean
 }
 
 type experimental_StreamedQueryOptions = Omit<Parameters<typeof streamedQuery>[0]['refetchMode'], 'queryFn'>
@@ -44,7 +44,7 @@ export interface InfiniteOptionsBase<TOutput, TError, TPageParam> {
   queryFn(ctx: QueryFunctionContext<QueryKey, TPageParam>): Promise<TOutput>
   throwOnError?(error: TError): boolean // Help TQ infer TError
   retryDelay?: (count: number, error: TError) => number // Help TQ infer TError (suspense hooks)
-  enabled: boolean | undefined
+  enabled?: boolean
 }
 
 export type MutationOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TMutationContext>

--- a/packages/svelte-query/src/procedure-utils.test.tsx
+++ b/packages/svelte-query/src/procedure-utils.test.tsx
@@ -33,6 +33,7 @@ describe('createProcedureUtils', () => {
     it('without skipToken', async () => {
       const options = utils.queryOptions({ input: { search: '__search__' }, context: { batch: '__batch__' } })
 
+      expect('enabled' in options).toBe(false)
       expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
@@ -72,6 +73,7 @@ describe('createProcedureUtils', () => {
         queryFnOptions: { refetchMode: 'replace' },
       })
 
+      expect('enabled' in options).toBe(false)
       expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
@@ -130,6 +132,7 @@ describe('createProcedureUtils', () => {
         initialPageParam: '__initialPageParam__',
       })
 
+      expect('enabled' in options).toBe(false)
       expect(options.enabled).toBe(undefined)
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)

--- a/packages/svelte-query/src/procedure-utils.ts
+++ b/packages/svelte-query/src/procedure-utils.ts
@@ -77,14 +77,13 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
 
           return client(optionsIn.input, { signal, context: optionsIn.context })
         },
-        enabled: optionsIn.input === skipToken ? false : undefined,
+        ...optionsIn.input === skipToken ? { enabled: false } : {},
         ...optionsIn,
       }
     },
 
     experimental_streamedOptions(...[optionsIn = {} as any]) {
       return {
-        enabled: optionsIn.input === skipToken ? false : undefined,
         queryKey: generateOperationKey(options.path, { type: 'streamed', input: optionsIn.input, fnOptions: optionsIn.queryFnOptions }),
         queryFn: experimental_streamedQuery({
           queryFn: async ({ signal }) => {
@@ -102,6 +101,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
           },
           ...optionsIn.queryFnOptions,
         }),
+        ...optionsIn.input === skipToken ? { enabled: false } : {},
         ...optionsIn,
       }
     },
@@ -119,7 +119,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
 
           return client(optionsIn.input(pageParam as any), { signal, context: optionsIn.context as any })
         },
-        enabled: optionsIn.input === skipToken ? false : undefined,
+        ...optionsIn.input === skipToken ? { enabled: false } : {},
         ...(optionsIn as any),
       }
     },

--- a/packages/svelte-query/src/types.ts
+++ b/packages/svelte-query/src/types.ts
@@ -20,7 +20,7 @@ export interface QueryOptionsBase<TOutput, TError> {
   queryFn(ctx: QueryFunctionContext): Promise<TOutput>
   throwOnError?(error: TError): boolean // Help TQ infer TError
   retryDelay?: (count: number, error: TError) => number // Help TQ infer TError (suspense hooks)
-  enabled: boolean | undefined
+  enabled?: boolean
 }
 
 type experimental_StreamedQueryOptions = Omit<Parameters<typeof experimental_streamedQuery>[0], 'queryFn'>
@@ -44,7 +44,7 @@ export interface InfiniteOptionsBase<TOutput, TError, TPageParam> {
   queryFn(ctx: QueryFunctionContext<QueryKey, TPageParam>): Promise<TOutput>
   throwOnError?(error: TError): boolean // Help TQ infer TError
   retryDelay?: (count: number, error: TError) => number // Help TQ infer TError (suspense hooks)
-  enabled: boolean | undefined
+  enabled?: boolean
 }
 
 export type MutationOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TMutationContext>

--- a/packages/tanstack-query/src/procedure-utils.test-d.ts
+++ b/packages/tanstack-query/src/procedure-utils.test-d.ts
@@ -148,7 +148,7 @@ describe('ProcedureUtils', () => {
         maxPages: number
         queryFn: QueryFunction<UtilsOutput>
         throwOnError?(error: UtilsError): boolean
-        enabled: boolean | undefined
+        enabled?: boolean
       }>()
     })
 
@@ -281,7 +281,7 @@ describe('ProcedureUtils', () => {
         maxPages: number
         queryFn: QueryFunction<UtilsOutput>
         throwOnError?(error: UtilsError): boolean
-        enabled: boolean | undefined
+        enabled?: boolean
       }>()
     })
 
@@ -410,7 +410,7 @@ describe('ProcedureUtils', () => {
         maxPages: number
         queryFn: QueryFunction<UtilsOutput[number]>
         throwOnError?(error: UtilsError): boolean
-        enabled: boolean | undefined
+        enabled?: boolean
       }>()
     })
 
@@ -661,7 +661,7 @@ describe('ProcedureUtils', () => {
         maxPages: number
         queryFn: QueryFunction<UtilsOutput>
         throwOnError?(error: UtilsError): boolean
-        enabled: boolean | undefined
+        enabled?: boolean
       }>()
     })
 

--- a/packages/tanstack-query/src/procedure-utils.test.ts
+++ b/packages/tanstack-query/src/procedure-utils.test.ts
@@ -46,7 +46,8 @@ describe('createProcedureUtils', () => {
     it('without skipToken', async () => {
       const options = utils.queryOptions({ input: { search: '__search__' }, context: { batch: '__batch__' } })
 
-      expect(options.enabled).toBe(undefined)
+      expect('enabled' in options).toBe(false)
+      expect(options.enabled).toBeUndefined()
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
@@ -97,7 +98,8 @@ describe('createProcedureUtils', () => {
         },
       })
 
-      expect(options.enabled).toBe(undefined)
+      expect('enabled' in options).toBe(false)
+      expect(options.enabled).toBeUndefined()
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
@@ -182,7 +184,8 @@ describe('createProcedureUtils', () => {
         context: { batch: '__batch__' },
       })
 
-      expect(options.enabled).toBe(undefined)
+      expect('enabled' in options).toBe(false)
+      expect(options.enabled).toBeUndefined()
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
@@ -268,7 +271,8 @@ describe('createProcedureUtils', () => {
         initialPageParam: '__initialPageParam__',
       })
 
-      expect(options.enabled).toBe(undefined)
+      expect('enabled' in options).toBe(false)
+      expect(options.enabled).toBeUndefined()
 
       expect(options.queryKey).toBe(generateOperationKeySpy.mock.results[0]!.value)
       expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)

--- a/packages/tanstack-query/src/procedure-utils.ts
+++ b/packages/tanstack-query/src/procedure-utils.ts
@@ -184,7 +184,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
             } satisfies OperationContext,
           })
         },
-        enabled: optionsIn.input === skipToken ? false : undefined,
+        ...optionsIn.input === skipToken ? { enabled: false } : {},
         ...optionsIn,
         queryKey,
       }
@@ -200,7 +200,6 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
       const queryKey = utils.experimental_streamedKey(optionsIn)
 
       return {
-        enabled: optionsIn.input === skipToken ? false : undefined,
         queryFn: experimental_streamedQuery({
           queryFn: async ({ signal }) => {
             if (optionsIn.input === skipToken) {
@@ -226,6 +225,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
           },
           ...optionsIn.queryFnOptions,
         }),
+        ...optionsIn.input === skipToken ? { enabled: false } : {},
         ...optionsIn,
         queryKey,
       }
@@ -241,7 +241,6 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
       const queryKey = utils.experimental_liveKey(optionsIn)
 
       return {
-        enabled: optionsIn.input === skipToken ? false : undefined,
         queryFn: experimental_liveQuery(async ({ signal }) => {
           if (optionsIn.input === skipToken) {
             throw new Error('queryFn should not be called with skipToken used as input')
@@ -264,6 +263,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
 
           return output
         }),
+        ...optionsIn.input === skipToken ? { enabled: false } : {},
         ...optionsIn,
         queryKey,
       }
@@ -298,7 +298,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
             } as any,
           })
         },
-        enabled: optionsIn.input === skipToken ? false : undefined,
+        ...optionsIn.input === skipToken ? { enabled: false } : {},
         ...(optionsIn as any),
         queryKey,
       }

--- a/packages/tanstack-query/src/types.ts
+++ b/packages/tanstack-query/src/types.ts
@@ -50,7 +50,7 @@ export interface QueryOptionsBase<TOutput, TError> {
   queryFn: QueryFunction<TOutput>
   throwOnError?: (error: TError) => boolean // Help TQ infer TError
   retryDelay?: (count: number, error: TError) => number // Help TQ infer TError (suspense hooks)
-  enabled: boolean | undefined
+  enabled?: boolean
 }
 
 export type experimental_StreamedKeyOptions<TInput>
@@ -75,7 +75,7 @@ export interface InfiniteOptionsBase<TOutput, TError, TPageParam> {
   select?(): InfiniteData<TOutput, TPageParam> // Help TQ infer TPageParam
   throwOnError?: (error: TError) => boolean // Help TQ infer TError
   retryDelay?: (count: number, error: TError) => number // Help TQ infer TError (suspense hooks)
-  enabled: boolean | undefined
+  enabled?: boolean
 }
 
 export type MutationOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TMutationContext>


### PR DESCRIPTION
When using `"exactOptionalPropertyTypes": true` in my tsconfig, I get an error saying that `enabled cannot be undefined (as it is marked explicitly as undefined by ORPC, but is optional for tanstack query)`:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Options objects no longer include an "enabled" field unless explicitly required (e.g., when skipping), resulting in cleaner shapes across React, Solid, Svelte, and core query utilities.
  * Type definitions updated: `enabled` is now optional (`enabled?: boolean`) in query and infinite option interfaces, improving TypeScript ergonomics without changing runtime behavior.
* **Tests**
  * Assertions updated to verify the absence of the "enabled" property when not needed, aligning tests with the new option shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->