### PR TITLE
fix(openapi): spec generator in case commonSchemas + GET + compact + no params

### DIFF
--- a/packages/openapi/src/openapi-generator.test.ts
+++ b/packages/openapi/src/openapi-generator.test.ts
@@ -1082,6 +1082,7 @@ describe('openAPIGenerator', () => {
       detailedStructure: oc.route({ path: '/detailed/{pet}', inputStructure: 'detailed', outputStructure: 'detailed' })
         .input(InputDetailedStructure)
         .output(OutputDetailedStructure),
+      getWithoutParams: oc.route({ method: 'GET' }).input(Query),
     }, {
       commonSchemas: {
         User: {
@@ -1507,6 +1508,43 @@ describe('openAPIGenerator', () => {
                 'application/json': {
                   schema: {
                     $ref: '#/components/schemas/User',
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+    })
+
+    it('work with method=GET, inputStructure=compact, and without params', async () => {
+      expect(spec.paths!['/getWithoutParams']).toEqual({
+        get: {
+          operationId: 'getWithoutParams',
+          parameters: [
+            {
+              allowEmptyValue: true,
+              allowReserved: true,
+              name: 'user',
+              in: 'query',
+              explode: true,
+              required: true,
+              schema: {
+                $ref: '#/components/schemas/User',
+              },
+              style: 'deepObject',
+            },
+          ],
+          responses: {
+            200: {
+              description: 'OK',
+              content: {
+                'application/json': {
+                  schema: {
+                    anyOf: [
+                      {},
+                      { not: {} },
+                    ],
                   },
                 },
               },

--- a/packages/openapi/src/openapi-generator.ts
+++ b/packages/openapi/src/openapi-generator.ts
@@ -323,14 +323,16 @@ export class OpenAPIGenerator {
       }
 
       if (method === 'GET') {
-        if (!isObjectSchema(schema)) {
+        const resolvedSchema = resolveOpenAPIJsonSchemaRef(doc, schema)
+
+        if (!isObjectSchema(resolvedSchema)) {
           throw new OpenAPIGeneratorError(
             'When method is "GET", input schema must satisfy: object | any | unknown',
           )
         }
 
         ref.parameters ??= []
-        ref.parameters.push(...toOpenAPIParameters(schema, 'query'))
+        ref.parameters.push(...toOpenAPIParameters(resolvedSchema, 'query'))
       }
       else {
         ref.requestBody = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected OpenAPI generation for GET endpoints using referenced query schemas, ensuring parameters are accurately expanded and validated.
  * Improved handling of complex query objects (e.g., deepObject style), producing precise parameter definitions in the spec.

* **Tests**
  * Added a test case for a GET route with a referenced query object to verify correct parameter generation and response schema handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->