### PR TITLE
refactor: migrate async generator to AsyncIteratorClass

### DIFF
--- a/packages/standard-server/src/batch/response.ts
+++ b/packages/standard-server/src/batch/response.ts
@@ -87,10 +87,6 @@ export function parseBatchResponse(response: StandardResponse): AsyncGenerator<B
     const iterator = (async function* () {
       for await (const item of body) {
         if (!isObject(item) || !('index' in item) || typeof item.index !== 'number') {
-          if (isAsyncIteratorObject(body)) {
-            await body.return?.()
-          }
-
           throw new TypeError('Invalid batch response', {
             cause: item,
           })

--- a/packages/standard-server/src/batch/response.ts
+++ b/packages/standard-server/src/batch/response.ts
@@ -1,6 +1,6 @@
 import type { Promisable } from '@orpc/shared'
 import type { StandardHeaders, StandardResponse } from '../types'
-import { isAsyncIteratorObject, isObject } from '@orpc/shared'
+import { AsyncIteratorClass, isAsyncIteratorObject, isObject } from '@orpc/shared'
 
 export type BatchResponseMode = 'streaming' | 'buffered'
 
@@ -53,21 +53,30 @@ export function toBatchResponse(options: ToBatchResponseOptions): Promisable<Sta
   return {
     headers: options.headers,
     status: options.status,
-    body: (async function* () {
-      try {
-        for await (const item of options.body) {
-          yield {
-            index: item.index,
-            status: item.status === options.status ? undefined : item.status,
-            headers: Object.keys(item.headers).length ? item.headers : undefined,
-            body: item.body,
-          } satisfies Partial<BatchResponseBodyItem>
+    body: new AsyncIteratorClass(
+      async () => {
+        const { done, value } = await options.body.next()
+
+        if (done) {
+          return { done, value }
         }
-      }
-      finally {
-        await options.body.return?.()
-      }
-    })(),
+
+        return {
+          done,
+          value: {
+            index: value.index,
+            status: value.status === options.status ? undefined : value.status,
+            headers: Object.keys(value.headers).length ? value.headers : undefined,
+            body: value.body,
+          } satisfies Partial<BatchResponseBodyItem>,
+        }
+      },
+      async (reason) => {
+        if (reason !== 'next') {
+          await options.body.return?.()
+        }
+      },
+    ),
   }
 }
 
@@ -75,29 +84,35 @@ export function parseBatchResponse(response: StandardResponse): AsyncGenerator<B
   const body = response.body
 
   if (isAsyncIteratorObject(body) || Array.isArray(body)) {
-    return (async function* () {
-      try {
-        for await (const item of body) {
-          if (!isObject(item) || !('index' in item) || typeof item.index !== 'number') {
-            throw new TypeError('Invalid batch response', {
-              cause: item,
-            })
+    const iterator = (async function* () {
+      for await (const item of body) {
+        if (!isObject(item) || !('index' in item) || typeof item.index !== 'number') {
+          if (isAsyncIteratorObject(body)) {
+            await body.return?.()
           }
 
-          yield {
-            index: item.index,
-            status: item.status as undefined | number ?? response.status,
-            headers: item.headers as undefined | StandardHeaders ?? {},
-            body: item.body,
-          } satisfies BatchResponseBodyItem
+          throw new TypeError('Invalid batch response', {
+            cause: item,
+          })
         }
-      }
-      finally {
-        if (isAsyncIteratorObject(body)) {
-          await body.return?.()
-        }
+
+        yield {
+          index: item.index,
+          status: item.status as undefined | number ?? response.status,
+          headers: item.headers as undefined | StandardHeaders ?? {},
+          body: item.body,
+        } satisfies BatchResponseBodyItem
       }
     })()
+
+    return new AsyncIteratorClass(
+      () => iterator.next(),
+      async (reason) => {
+        if (reason !== 'next' && isAsyncIteratorObject(body)) {
+          await body.return?.()
+        }
+      },
+    )
   }
 
   throw new TypeError('Invalid batch response', {


### PR DESCRIPTION
if async generator waiting for next event - can block .return - but in AsyncIteratorClass .return is allowed execute in parallel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Unified streaming wrappers across client and server for more consistent event and batch streaming and termination behavior.
- Bug Fixes
  - Streamed items now deliver full event objects and preserve/reuse metadata; streams are finalized only when appropriate to avoid resource leaks.
  - Stronger validation rejects invalid batch items and ensures cleanup runs on error or cancellation.
- Tests
  - Added tests covering cleanup on errors, retries, and explicit cancellation of batch parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->