### PR TITLE
feat(client, server): message port transfer

### DIFF
--- a/apps/content/docs/adapters/message-port.md
+++ b/apps/content/docs/adapters/message-port.md
@@ -77,7 +77,7 @@ const link = new RPCLink({
 :::
 
 ::: warning
-When `transfer` returns an array, messages using [the structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) for sending, which doesn't support all data types such as [Event Iterator's Metadata](/docs/event-iterator#last-event-id-event-metadata). So I recommend you only enable this only when needed.
+When `transfer` returns an array, messages using [the structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) for sending, which doesn't support all data types such as [Event Iterator's Metadata](/docs/event-iterator#last-event-id-event-metadata). So I recommend you only enable this when needed.
 :::
 
 ::: tip

--- a/apps/content/docs/adapters/message-port.md
+++ b/apps/content/docs/adapters/message-port.md
@@ -48,3 +48,38 @@ clientPort.start()
 :::info
 This only shows how to configure the link. For full client examples, see [Client-Side Clients](/docs/client/client-side).
 :::
+
+## Transfer
+
+By default, oRPC serializes request/response messages to string/binary data before send over message port. But if needed, you can define the `transfer` option to utilize full power of [MessagePort: postMessage() method](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/postMessage), such as transfer ownership of objects to the other side or support unserializable objects like `OffscreenCanvas`.
+
+::: code-group
+
+```ts [handler]
+handler.upgrade(serverPort, {
+  experimental_transfer: (message) => {
+    const transfer = deepFindTransferableObjects(message) // implement your own logic
+    return transfer.length ? transfer : null // only enable when needed
+  }
+})
+```
+
+```ts [link]
+const link = new RPCLink({
+  port: clientPort,
+  experimental_transfer: (message) => {
+    const transfer = deepFindTransferableObjects(message) // implement your own logic
+    return transfer.length ? transfer : null // only enable when needed
+  }
+})
+```
+
+:::
+
+::: warning
+When `transfer` returns an array, messages using [the structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) for sending, which doesn't support all data types such as [Event Iterator's Metadata](/docs/event-iterator#last-event-id-event-metadata). So I recommend you only enable this only when needed.
+:::
+
+::: tip
+The `transfer` option run after [RPC JSON Serializer](/docs/advanced/rpc-json-serializer) so you can combine them together to support more data types.
+:::

--- a/apps/content/docs/adapters/message-port.md
+++ b/apps/content/docs/adapters/message-port.md
@@ -51,7 +51,7 @@ This only shows how to configure the link. For full client examples, see [Client
 
 ## Transfer
 
-By default, oRPC serializes request/response messages to string/binary data before send over message port. But if needed, you can define the `transfer` option to utilize full power of [MessagePort: postMessage() method](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/postMessage), such as transfer ownership of objects to the other side or support unserializable objects like `OffscreenCanvas`.
+By default, oRPC serializes request/response messages to string/binary data before sending over message port. If needed, you can define the `transfer` option to utilize full power of [MessagePort: postMessage() method](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/postMessage), such as transferring ownership of objects to the other side or support unserializable objects like `OffscreenCanvas`.
 
 ::: code-group
 

--- a/apps/content/docs/adapters/message-port.md
+++ b/apps/content/docs/adapters/message-port.md
@@ -56,8 +56,8 @@ By default, oRPC serializes request/response messages to string/binary data befo
 ::: code-group
 
 ```ts [handler]
-handler.upgrade(serverPort, {
-  experimental_transfer: (message) => {
+const handler = new RPCHandler(router, {
+  experimental_transfer: (message, port) => {
     const transfer = deepFindTransferableObjects(message) // implement your own logic
     return transfer.length ? transfer : null // only enable when needed
   }

--- a/packages/client/src/adapters/message-port/link-client.ts
+++ b/packages/client/src/adapters/message-port/link-client.ts
@@ -1,11 +1,11 @@
 import type { Promisable, Value } from '@orpc/shared'
 import type { StandardLazyResponse, StandardRequest } from '@orpc/standard-server'
-import type { DecodedRequestMessage, DecodedResponseMessage } from '@orpc/standard-server-peer'
+import type { DecodedRequestMessage, serializeResponseMessage } from '@orpc/standard-server-peer'
 import type { ClientContext, ClientOptions } from '../../types'
 import type { StandardLinkClient } from '../standard'
 import type { SupportedMessagePort } from './message-port'
-import { value } from '@orpc/shared'
-import { experimental_ClientPeerWithoutCodec as ClientPeerWithoutCodec, decodeResponseMessage, encodeRequestMessage } from '@orpc/standard-server-peer'
+import { isObject, value } from '@orpc/shared'
+import { experimental_ClientPeerWithoutCodec as ClientPeerWithoutCodec, decodeResponseMessage, deserializeResponseMessage, encodeRequestMessage, serializeRequestMessage } from '@orpc/standard-server-peer'
 import { onMessagePortClose, onMessagePortMessage, postMessagePortMessage } from './message-port'
 
 export interface LinkMessagePortClientOptions {
@@ -34,19 +34,19 @@ export class LinkMessagePortClient<T extends ClientContext> implements StandardL
 
   constructor(options: LinkMessagePortClientOptions) {
     this.peer = new ClientPeerWithoutCodec(async (message) => {
+      const [id, type, payload] = message
       const transfer = options.experimental_transfer && await value(options.experimental_transfer, message)
 
       if (transfer) {
-        return postMessagePortMessage(options.port, message, transfer)
+        return postMessagePortMessage(options.port, serializeRequestMessage(id, type, payload), transfer)
       }
 
-      const [id, type, payload] = message
       return postMessagePortMessage(options.port, await encodeRequestMessage(id, type, payload))
     })
 
     onMessagePortMessage(options.port, async (message) => {
-      if (Array.isArray(message)) {
-        return await this.peer.message(message as DecodedResponseMessage)
+      if (isObject(message)) {
+        return await this.peer.message(deserializeResponseMessage(message as any as ReturnType<typeof serializeResponseMessage>))
       }
 
       return await this.peer.message(await decodeResponseMessage(message))

--- a/packages/client/src/adapters/message-port/link-client.ts
+++ b/packages/client/src/adapters/message-port/link-client.ts
@@ -42,18 +42,20 @@ export class LinkMessagePortClient<T extends ClientContext> implements StandardL
       const transfer = await value(options.experimental_transfer, message)
 
       if (transfer) {
-        return postMessagePortMessage(options.port, serializeRequestMessage(id, type, payload), transfer)
+        postMessagePortMessage(options.port, serializeRequestMessage(id, type, payload), transfer)
       }
-
-      return postMessagePortMessage(options.port, await encodeRequestMessage(id, type, payload))
+      else {
+        postMessagePortMessage(options.port, await encodeRequestMessage(id, type, payload))
+      }
     })
 
     onMessagePortMessage(options.port, async (message) => {
       if (isObject(message)) {
-        return await this.peer.message(deserializeResponseMessage(message as any as ReturnType<typeof serializeResponseMessage>))
+        await this.peer.message(deserializeResponseMessage(message as any as ReturnType<typeof serializeResponseMessage>))
       }
-
-      return await this.peer.message(await decodeResponseMessage(message))
+      else {
+        await this.peer.message(await decodeResponseMessage(message))
+      }
     })
 
     onMessagePortClose(options.port, () => {

--- a/packages/client/src/adapters/message-port/link-client.ts
+++ b/packages/client/src/adapters/message-port/link-client.ts
@@ -12,9 +12,9 @@ export interface LinkMessagePortClientOptions {
   port: SupportedMessagePort
 
   /**
-   * By default, oRPC serializes request/response messages to string/binary data before send over message port.
-   * But if needed, you can define the this option to utilize full power of [MessagePort: postMessage() method](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/postMessage),
-   * such as transfer ownership of objects to the other side or support unserializable objects like `OffscreenCanvas`.
+   * By default, oRPC serializes request/response messages to string/binary data before sending over message port.
+   * If needed, you can define the this option to utilize full power of [MessagePort: postMessage() method](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/postMessage),
+   * such as transferring ownership of objects to the other side or support unserializable objects like `OffscreenCanvas`.
    *
    * @remarks
    * - return null | undefined to disable this feature

--- a/packages/client/src/adapters/message-port/link-client.ts
+++ b/packages/client/src/adapters/message-port/link-client.ts
@@ -22,7 +22,7 @@ export interface LinkMessagePortClientOptions {
    * @warning Make sure your message port supports `transfer` before using this feature.
    * @example
    * ```ts
-   * experimental_transfer: (message) => {
+   * experimental_transfer: (message, port) => {
    *   const transfer = deepFindTransferableObjects(message) // implement your own logic
    *   return transfer.length ? transfer : null // only enable when needed
    * }
@@ -30,7 +30,7 @@ export interface LinkMessagePortClientOptions {
    *
    * @see {@link https://orpc.unnoq.com/docs/adapters/message-port#transfer Message Port Transfer Docs}
    */
-  experimental_transfer?: Value<Promisable<object[] | null | undefined>, [message: DecodedRequestMessage]>
+  experimental_transfer?: Value<Promisable<object[] | null | undefined>, [message: DecodedRequestMessage, port: SupportedMessagePort]>
 }
 
 export class LinkMessagePortClient<T extends ClientContext> implements StandardLinkClient<T> {
@@ -39,7 +39,7 @@ export class LinkMessagePortClient<T extends ClientContext> implements StandardL
   constructor(options: LinkMessagePortClientOptions) {
     this.peer = new ClientPeerWithoutCodec(async (message) => {
       const [id, type, payload] = message
-      const transfer = await value(options.experimental_transfer, message)
+      const transfer = await value(options.experimental_transfer, message, options.port)
 
       if (transfer) {
         postMessagePortMessage(options.port, serializeRequestMessage(id, type, payload), transfer)

--- a/packages/client/src/adapters/message-port/link-client.ts
+++ b/packages/client/src/adapters/message-port/link-client.ts
@@ -1,24 +1,55 @@
+import type { Promisable, Value } from '@orpc/shared'
 import type { StandardLazyResponse, StandardRequest } from '@orpc/standard-server'
+import type { DecodedRequestMessage, DecodedResponseMessage } from '@orpc/standard-server-peer'
 import type { ClientContext, ClientOptions } from '../../types'
 import type { StandardLinkClient } from '../standard'
 import type { SupportedMessagePort } from './message-port'
-import { ClientPeer } from '@orpc/standard-server-peer'
+import { value } from '@orpc/shared'
+import { experimental_ClientPeerWithoutCodec as ClientPeerWithoutCodec, decodeResponseMessage, encodeRequestMessage } from '@orpc/standard-server-peer'
 import { onMessagePortClose, onMessagePortMessage, postMessagePortMessage } from './message-port'
 
 export interface LinkMessagePortClientOptions {
   port: SupportedMessagePort
+
+  /**
+   * Specify transferable objects (like ArrayBuffers, MessagePorts)
+   * that should be transferred rather than cloned when sending messages.
+   *
+   * @remarks
+   * - return null | undefined to disable this feature
+   *
+   * @warning Make sure your message port supports `transfer` before using this feature.
+   * @example
+   * ```ts
+   * experimental_transfer: (message) => {
+   *   return deepFindTransferableObjects(message)
+   * }
+   * ```
+   */
+  experimental_transfer?: Value<Promisable<object[] | null | undefined>, [message: DecodedRequestMessage]>
 }
 
 export class LinkMessagePortClient<T extends ClientContext> implements StandardLinkClient<T> {
-  private readonly peer: ClientPeer
+  private readonly peer: ClientPeerWithoutCodec
 
   constructor(options: LinkMessagePortClientOptions) {
-    this.peer = new ClientPeer((message) => {
-      return postMessagePortMessage(options.port, message)
+    this.peer = new ClientPeerWithoutCodec(async (message) => {
+      const transfer = options.experimental_transfer && await value(options.experimental_transfer, message)
+
+      if (transfer) {
+        return postMessagePortMessage(options.port, message, transfer)
+      }
+
+      const [id, type, payload] = message
+      return postMessagePortMessage(options.port, await encodeRequestMessage(id, type, payload))
     })
 
     onMessagePortMessage(options.port, async (message) => {
-      await this.peer.message(message)
+      if (Array.isArray(message)) {
+        return await this.peer.message(message as DecodedResponseMessage)
+      }
+
+      return await this.peer.message(await decodeResponseMessage(message))
     })
 
     onMessagePortClose(options.port, () => {

--- a/packages/client/src/adapters/message-port/message-port.test.ts
+++ b/packages/client/src/adapters/message-port/message-port.test.ts
@@ -11,6 +11,18 @@ describe('postMessagePortMessage', () => {
     expect(mockPort.postMessage).toBeCalledTimes(1)
     expect(mockPort.postMessage).toHaveBeenCalledWith(data)
   })
+
+  it('calls postMessage on the port with transfer', () => {
+    const mockPort = {
+      addEventListener: vi.fn(),
+      postMessage: vi.fn(),
+    }
+    const data = new Uint8Array([1, 2, 3])
+    const transfer = [data.buffer]
+    postMessagePortMessage(mockPort, data, transfer)
+    expect(mockPort.postMessage).toBeCalledTimes(1)
+    expect(mockPort.postMessage).toHaveBeenCalledWith(data, transfer)
+  })
 })
 
 describe('onMessagePortMessage', () => {

--- a/packages/client/src/adapters/message-port/message-port.ts
+++ b/packages/client/src/adapters/message-port/message-port.ts
@@ -3,7 +3,7 @@
  */
 export interface MessagePortMainLike {
   on: <T extends string>(event: T, callback: (event?: { data: any }) => void) => void
-  postMessage: (data: any) => void
+  postMessage: (data: any, transfer?: any[]) => void
 }
 
 /**
@@ -24,10 +24,19 @@ export type SupportedMessagePort = Pick<MessagePort, 'addEventListener' | 'postM
 /**
  *  Message port can support [The structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm)
  */
-export type SupportedMessagePortData = string | ArrayBufferLike | Uint8Array
+export type SupportedMessagePortData = any
 
-export function postMessagePortMessage(port: SupportedMessagePort, data: SupportedMessagePortData): void {
-  port.postMessage(data)
+export function postMessagePortMessage(
+  port: SupportedMessagePort,
+  data: SupportedMessagePortData,
+  transfer?: any[],
+): void {
+  if (transfer) {
+    port.postMessage(data, transfer)
+  }
+  else {
+    port.postMessage(data)
+  }
 }
 
 export function onMessagePortMessage(port: SupportedMessagePort, callback: (data: SupportedMessagePortData) => void): void {

--- a/packages/client/src/adapters/message-port/rpc-link.test.ts
+++ b/packages/client/src/adapters/message-port/rpc-link.test.ts
@@ -90,7 +90,7 @@ describe('rpcLink', () => {
       body: { json: expect.toBeOneOf([array]) },
       headers: {},
       method: 'POST',
-    })])
+    })], expect.toBeOneOf([clientPort]))
 
     expect(id).toBeTypeOf('string')
     expect(payload).toEqual({

--- a/packages/client/src/adapters/message-port/rpc-link.test.ts
+++ b/packages/client/src/adapters/message-port/rpc-link.test.ts
@@ -1,13 +1,15 @@
 import { MessageChannel } from 'node:worker_threads'
-import { decodeRequestMessage, encodeResponseMessage, MessageType } from '@orpc/standard-server-peer'
+import { isObject } from '@orpc/shared'
+import { decodeRequestMessage, deserializeRequestMessage, encodeResponseMessage, MessageType, serializeResponseMessage } from '@orpc/standard-server-peer'
 import { createORPCClient } from '../../client'
 import { RPCLink } from './rpc-link'
 
 describe('rpcLink', () => {
   let orpc: any
-  let sentMessages: any[]
+  let receivedMessages: any[]
   let clientPort: any
   let serverPort: any
+  let transfer: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     const channel = new MessageChannel()
@@ -17,22 +19,24 @@ describe('rpcLink', () => {
     clientPort.start()
     serverPort.start()
 
-    sentMessages = []
+    receivedMessages = []
     serverPort.addEventListener('message', (event: any) => {
-      sentMessages.push(event.data)
+      receivedMessages.push(event.data)
     })
 
+    transfer = vi.fn()
     orpc = createORPCClient(new RPCLink({
       port: clientPort,
+      experimental_transfer: transfer,
     }))
   })
 
   it('on success', async () => {
     expect(orpc.ping('input')).resolves.toEqual('pong')
 
-    await vi.waitFor(() => expect(sentMessages.length).toBe(1))
+    await vi.waitFor(() => expect(receivedMessages.length).toBe(1))
 
-    const [id, , payload] = (await decodeRequestMessage(sentMessages[0]))
+    const [id, , payload] = (await decodeRequestMessage(receivedMessages[0]))
 
     expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
@@ -50,9 +54,9 @@ describe('rpcLink', () => {
   it('on success with blob', async () => {
     expect(orpc.ping(new Blob(['input']))).resolves.toEqual('pong')
 
-    await vi.waitFor(() => expect(sentMessages.length).toBe(1))
+    await vi.waitFor(() => expect(receivedMessages.length).toBe(1))
 
-    const [id, , payload] = (await decodeRequestMessage(sentMessages[0]))
+    const [id, , payload] = (await decodeRequestMessage(receivedMessages[0]))
 
     expect(id).toBeTypeOf('string')
     expect(payload).toEqual({
@@ -65,6 +69,42 @@ describe('rpcLink', () => {
     serverPort.postMessage(
       await encodeResponseMessage(id, MessageType.RESPONSE, { body: { json: 'pong' }, status: 200, headers: {} }),
     )
+  })
+
+  it('on success with transfer', async () => {
+    const array = new Uint8Array([1, 2, 3])
+
+    transfer.mockResolvedValueOnce([array.buffer])
+
+    const promise = expect(orpc.ping(array)).resolves.toEqual('pong')
+
+    await vi.waitFor(() => expect(receivedMessages.length).toBe(1))
+    expect(receivedMessages[0]).toSatisfy(isObject)
+    const [id, type, payload] = deserializeRequestMessage(receivedMessages[0])
+
+    expect(array.byteLength).toBe(0) // transferred so length is 0
+
+    expect(transfer).toHaveBeenCalledTimes(1)
+    expect(transfer).toHaveBeenCalledWith([id, type, expect.objectContaining({
+      url: new URL('orpc://localhost/ping'),
+      body: { json: expect.toBeOneOf([array]) },
+      headers: {},
+      method: 'POST',
+    })])
+
+    expect(id).toBeTypeOf('string')
+    expect(payload).toEqual({
+      url: new URL('orpc://localhost/ping'),
+      body: { json: expect.toSatisfy(v => v !== array && v instanceof Uint8Array && v.byteLength === 3) },
+      headers: {},
+      method: 'POST',
+    })
+
+    serverPort.postMessage(
+      serializeResponseMessage(id, MessageType.RESPONSE, { body: { json: 'pong' }, status: 200, headers: {} }),
+    )
+
+    await promise
   })
 
   it('on close', async () => {

--- a/packages/server/src/adapters/message-port/handler.ts
+++ b/packages/server/src/adapters/message-port/handler.ts
@@ -1,32 +1,67 @@
 import type { SupportedMessagePort } from '@orpc/client/message-port'
-import type { MaybeOptionalOptions } from '@orpc/shared'
+import type { MaybeOptionalOptions, Promisable, Value } from '@orpc/shared'
+import type { DecodedRequestMessage, DecodedResponseMessage } from '@orpc/standard-server-peer'
 import type { Context } from '../../context'
 import type { StandardHandler } from '../standard'
 import type {
   HandleStandardServerPeerMessageOptions,
 } from '../standard-peer'
 import { onMessagePortClose, onMessagePortMessage, postMessagePortMessage } from '@orpc/client/message-port'
-import { resolveMaybeOptionalOptions } from '@orpc/shared'
-import { ServerPeer } from '@orpc/standard-server-peer'
+import { resolveMaybeOptionalOptions, value } from '@orpc/shared'
+import { decodeRequestMessage, encodeResponseMessage, experimental_ServerPeerWithoutCodec as ServerPeerWithoutCodec } from '@orpc/standard-server-peer'
 import { createServerPeerHandleRequestFn } from '../standard-peer'
 
+export interface MessagePortHandlerOptions<_T extends Context> {
+  /**
+   * Specify transferable objects (like ArrayBuffers, MessagePorts)
+   * that should be transferred rather than cloned when sending messages.
+   *
+   * @remarks
+   * - return null | undefined to disable this feature
+   *
+   * @warning Make sure your message port supports `transfer` before using this feature.
+   * @example
+   * ```ts
+   * experimental_transfer: (message) => {
+   *   return deepFindTransferableObjects(message)
+   * }
+   * ```
+   */
+  experimental_transfer?: Value<Promisable<object[] | null | undefined>, [message: DecodedResponseMessage]>
+}
+
 export class MessagePortHandler<T extends Context> {
+  private readonly transfer: MessagePortHandlerOptions<T>['experimental_transfer']
+
   constructor(
     private readonly standardHandler: StandardHandler<T>,
+    options: NoInfer<MessagePortHandlerOptions<T>> = {},
   ) {
+    this.transfer = options.experimental_transfer
   }
 
   upgrade(
     port: SupportedMessagePort,
     ...rest: MaybeOptionalOptions<HandleStandardServerPeerMessageOptions<T>>
   ): void {
-    const peer = new ServerPeer((message) => {
-      return postMessagePortMessage(port, message)
+    const peer = new ServerPeerWithoutCodec(async (message) => {
+      const transfer = this.transfer && await value(this.transfer, message)
+
+      if (transfer) {
+        return postMessagePortMessage(port, message, transfer)
+      }
+
+      const [id, type, payload] = message
+      return postMessagePortMessage(port, await encodeResponseMessage(id, type, payload))
     })
 
     onMessagePortMessage(port, async (message) => {
+      if (Array.isArray(message)) {
+        return await peer.message(message as DecodedRequestMessage)
+      }
+
       await peer.message(
-        message,
+        await decodeRequestMessage(message),
         createServerPeerHandleRequestFn(this.standardHandler, resolveMaybeOptionalOptions(rest)),
       )
     })

--- a/packages/server/src/adapters/message-port/handler.ts
+++ b/packages/server/src/adapters/message-port/handler.ts
@@ -23,7 +23,7 @@ export interface MessagePortHandlerOptions<_T extends Context> {
    * @warning Make sure your message port supports `transfer` before using this feature.
    * @example
    * ```ts
-   * experimental_transfer: (message) => {
+   * experimental_transfer: (message, port) => {
    *   const transfer = deepFindTransferableObjects(message) // implement your own logic
    *   return transfer.length ? transfer : null // only enable when needed
    * }
@@ -31,7 +31,7 @@ export interface MessagePortHandlerOptions<_T extends Context> {
    *
    * @see {@link https://orpc.unnoq.com/docs/adapters/message-port#transfer Message Port Transfer Docs}
    */
-  experimental_transfer?: Value<Promisable<object[] | null | undefined>, [message: DecodedResponseMessage]>
+  experimental_transfer?: Value<Promisable<object[] | null | undefined>, [message: DecodedResponseMessage, port: SupportedMessagePort]>
 }
 
 export class MessagePortHandler<T extends Context> {
@@ -50,7 +50,7 @@ export class MessagePortHandler<T extends Context> {
   ): void {
     const peer = new ServerPeerWithoutCodec(async (message) => {
       const [id, type, payload] = message
-      const transfer = await value(this.transfer, message)
+      const transfer = await value(this.transfer, message, port)
 
       if (transfer) {
         return postMessagePortMessage(port, serializeResponseMessage(id, type, payload), transfer)

--- a/packages/server/src/adapters/message-port/handler.ts
+++ b/packages/server/src/adapters/message-port/handler.ts
@@ -13,9 +13,9 @@ import { createServerPeerHandleRequestFn } from '../standard-peer'
 
 export interface MessagePortHandlerOptions<_T extends Context> {
   /**
-   * By default, oRPC serializes request/response messages to string/binary data before send over message port.
-   * But if needed, you can define the this option to utilize full power of [MessagePort: postMessage() method](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/postMessage),
-   * such as transfer ownership of objects to the other side or support unserializable objects like `OffscreenCanvas`.
+   * By default, oRPC serializes request/response messages to string/binary data before sending over message port.
+   * If needed, you can define the this option to utilize full power of [MessagePort: postMessage() method](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/postMessage),
+   * such as transferring ownership of objects to the other side or support unserializable objects like `OffscreenCanvas`.
    *
    * @remarks
    * - return null | undefined to disable this feature

--- a/packages/server/src/adapters/message-port/handler.ts
+++ b/packages/server/src/adapters/message-port/handler.ts
@@ -53,26 +53,28 @@ export class MessagePortHandler<T extends Context> {
       const transfer = await value(this.transfer, message, port)
 
       if (transfer) {
-        return postMessagePortMessage(port, serializeResponseMessage(id, type, payload), transfer)
+        postMessagePortMessage(port, serializeResponseMessage(id, type, payload), transfer)
       }
-
-      return postMessagePortMessage(port, await encodeResponseMessage(id, type, payload))
+      else {
+        postMessagePortMessage(port, await encodeResponseMessage(id, type, payload))
+      }
     })
 
     onMessagePortMessage(port, async (message) => {
       const handleFn = createServerPeerHandleRequestFn(this.standardHandler, resolveMaybeOptionalOptions(rest))
 
       if (isObject(message)) {
-        return await peer.message(
+        await peer.message(
           deserializeRequestMessage(message as any as ReturnType<typeof serializeRequestMessage>),
           handleFn,
         )
       }
-
-      await peer.message(
-        await decodeRequestMessage(message),
-        handleFn,
-      )
+      else {
+        await peer.message(
+          await decodeRequestMessage(message),
+          handleFn,
+        )
+      }
     })
 
     onMessagePortClose(port, () => {

--- a/packages/server/src/adapters/message-port/rpc-handler.test.ts
+++ b/packages/server/src/adapters/message-port/rpc-handler.test.ts
@@ -78,7 +78,7 @@ describe('rpcHandler', async () => {
     expect(transfer).toHaveBeenCalledWith([id, type, expect.objectContaining({
       body: { json: expect.toBeOneOf([array]) },
       headers: {},
-    })])
+    })], expect.toBeOneOf([serverPort]))
 
     expect(id).toBeTypeOf('string')
     expect(payload).toEqual({

--- a/packages/server/src/adapters/message-port/rpc-handler.test.ts
+++ b/packages/server/src/adapters/message-port/rpc-handler.test.ts
@@ -1,4 +1,5 @@
-import { encodeRequestMessage, MessageType } from '@orpc/standard-server-peer'
+import { isObject, onError } from '@orpc/shared'
+import { decodeRequestMessage, deserializeResponseMessage, encodeRequestMessage, MessageType, serializeRequestMessage } from '@orpc/standard-server-peer'
 import { os } from '../../builder'
 import { RPCHandler } from './rpc-handler'
 
@@ -10,7 +11,9 @@ describe('rpcHandler', async () => {
   let signal: AbortSignal | undefined
   let serverPort: any
   let clientPort: any
-  let sentMessages: any[]
+  let receivedMessages: any[]
+  let transfer: ReturnType<typeof vi.fn>
+  let handler: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
     signal = undefined
@@ -18,20 +21,26 @@ describe('rpcHandler', async () => {
     clientPort = channel.port1
     serverPort = channel.port2
 
-    sentMessages = []
+    receivedMessages = []
     clientPort.addEventListener('message', (event: any) => {
-      sentMessages.push(event.data)
+      receivedMessages.push(event.data)
     })
 
-    const handler = new RPCHandler({
-      ping: os.handler(async ({ signal: _signal }) => {
-        signal = _signal!
-        await new Promise(resolve => setTimeout(resolve, 10))
-        return 'pong'
-      }),
+    transfer = vi.fn()
+    handler = vi.fn(async ({ signal: _signal }) => {
+      signal = _signal!
+      await new Promise(resolve => setTimeout(resolve, 10))
+      return 'pong'
     })
 
-    handler.upgrade(serverPort)
+    const handlerClass = new RPCHandler({
+      ping: os.handler(handler),
+    }, {
+      experimental_transfer: transfer,
+      interceptors: [onError(e => console.error(e))],
+    })
+
+    handlerClass.upgrade(serverPort)
   })
 
   const string_request_message = await encodeRequestMessage('19', MessageType.REQUEST, {
@@ -45,13 +54,38 @@ describe('rpcHandler', async () => {
 
   it('work with string event', async () => {
     clientPort.postMessage(string_request_message)
-
-    await vi.waitFor(() => expect(sentMessages.length).toBe(1))
+    await vi.waitFor(() => expect(receivedMessages.length).toBe(1))
   })
 
   it('works with file/buffer data', async () => {
     clientPort.postMessage(buffer_request_message)
-    await vi.waitFor(() => expect(sentMessages.length).toBe(1))
+    await vi.waitFor(() => expect(receivedMessages.length).toBe(1))
+  })
+
+  it('works with transfer', async () => {
+    const array = new Uint8Array([1, 2, 3])
+    transfer.mockResolvedValueOnce([array.buffer])
+    handler.mockResolvedValueOnce(array)
+
+    clientPort.postMessage(serializeRequestMessage(...await decodeRequestMessage(string_request_message) as [any, any, any]))
+    await vi.waitFor(() => expect(receivedMessages.length).toBe(1))
+    expect(receivedMessages[0]).toSatisfy(isObject)
+    const [id, type, payload] = deserializeResponseMessage(receivedMessages[0])
+
+    expect(array.byteLength).toBe(0) // transferred so length is 0
+
+    expect(transfer).toHaveBeenCalledTimes(1)
+    expect(transfer).toHaveBeenCalledWith([id, type, expect.objectContaining({
+      body: { json: expect.toBeOneOf([array]) },
+      headers: {},
+    })])
+
+    expect(id).toBeTypeOf('string')
+    expect(payload).toEqual({
+      status: 200,
+      body: { json: expect.toSatisfy(v => v !== array && v instanceof Uint8Array && v.byteLength === 3) },
+      headers: {},
+    })
   })
 
   it('abort on close', { retry: 3 }, async () => {
@@ -60,10 +94,10 @@ describe('rpcHandler', async () => {
     await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(signal?.aborted).toBe(false)
-    expect(sentMessages).toHaveLength(0)
+    expect(receivedMessages).toHaveLength(0)
 
     clientPort.close()
     await vi.waitFor(() => expect(signal?.aborted).toBe(true))
-    expect(sentMessages).toHaveLength(0)
+    expect(receivedMessages).toHaveLength(0)
   })
 })

--- a/packages/server/src/adapters/message-port/rpc-handler.ts
+++ b/packages/server/src/adapters/message-port/rpc-handler.ts
@@ -1,8 +1,11 @@
 import type { Context } from '../../context'
 import type { Router } from '../../router'
 import type { StandardRPCHandlerOptions } from '../standard'
+import type { MessagePortHandlerOptions } from './handler'
 import { StandardRPCHandler } from '../standard'
 import { MessagePortHandler } from './handler'
+
+export interface RPCHandlerOptions<T extends Context> extends StandardRPCHandlerOptions<T>, MessagePortHandlerOptions<T> {}
 
 /**
  * RPC Handler for common message port implementations.
@@ -11,7 +14,7 @@ import { MessagePortHandler } from './handler'
  * @see {@link https://orpc.unnoq.com/docs/adapters/message-port Message Port Adapter Docs}
  */
 export class RPCHandler<T extends Context> extends MessagePortHandler<T> {
-  constructor(router: Router<any, T>, options: NoInfer<StandardRPCHandlerOptions<T>> = {}) {
-    super(new StandardRPCHandler(router, options))
+  constructor(router: Router<any, T>, options: NoInfer<RPCHandlerOptions<T>> = {}) {
+    super(new StandardRPCHandler(router, options), options)
   }
 }


### PR DESCRIPTION
This PR introduces a new `transfer` feature that allows `message port adapter` to utilize their own `transfer/structureClone layer`. Currently, messages are encoded to string/binary before being sent. By using this feature, oRPC can achieve near-native performance and support additional instances that can't be serialized/described, such as `OffscreenCanvas`.

- [x] draft
- [x] minify + transform message before send (can't clone standard request/response's `URL`)
- [x] test
- [x] docs

Closes: #1101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experimental MessagePort transfer support — optional transferable payloads for faster postMessage transfers; client/server handlers and links can opt into transfer-aware messaging.
  * Expanded serialization API — new serialize/deserialize helpers and codec improvements to handle richer payloads (Blobs, streams, event iterators).

* **Documentation**
  * Added "Transfer" docs with examples, guidance, structured-clone warning, and JSON-serializer tip.

* **Tests**
  * New tests covering transfer flows and serialization/deserialization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->