### PR TITLE
feat(client): support fetch headers in link options

### DIFF
--- a/apps/content/docs/adapters/next.md
+++ b/apps/content/docs/adapters/next.md
@@ -102,7 +102,7 @@ const link = new RPCLink({
     }
 
     const { headers } = await import('next/headers')
-    return Object.fromEntries(await headers())
+    return await headers()
   },
 })
 ```

--- a/apps/content/docs/adapters/nuxt.md
+++ b/apps/content/docs/adapters/nuxt.md
@@ -57,7 +57,7 @@ export default defineNuxtPlugin(() => {
 
   const link = new RPCLink({
     url: `${typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3000'}/rpc`,
-    headers: () => Object.fromEntries(event?.headers ?? []),
+    headers: event?.headers,
   })
 
   const client: RouterClient<typeof router> = createORPCClient(link)

--- a/apps/content/docs/adapters/solid-start.md
+++ b/apps/content/docs/adapters/solid-start.md
@@ -61,7 +61,7 @@ import { getRequestEvent } from 'solid-js/web'
 
 const link = new RPCLink({
   url: `${typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3000'}/rpc`,
-  headers: () => Object.fromEntries(getRequestEvent()?.request.headers ?? []),
+  headers: () => getRequestEvent()?.request.headers ?? {},
 })
 ```
 

--- a/packages/client/src/adapters/standard/rpc-link-codec.test.ts
+++ b/packages/client/src/adapters/standard/rpc-link-codec.test.ts
@@ -104,6 +104,26 @@ describe('standardRPCLinkCodec', () => {
       expect(request.headers).toBe(mergeStandardHeadersSpy.mock.results[0]!.value)
     })
 
+    it('support fetch headers', async () => {
+      const headers = new Headers()
+      headers.append('cookie', 'a=1')
+      headers.append('cookie', 'b=2')
+      headers.append('set-cookie', 'a1=1')
+      headers.append('set-cookie', 'b1=2')
+
+      const codec = new StandardRPCLinkCodec(serializer, {
+        url: 'http://localhost:3000',
+        headers,
+      })
+
+      const request = await codec.encode(['test'], 'input', { context: {} })
+
+      expect(request.headers).toEqual({
+        'cookie': 'a=1; b=2',
+        'set-cookie': ['a1=1', 'b1=2'],
+      })
+    })
+
     describe('base url', () => {
       it('works with /prefix', async () => {
         const codec = new StandardRPCLinkCodec(serializer, {

--- a/packages/client/src/adapters/standard/utils.test.ts
+++ b/packages/client/src/adapters/standard/utils.test.ts
@@ -1,9 +1,15 @@
-import { getMalformedResponseErrorCode, toHttpPath } from './utils'
+import { getMalformedResponseErrorCode, toHttpPath, toStandardHeaders } from './utils'
 
 it('convertPathToHttpPath', () => {
   expect(toHttpPath(['ping'])).toEqual('/ping')
   expect(toHttpPath(['nested', 'ping'])).toEqual('/nested/ping')
   expect(toHttpPath(['nested/', 'ping'])).toEqual('/nested%2F/ping')
+})
+
+it('toStandardHeaders', () => {
+  expect(toStandardHeaders({})).toEqual({})
+  expect(toStandardHeaders(new Headers())).toEqual({})
+  expect(toStandardHeaders(new Headers({ 'content-type': 'application/json' }))).toEqual({ 'content-type': 'application/json' })
 })
 
 it('getMalformedResponseErrorCode', () => {

--- a/packages/client/src/adapters/standard/utils.test.ts
+++ b/packages/client/src/adapters/standard/utils.test.ts
@@ -8,8 +8,12 @@ it('convertPathToHttpPath', () => {
 
 it('toStandardHeaders', () => {
   expect(toStandardHeaders({})).toEqual({})
+  expect(toStandardHeaders({ 'content-type': 'application/json' })).toEqual({ 'content-type': 'application/json' })
+
   expect(toStandardHeaders(new Headers())).toEqual({})
-  expect(toStandardHeaders(new Headers({ 'content-type': 'application/json' }))).toEqual({ 'content-type': 'application/json' })
+  const headers = new Headers({ 'content-type': 'application/json' })
+  expect(toStandardHeaders(headers)).toEqual({ 'content-type': 'application/json' })
+  expect(toStandardHeaders({ forEach: headers.forEach.bind(headers) } as any)).toEqual({ 'content-type': 'application/json' })
 })
 
 it('getMalformedResponseErrorCode', () => {

--- a/packages/client/src/adapters/standard/utils.ts
+++ b/packages/client/src/adapters/standard/utils.ts
@@ -9,10 +9,11 @@ export function toHttpPath(path: readonly string[]): HTTPPath {
 
 export function toStandardHeaders(headers: Headers | StandardHeaders): StandardHeaders {
   /**
-   * The Headers constructor might not be available in all environments since these are standard APIs.
+   * Determines if the provided `headers` is a headers-like object.
+   * Avoids `instanceof` checks as this is intended for standard APIs where the Headers constructor may not be available.
    */
-  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
-    return fetchHeadersToStandardHeaders(headers)
+  if (typeof headers.forEach === 'function') {
+    return fetchHeadersToStandardHeaders(headers as Headers)
   }
 
   return headers as StandardHeaders

--- a/packages/client/src/adapters/standard/utils.ts
+++ b/packages/client/src/adapters/standard/utils.ts
@@ -1,8 +1,21 @@
+import type { StandardHeaders } from '@orpc/standard-server'
 import type { HTTPPath } from '../../types'
+import { toStandardHeaders as fetchHeadersToStandardHeaders } from '@orpc/standard-server-fetch'
 import { COMMON_ORPC_ERROR_DEFS } from '../../error'
 
 export function toHttpPath(path: readonly string[]): HTTPPath {
   return `/${path.map(encodeURIComponent).join('/')}`
+}
+
+export function toStandardHeaders(headers: Headers | StandardHeaders): StandardHeaders {
+  /**
+   * The Headers constructor might not be available in all environments since these are standard APIs.
+   */
+  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+    return fetchHeadersToStandardHeaders(headers)
+  }
+
+  return headers as StandardHeaders
 }
 
 export function getMalformedResponseErrorCode(status: number): string {

--- a/packages/openapi-client/src/adapters/standard/openapi-link-codec.test.ts
+++ b/packages/openapi-client/src/adapters/standard/openapi-link-codec.test.ts
@@ -50,6 +50,26 @@ describe('standardOpenapiLinkCodecOptions', () => {
       expect(request.headers['x-custom']).toEqual('value')
     })
 
+    it('support fetch headers', async () => {
+      const headers = new Headers()
+      headers.append('cookie', 'a=1')
+      headers.append('cookie', 'b=2')
+      headers.append('set-cookie', 'a1=1')
+      headers.append('set-cookie', 'b1=2')
+
+      const codec = new StandardOpenapiLinkCodec({ ping: oc }, serializer, {
+        url: 'http://localhost:3000',
+        headers,
+      })
+
+      const request = await codec.encode(['ping'], 'input', { context: {} })
+
+      expect(request.headers).toEqual({
+        'cookie': 'a=1; b=2',
+        'set-cookie': ['a1=1', 'b1=2'],
+      })
+    })
+
     describe('inputStructure=compact', () => {
       describe('with dynamic params', () => {
         const codec = new StandardOpenapiLinkCodec({ ping: oc.route({ path: '/ping/{date}' }) }, serializer, {

--- a/packages/standard-server-fetch/src/headers.ts
+++ b/packages/standard-server-fetch/src/headers.ts
@@ -5,7 +5,7 @@ import type { StandardHeaders } from '@orpc/standard-server'
  * @param standardHeaders - The base headers can be changed by the function and effects on the original headers.
  */
 export function toStandardHeaders(headers: Headers, standardHeaders: StandardHeaders = {}): StandardHeaders {
-  for (const [key, value] of headers) {
+  headers.forEach((value, key) => {
     if (Array.isArray(standardHeaders[key])) {
       standardHeaders[key].push(value)
     }
@@ -15,7 +15,7 @@ export function toStandardHeaders(headers: Headers, standardHeaders: StandardHea
     else {
       standardHeaders[key] = value
     }
-  }
+  })
 
   return standardHeaders
 }

--- a/playgrounds/solid-start/src/lib/orpc.ts
+++ b/playgrounds/solid-start/src/lib/orpc.ts
@@ -15,7 +15,7 @@ declare global {
 
 const link = new RPCLink({
   url: `${typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3000'}/rpc`,
-  headers: () => Object.fromEntries(getRequestEvent()?.request.headers ?? []),
+  headers: () => getRequestEvent()?.request.headers ?? {},
 })
 
 export const client: RouterClient<typeof router> = globalThis.$client ?? createORPCClient(link)


### PR DESCRIPTION
Support fetch `Headers` in `headers` link option - no more `Object.fromEntries`

```diff
 import { RPCLink } from '@orpc/client/fetch'
 const link = new RPCLink({
   url: `${typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3000'}/rpc`,
   headers: async () => {
     if (typeof window !== 'undefined') {
       return {}
     }

    const { headers } = await import('next/headers')
-    return Object.fromEntries(await headers())
+    return await headers()
   },
 })
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Client and OpenAPI codecs now accept Fetch API Headers and normalize them for requests.
- Bug Fixes / Behavior
  - Header semantics preserved: cookies merged into a single header; multiple set-cookie values retained; last-event-id merged when present.
- Documentation
  - Next.js, Nuxt, Solid Start guides and examples updated to pass Headers directly.
- Tests
  - Added tests validating Fetch Headers handling, including cookie and set-cookie behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->