### PR TITLE
docs: add guide for disabling output validation

### DIFF
--- a/apps/content/.vitepress/config.ts
+++ b/apps/content/.vitepress/config.ts
@@ -284,6 +284,7 @@ export default withMermaid(defineConfig({
           collapsed: true,
           items: [
             { text: 'Customizing Error Response', link: '/docs/openapi/advanced/customizing-error-response' },
+            { text: 'Disabling Output Validation', link: '/docs/openapi/advanced/disabling-output-validation' },
             { text: 'Expanding Type Support for OpenAPI Link', link: '/docs/openapi/advanced/expanding-type-support-for-openapi-link' },
             { text: 'OpenAPI JSON Serializer', link: '/docs/openapi/advanced/openapi-json-serializer' },
             { text: 'Redirect Response', link: '/docs/openapi/advanced/redirect-response' },

--- a/apps/content/docs/openapi/advanced/disabling-output-validation.md
+++ b/apps/content/docs/openapi/advanced/disabling-output-validation.md
@@ -1,0 +1,49 @@
+---
+title: Disabling Output Validation
+description: Learn how to disable output validation in oRPC procedures for improved performance while maintaining OpenAPI specification generation.
+---
+
+# Disabling Output Validation
+
+By default, oRPC validates procedure outputs against their [defined schemas](/docs/procedure#input-output-validation) to ensure data consistency and type safety. If you only define output schemas for [OpenAPI specification generation](/docs/openapi/openapi-specification), you can disable output validation to improve performance.
+
+## Configuration
+
+Set `initialOutputValidationIndex` to `NaN` in the [`$config`](/docs/builder#config) method:
+
+```ts
+import { os } from '@orpc/server'
+
+const base = os
+  .$config({
+    initialOutputValidationIndex: Number.NaN, // [!code highlight]
+  })
+```
+
+All procedures built from `base` will now have output validation disabled.
+
+## Limitation
+
+This approach will not work correctly if your schema transforms the data into a different type during validation.
+
+```ts twoslash
+import { os } from '@orpc/server'
+import { z } from 'zod'
+
+const base = os
+  .$config({
+    initialOutputValidationIndex: Number.NaN,
+  })
+// ---cut---
+
+const procedure = base
+  .output(z.object({ value: z.number().transform(val => String(val)) }))
+  .handler(() => {
+    return { value: 123 }
+  })
+  .callable()
+
+const { value } = await procedure()
+```
+
+In this example, the client expects `value` to be a `string`, but because output validation is disabled, the transform logic is skipped. The client will receive a `number` instead, causing type mismatches.

--- a/apps/content/docs/openapi/advanced/disabling-output-validation.md
+++ b/apps/content/docs/openapi/advanced/disabling-output-validation.md
@@ -9,7 +9,7 @@ By default, oRPC validates procedure outputs against their [defined schemas](/do
 
 ## Configuration
 
-Set `initialOutputValidationIndex` to `NaN` in the [`$config`](/docs/builder#config) method:
+Set `initialOutputValidationIndex` to `NaN` in the [`$config`](/docs/procedure#initial-configuration) method:
 
 ```ts
 import { os } from '@orpc/server'

--- a/packages/server/tests/advanced.test.ts
+++ b/packages/server/tests/advanced.test.ts
@@ -1,0 +1,20 @@
+import z from 'zod'
+import { os } from '../src'
+
+it('support disable output validation by setting initialOutputValidationIndex to NaN', async () => {
+  // docs: apps/content/docs/openapi/advanced/disabling-output-validation.md
+
+  const procedure = os.$config({
+    initialOutputValidationIndex: Number.NaN,
+  })
+    .use(({ next }) => next())
+    .output(z.number())
+    .use(({ next }) => next())
+    // @ts-expect-error invalid output type
+    .handler(() => {
+      return 'invalid'
+    })
+    .callable()
+
+  await expect(procedure()).resolves.toBe('invalid')
+})


### PR DESCRIPTION
Closes: #602

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new guide explaining how to disable output validation in procedures, with configuration examples, limitations, and usage scenarios.

* **Tests**
  * Added test coverage verifying that output validation can be disabled and that procedures return raw handler results when disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->