### PR TITLE
feat(nest): add async configuration support for ORPCModule

### DIFF
--- a/apps/content/docs/openapi/integrations/implement-contract-in-nest.md
+++ b/apps/content/docs/openapi/integrations/implement-contract-in-nest.md
@@ -224,17 +224,23 @@ oRPC will use NestJS parsed body when it's available, and only use the oRPC pars
 Configure the `@orpc/nest` module by importing `ORPCModule` in your NestJS application:
 
 ```ts
+import { REQUEST } from '@nestjs/core'
 import { onError, ORPCModule } from '@orpc/nest'
+import { Request } from 'express' // if you use express adapter
 
 @Module({
   imports: [
-    ORPCModule.forRoot({
-      interceptors: [
-        onError((error) => {
-          console.error(error)
-        }),
-      ],
-      eventIteratorKeepAliveInterval: 5000, // 5 seconds
+    ORPCModule.forRootAsync({ // or .forRoot
+      useFactory: (request: Request) => ({
+        interceptors: [
+          onError((error) => {
+            console.error(error)
+          }),
+        ],
+        context: { request }, // oRPC context, accessible from middlewares, etc.
+        eventIteratorKeepAliveInterval: 5000, // 5 seconds
+      }),
+      inject: [REQUEST],
     }),
   ],
 })

--- a/packages/nest/src/module.ts
+++ b/packages/nest/src/module.ts
@@ -3,7 +3,6 @@ import type { AnySchema } from '@orpc/contract'
 import type { CreateProcedureClientOptions } from '@orpc/server'
 import type { SendStandardResponseOptions } from '@orpc/standard-server-node'
 import { Module } from '@nestjs/common'
-import { toArray } from '@orpc/shared'
 import { ImplementInterceptor } from './implement'
 
 export const ORPC_MODULE_CONFIG_SYMBOL = Symbol('ORPC_MODULE_CONFIG')
@@ -31,16 +30,18 @@ export class ORPCModule {
   }
 
   static forRootAsync(options: {
+    imports?: any[]
     useFactory: (...args: any[]) => Promise<ORPCModuleConfig> | ORPCModuleConfig
     inject?: any[]
   }): DynamicModule {
     return {
       module: ORPCModule,
+      imports: options.imports,
       providers: [
         {
           provide: ORPC_MODULE_CONFIG_SYMBOL,
           useFactory: options.useFactory,
-          inject: toArray(options.inject),
+          inject: options.inject,
         },
         ImplementInterceptor,
       ],

--- a/packages/nest/src/module.ts
+++ b/packages/nest/src/module.ts
@@ -3,6 +3,7 @@ import type { AnySchema } from '@orpc/contract'
 import type { CreateProcedureClientOptions } from '@orpc/server'
 import type { SendStandardResponseOptions } from '@orpc/standard-server-node'
 import { Module } from '@nestjs/common'
+import { toArray } from '@orpc/shared'
 import { ImplementInterceptor } from './implement'
 
 export const ORPC_MODULE_CONFIG_SYMBOL = Symbol('ORPC_MODULE_CONFIG')
@@ -21,6 +22,25 @@ export class ORPCModule {
         {
           provide: ORPC_MODULE_CONFIG_SYMBOL,
           useValue: config,
+        },
+        ImplementInterceptor,
+      ],
+      exports: [ORPC_MODULE_CONFIG_SYMBOL, ImplementInterceptor],
+      global: true,
+    }
+  }
+
+  static forRootAsync(options: {
+    useFactory: (...args: any[]) => Promise<ORPCModuleConfig> | ORPCModuleConfig
+    inject?: any[]
+  }): DynamicModule {
+    return {
+      module: ORPCModule,
+      providers: [
+        {
+          provide: ORPC_MODULE_CONFIG_SYMBOL,
+          useFactory: options.useFactory,
+          inject: toArray(options.inject),
         },
         ImplementInterceptor,
       ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NestJS integration now supports asynchronous configuration with per-request context, enabling access to the HTTP request in interceptors and middleware while preserving existing static configuration as an alternative.
* **Documentation**
  * Updated NestJS setup guide to show the asynchronous configuration pattern and how to expose the request in context, including keep-alive settings.
* **Tests**
  * Added tests validating async configuration, single interceptor invocation, correct propagation of request metadata (URL/headers), and keep-alive option handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->