### PR TITLE
refactor: use AbortError for queue and iterator cancellation scenarios

### DIFF
--- a/packages/shared/src/queue.test.ts
+++ b/packages/shared/src/queue.test.ts
@@ -1,3 +1,4 @@
+import { AbortError } from './error'
 import { AsyncIdQueue } from './queue'
 
 describe('asyncIdQueue', () => {
@@ -11,13 +12,13 @@ describe('asyncIdQueue', () => {
 
   it('should require queue to be opened before push', () => {
     expect(() => queue.push(queueId1, 'item1')).toThrow(
-      `[AsyncIdQueue] Cannot access queue[${queueId1}] because it is not open or aborted.`,
+      new Error(`[AsyncIdQueue] Cannot access queue[${queueId1}] because it is not open or aborted.`),
     )
   })
 
   it('should require queue to be opened before pull', async () => {
     await expect(queue.pull(queueId1)).rejects.toThrow(
-      `[AsyncIdQueue] Cannot access queue[${queueId1}] because it is not open or aborted.`,
+      new Error(`[AsyncIdQueue] Cannot access queue[${queueId1}] because it is not open or aborted.`),
     )
   })
 
@@ -60,10 +61,10 @@ describe('asyncIdQueue', () => {
 
     expect(queue.isOpen(queueId1)).toBe(false)
     expect(() => queue.push(queueId1, 'item2')).toThrow(
-      `[AsyncIdQueue] Cannot access queue[${queueId1}] because it is not open or aborted.`,
+      new Error(`[AsyncIdQueue] Cannot access queue[${queueId1}] because it is not open or aborted.`),
     )
     await expect(queue.pull(queueId1)).rejects.toThrow(
-      `[AsyncIdQueue] Cannot access queue[${queueId1}] because it is not open or aborted.`,
+      new Error(`[AsyncIdQueue] Cannot access queue[${queueId1}] because it is not open or aborted.`),
     )
   })
 
@@ -76,13 +77,13 @@ describe('asyncIdQueue', () => {
     queue.close({ id: queueId1 })
 
     await expect(pullPromise1).rejects.toThrow(
-      `[AsyncIdQueue] Queue[${queueId1}] was closed or aborted while waiting for pulling.`,
+      new AbortError(`[AsyncIdQueue] Queue[${queueId1}] was closed or aborted while waiting for pulling.`),
     )
 
     queue.close()
 
     await expect(pullPromise2).rejects.toThrow(
-      `[AsyncIdQueue] Queue[${queueId2}] was closed or aborted while waiting for pulling.`,
+      new AbortError(`[AsyncIdQueue] Queue[${queueId2}] was closed or aborted while waiting for pulling.`),
     )
   })
 

--- a/packages/shared/src/queue.ts
+++ b/packages/shared/src/queue.ts
@@ -86,9 +86,8 @@ export class AsyncIdQueue<T> {
   close({ id, reason }: AsyncIdQueueCloseOptions = {}): void {
     if (id === undefined) {
       this.waiters.forEach((pendingPulls, id) => {
-        pendingPulls.forEach(([, reject]) => {
-          reject(reason ?? new AbortError(`[AsyncIdQueue] Queue[${id}] was closed or aborted while waiting for pulling.`))
-        })
+        const error = reason ?? new AbortError(`[AsyncIdQueue] Queue[${id}] was closed or aborted while waiting for pulling.`)
+        pendingPulls.forEach(([, reject]) => reject(error))
       })
 
       this.waiters.clear()
@@ -97,9 +96,8 @@ export class AsyncIdQueue<T> {
       return
     }
 
-    this.waiters.get(id)?.forEach(([, reject]) => {
-      reject(reason ?? new AbortError(`[AsyncIdQueue] Queue[${id}] was closed or aborted while waiting for pulling.`))
-    })
+    const error = reason ?? new AbortError(`[AsyncIdQueue] Queue[${id}] was closed or aborted while waiting for pulling.`)
+    this.waiters.get(id)?.forEach(([, reject]) => reject(error))
 
     this.waiters.delete(id)
     this.openIds.delete(id)

--- a/packages/shared/src/queue.ts
+++ b/packages/shared/src/queue.ts
@@ -1,3 +1,5 @@
+import { AbortError } from './error'
+
 export interface AsyncIdQueueCloseOptions {
   id?: string
   reason?: unknown
@@ -85,7 +87,7 @@ export class AsyncIdQueue<T> {
     if (id === undefined) {
       this.waiters.forEach((pendingPulls, id) => {
         pendingPulls.forEach(([, reject]) => {
-          reject(reason ?? new Error(`[AsyncIdQueue] Queue[${id}] was closed or aborted while waiting for pulling.`))
+          reject(reason ?? new AbortError(`[AsyncIdQueue] Queue[${id}] was closed or aborted while waiting for pulling.`))
         })
       })
 
@@ -96,7 +98,7 @@ export class AsyncIdQueue<T> {
     }
 
     this.waiters.get(id)?.forEach(([, reject]) => {
-      reject(reason ?? new Error(`[AsyncIdQueue] Queue[${id}] was closed or aborted while waiting for pulling.`))
+      reject(reason ?? new AbortError(`[AsyncIdQueue] Queue[${id}] was closed or aborted while waiting for pulling.`))
     })
 
     this.waiters.delete(id)

--- a/packages/standard-server-peer/src/client.test.ts
+++ b/packages/standard-server-peer/src/client.test.ts
@@ -1,4 +1,4 @@
-import { isAsyncIteratorObject } from '@orpc/shared'
+import { AbortError, isAsyncIteratorObject } from '@orpc/shared'
 import { getEventMeta, withEventMeta } from '@orpc/standard-server'
 import { ClientPeer } from './client'
 import { decodeRequestMessage, encodeResponseMessage, MessageType } from './codec'
@@ -428,7 +428,12 @@ describe('clientPeer', () => {
         return true
       })
 
+      // should throw if .return is called while waiting for .next()
+      const nextPromise = expect(iterator.next()).rejects.toBeInstanceOf(AbortError)
+      await new Promise(resolve => setTimeout(resolve, 1))
+
       expect(await iterator.return?.(undefined)).toEqual({ done: true, value: undefined })
+      await nextPromise
       expect(await iterator.next()).toEqual({ done: true, value: undefined })
 
       expect(send).toHaveBeenCalledTimes(2)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exported AbortError for consistent cancellation handling.

* **Bug Fixes**
  * Closed/aborted operations now reject with AbortError instead of generic errors, improving abort detection across queues and iterators.

* **Tests**
  * Updated tests to assert AbortError for aborted in-flight reads and adjusted iterator/stream expectations and timing.

* **Documentation**
  * Clarified behavior: aborted in-flight next() rejects with AbortError; subsequent next() yields done: true.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->