### PR TITLE
feat(client, server): add eventIteratorToUnproxiedDataStream util

### DIFF
--- a/apps/content/docs/integrations/ai-sdk.md
+++ b/apps/content/docs/integrations/ai-sdk.md
@@ -59,13 +59,13 @@ export const chat = os
 const client = { chat }
 // ---cut---
 import { useChat } from '@ai-sdk/react'
-import { eventIteratorToStream } from '@orpc/client'
+import { eventIteratorToUnproxiedDataStream } from '@orpc/client'
 
 export function Example() {
   const { messages, sendMessage, status } = useChat({
     transport: {
       async sendMessages(options) {
-        return eventIteratorToStream(await client.chat({
+        return eventIteratorToUnproxiedDataStream(await client.chat({
           chatId: options.chatId,
           messages: options.messages,
         }, { signal: options.abortSignal }))
@@ -114,4 +114,8 @@ export function Example() {
 
 ::: info
 The `reconnectToStream` function is not supported by default, which is fine for most use cases. If you need reconnection support, implement it similar to `sendMessages` with custom reconnection logic. See this [reconnect example](<https://github.com/vercel/ai-chatbot/blob/main/app/(chat)/api/chat/%5Bid%5D/stream/route.ts>).
+:::
+
+::: info
+Use `eventIteratorToUnproxiedDataStream` instead of `eventIteratorToStream`. AI SDK uses `structuredClone` internally, which doesn't support proxied data. Since oRPC sometimes uses proxies to track event metadata, unproxy the data before passing it to AI SDK.
 :::

--- a/apps/content/docs/integrations/ai-sdk.md
+++ b/apps/content/docs/integrations/ai-sdk.md
@@ -117,5 +117,7 @@ The `reconnectToStream` function is not supported by default, which is fine for 
 :::
 
 ::: info
-Use `eventIteratorToUnproxiedDataStream` instead of `eventIteratorToStream`. AI SDK uses `structuredClone` internally, which doesn't support proxied data. Since oRPC sometimes uses proxies to track event metadata, unproxy the data before passing it to AI SDK.
+Prefer `eventIteratorToUnproxiedDataStream` over `eventIteratorToStream`.
+AI SDK uses `structuredClone`, which doesn't support proxied data.
+oRPC may proxy events for metadata, so unproxy before passing to AI SDK.
 :::

--- a/apps/content/docs/integrations/ai-sdk.md
+++ b/apps/content/docs/integrations/ai-sdk.md
@@ -118,6 +118,6 @@ The `reconnectToStream` function is not supported by default, which is fine for 
 
 ::: info
 Prefer `eventIteratorToUnproxiedDataStream` over `eventIteratorToStream`.
-AI SDK uses `structuredClone`, which doesn't support proxied data.
+AI SDK internally uses `structuredClone`, which doesn't support proxied data.
 oRPC may proxy events for metadata, so unproxy before passing to AI SDK.
 :::

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -10,6 +10,7 @@ export * from './utils'
 export {
   AsyncIteratorClass,
   asyncIteratorToStream as eventIteratorToStream,
+  asyncIteratorToUnproxiedDataStream as eventIteratorToUnproxiedDataStream,
   EventPublisher,
   onError,
   onFinish,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -43,6 +43,7 @@ export type { IntersectPick } from '@orpc/shared'
 export {
   AsyncIteratorClass,
   asyncIteratorToStream as eventIteratorToStream,
+  asyncIteratorToUnproxiedDataStream as eventIteratorToUnproxiedDataStream,
   EventPublisher,
   onError,
   onFinish,

--- a/packages/shared/src/stream.test.ts
+++ b/packages/shared/src/stream.test.ts
@@ -208,10 +208,17 @@ describe('asyncIteratorToUnproxiedDataStream', () => {
   }
 
   it('should convert an AsyncIterator to ReadableStream and unproxied data', async () => {
+    const date = new Date()
+    const set = new Set([date])
+
     async function* generator() {
       yield 1
       yield proxy({ order: 2 })
       yield { order: 3 }
+      yield [4]
+      yield proxy([5])
+      yield date // support native Date
+      yield set // support native Set
     }
 
     const asyncIterator = generator()
@@ -232,9 +239,13 @@ describe('asyncIteratorToUnproxiedDataStream', () => {
       1,
       { order: 2 },
       { order: 3 },
+      [4],
+      [5],
+      date,
+      set,
     ])
 
-    expect(results.every(isProxied)).toBe(false)
+    expect(results.some(isProxied)).toBe(false)
   })
 
   it('should handle empty async iterator', async () => {

--- a/packages/shared/src/stream.ts
+++ b/packages/shared/src/stream.ts
@@ -60,7 +60,7 @@ export function asyncIteratorToUnproxiedDataStream<T>(
         const unproxied = isObject(value)
           ? { ...value }
           : Array.isArray(value)
-            ? [...value] as T
+            ? value.map(i => i) as T // use .map instead of ... to deal with sparse arrays
             : value
 
         controller.enqueue(unproxied)

--- a/packages/shared/src/stream.ts
+++ b/packages/shared/src/stream.ts
@@ -57,7 +57,13 @@ export function asyncIteratorToUnproxiedDataStream<T>(
         controller.close()
       }
       else {
-        controller.enqueue(isObject(value) ? { ...value } : value)
+        const unproxied = isObject(value)
+          ? { ...value }
+          : Array.isArray(value)
+            ? [...value] as T
+            : value
+
+        controller.enqueue(unproxied)
       }
     },
     async cancel() {


### PR DESCRIPTION
Some event iterators proxy their emitted data to track event metadata. When integrating with tools that don't support proxied data (such as AI SDK), use eventIteratorToUnproxiedDataStream instead of eventIteratorToStream to ensure raw, unproxied data is emitted.

Fixed: #977

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a data-stream conversion that returns unproxied values for streamed results, exposed across client and server packages for better compatibility with AI SDKs and integrations.

* **Documentation**
  * Updated AI SDK integration docs to recommend using the new unproxied data-stream handling for reliable structured-data processing.

* **Tests**
  * Added tests covering normal, empty, error, and cancellation scenarios for the new data-stream behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->