### PR TITLE
feat(ai-sdk): disable validation at oRPC level in createTool to avoid double validation

### DIFF
--- a/apps/content/docs/integrations/ai-sdk.md
+++ b/apps/content/docs/integrations/ai-sdk.md
@@ -160,6 +160,7 @@ const getWeatherTool = implementTool(getWeatherContract, {
     location,
     temperature: 72 + Math.floor(Math.random() * 21) - 10,
   }),
+  // ...add any additional configuration or overrides here
 })
 ```
 
@@ -210,13 +211,10 @@ const getWeatherProcedure = base
 
 const getWeatherTool = createTool(getWeatherProcedure, {
   context: {}, // provide initial context if needed
+  // ...add any additional configuration or overrides here
 })
 ```
 
 ::: warning
 The `createTool` helper requires a procedure with an `input` schema defined
-:::
-
-::: warning
-Validation occurs twice (once for the tool, once for the procedure call). So validation may fail if `inputSchema` or `outputSchema` transform the data into different shapes.
 :::

--- a/packages/ai-sdk/src/tool.ts
+++ b/packages/ai-sdk/src/tool.ts
@@ -1,9 +1,9 @@
 import type { ClientOptions } from '@orpc/client'
 import type { AnySchema, ContractProcedure, ErrorMap, InferSchemaInput, InferSchemaOutput, Meta, Schema } from '@orpc/contract'
-import type { Context, CreateProcedureClientOptions, Procedure } from '@orpc/server'
+import type { Context, CreateProcedureClientOptions } from '@orpc/server'
 import type { MaybeOptionalOptions, SetOptional } from '@orpc/shared'
 import type { Tool } from 'ai'
-import { call } from '@orpc/server'
+import { call, Procedure } from '@orpc/server'
 import { resolveMaybeOptionalOptions } from '@orpc/shared'
 import { tool } from 'ai'
 
@@ -88,8 +88,6 @@ export function implementTool<TOutInput, TInOutput>(
  * by leveraging existing procedure definitions.
  *
  * @warning Requires a contract with an `input` schema defined.
- * @warning Validation occurs twice (once for the tool, once for the procedure call).
- * So validation may fail if inputSchema or outputSchema transform the data into different shapes.
  *
  * @example
  * ```ts
@@ -147,9 +145,19 @@ export function createTool<
   const options = resolveMaybeOptionalOptions(rest)
 
   return implementTool(procedure, {
-    execute: (input: InferSchemaOutput<TInputSchema>) => {
-      return call(procedure, input as InferSchemaInput<TInputSchema>, options)
-    },
+    execute: ((input, callingOptions) => {
+      const disabledValidation = new Procedure({
+        ...procedure['~orpc'],
+        inputValidationIndex: Number.NaN, // disable input validation
+        outputValidationIndex: Number.NaN, // disable output validation
+      })
+
+      return call(
+        disabledValidation,
+        input as InferSchemaInput<TInputSchema>,
+        { signal: callingOptions.abortSignal, ...options },
+      ) as InferSchemaInput<TOutputSchema>
+    }) satisfies (Tool<InferSchemaOutput<TInputSchema>, InferSchemaInput<TOutputSchema>>['execute']),
     ...options,
   } as any)
 }

--- a/packages/ai-sdk/src/tool.ts
+++ b/packages/ai-sdk/src/tool.ts
@@ -156,7 +156,7 @@ export function createTool<
         disabledValidation,
         input as InferSchemaInput<TInputSchema>,
         { signal: callingOptions.abortSignal, ...options },
-      ) as InferSchemaInput<TOutputSchema>
+      ) as Promise<InferSchemaInput<TOutputSchema>>
     }) satisfies (Tool<InferSchemaOutput<TInputSchema>, InferSchemaInput<TOutputSchema>>['execute']),
     ...options,
   } as any)

--- a/packages/server/src/procedure-client.test.ts
+++ b/packages/server/src/procedure-client.test.ts
@@ -652,3 +652,21 @@ it('has helper `output` in meta', async () => {
 
   expect(preMid1).toReturnWith(Promise.resolve({ output: { val: '99990' }, context: {} }))
 })
+
+it('support disable input/output validation by setting validation index to NaN', async () => {
+  const procedure = new Procedure({
+    inputSchema: schema,
+    outputSchema: schema,
+    errorMap: {},
+    route: {},
+    meta: {},
+    handler: ({ input }) => input,
+    middlewares: [],
+    inputValidationIndex: Number.NaN,
+    outputValidationIndex: Number.NaN,
+  })
+
+  const client = createProcedureClient(procedure)
+
+  await expect(client('invalid' as any)).resolves.toEqual('invalid')
+})


### PR DESCRIPTION
Refactors validation handling in tool creation by setting input/output validation indices to NaN, replacing the previous proxy-based approach. This prevents validation from occurring twice - once at the tool level and once at the procedure call level - which was causing issues when schemas transform data into different shapes. Includes test coverage for the new validation disabling behavior and updates related tRPC integration to use the same approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool execution now forwards abort/cancel signals and accepts calling options for finer control.
  * Added support to disable input/output validation when desired for flexible handling.

* **Documentation**
  * Simplified docs and removed a redundant validation warning for clearer guidance.

* **Tests**
  * Expanded tests covering abort-signal propagation and disabled-validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->