### PR TITLE
perf(durable-iterator): improve resume events cleanup logic

### DIFF
--- a/packages/durable-iterator/src/durable-object/resume-storage.ts
+++ b/packages/durable-iterator/src/durable-object/resume-storage.ts
@@ -13,9 +13,9 @@ export interface EventResumeStorageOptions extends StandardRPCJsonSerializerOpti
    *
    * @remarks
    * - Use infinite values to disable
-   * - Note that event cleanup is deferred for performance reasons — meaning some
-   *  expired events may still be available for a short period of time, and clients
-   *  might still receive them.
+   * - Note that for performance, expired event cleanup is deferred. This means
+   *  expired events may remain in storage for a short period beyond their
+   *  retention time.
    *
    * @default NaN (disabled)
    */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Performance
  * Cleanup of expired events is now throttled to reduce overhead and improve responsiveness under load.
  * An initial cleanup still runs at startup when retention is enabled.

* Behavior
  * Expired events may remain briefly accessible before being removed due to deferred cleanup.

* Documentation
  * Retention settings updated to note that cleanup is deferred and some expired events can be temporarily available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->