### PR TITLE
fix(tanstack-query): correct error type on streamed and live options

### DIFF
--- a/packages/react-query/src/procedure-utils.test-d.ts
+++ b/packages/react-query/src/procedure-utils.test-d.ts
@@ -218,13 +218,13 @@ describe('ProcedureUtils', () => {
         const query = useQuery(utils.experimental_streamedOptions({
           select: data => ({ mapped: data }),
           throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap>>()
+            expectTypeOf(error).toEqualTypeOf<Error>()
             return false
           },
         }))
 
         expectTypeOf(query.data).toEqualTypeOf<{ mapped: UtilsOutput } | undefined>()
-        expectTypeOf(query.error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap> | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
 
       it('with initial data', () => {
@@ -234,7 +234,7 @@ describe('ProcedureUtils', () => {
         }))
 
         expectTypeOf(query.data).toEqualTypeOf<{ mapped: UtilsOutput }>()
-        expectTypeOf(query.error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap> | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
     })
 
@@ -254,8 +254,8 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries[0].data).toEqualTypeOf<{ mapped: UtilsOutput } | undefined>()
       expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput | undefined>()
 
-      expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
-      expectTypeOf(queries[1].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries[1].error).toEqualTypeOf<null | Error>()
     })
 
     it('works with useSuspenseQueries', () => {
@@ -274,8 +274,8 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries[0].data).toEqualTypeOf<{ mapped: UtilsOutput }>()
       expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput>()
 
-      expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
-      expectTypeOf(queries[1].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries[1].error).toEqualTypeOf<null | Error>()
     })
 
     it('works with fetchQuery', () => {

--- a/packages/react-query/src/procedure-utils.ts
+++ b/packages/react-query/src/procedure-utils.ts
@@ -1,6 +1,6 @@
 import type { Client, ClientContext } from '@orpc/client'
 import type { MaybeOptionalOptions } from '@orpc/shared'
-import type { InfiniteData } from '@tanstack/react-query'
+import type { DefaultError, InfiniteData } from '@tanstack/react-query'
 import type {
   experimental_InferStreamedOutput,
   InfiniteOptionsBase,
@@ -40,12 +40,13 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
    * Built on top of [steamedQuery](https://tanstack.com/query/latest/docs/reference/streamedQuery)
    *
    * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query-old/basic#streamed-query-options-utility Tanstack Streamed Query Options Utility Docs}
+   * @remarks Uses DefaultError instead of TError because TError only applies to the initial request. Streaming errors are not validated, so type safety cannot be guaranteed for error types.
    */
   experimental_streamedOptions<U, USelectData = experimental_InferStreamedOutput<TOutput>>(
     ...rest: MaybeOptionalOptions<
-      U & StreamedOptionsIn<TClientContext, TInput, experimental_InferStreamedOutput<TOutput>, TError, USelectData>
+      U & StreamedOptionsIn<TClientContext, TInput, experimental_InferStreamedOutput<TOutput>, DefaultError, USelectData>
     >
-  ): NoInfer<U & Omit<StreamedOptionsBase<experimental_InferStreamedOutput<TOutput>, TError>, keyof U>>
+  ): NoInfer<U & Omit<StreamedOptionsBase<experimental_InferStreamedOutput<TOutput>, DefaultError>, keyof U>>
 
   /**
    * Generate options used for useInfiniteQuery/useSuspenseInfiniteQuery/prefetchInfiniteQuery/...

--- a/packages/react-query/tests/e2e.test-d.ts
+++ b/packages/react-query/tests/e2e.test-d.ts
@@ -141,16 +141,14 @@ describe('.streamedOptions', () => {
     const query = useQuery(streamedOrpc.streamed.experimental_streamedOptions({
       input: { input: 123 },
       retry(failureCount, error) {
-        if (isDefinedError(error) && error.code === 'BASE') {
-          expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
-        }
+        expectTypeOf(error).toEqualTypeOf<Error>()
 
         return false
       },
     }))
 
-    if (query.status === 'error' && isDefinedError(query.error) && query.error.code === 'OVERRIDE') {
-      expectTypeOf(query.error.data).toEqualTypeOf<unknown>()
+    if (query.status === 'error') {
+      expectTypeOf(query.error).toEqualTypeOf<Error>()
     }
 
     if (query.status === 'success') {
@@ -177,16 +175,14 @@ describe('.streamedOptions', () => {
     const query = useSuspenseQuery(streamedOrpc.streamed.experimental_streamedOptions({
       input: { input: 123 },
       retry(failureCount, error) {
-        if (isDefinedError(error) && error.code === 'BASE') {
-          expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
-        }
+        expectTypeOf(error).toEqualTypeOf<Error>()
 
         return false
       },
     }))
 
-    if (query.status === 'error' && isDefinedError(query.error) && query.error.code === 'OVERRIDE') {
-      expectTypeOf(query.error.data).toEqualTypeOf<unknown>()
+    if (query.status === 'error') {
+      expectTypeOf(query.error).toEqualTypeOf<Error>()
     }
 
     expectTypeOf(query.data).toEqualTypeOf<{ output: string }[]>()
@@ -214,9 +210,7 @@ describe('.streamedOptions', () => {
           input: { input: 123 },
           select: data => ({ mapped: data }),
           retry(failureCount, error) {
-            if (isDefinedError(error) && error.code === 'BASE') {
-              expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
-            }
+            expectTypeOf(error).toEqualTypeOf<Error>()
 
             return false
           },
@@ -227,8 +221,8 @@ describe('.streamedOptions', () => {
       ],
     })
 
-    if (queries[0].status === 'error' && isDefinedError(queries[0].error) && queries[0].error.code === 'BASE') {
-      expectTypeOf(queries[0].error.data).toEqualTypeOf<{ output: string }>()
+    if (queries[0].status === 'error') {
+      expectTypeOf(queries[0].error).toEqualTypeOf<Error>()
     }
 
     if (queries[0].status === 'success') {
@@ -251,9 +245,7 @@ describe('.streamedOptions', () => {
           input: { input: 123 },
           select: data => ({ mapped: data }),
           retry(failureCount, error) {
-            if (isDefinedError(error) && error.code === 'BASE') {
-              expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
-            }
+            expectTypeOf(error).toEqualTypeOf<Error>()
 
             return false
           },
@@ -264,8 +256,8 @@ describe('.streamedOptions', () => {
       ],
     })
 
-    if (queries[0].status === 'error' && isDefinedError(queries[0].error) && queries[0].error.code === 'OVERRIDE') {
-      expectTypeOf(queries[0].error.data).toEqualTypeOf<unknown>()
+    if (queries[0].status === 'error') {
+      expectTypeOf(queries[0].error).toEqualTypeOf<Error>()
     }
 
     expectTypeOf(queries[0].data.mapped).toEqualTypeOf<{ output: string }[]>()

--- a/packages/solid-query/src/procedure-utils.test-d.ts
+++ b/packages/solid-query/src/procedure-utils.test-d.ts
@@ -185,13 +185,13 @@ describe('ProcedureUtils', () => {
         const query = useQuery(() => utils.experimental_streamedOptions({
           select: data => ({ mapped: data }),
           throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap>>()
+            expectTypeOf(error).toEqualTypeOf<Error>()
             return false
           },
         }))
 
         expectTypeOf(query.data).toEqualTypeOf<{ mapped: UtilsOutput } | undefined>()
-        expectTypeOf(query.error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap> | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
 
       it('with initial data', () => {
@@ -201,7 +201,7 @@ describe('ProcedureUtils', () => {
         }))
 
         expectTypeOf(query.data).toEqualTypeOf<{ mapped: UtilsOutput }>()
-        expectTypeOf(query.error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap> | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
     })
 
@@ -221,8 +221,8 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries[0].data).toEqualTypeOf<{ mapped: UtilsOutput } | undefined>()
       expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput | undefined>()
 
-      expectTypeOf(queries[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
-      expectTypeOf(queries[1].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries[1].error).toEqualTypeOf<null | Error>()
     })
 
     it('works with fetchQuery', () => {

--- a/packages/solid-query/src/procedure-utils.ts
+++ b/packages/solid-query/src/procedure-utils.ts
@@ -1,6 +1,6 @@
 import type { Client, ClientContext } from '@orpc/client'
 import type { MaybeOptionalOptions } from '@orpc/shared'
-import type { InfiniteData } from '@tanstack/solid-query'
+import type { DefaultError, InfiniteData } from '@tanstack/solid-query'
 import type { experimental_InferStreamedOutput, experimental_StreamedOptionsBase, experimental_StreamedOptionsIn, InfiniteOptionsBase, InfiniteOptionsIn, MutationOptions, MutationOptionsIn, QueryOptionsBase, QueryOptionsIn } from './types'
 import { isAsyncIteratorObject } from '@orpc/shared'
 import { generateOperationKey } from '@orpc/tanstack-query'
@@ -30,12 +30,13 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
    * Built on top of [steamedQuery](https://tanstack.com/query/latest/docs/reference/streamedQuery)
    *
    * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query-old/basic#streamed-query-options-utility Tanstack Streamed Query Options Utility Docs}
+   * @remarks Uses DefaultError instead of TError because TError only applies to the initial request. Streaming errors are not validated, so type safety cannot be guaranteed for error types.
    */
   experimental_streamedOptions<U, USelectData = experimental_InferStreamedOutput<TOutput>>(
     ...rest: MaybeOptionalOptions<
-      U & experimental_StreamedOptionsIn<TClientContext, TInput, experimental_InferStreamedOutput<TOutput>, TError, USelectData>
+      U & experimental_StreamedOptionsIn<TClientContext, TInput, experimental_InferStreamedOutput<TOutput>, DefaultError, USelectData>
     >
-  ): NoInfer<U & Omit<experimental_StreamedOptionsBase<experimental_InferStreamedOutput<TOutput>, TError>, keyof U>>
+  ): NoInfer<U & Omit<experimental_StreamedOptionsBase<experimental_InferStreamedOutput<TOutput>, DefaultError>, keyof U>>
 
   /**
    * Generate options used for createInfiniteQuery/prefetchInfiniteQuery/...

--- a/packages/solid-query/tests/e2e.test-d.ts
+++ b/packages/solid-query/tests/e2e.test-d.ts
@@ -113,16 +113,14 @@ describe('.streamedOptions', () => {
     const query = useQuery(() => streamedOrpc.streamed.experimental_streamedOptions({
       input: { input: 123 },
       retry(failureCount, error) {
-        if (isDefinedError(error) && error.code === 'BASE') {
-          expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
-        }
+        expectTypeOf(error).toEqualTypeOf<Error>()
 
         return false
       },
     }))
 
-    if (query.status === 'error' && isDefinedError(query.error) && query.error.code === 'OVERRIDE') {
-      expectTypeOf(query.error.data).toEqualTypeOf<unknown>()
+    if (query.status === 'error') {
+      expectTypeOf(query.error).toEqualTypeOf<Error>()
     }
 
     if (query.status === 'success') {
@@ -152,9 +150,7 @@ describe('.streamedOptions', () => {
           input: { input: 123 },
           select: data => ({ mapped: data }),
           retry(failureCount, error) {
-            if (isDefinedError(error) && error.code === 'BASE') {
-              expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
-            }
+            expectTypeOf(error).toEqualTypeOf<Error>()
 
             return false
           },
@@ -165,8 +161,8 @@ describe('.streamedOptions', () => {
       ],
     }))
 
-    if (queries[0].status === 'error' && isDefinedError(queries[0].error) && queries[0].error.code === 'BASE') {
-      expectTypeOf(queries[0].error.data).toEqualTypeOf<{ output: string }>()
+    if (queries[0].status === 'error') {
+      expectTypeOf(queries[0].error).toEqualTypeOf<Error>()
     }
 
     if (queries[0].status === 'success') {

--- a/packages/svelte-query/src/procedure-utils.test-d.ts
+++ b/packages/svelte-query/src/procedure-utils.test-d.ts
@@ -186,13 +186,13 @@ describe('ProcedureUtils', () => {
         const query = createQuery(utils.experimental_streamedOptions({
           select: data => ({ mapped: data }),
           throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap>>()
+            expectTypeOf(error).toEqualTypeOf<Error>()
             return false
           },
         }))
 
         expectTypeOf(get(query).data).toEqualTypeOf<{ mapped: UtilsOutput } | undefined>()
-        expectTypeOf(get(query).error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap> | null>()
+        expectTypeOf(get(query).error).toEqualTypeOf<Error | null>()
       })
 
       it('with initial data', () => {
@@ -202,7 +202,7 @@ describe('ProcedureUtils', () => {
         }))
 
         expectTypeOf(get(query).data).toEqualTypeOf<{ mapped: UtilsOutput }>()
-        expectTypeOf(get(query).error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap> | null>()
+        expectTypeOf(get(query).error).toEqualTypeOf<Error | null>()
       })
     })
 
@@ -222,8 +222,8 @@ describe('ProcedureUtils', () => {
       expectTypeOf(get(queries)[0].data).toEqualTypeOf<{ mapped: UtilsOutput } | undefined>()
       expectTypeOf(get(queries)[1].data).toEqualTypeOf<UtilsOutput | undefined>()
 
-      expectTypeOf(get(queries)[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
-      expectTypeOf(get(queries)[1].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
+      expectTypeOf(get(queries)[0].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(get(queries)[1].error).toEqualTypeOf<null | Error>()
     })
 
     it('works with fetchQuery', () => {

--- a/packages/svelte-query/src/procedure-utils.ts
+++ b/packages/svelte-query/src/procedure-utils.ts
@@ -1,6 +1,6 @@
 import type { Client, ClientContext } from '@orpc/client'
 import type { MaybeOptionalOptions } from '@orpc/shared'
-import type { InfiniteData } from '@tanstack/svelte-query'
+import type { DefaultError, InfiniteData } from '@tanstack/svelte-query'
 import type { experimental_InferStreamedOutput, experimental_StreamedOptionsBase, experimental_StreamedOptionsIn, InfiniteOptionsBase, InfiniteOptionsIn, MutationOptions, MutationOptionsIn, QueryOptionsBase, QueryOptionsIn } from './types'
 import { isAsyncIteratorObject } from '@orpc/shared'
 import { generateOperationKey } from '@orpc/tanstack-query'
@@ -30,12 +30,13 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
    * Built on top of [steamedQuery](https://tanstack.com/query/latest/docs/reference/streamedQuery)
    *
    * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query-old/basic#streamed-query-options-utility Tanstack Streamed Query Options Utility Docs}
+   * @remarks Uses DefaultError instead of TError because TError only applies to the initial request. Streaming errors are not validated, so type safety cannot be guaranteed for error types.
    */
   experimental_streamedOptions<U, USelectData = experimental_InferStreamedOutput<TOutput>>(
     ...rest: MaybeOptionalOptions<
-      U & experimental_StreamedOptionsIn<TClientContext, TInput, experimental_InferStreamedOutput<TOutput>, TError, USelectData>
+      U & experimental_StreamedOptionsIn<TClientContext, TInput, experimental_InferStreamedOutput<TOutput>, DefaultError, USelectData>
     >
-  ): NoInfer<U & Omit<experimental_StreamedOptionsBase<experimental_InferStreamedOutput<TOutput>, TError>, keyof U>>
+  ): NoInfer<U & Omit<experimental_StreamedOptionsBase<experimental_InferStreamedOutput<TOutput>, DefaultError>, keyof U>>
 
   /**
    * Generate options used for createInfiniteQuery/prefetchInfiniteQuery/...

--- a/packages/svelte-query/tests/e2e.test-d.ts
+++ b/packages/svelte-query/tests/e2e.test-d.ts
@@ -118,9 +118,7 @@ describe('.streamedOptions', () => {
     const queryStore = createQuery(streamedOrpc.streamed.experimental_streamedOptions({
       input: { input: 123 },
       retry(failureCount, error) {
-        if (isDefinedError(error) && error.code === 'BASE') {
-          expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
-        }
+        expectTypeOf(error).toEqualTypeOf<Error>()
 
         return false
       },
@@ -128,8 +126,8 @@ describe('.streamedOptions', () => {
 
     const query = get(queryStore)
 
-    if (query.status === 'error' && isDefinedError(query.error) && query.error.code === 'OVERRIDE') {
-      expectTypeOf(query.error.data).toEqualTypeOf<unknown>()
+    if (query.status === 'error') {
+      expectTypeOf(query.error).toEqualTypeOf<Error>()
     }
 
     if (query.status === 'success') {
@@ -159,9 +157,7 @@ describe('.streamedOptions', () => {
           input: { input: 123 },
           select: data => ({ mapped: data }),
           retry(failureCount, error) {
-            if (isDefinedError(error) && error.code === 'BASE') {
-              expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
-            }
+            expectTypeOf(error).toEqualTypeOf<Error>()
 
             return false
           },
@@ -174,8 +170,8 @@ describe('.streamedOptions', () => {
 
     const queries = get(queriesStore)
 
-    if (queries[0].status === 'error' && isDefinedError(queries[0].error) && queries[0].error.code === 'BASE') {
-      expectTypeOf(queries[0].error.data).toEqualTypeOf<{ output: string }>()
+    if (queries[0].status === 'error') {
+      expectTypeOf(queries[0].error).toEqualTypeOf<Error>()
     }
 
     if (queries[0].status === 'success') {

--- a/packages/tanstack-query/src/procedure-utils.angular.test-d.ts
+++ b/packages/tanstack-query/src/procedure-utils.angular.test-d.ts
@@ -97,18 +97,18 @@ describe('ProcedureUtils', () => {
       it('without args', () => {
         const query = injectQuery(() => streamUtils.experimental_streamedOptions())
         expectTypeOf(query.data()).toEqualTypeOf<UtilsOutput | undefined>()
-        expectTypeOf(query.error()).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error()).toEqualTypeOf<Error | null>()
       })
 
       it('can infer errors inside options', () => {
         const query = injectQuery(() => streamUtils.experimental_streamedOptions({
           throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<UtilsError>()
+            expectTypeOf(error).toEqualTypeOf<Error>()
             return false
           },
         }))
         expectTypeOf(query.data()).toEqualTypeOf<UtilsOutput | undefined>()
-        expectTypeOf(query.error()).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error()).toEqualTypeOf<Error | null>()
       })
 
       it('with initial data & select', () => {
@@ -118,7 +118,7 @@ describe('ProcedureUtils', () => {
         }))
 
         expectTypeOf(query.data()).toEqualTypeOf<{ mapped: UtilsOutput }>()
-        expectTypeOf(query.error()).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error()).toEqualTypeOf<Error | null>()
       })
     })
 
@@ -142,11 +142,9 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries()[1].data).toEqualTypeOf<UtilsOutput | undefined>()
       expectTypeOf(queries()[2].data).toEqualTypeOf<{ mapped: UtilsOutput } | undefined>()
 
-      // @ts-expect-error - TODO: fix this, injectQueries not work at all
-      expectTypeOf(queries()[0].error).toEqualTypeOf<null | UtilsError>()
-      // @ts-expect-error - TODO: fix this, injectQueries not work at all
-      expectTypeOf(queries()[1].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(queries()[2].error).toEqualTypeOf<null | UtilsError>()
+      expectTypeOf(queries()[0].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries()[1].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries()[2].error).toEqualTypeOf<null | Error>()
     })
 
     it('fetchQuery', () => {
@@ -163,18 +161,18 @@ describe('ProcedureUtils', () => {
       it('without args', () => {
         const query = injectQuery(() => streamUtils.experimental_liveOptions())
         expectTypeOf(query.data()).toEqualTypeOf<UtilsOutput[number] | undefined>()
-        expectTypeOf(query.error()).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error()).toEqualTypeOf<Error | null>()
       })
 
       it('can infer errors inside options', () => {
         const query = injectQuery(() => streamUtils.experimental_liveOptions({
           throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<UtilsError>()
+            expectTypeOf(error).toEqualTypeOf<Error>()
             return false
           },
         }))
         expectTypeOf(query.data()).toEqualTypeOf<UtilsOutput[number] | undefined>()
-        expectTypeOf(query.error()).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error()).toEqualTypeOf<Error | null>()
       })
 
       it('with initial data & select', () => {
@@ -184,7 +182,7 @@ describe('ProcedureUtils', () => {
         }))
 
         expectTypeOf(query.data()).toEqualTypeOf<{ mapped: UtilsOutput[number] }>()
-        expectTypeOf(query.error()).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error()).toEqualTypeOf<Error | null>()
       })
     })
 
@@ -208,11 +206,9 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries()[1].data).toEqualTypeOf<UtilsOutput[number] | undefined>()
       expectTypeOf(queries()[2].data).toEqualTypeOf<{ mapped: UtilsOutput[number] } | undefined>()
 
-      // @ts-expect-error - TODO: fix this, injectQueries not work at all
-      expectTypeOf(queries()[0].error).toEqualTypeOf<null | UtilsError>()
-      // @ts-expect-error - TODO: fix this, injectQueries not work at all
-      expectTypeOf(queries()[1].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(queries()[2].error).toEqualTypeOf<null | UtilsError>()
+      expectTypeOf(queries()[0].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries()[1].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries()[2].error).toEqualTypeOf<null | Error>()
     })
 
     it('fetchQuery', () => {

--- a/packages/tanstack-query/src/procedure-utils.react.test-d.ts
+++ b/packages/tanstack-query/src/procedure-utils.react.test-d.ts
@@ -144,18 +144,18 @@ describe('ProcedureUtils', () => {
       it('without args', () => {
         const query = useQuery(streamUtils.experimental_streamedOptions())
         expectTypeOf(query.data).toEqualTypeOf<UtilsOutput | undefined>()
-        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
 
       it('can infer errors inside options', () => {
         const query = useQuery(streamUtils.experimental_streamedOptions({
           throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<UtilsError>()
+            expectTypeOf(error).toEqualTypeOf<Error>()
             return false
           },
         }))
         expectTypeOf(query.data).toEqualTypeOf<UtilsOutput | undefined>()
-        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
 
       it('with initial data & select', () => {
@@ -165,7 +165,7 @@ describe('ProcedureUtils', () => {
         }))
 
         expectTypeOf(query.data).toEqualTypeOf<{ mapped: UtilsOutput }>()
-        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
     })
 
@@ -173,19 +173,19 @@ describe('ProcedureUtils', () => {
       it('without args', () => {
         const query = useSuspenseQuery(streamUtils.experimental_streamedOptions())
         expectTypeOf(query.data).toEqualTypeOf<UtilsOutput>()
-        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
 
       it('can infer errors inside options', () => {
         const query = useSuspenseQuery(streamUtils.experimental_streamedOptions({
           throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<UtilsError>()
+            expectTypeOf(error).toEqualTypeOf<Error>()
             return false
           },
         }))
 
         expectTypeOf(query.data).toEqualTypeOf<UtilsOutput>()
-        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
 
       it('with select', () => {
@@ -194,7 +194,7 @@ describe('ProcedureUtils', () => {
         }))
 
         expectTypeOf(query.data).toEqualTypeOf<{ mapped: UtilsOutput }>()
-        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
     })
 
@@ -216,9 +216,9 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput | undefined>()
       expectTypeOf(queries[2].data).toEqualTypeOf<{ mapped: UtilsOutput } | undefined>()
 
-      expectTypeOf(queries[0].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(queries[1].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(queries[2].error).toEqualTypeOf<null | UtilsError>()
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries[1].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries[2].error).toEqualTypeOf<null | Error>()
     })
 
     it('useSuspenseQueries', () => {
@@ -239,9 +239,9 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput>()
       expectTypeOf(queries[2].data).toEqualTypeOf<{ mapped: UtilsOutput }>()
 
-      expectTypeOf(queries[0].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(queries[1].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(queries[2].error).toEqualTypeOf<null | UtilsError>()
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries[1].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries[2].error).toEqualTypeOf<null | Error>()
     })
 
     it('fetchQuery', () => {
@@ -258,18 +258,18 @@ describe('ProcedureUtils', () => {
       it('without args', () => {
         const query = useQuery(streamUtils.experimental_liveOptions())
         expectTypeOf(query.data).toEqualTypeOf<UtilsOutput[number] | undefined>()
-        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
 
       it('can infer errors inside options', () => {
         const query = useQuery(streamUtils.experimental_liveOptions({
           throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<UtilsError>()
+            expectTypeOf(error).toEqualTypeOf<Error>()
             return false
           },
         }))
         expectTypeOf(query.data).toEqualTypeOf<UtilsOutput[number] | undefined>()
-        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
 
       it('with initial data & select', () => {
@@ -279,7 +279,7 @@ describe('ProcedureUtils', () => {
         }))
 
         expectTypeOf(query.data).toEqualTypeOf<{ mapped: UtilsOutput[number] }>()
-        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
     })
 
@@ -287,19 +287,19 @@ describe('ProcedureUtils', () => {
       it('without args', () => {
         const query = useSuspenseQuery(streamUtils.experimental_liveOptions())
         expectTypeOf(query.data).toEqualTypeOf<UtilsOutput[number]>()
-        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
 
       it('can infer errors inside options', () => {
         const query = useSuspenseQuery(streamUtils.experimental_liveOptions({
           throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<UtilsError>()
+            expectTypeOf(error).toEqualTypeOf<Error>()
             return false
           },
         }))
 
         expectTypeOf(query.data).toEqualTypeOf<UtilsOutput[number]>()
-        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
 
       it('with select', () => {
@@ -308,7 +308,7 @@ describe('ProcedureUtils', () => {
         }))
 
         expectTypeOf(query.data).toEqualTypeOf<{ mapped: UtilsOutput[number] }>()
-        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
     })
 
@@ -330,9 +330,9 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput[number] | undefined>()
       expectTypeOf(queries[2].data).toEqualTypeOf<{ mapped: UtilsOutput[number] } | undefined>()
 
-      expectTypeOf(queries[0].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(queries[1].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(queries[2].error).toEqualTypeOf<null | UtilsError>()
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries[1].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries[2].error).toEqualTypeOf<null | Error>()
     })
 
     it('useSuspenseQueries', () => {
@@ -353,9 +353,9 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput[number]>()
       expectTypeOf(queries[2].data).toEqualTypeOf<{ mapped: UtilsOutput[number] }>()
 
-      expectTypeOf(queries[0].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(queries[1].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(queries[2].error).toEqualTypeOf<null | UtilsError>()
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries[1].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries[2].error).toEqualTypeOf<null | Error>()
     })
 
     it('fetchQuery', () => {

--- a/packages/tanstack-query/src/procedure-utils.solid.test-d.ts
+++ b/packages/tanstack-query/src/procedure-utils.solid.test-d.ts
@@ -92,18 +92,18 @@ describe('ProcedureUtils', () => {
       it('without args', () => {
         const query = useQuery(() => streamUtils.experimental_streamedOptions())
         expectTypeOf(query.data).toEqualTypeOf<UtilsOutput | undefined>()
-        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
 
       it('can infer errors inside options', () => {
         const query = useQuery(() => streamUtils.experimental_streamedOptions({
           throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<UtilsError>()
+            expectTypeOf(error).toEqualTypeOf<Error>()
             return false
           },
         }))
         expectTypeOf(query.data).toEqualTypeOf<UtilsOutput | undefined>()
-        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
 
       it('with initial data & select', () => {
@@ -113,7 +113,7 @@ describe('ProcedureUtils', () => {
         }))
 
         expectTypeOf(query.data).toEqualTypeOf<{ mapped: UtilsOutput }>()
-        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
     })
 
@@ -135,9 +135,9 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput | undefined>()
       expectTypeOf(queries[2].data).toEqualTypeOf<{ mapped: UtilsOutput } | undefined>()
 
-      expectTypeOf(queries[0].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(queries[1].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(queries[2].error).toEqualTypeOf<null | UtilsError>()
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries[1].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries[2].error).toEqualTypeOf<null | Error>()
     })
 
     it('fetchQuery', () => {
@@ -154,18 +154,18 @@ describe('ProcedureUtils', () => {
       it('without args', () => {
         const query = useQuery(() => streamUtils.experimental_liveOptions())
         expectTypeOf(query.data).toEqualTypeOf<UtilsOutput[number] | undefined>()
-        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
 
       it('can infer errors inside options', () => {
         const query = useQuery(() => streamUtils.experimental_liveOptions({
           throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<UtilsError>()
+            expectTypeOf(error).toEqualTypeOf<Error>()
             return false
           },
         }))
         expectTypeOf(query.data).toEqualTypeOf<UtilsOutput[number] | undefined>()
-        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
 
       it('with initial data & select', () => {
@@ -175,7 +175,7 @@ describe('ProcedureUtils', () => {
         }))
 
         expectTypeOf(query.data).toEqualTypeOf<{ mapped: UtilsOutput[number] }>()
-        expectTypeOf(query.error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error).toEqualTypeOf<Error | null>()
       })
     })
 
@@ -197,9 +197,9 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries[1].data).toEqualTypeOf<UtilsOutput[number] | undefined>()
       expectTypeOf(queries[2].data).toEqualTypeOf<{ mapped: UtilsOutput[number] } | undefined>()
 
-      expectTypeOf(queries[0].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(queries[1].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(queries[2].error).toEqualTypeOf<null | UtilsError>()
+      expectTypeOf(queries[0].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries[1].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries[2].error).toEqualTypeOf<null | Error>()
     })
 
     it('fetchQuery', () => {

--- a/packages/tanstack-query/src/procedure-utils.svelte.test-d.ts
+++ b/packages/tanstack-query/src/procedure-utils.svelte.test-d.ts
@@ -93,18 +93,18 @@ describe('ProcedureUtils', () => {
       it('without args', () => {
         const query = createQuery(streamUtils.experimental_streamedOptions())
         expectTypeOf(get(query).data).toEqualTypeOf<UtilsOutput | undefined>()
-        expectTypeOf(get(query).error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(get(query).error).toEqualTypeOf<Error | null>()
       })
 
       it('can infer errors inside options', () => {
         const query = createQuery(streamUtils.experimental_streamedOptions({
           throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<UtilsError>()
+            expectTypeOf(error).toEqualTypeOf<Error>()
             return false
           },
         }))
         expectTypeOf(get(query).data).toEqualTypeOf<UtilsOutput | undefined>()
-        expectTypeOf(get(query).error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(get(query).error).toEqualTypeOf<Error | null>()
       })
 
       it('with initial data & select', () => {
@@ -114,7 +114,7 @@ describe('ProcedureUtils', () => {
         }))
 
         expectTypeOf(get(query).data).toEqualTypeOf<{ mapped: UtilsOutput }>()
-        expectTypeOf(get(query).error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(get(query).error).toEqualTypeOf<Error | null>()
       })
     })
 
@@ -136,9 +136,9 @@ describe('ProcedureUtils', () => {
       expectTypeOf(get(queries)[1].data).toEqualTypeOf<UtilsOutput | undefined>()
       expectTypeOf(get(queries)[2].data).toEqualTypeOf<{ mapped: UtilsOutput } | undefined>()
 
-      expectTypeOf(get(queries)[0].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(get(queries)[1].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(get(queries)[2].error).toEqualTypeOf<null | UtilsError>()
+      expectTypeOf(get(queries)[0].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(get(queries)[1].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(get(queries)[2].error).toEqualTypeOf<null | Error>()
     })
 
     it('fetchQuery', () => {
@@ -155,18 +155,18 @@ describe('ProcedureUtils', () => {
       it('without args', () => {
         const query = createQuery(streamUtils.experimental_liveOptions())
         expectTypeOf(get(query).data).toEqualTypeOf<UtilsOutput[number] | undefined>()
-        expectTypeOf(get(query).error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(get(query).error).toEqualTypeOf<Error | null>()
       })
 
       it('can infer errors inside options', () => {
         const query = createQuery(streamUtils.experimental_liveOptions({
           throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<UtilsError>()
+            expectTypeOf(error).toEqualTypeOf<Error>()
             return false
           },
         }))
         expectTypeOf(get(query).data).toEqualTypeOf<UtilsOutput[number] | undefined>()
-        expectTypeOf(get(query).error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(get(query).error).toEqualTypeOf<Error | null>()
       })
 
       it('with initial data & select', () => {
@@ -176,7 +176,7 @@ describe('ProcedureUtils', () => {
         }))
 
         expectTypeOf(get(query).data).toEqualTypeOf<{ mapped: UtilsOutput[number] }>()
-        expectTypeOf(get(query).error).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(get(query).error).toEqualTypeOf<Error | null>()
       })
     })
 
@@ -198,9 +198,9 @@ describe('ProcedureUtils', () => {
       expectTypeOf(get(queries)[1].data).toEqualTypeOf<UtilsOutput[number] | undefined>()
       expectTypeOf(get(queries)[2].data).toEqualTypeOf<{ mapped: UtilsOutput[number] } | undefined>()
 
-      expectTypeOf(get(queries)[0].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(get(queries)[1].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(get(queries)[2].error).toEqualTypeOf<null | UtilsError>()
+      expectTypeOf(get(queries)[0].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(get(queries)[1].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(get(queries)[2].error).toEqualTypeOf<null | Error>()
     })
 
     it('fetchQuery', () => {

--- a/packages/tanstack-query/src/procedure-utils.test-d.ts
+++ b/packages/tanstack-query/src/procedure-utils.test-d.ts
@@ -217,7 +217,7 @@ describe('ProcedureUtils', () => {
     it('.getQueryState is typed correctly', () => {
       const state = queryClient.getQueryState(streamUtils.experimental_streamedKey())
       expectTypeOf(state?.data).toEqualTypeOf<UtilsOutput | undefined>()
-      expectTypeOf(state?.error).toEqualTypeOf<UtilsError | null | undefined>()
+      expectTypeOf(state?.error).toEqualTypeOf<Error | null | undefined>()
     })
   })
 
@@ -294,7 +294,7 @@ describe('ProcedureUtils', () => {
     it('.getQueryState is typed correctly', () => {
       const state = queryClient.getQueryState(streamUtils.experimental_streamedOptions().queryKey)
       expectTypeOf(state?.data).toEqualTypeOf<UtilsOutput | undefined>()
-      expectTypeOf(state?.error).toEqualTypeOf<UtilsError | null | undefined>()
+      expectTypeOf(state?.error).toEqualTypeOf<Error | null | undefined>()
     })
   })
 
@@ -346,7 +346,7 @@ describe('ProcedureUtils', () => {
     it('.getQueryState is typed correctly', () => {
       const state = queryClient.getQueryState(streamUtils.experimental_liveKey())
       expectTypeOf(state?.data).toEqualTypeOf<UtilsOutput[number] | undefined>()
-      expectTypeOf(state?.error).toEqualTypeOf<UtilsError | null | undefined>()
+      expectTypeOf(state?.error).toEqualTypeOf<Error | null | undefined>()
     })
   })
 
@@ -423,7 +423,7 @@ describe('ProcedureUtils', () => {
     it('.getQueryState is typed correctly', () => {
       const state = queryClient.getQueryState(streamUtils.experimental_liveOptions().queryKey)
       expectTypeOf(state?.data).toEqualTypeOf<UtilsOutput[number] | undefined>()
-      expectTypeOf(state?.error).toEqualTypeOf<UtilsError | null | undefined>()
+      expectTypeOf(state?.error).toEqualTypeOf<Error | null | undefined>()
     })
   })
 

--- a/packages/tanstack-query/src/procedure-utils.ts
+++ b/packages/tanstack-query/src/procedure-utils.ts
@@ -1,6 +1,6 @@
 import type { Client, ClientContext } from '@orpc/client'
 import type { MaybeOptionalOptions } from '@orpc/shared'
-import type { DataTag, InfiniteData, QueryKey } from '@tanstack/query-core'
+import type { DataTag, DefaultError, InfiniteData, QueryKey } from '@tanstack/query-core'
 import type {
   experimental_LiveQueryOutput,
   experimental_StreamedKeyOptions,
@@ -58,12 +58,13 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
    * Generate a **full matching** key for [Streamed Query Options](https://orpc.unnoq.com/docs/integrations/tanstack-query#streamed-query-options).
    *
    * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#query-mutation-key Tanstack Query/Mutation Key Docs}
+   * @remarks Uses DefaultError instead of TError because TError only applies to the initial request. Streaming errors are not validated, so type safety cannot be guaranteed for error types.
    */
   experimental_streamedKey(
     ...rest: MaybeOptionalOptions<
       experimental_StreamedKeyOptions<TInput>
     >
-  ): DataTag<QueryKey, experimental_StreamedQueryOutput<TOutput>, TError>
+  ): DataTag<QueryKey, experimental_StreamedQueryOutput<TOutput>, DefaultError>
 
   /**
    * Configure queries for [Event Iterator](https://orpc.unnoq.com/docs/event-iterator).
@@ -71,23 +72,25 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
    * and works with hooks like `useQuery`, `useSuspenseQuery`, or `prefetchQuery`.
    *
    * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#streamed-query-options Tanstack Streamed Query Options Utility Docs}
+   * @remarks Uses DefaultError instead of TError because TError only applies to the initial request. Streaming errors are not validated, so type safety cannot be guaranteed for error types.
    */
   experimental_streamedOptions<U, USelectData = experimental_StreamedQueryOutput<TOutput>>(
     ...rest: MaybeOptionalOptions<
-      U & StreamedOptionsIn<TClientContext, TInput, experimental_StreamedQueryOutput<TOutput>, TError, USelectData>
+      U & StreamedOptionsIn<TClientContext, TInput, experimental_StreamedQueryOutput<TOutput>, DefaultError, USelectData>
     >
-  ): NoInfer<U & Omit<StreamedOptionsBase<experimental_StreamedQueryOutput<TOutput>, TError>, keyof U>>
+  ): NoInfer<U & Omit<StreamedOptionsBase<experimental_StreamedQueryOutput<TOutput>, DefaultError>, keyof U>>
 
   /**
    * Generate a **full matching** key for [Live Query Options](https://orpc.unnoq.com/docs/integrations/tanstack-query#live-query-options).
    *
    * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#query-mutation-key Tanstack Query/Mutation Key Docs}
+   * @remarks Uses DefaultError instead of TError because TError only applies to the initial request. Streaming errors are not validated, so type safety cannot be guaranteed for error types.
    */
   experimental_liveKey(
     ...rest: MaybeOptionalOptions<
       QueryKeyOptions<TInput>
     >
-  ): DataTag<QueryKey, experimental_LiveQueryOutput<TOutput>, TError>
+  ): DataTag<QueryKey, experimental_LiveQueryOutput<TOutput>, DefaultError>
 
   /**
    * Configure live queries for [Event Iterator](https://orpc.unnoq.com/docs/event-iterator).
@@ -95,12 +98,13 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
    * Works with hooks like `useQuery`, `useSuspenseQuery`, or `prefetchQuery`.
    *
    * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#live-query-options Tanstack Live Query Options Utility Docs}
+   * @remarks Uses DefaultError instead of TError because TError only applies to the initial request. Streaming errors are not validated, so type safety cannot be guaranteed for error types.
    */
   experimental_liveOptions<U, USelectData = experimental_LiveQueryOutput<TOutput>>(
     ...rest: MaybeOptionalOptions<
-      U & QueryOptionsIn<TClientContext, TInput, experimental_LiveQueryOutput<TOutput>, TError, USelectData>
+      U & QueryOptionsIn<TClientContext, TInput, experimental_LiveQueryOutput<TOutput>, DefaultError, USelectData>
     >
-  ): NoInfer<U & Omit<QueryOptionsBase<experimental_LiveQueryOutput<TOutput>, TError>, keyof U>>
+  ): NoInfer<U & Omit<QueryOptionsBase<experimental_LiveQueryOutput<TOutput>, DefaultError>, keyof U>>
 
   /**
    * Generate a **full matching** key for [Infinite Query Options](https://orpc.unnoq.com/docs/integrations/tanstack-query#infinite-query-options).

--- a/packages/tanstack-query/src/procedure-utils.vue.test-d.ts
+++ b/packages/tanstack-query/src/procedure-utils.vue.test-d.ts
@@ -98,19 +98,19 @@ describe('ProcedureUtils', () => {
         const query = useQuery(computed(() => streamUtils.experimental_streamedOptions()))
 
         expectTypeOf(query.data.value).toEqualTypeOf<UtilsOutput | undefined>()
-        expectTypeOf(query.error.value).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error.value).toEqualTypeOf<Error | null>()
       })
 
       it('can infer errors inside options', () => {
         const query = useQuery(computed(() => streamUtils.experimental_streamedOptions({
           throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<UtilsError>()
+            expectTypeOf(error).toEqualTypeOf<Error>()
             return false
           },
         })))
 
         expectTypeOf(query.data.value).toEqualTypeOf<UtilsOutput | undefined>()
-        expectTypeOf(query.error.value).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error.value).toEqualTypeOf<Error | null>()
       })
 
       it('with initial data & select', () => {
@@ -121,7 +121,7 @@ describe('ProcedureUtils', () => {
 
         // @ts-expect-error - TODO: fix this, seem vue-query do not understand initialData
         expectTypeOf(query.data.value).toEqualTypeOf<{ mapped: UtilsOutput }>()
-        expectTypeOf(query.error.value).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error.value).toEqualTypeOf<Error | null>()
       })
     })
 
@@ -144,9 +144,9 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries.value[1].data).toEqualTypeOf<UtilsOutput | undefined>()
       expectTypeOf(queries.value[2].data).toEqualTypeOf<{ mapped: UtilsOutput } | undefined>()
 
-      expectTypeOf(queries.value[0].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(queries.value[1].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(queries.value[2].error).toEqualTypeOf<null | UtilsError>()
+      expectTypeOf(queries.value[0].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries.value[1].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries.value[2].error).toEqualTypeOf<null | Error>()
     })
 
     it('fetchQuery', () => {
@@ -164,19 +164,19 @@ describe('ProcedureUtils', () => {
         const query = useQuery(computed(() => streamUtils.experimental_liveOptions()))
 
         expectTypeOf(query.data.value).toEqualTypeOf<UtilsOutput[number] | undefined>()
-        expectTypeOf(query.error.value).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error.value).toEqualTypeOf<Error | null>()
       })
 
       it('can infer errors inside options', () => {
         const query = useQuery(computed(() => streamUtils.experimental_liveOptions({
           throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<UtilsError>()
+            expectTypeOf(error).toEqualTypeOf<Error>()
             return false
           },
         })))
 
         expectTypeOf(query.data.value).toEqualTypeOf<UtilsOutput[number] | undefined>()
-        expectTypeOf(query.error.value).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error.value).toEqualTypeOf<Error | null>()
       })
 
       it('with initial data & select', () => {
@@ -187,7 +187,7 @@ describe('ProcedureUtils', () => {
 
         // @ts-expect-error - TODO: fix this, seem vue-query do not understand initialData
         expectTypeOf(query.data.value).toEqualTypeOf<{ mapped: UtilsOutput[number] }>()
-        expectTypeOf(query.error.value).toEqualTypeOf<UtilsError | null>()
+        expectTypeOf(query.error.value).toEqualTypeOf<Error | null>()
       })
     })
 
@@ -210,9 +210,9 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries.value[1].data).toEqualTypeOf<UtilsOutput[number] | undefined>()
       expectTypeOf(queries.value[2].data).toEqualTypeOf<{ mapped: UtilsOutput[number] } | undefined>()
 
-      expectTypeOf(queries.value[0].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(queries.value[1].error).toEqualTypeOf<null | UtilsError>()
-      expectTypeOf(queries.value[2].error).toEqualTypeOf<null | UtilsError>()
+      expectTypeOf(queries.value[0].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries.value[1].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries.value[2].error).toEqualTypeOf<null | Error>()
     })
 
     it('fetchQuery', () => {

--- a/packages/tanstack-query/tests/e2e.test-d.ts
+++ b/packages/tanstack-query/tests/e2e.test-d.ts
@@ -184,9 +184,7 @@ it('.streamedKey', () => {
 
   expectTypeOf(state?.data).toEqualTypeOf<{ output: string }[] | undefined>()
 
-  if (isDefinedError(state?.error) && state.error.code === 'OVERRIDE') {
-    expectTypeOf(state.error.data).toEqualTypeOf<unknown>()
-  }
+  expectTypeOf(state?.error).toEqualTypeOf<Error | null | undefined>()
 })
 
 describe('.streamedOptions', () => {
@@ -194,16 +192,14 @@ describe('.streamedOptions', () => {
     const query = useQuery(streamedOrpc.streamed.experimental_streamedOptions({
       input: { input: 123 },
       retry(failureCount, error) {
-        if (isDefinedError(error) && error.code === 'BASE') {
-          expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
-        }
+        expectTypeOf(error).toEqualTypeOf<Error>()
 
         return false
       },
     }))
 
-    if (query.status === 'error' && isDefinedError(query.error) && query.error.code === 'OVERRIDE') {
-      expectTypeOf(query.error.data).toEqualTypeOf<unknown>()
+    if (query.status === 'error') {
+      expectTypeOf(query.error).toEqualTypeOf<Error>()
     }
 
     if (query.status === 'success') {
@@ -230,16 +226,14 @@ describe('.streamedOptions', () => {
     const query = useSuspenseQuery(streamedOrpc.streamed.experimental_streamedOptions({
       input: { input: 123 },
       retry(failureCount, error) {
-        if (isDefinedError(error) && error.code === 'BASE') {
-          expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
-        }
+        expectTypeOf(error).toEqualTypeOf<Error>()
 
         return false
       },
     }))
 
-    if (query.status === 'error' && isDefinedError(query.error) && query.error.code === 'OVERRIDE') {
-      expectTypeOf(query.error.data).toEqualTypeOf<unknown>()
+    if (query.status === 'error') {
+      expectTypeOf(query.error).toEqualTypeOf<Error>()
     }
 
     expectTypeOf(query.data).toEqualTypeOf<{ output: string }[]>()
@@ -267,9 +261,7 @@ describe('.streamedOptions', () => {
           input: { input: 123 },
           select: data => ({ mapped: data }),
           retry(failureCount, error) {
-            if (isDefinedError(error) && error.code === 'BASE') {
-              expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
-            }
+            expectTypeOf(error).toEqualTypeOf<Error>()
 
             return false
           },
@@ -280,8 +272,8 @@ describe('.streamedOptions', () => {
       ],
     })
 
-    if (queries[0].status === 'error' && isDefinedError(queries[0].error) && queries[0].error.code === 'BASE') {
-      expectTypeOf(queries[0].error.data).toEqualTypeOf<{ output: string }>()
+    if (queries[0].status === 'error') {
+      expectTypeOf(queries[0].error).toEqualTypeOf<Error>()
     }
 
     if (queries[0].status === 'success') {
@@ -304,9 +296,7 @@ describe('.streamedOptions', () => {
           input: { input: 123 },
           select: data => ({ mapped: data }),
           retry(failureCount, error) {
-            if (isDefinedError(error) && error.code === 'BASE') {
-              expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
-            }
+            expectTypeOf(error).toEqualTypeOf<Error>()
 
             return false
           },
@@ -317,8 +307,8 @@ describe('.streamedOptions', () => {
       ],
     })
 
-    if (queries[0].status === 'error' && isDefinedError(queries[0].error) && queries[0].error.code === 'OVERRIDE') {
-      expectTypeOf(queries[0].error.data).toEqualTypeOf<unknown>()
+    if (queries[0].status === 'error') {
+      expectTypeOf(queries[0].error).toEqualTypeOf<Error>()
     }
 
     expectTypeOf(queries[0].data.mapped).toEqualTypeOf<{ output: string }[]>()

--- a/packages/vue-query/src/procedure-utils.test-d.ts
+++ b/packages/vue-query/src/procedure-utils.test-d.ts
@@ -218,13 +218,13 @@ describe('ProcedureUtils', () => {
         const query = useQuery(utils.experimental_streamedOptions({
           select: data => ({ mapped: data }),
           throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap>>()
+            expectTypeOf(error).toEqualTypeOf<Error>()
             return false
           },
         }))
 
         expectTypeOf(query.data.value).toEqualTypeOf<{ mapped: UtilsOutput } | undefined>()
-        expectTypeOf(query.error.value).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap> | null>()
+        expectTypeOf(query.error.value).toEqualTypeOf<Error | null>()
       })
 
       it('with initial data', () => {
@@ -232,13 +232,13 @@ describe('ProcedureUtils', () => {
           select: data => ({ mapped: data }),
           initialData: [{ title: 'title' }],
           throwOnError(error) {
-            expectTypeOf(error).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap>>()
+            expectTypeOf(error).toEqualTypeOf<Error>()
             return false
           },
         }))
 
         expectTypeOf(query.data.value).toEqualTypeOf<{ mapped: UtilsOutput }>()
-        expectTypeOf(query.error.value).toEqualTypeOf<ErrorFromErrorMap<typeof baseErrorMap> | null>()
+        expectTypeOf(query.error.value).toEqualTypeOf<Error | null>()
       })
     })
 
@@ -258,8 +258,8 @@ describe('ProcedureUtils', () => {
       expectTypeOf(queries.value[0].data).toEqualTypeOf<{ mapped: UtilsOutput } | undefined>()
       expectTypeOf(queries.value[1].data).toEqualTypeOf<UtilsOutput | undefined>()
 
-      expectTypeOf(queries.value[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
-      expectTypeOf(queries.value[0].error).toEqualTypeOf<null | ErrorFromErrorMap<typeof baseErrorMap>>()
+      expectTypeOf(queries.value[0].error).toEqualTypeOf<null | Error>()
+      expectTypeOf(queries.value[0].error).toEqualTypeOf<null | Error>()
     })
 
     it('works with fetchQuery', () => {

--- a/packages/vue-query/src/procedure-utils.ts
+++ b/packages/vue-query/src/procedure-utils.ts
@@ -1,6 +1,6 @@
 import type { Client, ClientContext } from '@orpc/client'
 import type { MaybeOptionalOptions } from '@orpc/shared'
-import type { InfiniteData } from '@tanstack/vue-query'
+import type { DefaultError, InfiniteData } from '@tanstack/vue-query'
 import type { experimental_InferStreamedOutput, experimental_StreamedOptionsBase, experimental_StreamedOptionsIn, InfiniteOptionsBase, InfiniteOptionsIn, MutationOptions, MutationOptionsIn, QueryOptionsBase, QueryOptionsIn } from './types'
 import { isAsyncIteratorObject } from '@orpc/shared'
 import { generateOperationKey } from '@orpc/tanstack-query'
@@ -32,12 +32,13 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
    * Built on top of [steamedQuery](https://tanstack.com/query/latest/docs/reference/streamedQuery)
    *
    * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query-old/basic#streamed-query-options-utility Tanstack Streamed Query Options Utility Docs}
+   * @remarks Uses DefaultError instead of TError because TError only applies to the initial request. Streaming errors are not validated, so type safety cannot be guaranteed for error types.
    */
   experimental_streamedOptions<U, USelectData = experimental_InferStreamedOutput<TOutput>>(
     ...rest: MaybeOptionalOptions<
-      U & experimental_StreamedOptionsIn<TClientContext, TInput, experimental_InferStreamedOutput<TOutput>, TError, USelectData>
+      U & experimental_StreamedOptionsIn<TClientContext, TInput, experimental_InferStreamedOutput<TOutput>, DefaultError, USelectData>
     >
-  ): NoInfer<U & Omit<experimental_StreamedOptionsBase<experimental_InferStreamedOutput<TOutput>, TError>, keyof U>>
+  ): NoInfer<U & Omit<experimental_StreamedOptionsBase<experimental_InferStreamedOutput<TOutput>, DefaultError>, keyof U>>
 
   /**
    * Generate options used for useInfiniteQuery/prefetchInfiniteQuery/...

--- a/packages/vue-query/tests/e2e.test-d.ts
+++ b/packages/vue-query/tests/e2e.test-d.ts
@@ -111,16 +111,14 @@ describe('.streamedOptions', () => {
     const query = useQuery(streamedOrpc.streamed.experimental_streamedOptions({
       input: computed(() => ({ input: 123 })),
       retry(failureCount, error) {
-        if (isDefinedError(error) && error.code === 'BASE') {
-          expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
-        }
+        expectTypeOf(error).toEqualTypeOf<Error>()
 
         return false
       },
     }))
 
-    if (query.status.value === 'error' && isDefinedError(query.error.value) && query.error.value.code === 'OVERRIDE') {
-      expectTypeOf(query.error.value.data).toEqualTypeOf<unknown>()
+    if (query.status.value === 'error' && query.error.value) {
+      expectTypeOf(query.error.value).toEqualTypeOf<Error>()
     }
 
     expectTypeOf(query.data.value).toEqualTypeOf<{ output: string }[] | undefined>()
@@ -148,9 +146,7 @@ describe('.streamedOptions', () => {
           input: { input: 123 },
           select: data => ({ mapped: data }),
           retry(failureCount, error) {
-            if (isDefinedError(error) && error.code === 'BASE') {
-              expectTypeOf(error.data).toEqualTypeOf<{ output: string }>()
-            }
+            expectTypeOf(error).toEqualTypeOf<Error>()
 
             return false
           },
@@ -161,8 +157,8 @@ describe('.streamedOptions', () => {
       ],
     })
 
-    if (queries.value[0].status === 'error' && isDefinedError(queries.value[0].error) && queries.value[0].error.code === 'BASE') {
-      expectTypeOf(queries.value[0].error.data).toEqualTypeOf<{ output: string }>()
+    if (queries.value[0].status === 'error' && queries.value[0].error) {
+      expectTypeOf(queries.value[0].error).toEqualTypeOf<Error>()
     }
 
     if (queries.value[0].status === 'success') {


### PR DESCRIPTION
Uses DefaultError instead of TError because TError only applies to the initial request. Streaming errors are not validated, so type safety cannot be guaranteed for error types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Simplified TypeScript error typing for streaming/live query utilities across React, Solid, Svelte, Vue, and Angular to use the standard Error (DefaultError) instead of mapped error types. Affects streamed/live keys and options; non-streamed queries and mutations unchanged. No runtime behavior changes.

- Documentation
  - Added notes clarifying that streaming errors use DefaultError and aren’t type-validated like initial request errors.

- Tests
  - Updated type tests to expect Error for error values and callback parameters in streaming/live scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->