### PR TITLE
feat(ai-sdk): createTool, implementTool helpers

### DIFF
--- a/apps/content/docs/integrations/ai-sdk.md
+++ b/apps/content/docs/integrations/ai-sdk.md
@@ -122,25 +122,25 @@ AI SDK internally uses `structuredClone`, which doesn't support proxied data.
 oRPC may proxy events for [metadata](/docs/event-iterator#last-event-id-event-metadata), so unproxy before passing to AI SDK.
 :::
 
-## `createTool` helper
+## `implementTool` helper
 
-The `createTool` helper from `@orpc/ai-sdk` leverages your existing [oRPC contract](/docs/contract-first/define-contract) definitions to create [AI SDK tools](https://ai-sdk.dev/docs/foundations/tools).
+Implements [procedure contract](/docs/contract-first/define-contract) as an [AI SDK tools](https://ai-sdk.dev/docs/foundations/tools) by leveraging existing contract definitions.
 
 ```ts twoslash
 import { oc } from '@orpc/contract'
 import {
-  CREATE_AI_SDK_TOOL_META_SYMBOL,
-  CreateAiSdkToolMeta,
-  createTool
+  AI_SDK_TOOL_META_SYMBOL,
+  AiSdkToolMeta,
+  implementTool
 } from '@orpc/ai-sdk'
 import { z } from 'zod'
 
-interface ORPCMeta extends CreateAiSdkToolMeta {} // optional extend meta
+interface ORPCMeta extends AiSdkToolMeta {} // optional extend meta
 const base = oc.$meta<ORPCMeta>({})
 
 const getWeatherContract = base
   .meta({
-    [CREATE_AI_SDK_TOOL_META_SYMBOL]: {
+    [AI_SDK_TOOL_META_SYMBOL]: {
       name: 'custom-tool-name', // AI SDK tool name
     },
   })
@@ -155,7 +155,7 @@ const getWeatherContract = base
     temperature: z.number().describe('The temperature in Celsius'),
   }))
 
-const getWeatherTool = createTool(getWeatherContract, {
+const getWeatherTool = implementTool(getWeatherContract, {
   execute: async ({ location }) => ({
     location,
     temperature: 72 + Math.floor(Math.random() * 21) - 10,
@@ -164,5 +164,59 @@ const getWeatherTool = createTool(getWeatherContract, {
 ```
 
 ::: warning
-The `createTool` helper requires a contract with an `input` schema defined
+The `implementTool` helper requires a contract with an `input` schema defined
+:::
+
+::: info
+Standard [procedures](/docs/procedure) are also compatible with [procedure contracts](/docs/contract-first/define-contract).
+:::
+
+## `createTool` helper
+
+Converts a [procedure](/docs/procedure) into an [AI SDK Tool](https://ai-sdk.dev/docs/foundations/tools) by leveraging existing procedure definitions.
+
+```ts twoslash
+import { os } from '@orpc/server'
+import {
+  AI_SDK_TOOL_META_SYMBOL,
+  AiSdkToolMeta,
+  createTool
+} from '@orpc/ai-sdk'
+import { z } from 'zod'
+
+interface ORPCMeta extends AiSdkToolMeta {} // optional extend meta
+const base = os.$meta<ORPCMeta>({})
+
+const getWeatherProcedure = base
+  .meta({
+    [AI_SDK_TOOL_META_SYMBOL]: {
+      name: 'custom-tool-name', // AI SDK tool name
+    },
+  })
+  .route({
+    summary: 'Get the weather in a location',
+  })
+  .input(z.object({
+    location: z.string().describe('The location to get the weather for'),
+  }))
+  .output(z.object({
+    location: z.string().describe('The location the weather is for'),
+    temperature: z.number().describe('The temperature in Celsius'),
+  }))
+  .handler(async ({ input }) => ({
+    location: input.location,
+    temperature: 72 + Math.floor(Math.random() * 21) - 10,
+  }))
+
+const getWeatherTool = createTool(getWeatherProcedure, {
+  context: {}, // provide initial context if needed
+})
+```
+
+::: warning
+The `createTool` helper requires a procedure with an `input` schema defined
+:::
+
+::: warning
+Validation occurs twice (once for the tool, once for the procedure call). So validation may fail if `inputSchema` or `outputSchema` transform the data into different shapes.
 :::

--- a/apps/content/docs/integrations/ai-sdk.md
+++ b/apps/content/docs/integrations/ai-sdk.md
@@ -121,3 +121,48 @@ Prefer `eventIteratorToUnproxiedDataStream` over `eventIteratorToStream`.
 AI SDK internally uses `structuredClone`, which doesn't support proxied data.
 oRPC may proxy events for [metadata](/docs/event-iterator#last-event-id-event-metadata), so unproxy before passing to AI SDK.
 :::
+
+## `createTool` helper
+
+The `createTool` helper from `@orpc/ai-sdk` leverages your existing [oRPC contract](/docs/contract-first/define-contract) definitions to create [AI SDK tools](https://ai-sdk.dev/docs/foundations/tools).
+
+```ts twoslash
+import { oc } from '@orpc/contract'
+import {
+  CREATE_AI_SDK_TOOL_META_SYMBOL,
+  CreateAiSdkToolMeta,
+  createTool
+} from '@orpc/ai-sdk'
+import { z } from 'zod'
+
+interface ORPCMeta extends CreateAiSdkToolMeta {} // optional extend meta
+const base = oc.$meta<ORPCMeta>({})
+
+const getWeatherContract = base
+  .meta({
+    [CREATE_AI_SDK_TOOL_META_SYMBOL]: {
+      name: 'custom-tool-name', // AI SDK tool name
+    },
+  })
+  .route({
+    summary: 'Get the weather in a location', // AI SDK tool description
+  })
+  .input(z.object({
+    location: z.string().describe('The location to get the weather for'),
+  }))
+  .output(z.object({
+    location: z.string().describe('The location the weather is for'),
+    temperature: z.number().describe('The temperature in Celsius'),
+  }))
+
+const getWeatherTool = createTool(getWeatherContract, {
+  execute: async ({ location }) => ({
+    location,
+    temperature: 72 + Math.floor(Math.random() * 21) - 10,
+  }),
+})
+```
+
+::: warning
+The `createTool` helper requires a contract with an `input` schema defined
+:::

--- a/apps/content/package.json
+++ b/apps/content/package.json
@@ -13,6 +13,7 @@
     "@opentelemetry/instrumentation": "^0.207.0",
     "@opentelemetry/sdk-node": "^0.207.0",
     "@opentelemetry/sdk-trace-web": "^2.2.0",
+    "@orpc/ai-sdk": "workspace:*",
     "@orpc/arktype": "workspace:*",
     "@orpc/client": "workspace:*",
     "@orpc/contract": "workspace:*",

--- a/packages/ai-sdk/.gitignore
+++ b/packages/ai-sdk/.gitignore
@@ -1,0 +1,26 @@
+# Hidden folders and files
+.*
+!.gitignore
+!.*.example
+
+# Common generated folders
+logs/
+node_modules/
+out/
+dist/
+dist-ssr/
+build/
+coverage/
+temp/
+
+# Common generated files
+*.log
+*.log.*
+*.tsbuildinfo
+*.vitest-temp.json
+vite.config.ts.timestamp-*
+vitest.config.ts.timestamp-*
+
+# Common manual ignore files
+*.local
+*.pem

--- a/packages/ai-sdk/README.md
+++ b/packages/ai-sdk/README.md
@@ -1,0 +1,81 @@
+<div align="center">
+  <image align="center" src="https://orpc.unnoq.com/logo.webp" width=280 alt="oRPC logo" />
+</div>
+
+<h1></h1>
+
+<div align="center">
+  <a href="https://codecov.io/gh/unnoq/orpc">
+    <img alt="codecov" src="https://codecov.io/gh/unnoq/orpc/branch/main/graph/badge.svg">
+  </a>
+  <a href="https://www.npmjs.com/package/@orpc/ai-sdk">
+    <img alt="weekly downloads" src="https://img.shields.io/npm/dw/%40orpc%2Fai-sdk?logo=npm" />
+  </a>
+  <a href="https://github.com/unnoq/orpc/blob/main/LICENSE">
+    <img alt="MIT License" src="https://img.shields.io/github/license/unnoq/orpc?logo=open-source-initiative" />
+  </a>
+  <a href="https://discord.gg/TXEbwRBvQn">
+    <img alt="Discord" src="https://img.shields.io/discord/1308966753044398161?color=7389D8&label&logo=discord&logoColor=ffffff" />
+  </a>
+  <a href="https://deepwiki.com/unnoq/orpc">
+    <img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki">
+  </a>
+</div>
+
+<h3 align="center">Typesafe APIs Made Simple 🪄</h3>
+
+**oRPC is a powerful combination of RPC and OpenAPI**, makes it easy to build APIs that are end-to-end type-safe and adhere to OpenAPI standards
+
+---
+
+## Highlights
+
+- **🔗 End-to-End Type Safety**: Ensure type-safe inputs, outputs, and errors from client to server.
+- **📘 First-Class OpenAPI**: Built-in support that fully adheres to the OpenAPI standard.
+- **📝 Contract-First Development**: Optionally define your API contract before implementation.
+- **🔍 First-Class OpenTelemetry**: Seamlessly integrate with OpenTelemetry for observability.
+- **⚙️ Framework Integrations**: Seamlessly integrate with TanStack Query (React, Vue, Solid, Svelte, Angular), SWR, Pinia Colada, and more.
+- **🚀 Server Actions**: Fully compatible with React Server Actions on Next.js, TanStack Start, and other platforms.
+- **🔠 Standard Schema Support**: Works out of the box with Zod, Valibot, ArkType, and other schema validators.
+- **🗃️ Native Types**: Supports native types like Date, File, Blob, BigInt, URL, and more.
+- **⏱️ Lazy Router**: Enhance cold start times with our lazy routing feature.
+- **📡 SSE & Streaming**: Enjoy full type-safe support for SSE and streaming.
+- **🌍 Multi-Runtime Support**: Fast and lightweight on Cloudflare, Deno, Bun, Node.js, and beyond.
+- **🔌 Extendability**: Easily extend functionality with plugins, middleware, and interceptors.
+
+## Documentation
+
+You can find the full documentation [here](https://orpc.unnoq.com).
+
+## Packages
+
+- [@orpc/contract](https://www.npmjs.com/package/@orpc/contract): Build your API contract.
+- [@orpc/server](https://www.npmjs.com/package/@orpc/server): Build your API or implement API contract.
+- [@orpc/client](https://www.npmjs.com/package/@orpc/client): Consume your API on the client with type-safety.
+- [@orpc/openapi](https://www.npmjs.com/package/@orpc/openapi): Generate OpenAPI specs and handle OpenAPI requests.
+- [@orpc/otel](https://www.npmjs.com/package/@orpc/otel): [OpenTelemetry](https://opentelemetry.io/) integration for observability.
+- [@orpc/nest](https://www.npmjs.com/package/@orpc/nest): Deeply integrate oRPC with [NestJS](https://nestjs.com/).
+- [@orpc/react](https://www.npmjs.com/package/@orpc/react): Utilities for integrating oRPC with React and React Server Actions.
+- [@orpc/tanstack-query](https://www.npmjs.com/package/@orpc/tanstack-query): [TanStack Query](https://tanstack.com/query/latest) integration.
+- [@orpc/experimental-react-swr](https://www.npmjs.com/package/@orpc/experimental-react-swr): [SWR](https://swr.vercel.app/) integration.
+- [@orpc/vue-colada](https://www.npmjs.com/package/@orpc/vue-colada): Integration with [Pinia Colada](https://pinia-colada.esm.dev/).
+- [@orpc/hey-api](https://www.npmjs.com/package/@orpc/hey-api): [Hey API](https://heyapi.dev/) integration.
+- [@orpc/zod](https://www.npmjs.com/package/@orpc/zod): More schemas that [Zod](https://zod.dev/) doesn't support yet.
+- [@orpc/valibot](https://www.npmjs.com/package/@orpc/valibot): OpenAPI spec generation from [Valibot](https://valibot.dev/).
+- [@orpc/arktype](https://www.npmjs.com/package/@orpc/arktype): OpenAPI spec generation from [ArkType](https://arktype.io/).
+
+## `@orpc/ai-sdk`
+
+The [AI SDK](https://ai-sdk.dev/) integration for oRPC.
+
+## Sponsors
+
+<p align="center">
+  <a href="https://cdn.jsdelivr.net/gh/unnoq/unnoq/sponsors.svg">
+    <img src='https://cdn.jsdelivr.net/gh/unnoq/unnoq/sponsors.svg'/>
+  </a>
+</p>
+
+## License
+
+Distributed under the MIT License. See [LICENSE](https://github.com/unnoq/orpc/blob/main/LICENSE) for more information.

--- a/packages/ai-sdk/package.json
+++ b/packages/ai-sdk/package.json
@@ -36,8 +36,12 @@
   "peerDependencies": {
     "ai": ">=5.0.76"
   },
+  "dependencies": {
+    "@orpc/contract": "workspace:*",
+    "@orpc/shared": "workspace:*"
+  },
   "devDependencies": {
-    "ai": "^5.0.76",
+    "ai": "6.0.0-beta.85",
     "zod": "^4.1.12"
   }
 }

--- a/packages/ai-sdk/package.json
+++ b/packages/ai-sdk/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@orpc/ai-sdk",
+  "type": "module",
+  "version": "0.0.0",
+  "license": "MIT",
+  "homepage": "https://orpc.unnoq.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unnoq/orpc.git",
+    "directory": "packages/ai-sdk"
+  },
+  "keywords": [
+    "ai-sdk",
+    "orpc"
+  ],
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "unbuild",
+    "build:watch": "pnpm run build --watch",
+    "type:check": "tsc -b"
+  },
+  "peerDependencies": {
+    "ai": ">=5.0.76"
+  },
+  "devDependencies": {
+    "ai": "^5.0.76",
+    "zod": "^4.1.12"
+  }
+}

--- a/packages/ai-sdk/package.json
+++ b/packages/ai-sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orpc/ai-sdk",
   "type": "module",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "license": "MIT",
   "homepage": "https://orpc.unnoq.com",
   "repository": {

--- a/packages/ai-sdk/package.json
+++ b/packages/ai-sdk/package.json
@@ -37,7 +37,9 @@
     "ai": ">=5.0.76"
   },
   "dependencies": {
+    "@orpc/client": "workspace:*",
     "@orpc/contract": "workspace:*",
+    "@orpc/server": "workspace:*",
     "@orpc/shared": "workspace:*"
   },
   "devDependencies": {

--- a/packages/ai-sdk/src/index.test.ts
+++ b/packages/ai-sdk/src/index.test.ts
@@ -1,0 +1,3 @@
+it('exports createTool', async () => {
+  expect(Object.keys(await import('./index'))).toContain('createTool')
+})

--- a/packages/ai-sdk/src/index.ts
+++ b/packages/ai-sdk/src/index.ts
@@ -1,0 +1,6 @@
+export {
+  AsyncIteratorClass,
+  asyncIteratorToStream as eventIteratorToStream,
+  asyncIteratorToUnproxiedDataStream as eventIteratorToUnproxiedDataStream,
+  streamToAsyncIteratorClass as streamToEventIterator,
+} from '@orpc/shared'

--- a/packages/ai-sdk/src/index.ts
+++ b/packages/ai-sdk/src/index.ts
@@ -1,3 +1,5 @@
+export * from './tool'
+
 export {
   AsyncIteratorClass,
   asyncIteratorToStream as eventIteratorToStream,

--- a/packages/ai-sdk/src/tool.test-d.ts
+++ b/packages/ai-sdk/src/tool.test-d.ts
@@ -33,6 +33,38 @@ describe('createTool', () => {
     })
   })
 
+  it('infer correct input & output', () => {
+    const contract = oc
+      .route({
+        summary: 'Get the weather in a location',
+      })
+      .input(z.object({
+        stringToNumber: z.string().transform(val => Number(val)),
+      }))
+      .output(z.object({
+        numberToBoolean: z.number().transform(val => Boolean(val)),
+      }))
+
+    const tool = createTool(contract, {
+      execute: async ({ stringToNumber }) => {
+        expectTypeOf(stringToNumber).toEqualTypeOf<number>()
+
+        return {
+          numberToBoolean: stringToNumber,
+        }
+      },
+    })
+
+    const tool2 = createTool(contract, {
+      // @ts-expect-error invalid numberToBoolean
+      execute: async ({ stringToNumber }) => {
+        return {
+          numberToBoolean: true,
+        }
+      },
+    })
+  })
+
   it('throw on missing inputSchema is correct, because tool require inputSchema', () => {
     tool({
       inputSchema: z.object({}),

--- a/packages/ai-sdk/src/tool.test-d.ts
+++ b/packages/ai-sdk/src/tool.test-d.ts
@@ -1,0 +1,44 @@
+import { oc } from '@orpc/contract'
+import { generateText, tool } from 'ai'
+import { z } from 'zod'
+import { createTool } from './tool'
+
+describe('createTool', () => {
+  it('can use as a tool', () => {
+    const contract = oc
+      .route({
+        summary: 'Get the weather in a location',
+      })
+      .input(z.object({
+        location: z.string().describe('The location to get the weather for'),
+      }))
+      .output(z.object({
+        location: z.string(),
+        temperature: z.number().describe('The temperature in Fahrenheit'),
+      }))
+
+    const weatherTool = createTool(contract, {
+      execute: async ({ location }) => ({
+        location,
+        temperature: 72 + Math.floor(Math.random() * 21) - 10,
+      }),
+    })
+
+    void generateText({
+      model: 'openai/gpt-4o',
+      tools: {
+        weather: weatherTool,
+      },
+      prompt: 'What is the weather in San Francisco?',
+    })
+  })
+
+  it('throw on missing inputSchema is correct, because tool require inputSchema', () => {
+    tool({
+      inputSchema: z.object({}),
+    })
+
+    // @ts-expect-error inputSchema is required
+    tool({})
+  })
+})

--- a/packages/ai-sdk/src/tool.test-d.ts
+++ b/packages/ai-sdk/src/tool.test-d.ts
@@ -1,9 +1,21 @@
 import { oc } from '@orpc/contract'
+import { os } from '@orpc/server'
 import { generateText, tool } from 'ai'
 import { z } from 'zod'
-import { createTool } from './tool'
+import { createTool, implementTool } from './tool'
 
-describe('createTool', () => {
+describe('tool', () => {
+  it('throw on missing inputSchema is correct, because tool require inputSchema', () => {
+    tool({
+      inputSchema: z.object({}),
+    })
+
+    // @ts-expect-error inputSchema is required
+    tool({})
+  })
+})
+
+describe('implementTool', () => {
   it('can use as a tool', () => {
     const contract = oc
       .route({
@@ -17,7 +29,7 @@ describe('createTool', () => {
         temperature: z.number().describe('The temperature in Fahrenheit'),
       }))
 
-    const weatherTool = createTool(contract, {
+    const weatherTool = implementTool(contract, {
       execute: async ({ location }) => ({
         location,
         temperature: 72 + Math.floor(Math.random() * 21) - 10,
@@ -45,7 +57,7 @@ describe('createTool', () => {
         numberToBoolean: z.number().transform(val => Boolean(val)),
       }))
 
-    const tool = createTool(contract, {
+    const tool = implementTool(contract, {
       execute: async ({ stringToNumber }) => {
         expectTypeOf(stringToNumber).toEqualTypeOf<number>()
 
@@ -55,7 +67,76 @@ describe('createTool', () => {
       },
     })
 
-    const tool2 = createTool(contract, {
+    const tool2 = implementTool(contract, {
+      // @ts-expect-error invalid numberToBoolean
+      execute: async ({ stringToNumber }) => {
+        return {
+          numberToBoolean: true,
+        }
+      },
+    })
+  })
+})
+
+describe('createTool', () => {
+  it('can use as a tool', () => {
+    const procedure = os
+      .route({
+        summary: 'Get the weather in a location',
+      })
+      .input(z.object({
+        location: z.string().describe('The location to get the weather for'),
+      }))
+      .output(z.object({
+        location: z.string(),
+        temperature: z.number().describe('The temperature in Fahrenheit'),
+      }))
+      .handler(async ({ input }) => {
+        return {
+          location: input.location,
+          temperature: 72 + Math.floor(Math.random() * 21) - 10,
+        }
+      })
+
+    const weatherTool = createTool(procedure)
+
+    void generateText({
+      model: 'openai/gpt-4o',
+      tools: {
+        weather: weatherTool,
+      },
+      prompt: 'What is the weather in San Francisco?',
+    })
+  })
+
+  it('infer correct input & output', () => {
+    const procedure = os
+      .route({
+        summary: 'Get the weather in a location',
+      })
+      .input(z.object({
+        stringToNumber: z.string().transform(val => Number(val)),
+      }))
+      .output(z.object({
+        numberToBoolean: z.number().transform(val => Boolean(val)),
+      }))
+      .handler(async ({ input }) => {
+        return {
+          numberToBoolean: input.stringToNumber,
+        }
+      })
+
+    const tool = createTool(procedure, {
+      execute: async ({ stringToNumber }) => {
+        expectTypeOf(stringToNumber).toEqualTypeOf<number>()
+
+        return {
+          numberToBoolean: stringToNumber,
+        }
+      },
+    })
+
+    const tool2 = createTool(procedure, {
       // @ts-expect-error invalid numberToBoolean
       execute: async ({ stringToNumber }) => {
         return {
@@ -65,12 +146,19 @@ describe('createTool', () => {
     })
   })
 
-  it('throw on missing inputSchema is correct, because tool require inputSchema', () => {
-    tool({
-      inputSchema: z.object({}),
+  it('require provide initial context if required', () => {
+    const procedure = os
+      .$context<{ authToken: string }>()
+      .input(z.object({
+        location: z.string().describe('The location to get the weather for'),
+      }))
+      .handler(async ({ context, input }) => {})
+
+    void createTool(procedure, {
+      context: { authToken: '' },
     })
 
-    // @ts-expect-error inputSchema is required
-    tool({})
+    // @ts-expect-error missing context
+    void createTool(procedure, {})
   })
 })

--- a/packages/ai-sdk/src/tool.test.ts
+++ b/packages/ai-sdk/src/tool.test.ts
@@ -1,10 +1,11 @@
-import type { CreateAiSdkToolMeta } from './tool'
+import type { AiSdkToolMeta } from './tool'
 import { oc } from '@orpc/contract'
+import { os } from '@orpc/server'
 import z from 'zod'
-import { CREATE_AI_SDK_TOOL_META_SYMBOL, createTool } from './tool'
+import { AI_SDK_TOOL_META_SYMBOL, createTool, implementTool } from './tool'
 
-describe('createTool', () => {
-  const base = oc.$meta<CreateAiSdkToolMeta>({})
+describe('implementTool', () => {
+  const base = oc.$meta<AiSdkToolMeta>({})
 
   const inputSchema = z.object({
     name: z.string().describe('Name of the person'),
@@ -13,7 +14,7 @@ describe('createTool', () => {
     greeting: z.string().describe('Greeting message'),
   })
 
-  it('can create a tool', () => {
+  it('can implement a tool', () => {
     const contract = base
       .route({
         summary: 'Greet a person',
@@ -23,7 +24,7 @@ describe('createTool', () => {
 
     const execute = vi.fn()
 
-    const tool = createTool(contract, {
+    const tool = implementTool(contract, {
       execute,
     })
 
@@ -34,8 +35,8 @@ describe('createTool', () => {
   })
 
   it('require contract with inputSchema', () => {
-    expect(() => createTool(base.input(inputSchema), {})).not.toThrow()
-    expect(() => createTool(base, {})).toThrowError('Cannot create tool from a contract procedure without input schema.')
+    expect(() => implementTool(base.input(inputSchema), {})).not.toThrow()
+    expect(() => implementTool(base, {})).toThrowError('Cannot implement tool from a contract procedure without input schema.')
   })
 
   it('use route.description when route.summary is not present', () => {
@@ -44,7 +45,7 @@ describe('createTool', () => {
         description: 'Custom description',
       })
 
-    const tool = createTool(contract, {})
+    const tool = implementTool(contract, {})
 
     expect(tool.description).toBe('Custom description')
   })
@@ -52,19 +53,63 @@ describe('createTool', () => {
   it('support meta to provide default tool options', () => {
     const contract = base
       .meta({
-        [CREATE_AI_SDK_TOOL_META_SYMBOL]: {
+        [AI_SDK_TOOL_META_SYMBOL]: {
           name: 'custom-tool-name',
           description: 'Meta description',
         },
       })
       .input(inputSchema)
 
-    const tool = createTool(contract, {
+    const tool = implementTool(contract, {
       execute: vi.fn(),
       description: 'Override description',
     })
 
     expect((tool as any).name).toBe('custom-tool-name')
     expect(tool.description).toBe('Override description')
+  })
+})
+
+describe('createTool', () => {
+  const base = os.$meta<AiSdkToolMeta>({})
+
+  const inputSchema = z.object({
+    name: z.string().describe('Name of the person'),
+  })
+  const outputSchema = z.object({
+    greeting: z.string().describe('Greeting message'),
+  })
+
+  it('can create a tool', () => {
+    const handler = vi.fn(async ({ input }) => {
+      return {
+        greeting: `Hello, ${input.name}!`,
+      }
+    })
+    const procedure
+      = base
+        .route({
+          summary: 'Greet a person',
+        })
+        .input(inputSchema)
+        .output(outputSchema)
+        .handler(handler)
+
+    const tool = createTool(procedure, {
+      context: { authToken: 'auth-token' },
+    })
+
+    expect(tool.inputSchema).toBe(inputSchema)
+    expect(tool.outputSchema).toBe(outputSchema)
+    expect(tool.description).toBe('Greet a person')
+
+    return expect(
+      (tool as any).execute({ name: 'Alice' }),
+    ).resolves.toEqual({ greeting: 'Hello, Alice!' })
+
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({
+      input: { name: 'Alice' },
+      context: { authToken: 'auth-token' },
+    }))
   })
 })

--- a/packages/ai-sdk/src/tool.test.ts
+++ b/packages/ai-sdk/src/tool.test.ts
@@ -1,0 +1,70 @@
+import type { CreateAiSdkToolMeta } from './tool'
+import { oc } from '@orpc/contract'
+import z from 'zod'
+import { CREATE_AI_SDK_TOOL_META_SYMBOL, createTool } from './tool'
+
+describe('createTool', () => {
+  const base = oc.$meta<CreateAiSdkToolMeta>({})
+
+  const inputSchema = z.object({
+    name: z.string().describe('Name of the person'),
+  })
+  const outputSchema = z.object({
+    greeting: z.string().describe('Greeting message'),
+  })
+
+  it('can create a tool', () => {
+    const contract = base
+      .route({
+        summary: 'Greet a person',
+      })
+      .input(inputSchema)
+      .output(outputSchema)
+
+    const execute = vi.fn()
+
+    const tool = createTool(contract, {
+      execute,
+    })
+
+    expect(tool.inputSchema).toBe(inputSchema)
+    expect(tool.outputSchema).toBe(outputSchema)
+    expect(tool.description).toBe('Greet a person')
+    expect(tool.execute).toBe(execute)
+  })
+
+  it('require contract with inputSchema', () => {
+    expect(() => createTool(base.input(inputSchema), {})).not.toThrow()
+    expect(() => createTool(base, {})).toThrowError('Cannot create tool from a contract procedure without input schema.')
+  })
+
+  it('use route.description when route.summary is not present', () => {
+    const contract = base.input(inputSchema)
+      .route({
+        description: 'Custom description',
+      })
+
+    const tool = createTool(contract, {})
+
+    expect(tool.description).toBe('Custom description')
+  })
+
+  it('support meta to provide default tool options', () => {
+    const contract = base
+      .meta({
+        [CREATE_AI_SDK_TOOL_META_SYMBOL]: {
+          name: 'custom-tool-name',
+          description: 'Meta description',
+        },
+      })
+      .input(inputSchema)
+
+    const tool = createTool(contract, {
+      execute: vi.fn(),
+      description: 'Override description',
+    })
+
+    expect((tool as any).name).toBe('custom-tool-name')
+    expect(tool.description).toBe('Override description')
+  })
+})

--- a/packages/ai-sdk/src/tool.ts
+++ b/packages/ai-sdk/src/tool.ts
@@ -1,0 +1,29 @@
+import type { ContractProcedure, Meta, Schema } from '@orpc/contract'
+import type { SetOptional } from '@orpc/shared'
+import type { Tool } from 'ai'
+import { tool } from 'ai'
+
+export const CREATE_AI_SDK_TOOL_META_SYMBOL: unique symbol = Symbol('ORPC_CREATE_AI_SDK_TOOL_META')
+
+export interface CreateAiSdkToolMeta extends Meta {
+  [CREATE_AI_SDK_TOOL_META_SYMBOL]?: Partial<Tool<unknown, unknown>>
+}
+
+export class CreateToolError extends Error {}
+
+export function createTool<TInput, TOutput>(
+  contract: ContractProcedure<Schema<any, TInput>, Schema<any, TOutput>, any, CreateAiSdkToolMeta>,
+  options: SetOptional<Tool<TInput, TOutput>, 'inputSchema' | 'outputSchema'>,
+): Tool<TInput, TOutput> {
+  if (contract['~orpc'].inputSchema === undefined) {
+    throw new CreateToolError('Cannot create tool from a contract procedure without input schema.')
+  }
+
+  return tool({
+    inputSchema: contract['~orpc'].inputSchema,
+    outputSchema: contract['~orpc'].outputSchema,
+    description: contract['~orpc'].route.summary ?? contract['~orpc'].route.description,
+    ...contract['~orpc'].meta[CREATE_AI_SDK_TOOL_META_SYMBOL],
+    ...options,
+  } as any)
+}

--- a/packages/ai-sdk/src/tool.ts
+++ b/packages/ai-sdk/src/tool.ts
@@ -12,14 +12,14 @@ export interface CreateAiSdkToolMeta extends Meta {
 export class CreateToolError extends Error {}
 
 export function createTool<TInput, TOutput>(
-  contract: ContractProcedure<Schema<any, TInput>, Schema<any, TOutput>, any, CreateAiSdkToolMeta>,
+  contract: ContractProcedure<Schema<any, TInput>, Schema<TOutput, any>, any, CreateAiSdkToolMeta>,
   options: SetOptional<Tool<TInput, TOutput>, 'inputSchema' | 'outputSchema'>,
 ): Tool<TInput, TOutput> {
   if (contract['~orpc'].inputSchema === undefined) {
     throw new CreateToolError('Cannot create tool from a contract procedure without input schema.')
   }
 
-  return tool({
+  return tool<TInput, TOutput>({
     inputSchema: contract['~orpc'].inputSchema,
     outputSchema: contract['~orpc'].outputSchema,
     description: contract['~orpc'].route.summary ?? contract['~orpc'].route.description,

--- a/packages/ai-sdk/src/tool.ts
+++ b/packages/ai-sdk/src/tool.ts
@@ -1,29 +1,155 @@
-import type { ContractProcedure, Meta, Schema } from '@orpc/contract'
-import type { SetOptional } from '@orpc/shared'
+import type { ClientOptions } from '@orpc/client'
+import type { AnySchema, ContractProcedure, ErrorMap, InferSchemaInput, InferSchemaOutput, Meta, Schema } from '@orpc/contract'
+import type { Context, CreateProcedureClientOptions, Procedure } from '@orpc/server'
+import type { MaybeOptionalOptions, SetOptional } from '@orpc/shared'
 import type { Tool } from 'ai'
+import { call } from '@orpc/server'
+import { resolveMaybeOptionalOptions } from '@orpc/shared'
 import { tool } from 'ai'
 
-export const CREATE_AI_SDK_TOOL_META_SYMBOL: unique symbol = Symbol('ORPC_CREATE_AI_SDK_TOOL_META')
+export const AI_SDK_TOOL_META_SYMBOL: unique symbol = Symbol('ORPC_AI_SDK_TOOL_META')
 
-export interface CreateAiSdkToolMeta extends Meta {
-  [CREATE_AI_SDK_TOOL_META_SYMBOL]?: Partial<Tool<unknown, unknown>>
+export interface AiSdkToolMeta extends Meta {
+  [AI_SDK_TOOL_META_SYMBOL]?: Partial<Tool<unknown, unknown>>
 }
 
 export class CreateToolError extends Error {}
 
-export function createTool<TInput, TOutput>(
-  contract: ContractProcedure<Schema<any, TInput>, Schema<TOutput, any>, any, CreateAiSdkToolMeta>,
-  options: SetOptional<Tool<TInput, TOutput>, 'inputSchema' | 'outputSchema'>,
-): Tool<TInput, TOutput> {
+/**
+ * Implements [procedure contract](https://orpc.unnoq.com/docs/contract-first/define-contract#procedure-contract)
+ * as an [AI SDK Tool](https://ai-sdk.dev/docs/foundations/tools) by leveraging existing contract definitions.
+ *
+ * @warning Requires a contract with an `input` schema defined.
+ * @info Standard [procedures](https://orpc.unnoq.com/docs/procedure) are also compatible with [procedure contracts](https://orpc.unnoq.com/docs/contract-first/define-contract).
+ *
+ * @example
+ * ```ts
+ * import { oc } from '@orpc/contract'
+ * import {
+ *   AI_SDK_TOOL_META_SYMBOL,
+ *   AiSdkToolMeta,
+ *   implementTool,
+ * } from '@orpc/ai-sdk'
+ * import { z } from 'zod'
+ *
+ * interface ORPCMeta extends AiSdkToolMeta {} // optional extend meta
+ * const base = oc.$meta<ORPCMeta>({})
+ *
+ * const getWeatherContract = base
+ *   .meta({
+ *     [AI_SDK_TOOL_META_SYMBOL]: {
+ *       name: 'custom-tool-name', // AI SDK tool name
+ *     },
+ *   })
+ *   .route({
+ *     summary: 'Get the weather in a location', // AI SDK tool description
+ *   })
+ *   .input(
+ *     z.object({
+ *       location: z.string().describe('The location to get the weather for'),
+ *     }),
+ *   )
+ *   .output(
+ *     z.object({
+ *       location: z.string().describe('The location the weather is for'),
+ *       temperature: z.number().describe('The temperature in Celsius'),
+ *     }),
+ *   )
+ *
+ * const getWeatherTool = implementTool(getWeatherContract, {
+ *   execute: async ({ location }) => ({
+ *     location,
+ *     temperature: 72 + Math.floor(Math.random() * 21) - 10,
+ *   }),
+ * })
+ * ```
+ */
+export function implementTool<TOutInput, TInOutput>(
+  contract: ContractProcedure<Schema<any, TOutInput>, Schema<TInOutput, any>, any, AiSdkToolMeta>,
+  ...rest: MaybeOptionalOptions<SetOptional<Tool<TOutInput, TInOutput>, 'inputSchema' | 'outputSchema'>>
+): Tool<TOutInput, TInOutput> {
   if (contract['~orpc'].inputSchema === undefined) {
-    throw new CreateToolError('Cannot create tool from a contract procedure without input schema.')
+    throw new CreateToolError('Cannot implement tool from a contract procedure without input schema.')
   }
 
-  return tool<TInput, TOutput>({
+  const options = resolveMaybeOptionalOptions(rest)
+
+  return tool<TOutInput, TInOutput>({
     inputSchema: contract['~orpc'].inputSchema,
     outputSchema: contract['~orpc'].outputSchema,
     description: contract['~orpc'].route.summary ?? contract['~orpc'].route.description,
-    ...contract['~orpc'].meta[CREATE_AI_SDK_TOOL_META_SYMBOL],
+    ...contract['~orpc'].meta[AI_SDK_TOOL_META_SYMBOL],
+    ...options,
+  } as any)
+}
+
+/**
+ * Converts a [procedure](https://orpc.unnoq.com/docs/procedure) into an [AI SDK Tool](https://ai-sdk.dev/docs/foundations/tools)
+ * by leveraging existing procedure definitions.
+ *
+ * @warning Requires a contract with an `input` schema defined.
+ * @warning Validation occurs twice (once for the tool, once for the procedure call).
+ * So validation may fail if inputSchema or outputSchema transform the data into different shapes.
+ *
+ * @example
+ * ```ts
+ * import { os } from '@orpc/server'
+ * import {
+ *   AI_SDK_TOOL_META_SYMBOL,
+ *   AiSdkToolMeta,
+ *   createTool
+ * } from '@orpc/ai-sdk'
+ * import { z } from 'zod'
+ *
+ * interface ORPCMeta extends AiSdkToolMeta {} // optional extend meta
+ * const base = os.$meta<ORPCMeta>({})
+ *
+ * const getWeatherProcedure = base
+ *   .meta({
+ *     [AI_SDK_TOOL_META_SYMBOL]: {
+ *       name: 'custom-tool-name', // AI SDK tool name
+ *     },
+ *   })
+ *   .route({
+ *     summary: 'Get the weather in a location',
+ *   })
+ *   .input(z.object({
+ *     location: z.string().describe('The location to get the weather for'),
+ *   }))
+ *   .output(z.object({
+ *     location: z.string().describe('The location the weather is for'),
+ *     temperature: z.number().describe('The temperature in Celsius'),
+ *   }))
+ *   .handler(async ({ input }) => ({
+ *     location: input.location,
+ *     temperature: 72 + Math.floor(Math.random() * 21) - 10,
+ *   }))
+ *
+ * const getWeatherTool = createTool(getWeatherProcedure, {
+ *   context: {}, // provide initial context if needed
+ * })
+ * ```
+ */
+export function createTool<
+  TInitialContext extends Context,
+  TInputSchema extends AnySchema,
+  TOutputSchema extends AnySchema,
+  TErrorMap extends ErrorMap,
+  TMeta extends AiSdkToolMeta,
+>(
+  procedure: Procedure<TInitialContext, any, TInputSchema, TOutputSchema, TErrorMap, TMeta>,
+  ...rest: MaybeOptionalOptions<
+    & SetOptional<Tool<InferSchemaOutput<TInputSchema>, InferSchemaInput<TOutputSchema>>, 'inputSchema' | 'outputSchema' | 'execute'>
+    & CreateProcedureClientOptions<TInitialContext, TOutputSchema, TErrorMap, TMeta, Record<never, never>>
+    & Omit<ClientOptions<Record<never, never>>, 'context'>
+  >
+): Tool<InferSchemaOutput<TInputSchema>, InferSchemaInput<TOutputSchema>> {
+  const options = resolveMaybeOptionalOptions(rest)
+
+  return implementTool(procedure, {
+    execute: (input: InferSchemaOutput<TInputSchema>) => {
+      return call(procedure, input as InferSchemaInput<TInputSchema>, options)
+    },
     ...options,
   } as any)
 }

--- a/packages/ai-sdk/tsconfig.json
+++ b/packages/ai-sdk/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.lib.json",
+  "references": [
+    { "path": "../openapi" },
+    { "path": "../contract" },
+    { "path": "../server" }
+  ],
+  "include": ["src"],
+  "exclude": [
+    "**/*.test.*",
+    "**/*.test-d.ts",
+    "**/__tests__/**",
+    "**/__mocks__/**",
+    "**/__snapshots__/**"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       '@opentelemetry/sdk-trace-web':
         specifier: ^2.2.0
         version: 2.2.0(@opentelemetry/api@1.9.0)
+      '@orpc/ai-sdk':
+        specifier: workspace:*
+        version: link:../../packages/ai-sdk
       '@orpc/arktype':
         specifier: workspace:*
         version: link:../../packages/arktype
@@ -233,10 +236,17 @@ importers:
         version: 4.1.12
 
   packages/ai-sdk:
+    dependencies:
+      '@orpc/contract':
+        specifier: workspace:*
+        version: link:../contract
+      '@orpc/shared':
+        specifier: workspace:*
+        version: link:../shared
     devDependencies:
       ai:
-        specifier: 5.0.76
-        version: 5.0.76(zod@4.1.12)
+        specifier: 6.0.0-beta.85
+        version: 6.0.0-beta.85(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(arktype@2.1.23)(zod@4.1.12)
       zod:
         specifier: ^4.1.12
         version: 4.1.12
@@ -1660,6 +1670,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@2.0.0-beta.47':
+    resolution: {integrity: sha512-VsVveIENbzNSh477/UwihpIWcsmIudizlGPdDZ1L+kEDDOxULqt/avLt/qxKR8/8+4+xrGDVRFIkfM4RUadRug==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/google@2.0.23':
     resolution: {integrity: sha512-VbCnKR+6aWUVLkAiSW5gUEtST7KueEmlt+d6qwDikxlLnFG9pzy59je8MiDVeM5G2tuSXbvZQF78PGIfXDBmow==}
     engines: {node: '>=18'}
@@ -1672,8 +1688,28 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.0-beta.28':
+    resolution: {integrity: sha512-IJk4or+ultCcWiSHRRx3tP7Dxy8kSplhpkUlw+8c2eoEjXnFbp+Bz/BUI59JlGqSOhcnLMxPCWQqZR/a/IPDCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@valibot/to-json-schema': ^1.3.0
+      arktype: ^2.1.22
+      effect: ^3.18.4
+      zod: ^3.25.76 || ^4.1.8
+    peerDependenciesMeta:
+      '@valibot/to-json-schema':
+        optional: true
+      arktype:
+        optional: true
+      effect:
+        optional: true
+
   '@ai-sdk/provider@2.0.0':
     resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.0-beta.13':
+    resolution: {integrity: sha512-I1dQccnA+G8/RTrVDoHfjFdUG534z+371D1hZVeo8yLWoaLMvRiPrk+fIJkkGjvdZ3OQdsQMDNw3WCKW6GFSbw==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@2.0.76':
@@ -7165,6 +7201,12 @@ packages:
 
   ai@5.0.76:
     resolution: {integrity: sha512-ZCxi1vrpyCUnDbtYrO/W8GLvyacV9689f00yshTIQ3mFFphbD7eIv40a2AOZBv3GGRA7SSRYIDnr56wcS/gyQg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@6.0.0-beta.85:
+    resolution: {integrity: sha512-5qMfpZz5e2Yj/QkZPC9iBivV557txXW3FOvs39UWsnnkvsGxW0uCDcyMpZMRDQkRJoB8XiyVFJuj+6Kvrnebwg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -14643,6 +14685,17 @@ snapshots:
       '@vercel/oidc': 3.0.3
       zod: 4.1.12
 
+  '@ai-sdk/gateway@2.0.0-beta.47(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(arktype@2.1.23)(zod@4.1.12)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.0-beta.13
+      '@ai-sdk/provider-utils': 4.0.0-beta.28(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(arktype@2.1.23)(zod@4.1.12)
+      '@vercel/oidc': 3.0.3
+      zod: 4.1.12
+    transitivePeerDependencies:
+      - '@valibot/to-json-schema'
+      - arktype
+      - effect
+
   '@ai-sdk/google@2.0.23(zod@4.1.12)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
@@ -14656,7 +14709,21 @@ snapshots:
       eventsource-parser: 3.0.6
       zod: 4.1.12
 
+  '@ai-sdk/provider-utils@4.0.0-beta.28(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(arktype@2.1.23)(zod@4.1.12)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.0-beta.13
+      '@standard-schema/spec': 1.0.0
+      eventsource-parser: 3.0.6
+      zod: 4.1.12
+    optionalDependencies:
+      '@valibot/to-json-schema': 1.3.0(valibot@1.1.0(typescript@5.8.3))
+      arktype: 2.1.23
+
   '@ai-sdk/provider@2.0.0':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.0-beta.13':
     dependencies:
       json-schema: 0.4.0
 
@@ -21312,6 +21379,18 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.12(zod@4.1.12)
       '@opentelemetry/api': 1.9.0
       zod: 4.1.12
+
+  ai@6.0.0-beta.85(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(arktype@2.1.23)(zod@4.1.12):
+    dependencies:
+      '@ai-sdk/gateway': 2.0.0-beta.47(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(arktype@2.1.23)(zod@4.1.12)
+      '@ai-sdk/provider': 3.0.0-beta.13
+      '@ai-sdk/provider-utils': 4.0.0-beta.28(@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.8.3)))(arktype@2.1.23)(zod@4.1.12)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.1.12
+    transitivePeerDependencies:
+      - '@valibot/to-json-schema'
+      - arktype
+      - effect
 
   ajv-draft-04@1.0.0(ajv@8.17.1):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,15 @@ importers:
         specifier: ^4.1.12
         version: 4.1.12
 
+  packages/ai-sdk:
+    devDependencies:
+      ai:
+        specifier: 5.0.76
+        version: 5.0.76(zod@4.1.12)
+      zod:
+        specifier: ^4.1.12
+        version: 4.1.12
+
   packages/arktype:
     dependencies:
       '@ark/schema':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,9 +237,15 @@ importers:
 
   packages/ai-sdk:
     dependencies:
+      '@orpc/client':
+        specifier: workspace:*
+        version: link:../client
       '@orpc/contract':
         specifier: workspace:*
         version: link:../contract
+      '@orpc/server':
+        specifier: workspace:*
+        version: link:../server
       '@orpc/shared':
         specifier: workspace:*
         version: link:../shared


### PR DESCRIPTION
Implement or create AI SDK tool from contract/procedure.

Closes: #1150 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added @orpc/ai-sdk package enabling integration of oRPC contracts with the Vercel AI SDK
  * Provides functions to map contract-first definitions to AI SDK tools
  * Includes comprehensive documentation with TypeScript examples for AI SDK integration

* **Documentation**
  * Added detailed guides for integrating AI SDK tools with oRPC contracts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->