### PR TITLE
feat(server): compression plugin filter option should override default content type filter

### DIFF
--- a/packages/server/src/adapters/node/compression-plugin.ts
+++ b/packages/server/src/adapters/node/compression-plugin.ts
@@ -25,7 +25,7 @@ export class CompressionPlugin<T extends Context> implements NodeHttpHandlerPlug
     this.compressionHandler = compression({
       ...options,
       filter: (req, res) => {
-        const hasContentDisposition = res.getHeader('content-disposition') !== undefined
+        const hasContentDisposition = res.hasHeader('content-disposition')
         const contentType = res.getHeader('content-type')?.toString()
 
         /**

--- a/packages/server/src/adapters/node/compression-plugin.ts
+++ b/packages/server/src/adapters/node/compression-plugin.ts
@@ -6,9 +6,10 @@ import compression from '@orpc/interop/compression'
 
 export interface CompressionPluginOptions extends compression.CompressionOptions {
   /**
-   * A filter function to determine if a response should be compressed.
-   * This function is called in addition to the default compression checks
-   * and allows for custom compression logic based on the request and response.
+   * Override the default content-type filter used to determine which responses should be compressed.
+   *
+   * @warning [Event Iterator](https://orpc.unnoq.com/docs/event-iterator) responses are never compressed, regardless of this filter's return value.
+   * @default only responses with compressible content types are compressed.
    */
   filter?: (req: NodeHttpRequest, res: NodeHttpResponse) => boolean
 }
@@ -24,17 +25,19 @@ export class CompressionPlugin<T extends Context> implements NodeHttpHandlerPlug
     this.compressionHandler = compression({
       ...options,
       filter: (req, res) => {
-        if (res.getHeader('content-type')?.toString().startsWith('text/event-stream')) {
-          return false
-        }
+        const hasContentDisposition = res.getHeader('content-disposition') !== undefined
+        const contentType = res.getHeader('content-type')?.toString()
 
-        if (!compression.filter(req, res)) {
+        /**
+         * Never compress Event Iterator responses.
+         */
+        if (!hasContentDisposition && contentType?.startsWith('text/event-stream')) {
           return false
         }
 
         return options.filter
           ? options.filter(req, res)
-          : true
+          : compression.filter(req, res)
       },
     })
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support to override default compression decisions via a custom filter, enabling compression for custom content types.
- Bug Fixes
  - Ensured event-stream (Server-Sent Events) and Event Iterator responses are never compressed, even with a custom filter.
  - Confirmed no compression occurs when responses lack a content-type.
- Documentation
  - Clarified default compression behavior and the filter option, including the event-stream exception.
- Tests
  - Expanded coverage for custom filter behavior, event-stream handling, and missing content-type scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->