### PR TITLE
feat(standard-server): support parsed body in node adapter

### DIFF
--- a/apps/content/docs/adapters/express.md
+++ b/apps/content/docs/adapters/express.md
@@ -8,7 +8,7 @@ description: Use oRPC inside an Express.js project
 [Express.js](https://expressjs.com/) is a popular Node.js framework for building web applications. For additional context, refer to the [HTTP Adapter](/docs/adapters/http) guide.
 
 ::: warning
-oRPC uses its own request parser. To avoid conflicts, register any body-parsing middleware **after** your oRPC middleware or only on routes that don't use oRPC.
+Express's [body-parser](https://expressjs.com/en/resources/middleware/body-parser.html) handles common request body types, and oRPC will use the parsed body if available. However, it doesn't support features like [Bracket Notation](/docs/openapi/bracket-notation), and in case you upload a file with `application/json`, it may be parsed as plain JSON instead of a `File`. To avoid these issues, register any body-parsing middleware **after** your oRPC middleware or only on routes that don't use oRPC.
 :::
 
 ## Basic

--- a/apps/content/docs/adapters/next.md
+++ b/apps/content/docs/adapters/next.md
@@ -74,8 +74,7 @@ export default async (req, res) => {
 ```
 
 ::: warning
-
-Next.js default [body parser](https://nextjs.org/docs/pages/building-your-application/routing/api-routes#custom-config) blocks oRPC raw‑request handling. Ensure `bodyParser` is disabled in your API route:
+Next.js [body parser](https://nextjs.org/docs/pages/building-your-application/routing/api-routes#custom-config) may handle common request body types, and oRPC will use the parsed body if available. However, it doesn't support features like [Bracket Notation](/docs/openapi/bracket-notation), and in case you upload a file with `application/json`, it may be parsed as plain JSON instead of a `File`. To avoid these issues, disable the body parser:
 
 ```ts
 export const config = {

--- a/packages/nest/src/implement.ts
+++ b/packages/nest/src/implement.ts
@@ -126,7 +126,9 @@ export class ImplementInterceptor implements NestInterceptor {
         const standardRequest = toStandardLazyRequest(nodeReq, nodeRes)
         const fallbackStandardBody = standardRequest.body.bind(standardRequest)
         // Prefer NestJS parsed body (in nodejs body only allow parse once)
-        standardRequest.body = () => Promise.resolve(req.body ?? fallbackStandardBody())
+        standardRequest.body = () => Promise.resolve(
+          req.body === undefined ? fallbackStandardBody() : req.body,
+        )
 
         const standardResponse: StandardResponse = await (async () => {
           let isDecoding = false

--- a/packages/standard-server-node/src/body.test.ts
+++ b/packages/standard-server-node/src/body.test.ts
@@ -187,6 +187,19 @@ describe('toStandardBody', () => {
     expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledTimes(1)
     expect(getFilenameFromContentDispositionSpy).toHaveBeenCalledWith('attachment')
   })
+
+  it('prefer parsed body', async () => {
+    let standardBody: StandardBody = {} as any
+
+    await request(async (req: IncomingMessage, res: ServerResponse) => {
+      // @ts-expect-error fake body is parsed
+      req.body = { value: 123 }
+      standardBody = await toStandardBody(req)
+      res.end()
+    }).post('/').send()
+
+    expect(standardBody).toEqual({ value: 123 })
+  })
 })
 
 describe('toNodeHttpBody', () => {

--- a/packages/standard-server-node/src/body.ts
+++ b/packages/standard-server-node/src/body.ts
@@ -10,6 +10,10 @@ import { toEventIterator, toEventStream } from './event-iterator'
 export interface ToStandardBodyOptions extends ToEventIteratorOptions {}
 
 export function toStandardBody(req: NodeHttpRequest, options: ToStandardBodyOptions = {}): Promise<StandardBody> {
+  if (req.body !== undefined) {
+    return Promise.resolve(req.body)
+  }
+
   return runWithSpan({ name: 'parse_standard_body', signal: options.signal }, async () => {
     const contentDisposition = req.headers['content-disposition']
     const contentType = req.headers['content-type']

--- a/packages/standard-server-node/src/types.ts
+++ b/packages/standard-server-node/src/types.ts
@@ -7,6 +7,11 @@ export type NodeHttpRequest = (IncomingMessage | Http2ServerRequest) & {
    * This is useful for `express.js` middleware.
    */
   originalUrl?: string
+
+  /**
+   * Prefer parsed body if it is available.
+   */
+  body?: unknown
 }
 
 export type NodeHttpResponse = ServerResponse | Http2ServerResponse


### PR DESCRIPTION
Closes: https://github.com/unnoq/orpc/issues/958

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prefer an already-parsed request body when present to avoid double-parsing and preserve null values; consistent behavior across frameworks (including NestJS).

* **Documentation**
  * Clarified Express and Next.js adapter warnings about parser behavior and limitations (e.g., no Bracket Notation; application/json file uploads may be treated as JSON) and middleware placement guidance.

* **Tests**
  * Added test to verify preference for already-parsed request bodies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->