### PR TITLE
feat(contract): add failed data to ValidationError for debugging

### DIFF
--- a/packages/contract/src/error.ts
+++ b/packages/contract/src/error.ts
@@ -5,6 +5,10 @@ import type { AnySchema, InferSchemaOutput, Schema, SchemaIssue } from './schema
 export interface ValidationErrorOptions extends ErrorOptions {
   message: string
   issues: readonly SchemaIssue[]
+  /**
+   * @todo require this field in v2
+   */
+  data?: unknown
 }
 
 /**
@@ -14,11 +18,13 @@ export interface ValidationErrorOptions extends ErrorOptions {
  */
 export class ValidationError extends Error {
   readonly issues: readonly SchemaIssue[]
+  readonly data: unknown
 
   constructor(options: ValidationErrorOptions) {
     super(options.message, options)
 
     this.issues = options.issues
+    this.data = options.data
   }
 }
 

--- a/packages/contract/src/event-iterator.test.ts
+++ b/packages/contract/src/event-iterator.test.ts
@@ -45,6 +45,7 @@ describe('eventIterator', async () => {
       expect(e.code).toEqual('EVENT_ITERATOR_VALIDATION_FAILED')
       expect(e.cause).toBeInstanceOf(ValidationError)
       expect(e.cause.issues).toHaveLength(1)
+      expect(e.cause.data).toEqual({ order: '3' })
 
       return true
     })

--- a/packages/contract/src/event-iterator.ts
+++ b/packages/contract/src/event-iterator.ts
@@ -45,6 +45,7 @@ export function eventIterator<TYieldIn, TYieldOut, TReturnIn = unknown, TReturnO
                 cause: new ValidationError({
                   issues: result.issues,
                   message: 'Event iterator validation failed',
+                  data: value,
                 }),
               })
             }

--- a/packages/server/src/procedure-client.ts
+++ b/packages/server/src/procedure-client.ts
@@ -182,7 +182,11 @@ async function validateInput(procedure: AnyProcedure, input: unknown): Promise<a
           data: {
             issues: result.issues,
           },
-          cause: new ValidationError({ message: 'Input validation failed', issues: result.issues }),
+          cause: new ValidationError({
+            message: 'Input validation failed',
+            issues: result.issues,
+            data: input,
+          }),
         })
       }
 
@@ -206,7 +210,11 @@ async function validateOutput(procedure: AnyProcedure, output: unknown): Promise
       if (result.issues) {
         throw new ORPCError('INTERNAL_SERVER_ERROR', {
           message: 'Output validation failed',
-          cause: new ValidationError({ message: 'Output validation failed', issues: result.issues }),
+          cause: new ValidationError({
+            message: 'Output validation failed',
+            issues: result.issues,
+            data: output,
+          }),
         })
       }
 


### PR DESCRIPTION
Store original validation input/output in ValidationError.data to improve error debugging and troubleshooting capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Validation errors now include the offending data payload, improving debuggability for failed input/output validation and event iterator values. Existing error messages and codes are unchanged.
* **Tests**
  * Added test coverage to assert the data payload is present on validation error causes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->