### PR TITLE
fix(server): Compression Plugin (fetch) response invalid status

### DIFF
--- a/packages/server/src/adapters/fetch/compression-plugin.ts
+++ b/packages/server/src/adapters/fetch/compression-plugin.ts
@@ -119,7 +119,8 @@ export class CompressionPlugin<T extends Context> implements FetchHandlerPlugin<
       return {
         ...result,
         response: new Response(compressedBody, {
-          ...response,
+          status: response.status,
+          statusText: response.statusText,
           headers: compressedHeaders,
         }),
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Correctly preserves status and status text on compressed responses.
  - Ensures gzip-compressed error responses include proper Content-Encoding and body content.
  - Improves compatibility of compressed error handling across clients.
- Tests
  - Added test coverage for gzip-compressed error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->