### PR TITLE
docs: prefer fetch adapter for nuxtjs

### DIFF
--- a/apps/content/docs/adapters/nuxt.md
+++ b/apps/content/docs/adapters/nuxt.md
@@ -5,7 +5,7 @@ description: Use oRPC inside an Nuxt.js project
 
 # Nuxt.js Adapter
 
-[Nuxt.js](https://nuxtjs.org/) is a popular Vue.js framework for building server-side applications. It built on top of [Nitro](https://nitro.build/) server a lightweight, high-performance Node.js runtime. For more details, see the [HTTP Adapter](/docs/adapters/http) guide.
+[Nuxt.js](https://nuxtjs.org/) is a popular Vue.js framework for building server-side applications. For more details, see the [HTTP Adapter](/docs/adapters/http) guide.
 
 ## Server
 
@@ -14,22 +14,20 @@ You set up an oRPC server inside Nuxt using its [Server Routes](https://nuxt.com
 ::: code-group
 
 ```ts [server/routes/rpc/[...].ts]
-import { RPCHandler } from '@orpc/server/node'
+import { RPCHandler } from '@orpc/server/fetch'
 
 const handler = new RPCHandler(router)
 
 export default defineEventHandler(async (event) => {
-  const { matched } = await handler.handle(
-    event.node.req,
-    event.node.res,
-    {
-      prefix: '/rpc',
-      context: {}, // Provide initial context if needed
-    }
-  )
+  const request = toWebRequest(event)
 
-  if (matched) {
-    return
+  const { response } = await handler.handle(request, {
+    prefix: '/rpc',
+    context: {}, // Provide initial context if needed
+  })
+
+  if (response) {
+    return response
   }
 
   setResponseStatus(event, 404, 'Not Found')

--- a/apps/content/docs/adapters/nuxt.md
+++ b/apps/content/docs/adapters/nuxt.md
@@ -5,7 +5,7 @@ description: Use oRPC inside an Nuxt.js project
 
 # Nuxt.js Adapter
 
-[Nuxt.js](https://nuxtjs.org/) is a popular Vue.js framework for building server-side applications. For more details, see the [HTTP Adapter](/docs/adapters/http) guide.
+[Nuxt.js](https://nuxt.com/) is a popular Vue.js framework for building server-side applications. For more details, see the [HTTP Adapter](/docs/adapters/http) guide.
 
 ## Server
 

--- a/playgrounds/nuxt/server/routes/api/[...].ts
+++ b/playgrounds/nuxt/server/routes/api/[...].ts
@@ -1,4 +1,4 @@
-import { OpenAPIHandler } from '@orpc/openapi/node'
+import { OpenAPIHandler } from '@orpc/openapi/fetch'
 import { onError } from '@orpc/server'
 import { ZodToJsonSchemaConverter } from '@orpc/zod/zod4'
 import { experimental_SmartCoercionPlugin as SmartCoercionPlugin } from '@orpc/json-schema'
@@ -63,18 +63,20 @@ const openAPIHandler = new OpenAPIHandler(router, {
 })
 
 export default defineEventHandler(async (event) => {
+  const request = toWebRequest(event)
+
   const authorization = getHeader(event, 'authorization')
   const context = authorization
     ? { user: { id: 'test', name: 'John Doe', email: 'john@doe.com' } }
     : {}
 
-  const { matched } = await openAPIHandler.handle(event.node.req, event.node.res, {
+  const { response } = await openAPIHandler.handle(request, {
     prefix: '/api',
     context,
   })
 
-  if (matched) {
-    return
+  if (response) {
+    return response
   }
 
   setResponseStatus(event, 404, 'Not Found')

--- a/playgrounds/nuxt/server/routes/rpc/[...].ts
+++ b/playgrounds/nuxt/server/routes/rpc/[...].ts
@@ -1,5 +1,5 @@
 import { onError } from '@orpc/server'
-import { RPCHandler } from '@orpc/server/node'
+import { RPCHandler } from '@orpc/server/fetch'
 import { router } from '~/server/routers'
 
 const rpcHandler = new RPCHandler(router, {
@@ -11,15 +11,17 @@ const rpcHandler = new RPCHandler(router, {
 })
 
 export default defineEventHandler(async (event) => {
+  const request = toWebRequest(event)
+
   const context = { user: { id: 'test', name: 'John Doe', email: 'john@doe.com' } }
 
-  const { matched } = await rpcHandler.handle(event.node.req, event.node.res, {
+  const { response } = await rpcHandler.handle(request, {
     prefix: '/rpc',
     context,
   })
 
-  if (matched) {
-    return
+  if (response) {
+    return response
   }
 
   setResponseStatus(event, 404, 'Not Found')


### PR DESCRIPTION
closes: #1005 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Breaking Changes
  - Request handlers now use the Web Fetch API and return a response object; update integrations to the new handler signature.
- New Features
  - Nuxt integration and example routes now use Fetch-based handlers for broader runtime compatibility (including edge).
- Bug Fixes
  - API and RPC routes return explicit 404 responses when no endpoint matches.
- Documentation
  - Nuxt adapter docs updated to reflect Fetch-based usage and revised handler patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->