### PR TITLE
fix(standard-server): handle node:http malformed url

### DIFF
--- a/packages/standard-server-node/src/url.test.ts
+++ b/packages/standard-server-node/src/url.test.ts
@@ -18,4 +18,11 @@ describe('toStandardUrl', () => {
     expect(toStandardUrl({ url: '/foo/bar', headers: {}, socket: {} } as any).pathname).toEqual('/foo/bar')
     expect(toStandardUrl({ url: '/', originalUrl: '/foo/bar/baz', headers: {}, socket: {} } as any).pathname).toEqual('/foo/bar/baz')
   })
+
+  it('malformed input', () => {
+    expect(toStandardUrl({ headers: { host: ':::' }, socket: {}, url: '/hello' } as any).href).toEqual('http://localhost/hello')
+    expect(toStandardUrl({ headers: { host: 'test/test' }, socket: {}, url: '/hello' } as any).href).toEqual('http://test/hello')
+    expect(toStandardUrl({ headers: {}, socket: {}, url: '////' } as any).href).toEqual('http://localhost////')
+    expect(toStandardUrl({ headers: {}, socket: {}, url: ':::' } as any).href).toEqual('http://localhost/:::')
+  })
 })

--- a/packages/standard-server-node/src/url.test.ts
+++ b/packages/standard-server-node/src/url.test.ts
@@ -21,7 +21,11 @@ describe('toStandardUrl', () => {
 
   it('malformed input', () => {
     expect(toStandardUrl({ headers: { host: ':::' }, socket: {}, url: '/hello' } as any).href).toEqual('http://localhost/hello')
+    expect(toStandardUrl({ headers: { host: ':::' }, socket: { encrypted: true }, url: '/hello' } as any).href).toEqual('https://localhost/hello')
+
     expect(toStandardUrl({ headers: { host: 'test/test' }, socket: {}, url: '/hello' } as any).href).toEqual('http://test/hello')
+    expect(toStandardUrl({ headers: { host: 'test/test' }, socket: { encrypted: true }, url: '/hello' } as any).href).toEqual('https://test/hello')
+
     expect(toStandardUrl({ headers: {}, socket: {}, url: '////' } as any).href).toEqual('http://localhost////')
     expect(toStandardUrl({ headers: {}, socket: {}, url: ':::' } as any).href).toEqual('http://localhost/:::')
   })

--- a/packages/standard-server-node/src/url.ts
+++ b/packages/standard-server-node/src/url.ts
@@ -1,9 +1,13 @@
 import type { NodeHttpRequest } from './types'
+import { guard } from '@orpc/shared'
 
 export function toStandardUrl(req: NodeHttpRequest): URL {
   const protocol = ('encrypted' in req.socket && req.socket.encrypted ? 'https:' : 'http:')
-  const host = req.headers.host ?? 'localhost'
-  const url = new URL(req.originalUrl ?? req.url ?? '/', `${protocol}//${host}`)
 
-  return url
+  // Defensive fallback for malformed input
+  const origin = guard(() => new URL(`${protocol}//${req.headers.host ?? 'localhost'}`).origin) ?? 'http://localhost'
+
+  const path = req.originalUrl ?? req.url ?? '/'
+
+  return new URL(`${origin}${path.startsWith('/') ? '' : '/'}${path}`)
 }

--- a/packages/standard-server-node/src/url.ts
+++ b/packages/standard-server-node/src/url.ts
@@ -4,8 +4,8 @@ import { guard } from '@orpc/shared'
 export function toStandardUrl(req: NodeHttpRequest): URL {
   const protocol = ('encrypted' in req.socket && req.socket.encrypted ? 'https:' : 'http:')
 
-  // Defensive fallback for malformed input
-  const origin = guard(() => new URL(`${protocol}//${req.headers.host ?? 'localhost'}`).origin) ?? 'http://localhost'
+  // fallback for malformed host
+  const origin = guard(() => new URL(`${protocol}//${req.headers.host ?? 'localhost'}`).origin) ?? `${protocol}//localhost`
 
   const path = req.originalUrl ?? req.url ?? '/'
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Bug Fixes
  * Improves URL construction resilience when Host header or path is missing or malformed.
  * Defaults origin to http://localhost and normalizes paths to start with '/' to avoid invalid URLs.
  * Produces predictable hrefs in edge cases, reducing errors and unexpected behavior.

* Tests
  * Added test cases for malformed input to verify error-tolerant URL handling and default host behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->