### PR TITLE
fix(zod): union and intersection schema conversion

### DIFF
--- a/packages/zod/src/converter.test.ts
+++ b/packages/zod/src/converter.test.ts
@@ -212,7 +212,7 @@ const combinationCases: SchemaTestCase[] = [
   },
   {
     schema: z.union([z.string(), z.undefined()]),
-    input: [false, { type: 'string' }],
+    input: [false, { anyOf: [{ type: 'string' }] }],
   },
   {
     schema: z.intersection(z.string(), z.number()),

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -513,7 +513,7 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
         let required = true
 
         for (const item of schema_._def.options) {
-          const [itemRequired, itemJson] = this.convert(item, options, lazyDepth, false, false, structureDepth)
+          const [itemRequired, itemJson] = this.convert(item, options, lazyDepth, false, false, structureDepth + 1)
 
           if (!itemRequired) {
             required = false
@@ -527,10 +527,6 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
           }
         }
 
-        if (anyOf.length === 1) {
-          return [required, anyOf[0]!]
-        }
-
         return [required, { anyOf }]
       }
 
@@ -541,7 +537,7 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
         let required: boolean = false
 
         for (const item of [schema_._def.left, schema_._def.right]) {
-          const [itemRequired, itemJson] = this.convert(item, options, lazyDepth, false, false, structureDepth)
+          const [itemRequired, itemJson] = this.convert(item, options, lazyDepth, false, false, structureDepth + 1)
 
           allOf.push(itemJson)
 

--- a/packages/zod/src/zod4/converter.combination.test.ts
+++ b/packages/zod/src/zod4/converter.combination.test.ts
@@ -15,7 +15,7 @@ testSchemaConverter([
   {
     name: 'union([z.string(), z.undefined()])',
     schema: z.union([z.string(), z.undefined()]),
-    input: [false, { type: 'string' }],
+    input: [false, { anyOf: [{ type: 'string' }] }],
   },
   {
     name: 'intersection(z.string(), z.number())',

--- a/packages/zod/src/zod4/converter.ts
+++ b/packages/zod/src/zod4/converter.ts
@@ -325,7 +325,7 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
             let required = true
 
             for (const item of union._zod.def.options) {
-              const [itemRequired, itemJson] = this.#convert(item, options, lazyDepth, structureDepth)
+              const [itemRequired, itemJson] = this.#convert(item, options, lazyDepth, structureDepth + 1)
 
               if (!itemRequired) {
                 required = false
@@ -343,7 +343,7 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
               }
             }
 
-            return [required, anyOf.length === 1 ? anyOf[0]! : { anyOf }]
+            return [required, { anyOf }]
           }
 
           case 'intersection': {
@@ -353,7 +353,7 @@ export class ZodToJsonSchemaConverter implements ConditionalSchemaConverter {
             let required = false
 
             for (const item of [intersection._zod.def.left, intersection._zod.def.right]) {
-              const [itemRequired, itemJson] = this.#convert(item, options, lazyDepth, structureDepth)
+              const [itemRequired, itemJson] = this.#convert(item, options, lazyDepth, structureDepth + 1)
 
               json.allOf.push(itemJson)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved recursion depth handling for nested schema conversions to tighten depth tracking.
  * Unified union/intersection schema output to always produce a consistent anyOf array.

* **Tests**
  * Updated test expectations to match the new schema output format for unions including undefined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->