### PR TITLE
fix(standard-server): optimize withEventMeta to avoid unnecessary proxies event iterator data

### DIFF
--- a/packages/standard-server/src/event-iterator/meta.test.ts
+++ b/packages/standard-server/src/event-iterator/meta.test.ts
@@ -23,6 +23,7 @@ it('withEventMeta only proxy when make sense', () => {
   expect(withEventMeta(data, { id: '123' })).not.toBe(data)
 
   expect(withEventMeta(data, {})).toBe(data)
+  expect(withEventMeta(data, { notExists: true } as any)).toBe(data)
   expect(withEventMeta(data, { id: undefined })).toBe(data)
   expect(withEventMeta(data, { comments: [] })).toBe(data)
 })

--- a/packages/standard-server/src/event-iterator/meta.test.ts
+++ b/packages/standard-server/src/event-iterator/meta.test.ts
@@ -15,3 +15,14 @@ it('get/withEventMeta', () => {
   expect(() => withEventMeta(data, { retry: -1 })).toThrow('Event\'s retry must be a integer and >= 0')
   expect(() => withEventMeta(data, { comments: ['hi\n'] })).toThrow('Event\'s comment must not contain a newline character')
 })
+
+it('withEventMeta only proxy when make sense', () => {
+  const data = { value: 123, meta: undefined }
+
+  expect(withEventMeta(data, { id: '123', retry: 10000, comments: ['hello', 'world'] })).not.toBe(data)
+  expect(withEventMeta(data, { id: '123' })).not.toBe(data)
+
+  expect(withEventMeta(data, {})).toBe(data)
+  expect(withEventMeta(data, { id: undefined })).toBe(data)
+  expect(withEventMeta(data, { comments: [] })).toBe(data)
+})

--- a/packages/standard-server/src/event-iterator/meta.test.ts
+++ b/packages/standard-server/src/event-iterator/meta.test.ts
@@ -20,7 +20,9 @@ it('withEventMeta only proxy when make sense', () => {
   const data = { value: 123, meta: undefined }
 
   expect(withEventMeta(data, { id: '123', retry: 10000, comments: ['hello', 'world'] })).not.toBe(data)
-  expect(withEventMeta(data, { id: '123' })).not.toBe(data)
+  expect(withEventMeta(data, { id: '' })).not.toBe(data)
+  expect(withEventMeta(data, { retry: 0 })).not.toBe(data)
+  expect(withEventMeta(data, { comments: [''] })).not.toBe(data)
 
   expect(withEventMeta(data, {})).toBe(data)
   expect(withEventMeta(data, { notExists: true } as any)).toBe(data)

--- a/packages/standard-server/src/event-iterator/meta.ts
+++ b/packages/standard-server/src/event-iterator/meta.ts
@@ -10,7 +10,7 @@ export function withEventMeta<T extends object>(container: T, meta: EventMeta): 
   if (
     meta.id === undefined
     && meta.retry === undefined
-    && (meta.comments === undefined || meta.comments.length === 0)
+    && !meta.comments?.length
   ) {
     return container
   }

--- a/packages/standard-server/src/event-iterator/meta.ts
+++ b/packages/standard-server/src/event-iterator/meta.ts
@@ -7,6 +7,14 @@ const EVENT_SOURCE_META_SYMBOL = Symbol('ORPC_EVENT_SOURCE_META')
 export type EventMeta = Partial<Pick<EventMessage, 'retry' | 'id' | 'comments'>>
 
 export function withEventMeta<T extends object>(container: T, meta: EventMeta): T {
+  if (
+    meta.id === undefined
+    && meta.retry === undefined
+    && (meta.comments === undefined || meta.comments.length === 0)
+  ) {
+    return container
+  }
+
   if (meta.id !== undefined) {
     assertEventId(meta.id)
   }


### PR DESCRIPTION
This prevents structuredClone failures on proxy things 
Fixes: #977

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Skips metadata processing when no meaningful event metadata is present, reducing overhead while preserving existing behavior.
* **Tests**
  * Added tests covering cases where metadata should be applied vs. bypassed to ensure consistent, efficient handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->