### PR TITLE
fix(server): avoid opaque path in URL for better compatibility

### DIFF
--- a/packages/client/src/adapters/message-port/rpc-link.test.ts
+++ b/packages/client/src/adapters/message-port/rpc-link.test.ts
@@ -36,7 +36,7 @@ describe('rpcLink', () => {
 
     expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
-      url: new URL('orpc:/ping'),
+      url: new URL('orpc://localhost/ping'),
       body: { json: 'input' },
       headers: {},
       method: 'POST',
@@ -56,7 +56,7 @@ describe('rpcLink', () => {
 
     expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
-      url: new URL('orpc:/ping'),
+      url: new URL('orpc://localhost/ping'),
       body: expect.any(FormData),
       headers: expect.any(Object),
       method: 'POST',

--- a/packages/client/src/adapters/message-port/rpc-link.ts
+++ b/packages/client/src/adapters/message-port/rpc-link.ts
@@ -16,6 +16,6 @@ export interface RPCLinkOptions<T extends ClientContext>
 export class RPCLink<T extends ClientContext> extends StandardRPCLink<T> {
   constructor(options: RPCLinkOptions<T>) {
     const linkClient = new LinkMessagePortClient(options)
-    super(linkClient, { ...options, url: 'orpc:/' })
+    super(linkClient, { ...options, url: 'orpc://localhost' })
   }
 }

--- a/packages/client/src/adapters/websocket/rpc-link.test.ts
+++ b/packages/client/src/adapters/websocket/rpc-link.test.ts
@@ -56,7 +56,7 @@ describe('rpcLink', () => {
 
     expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
-      url: new URL('orpc:/ping'),
+      url: new URL('orpc://localhost/ping'),
       body: { json: 'input' },
       headers: {},
       method: 'POST',

--- a/packages/client/src/adapters/websocket/rpc-link.test.ts
+++ b/packages/client/src/adapters/websocket/rpc-link.test.ts
@@ -36,7 +36,7 @@ describe('rpcLink', () => {
 
     expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
-      url: new URL('orpc:/ping'),
+      url: new URL('orpc://localhost/ping'),
       body: { json: 'input' },
       headers: {},
       method: 'POST',

--- a/packages/client/src/adapters/websocket/rpc-link.ts
+++ b/packages/client/src/adapters/websocket/rpc-link.ts
@@ -17,6 +17,6 @@ export class RPCLink<T extends ClientContext> extends StandardRPCLink<T> {
   constructor(options: RPCLinkOptions<T>) {
     const linkClient = new LinkWebsocketClient(options)
 
-    super(linkClient, { ...options, url: 'orpc:/' })
+    super(linkClient, { ...options, url: 'orpc://localhost' })
   }
 }

--- a/packages/server/src/adapters/bun-ws/rpc-handler.test.ts
+++ b/packages/server/src/adapters/bun-ws/rpc-handler.test.ts
@@ -23,7 +23,7 @@ describe('rpcHandler', async () => {
   }
 
   const string_request_message = await encodeRequestMessage('19', MessageType.REQUEST, {
-    url: new URL('orpc:/ping'),
+    url: new URL('orpc://localhost/ping'),
     body: { json: 'input' },
     headers: {},
     method: 'POST',

--- a/packages/server/src/adapters/crossws/rpc-handler.test.ts
+++ b/packages/server/src/adapters/crossws/rpc-handler.test.ts
@@ -24,7 +24,7 @@ describe('rpcHandler', async () => {
 
   const ping_request_message = {
     rawData: await encodeRequestMessage('19', MessageType.REQUEST, {
-      url: new URL('orpc:/ping'),
+      url: new URL('orpc://localhost/ping'),
       body: { json: 'input' },
       headers: {},
       method: 'POST',

--- a/packages/server/src/adapters/message-port/rpc-handler.test.ts
+++ b/packages/server/src/adapters/message-port/rpc-handler.test.ts
@@ -35,7 +35,7 @@ describe('rpcHandler', async () => {
   })
 
   const string_request_message = await encodeRequestMessage('19', MessageType.REQUEST, {
-    url: new URL('orpc:/ping'),
+    url: new URL('orpc://localhost/ping'),
     body: { json: 'input' },
     headers: {},
     method: 'POST',

--- a/packages/server/src/adapters/websocket/rpc-handler.test.ts
+++ b/packages/server/src/adapters/websocket/rpc-handler.test.ts
@@ -35,7 +35,7 @@ describe('rpcHandler', async () => {
 
   const string_request_message = {
     data: await encodeRequestMessage('19', MessageType.REQUEST, {
-      url: new URL('orpc:/ping'),
+      url: new URL('orpc://localhost/ping'),
       body: { json: 'input' },
       headers: {},
       method: 'POST',

--- a/packages/server/src/adapters/ws/rpc-handler.test.ts
+++ b/packages/server/src/adapters/ws/rpc-handler.test.ts
@@ -35,7 +35,7 @@ describe('rpcHandler', async () => {
 
   const string_request_message = {
     data: await encodeRequestMessage('19', MessageType.REQUEST, {
-      url: new URL('orpc:/ping'),
+      url: new URL('orpc://localhost/ping'),
       body: { json: 'input' },
       headers: {},
       method: 'POST',

--- a/packages/standard-server-peer/src/codec.test.ts
+++ b/packages/standard-server-peer/src/codec.test.ts
@@ -49,6 +49,8 @@ describe('encode/decode request message', () => {
   })
 
   describe.each([
+    ['GET', new URL('orpc://localhost/api/v1/users/1?a=1&b=2'), {}],
+    ['GET', new URL('orpc:///localhost/api/v1/users/1?a=1&b=2'), {}],
     ['GET', new URL('orpc://example.com/api/v1/users/1?a=1&b=2'), {}],
     ['GET', new URL('orpc:///example.com/api/v1/users/1?a=1&b=2'), {}],
     ['GET', new URL('orpc:/api/v1/users/1?a=1&b=2'), {}],

--- a/packages/standard-server-peer/src/codec.ts
+++ b/packages/standard-server-peer/src/codec.ts
@@ -3,6 +3,9 @@ import type { EncodedMessage } from './types'
 import { isAsyncIteratorObject, readAsBuffer, stringifyJSON } from '@orpc/shared'
 import { flattenHeader, generateContentDisposition, getFilenameFromContentDisposition } from '@orpc/standard-server'
 
+const SHORTABLE_ORIGIN = 'orpc://localhost'
+const SHORTABLE_ORIGIN_MATCHER = /^orpc:\/\/localhost\//
+
 export enum MessageType {
   REQUEST = 1,
   RESPONSE = 2,
@@ -120,7 +123,7 @@ export async function encodeRequestMessage<T extends keyof RequestMessageMap>(
   )
 
   const serializedPayload: SerializedRequestPayload = {
-    u: request.url.toString().replace(/^orpc:\/\/localhost\//, '/'),
+    u: request.url.toString().replace(SHORTABLE_ORIGIN_MATCHER, '/'),
     b: processedBody instanceof Blob ? undefined : processedBody,
     h: Object.keys(processedHeaders).length > 0 ? processedHeaders : undefined,
     m: request.method === 'POST' ? undefined : request.method,
@@ -160,7 +163,7 @@ export async function decodeRequestMessage(raw: EncodedMessage): Promise<Decoded
   const body = await deserializeBody(headers, payload.b, buffer)
 
   return [id, MessageType.REQUEST, {
-    url: payload.u.startsWith('/') ? new URL(`orpc://localhost${payload.u}`) : new URL(payload.u),
+    url: payload.u.startsWith('/') ? new URL(`${SHORTABLE_ORIGIN}${payload.u}`) : new URL(payload.u),
     headers,
     method: payload.m ?? 'POST',
     body,

--- a/packages/standard-server-peer/src/codec.ts
+++ b/packages/standard-server-peer/src/codec.ts
@@ -54,7 +54,7 @@ interface SerializedRequestPayload {
   /**
    * The url of the request
    *
-   * might be relative path if it starts with `orpc:/`
+   * might be relative path if origin is `orpc://localhost`
    */
   u: string
 
@@ -120,7 +120,7 @@ export async function encodeRequestMessage<T extends keyof RequestMessageMap>(
   )
 
   const serializedPayload: SerializedRequestPayload = {
-    u: request.url.toString().replace(/^orpc:\//, '/'),
+    u: request.url.toString().replace(/^orpc:\/\/localhost\//, '/'),
     b: processedBody instanceof Blob ? undefined : processedBody,
     h: Object.keys(processedHeaders).length > 0 ? processedHeaders : undefined,
     m: request.method === 'POST' ? undefined : request.method,
@@ -159,7 +159,12 @@ export async function decodeRequestMessage(raw: EncodedMessage): Promise<Decoded
   const headers = payload.h ?? {}
   const body = await deserializeBody(headers, payload.b, buffer)
 
-  return [id, MessageType.REQUEST, { url: new URL(payload.u, 'orpc:/'), headers, method: payload.m ?? 'POST', body }]
+  return [id, MessageType.REQUEST, {
+    url: payload.u.startsWith('/') ? new URL(`orpc://localhost${payload.u}`) : new URL(payload.u),
+    headers,
+    method: payload.m ?? 'POST',
+    body,
+  }]
 }
 
 export async function encodeResponseMessage<T extends keyof ResponseMessageMap>(


### PR DESCRIPTION
Fixes: #1043 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Standardized ORPC URL format to include an explicit host (orpc://localhost), improving URL normalization and consistent request routing across clients and servers.
- Tests
  - Updated expectations to the new URL format and added coverage for additional ORPC URL variants to strengthen parsing and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->