### PR TITLE
feat(openapi): expand support for unions/intersection of objects when generating OpenAPI specs

### DIFF
--- a/packages/openapi/src/openapi-generator.test.ts
+++ b/packages/openapi/src/openapi-generator.test.ts
@@ -1667,6 +1667,18 @@ describe('openAPIGenerator', () => {
         .input(schema),
       pong: oc.route({ method: 'GET' })
         .input(schema),
+      peng: oc
+        .route({ path: '/{id}', inputStructure: 'detailed', outputStructure: 'detailed' })
+        .input(z.object({
+          params: z.union([z.object({ id: z.string() }), z.object({ id: z.number() })]),
+          query: schema,
+          headers: schema,
+          body: schema,
+        }))
+        .output(z.object({
+          headers: schema,
+          body: schema,
+        })),
     }
 
     const spec = await openAPIGenerator.generate(router)
@@ -1738,6 +1750,129 @@ describe('openAPIGenerator', () => {
         },
       ],
       responses: expect.any(Object),
+    })
+
+    expect(spec.paths!['/{id}']!.post).toEqual({
+      operationId: 'peng',
+      parameters: [
+        {
+          name: 'id',
+          in: 'path',
+          required: true,
+          schema: {
+            anyOf: [
+              {
+                type: 'string',
+              },
+              {
+                type: 'number',
+              },
+            ],
+          },
+        },
+        {
+          name: 'type',
+          in: 'query',
+          required: true,
+          schema: {
+            anyOf: [
+              {
+                const: 'a',
+              },
+              {
+                const: 'b',
+              },
+            ],
+          },
+          allowEmptyValue: true,
+          allowReserved: true,
+        },
+        {
+          name: 'a',
+          in: 'query',
+          required: false,
+          schema: {
+            type: 'string',
+          },
+          allowEmptyValue: true,
+          allowReserved: true,
+        },
+        {
+          name: 'b',
+          in: 'query',
+          required: false,
+          schema: {
+            type: 'number',
+          },
+          allowEmptyValue: true,
+          allowReserved: true,
+        },
+        {
+          name: 'type',
+          in: 'header',
+          required: true,
+          schema: {
+            anyOf: [
+              {
+                const: 'a',
+              },
+              {
+                const: 'b',
+              },
+            ],
+          },
+        },
+        {
+          name: 'a',
+          in: 'header',
+          required: false,
+          schema: {
+            type: 'string',
+          },
+        },
+        {
+          name: 'b',
+          in: 'header',
+          required: false,
+          schema: {
+            type: 'number',
+          },
+        },
+      ],
+      requestBody: expect.any(Object),
+      responses: {
+        200: {
+          description: 'OK',
+          headers: {
+            type: {
+              schema: {
+                anyOf: [
+                  {
+                    const: 'a',
+                  },
+                  {
+                    const: 'b',
+                  },
+                ],
+              },
+              required: true,
+            },
+            a: {
+              schema: {
+                type: 'string',
+              },
+              required: false,
+            },
+            b: {
+              schema: {
+                type: 'number',
+              },
+              required: false,
+            },
+          },
+          content: expect.any(Object),
+        },
+      },
     })
   })
 })

--- a/packages/openapi/src/openapi-utils.test.ts
+++ b/packages/openapi/src/openapi-utils.test.ts
@@ -752,6 +752,51 @@ describe('simplifyComposedObjectJsonSchemasAndRefs', () => {
         required: ['a', 'c'],
       })
     })
+
+    it('schema with object and composed schemas in the same level', () => {
+      expect(simplifyComposedObjectJsonSchemasAndRefs({
+        properties: {
+          a: { type: 'string' },
+          b: { type: 'string' },
+        },
+        required: ['a'],
+        anyOf: [
+          {
+            type: 'object',
+            properties: {
+              b: { type: 'number' },
+              c: { type: 'boolean' },
+            },
+            required: ['b', 'c'],
+          },
+          {
+            type: 'object',
+            properties: {
+              c: { type: 'boolean' },
+            },
+            required: ['c'],
+          },
+        ],
+        allOf: [
+          {
+            type: 'object',
+            properties: {
+              f: { type: 'string' },
+            },
+            required: ['f'],
+          },
+        ],
+      })).toEqual({
+        type: 'object',
+        properties: {
+          a: { type: 'string' },
+          b: { allOf: [{ type: 'string' }, { type: 'number' }] },
+          c: { type: 'boolean' },
+          f: { type: 'string' },
+        },
+        required: ['c', 'f', 'a'],
+      })
+    })
   })
 
   describe('with $ref', () => {

--- a/packages/openapi/src/openapi-utils.test.ts
+++ b/packages/openapi/src/openapi-utils.test.ts
@@ -1,6 +1,16 @@
 import type { OpenAPI } from '@orpc/contract'
 import type { FileSchema, JSONSchema, ObjectSchema } from './schema'
-import { checkParamsSchema, resolveOpenAPIJsonSchemaRef, toOpenAPIContent, toOpenAPIEventIteratorContent, toOpenAPIMethod, toOpenAPIParameters, toOpenAPIPath, toOpenAPISchema } from './openapi-utils'
+import {
+  checkParamsSchema,
+  resolveOpenAPIJsonSchemaRef,
+  simplifyComposedObjectJsonSchemasAndRefs,
+  toOpenAPIContent,
+  toOpenAPIEventIteratorContent,
+  toOpenAPIMethod,
+  toOpenAPIParameters,
+  toOpenAPIPath,
+  toOpenAPISchema,
+} from './openapi-utils'
 
 it('toOpenAPIPath', () => {
   expect(toOpenAPIPath('/path')).toBe('/path')
@@ -371,5 +381,438 @@ describe('resolveOpenAPIJsonSchemaRef', () => {
 
   it('not resolve if $ref not found', () => {
     expect(resolveOpenAPIJsonSchemaRef(doc, { $ref: '#/components/schemas/not-found' })).toEqual({ $ref: '#/components/schemas/not-found' })
+  })
+})
+
+describe('simplifyComposedObjectJsonSchemasAndRefs', () => {
+  it('does not simplify non-object or non-composed schemas', () => {
+    expect(simplifyComposedObjectJsonSchemasAndRefs(true)).toEqual(true)
+    expect(simplifyComposedObjectJsonSchemasAndRefs({ type: 'string' })).toEqual({ type: 'string' })
+    expect(simplifyComposedObjectJsonSchemasAndRefs({ anyOf: [{ type: 'string' }, { type: 'number' }] })).toEqual({ anyOf: [{ type: 'string' }, { type: 'number' }] })
+    expect(simplifyComposedObjectJsonSchemasAndRefs({ allOf: [{ type: 'array' }] })).toEqual({ allOf: [{ type: 'array' }] })
+
+    expect(simplifyComposedObjectJsonSchemasAndRefs({
+      anyOf: [
+        { type: 'object', properties: { a: { type: 'string' } } },
+        { type: 'number' },
+      ],
+    })).toEqual({
+      anyOf: [
+        { type: 'object', properties: { a: { type: 'string' } } },
+        { type: 'number' },
+      ],
+    })
+
+    expect(simplifyComposedObjectJsonSchemasAndRefs({
+      description: 'description',
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      additionalProperties: false,
+    })).toEqual({
+      description: 'description',
+      type: 'object',
+      properties: { a: { type: 'string' } },
+      additionalProperties: false,
+    })
+  })
+
+  it('only remain type, properties, required logics', () => {
+    expect(simplifyComposedObjectJsonSchemasAndRefs({
+      anyOf: [
+        {
+          type: 'object',
+          properties: { a: { type: 'string' } },
+          required: ['a'],
+          description: 'description a',
+        },
+        {
+          type: 'object',
+          properties: { b: { type: 'number' } },
+          required: ['b'],
+          additionalProperties: false,
+        },
+      ],
+      description: 'object description',
+      additionalProperties: true,
+    })).toEqual({
+      type: 'object',
+      properties: {
+        a: { type: 'string' },
+        b: { type: 'number' },
+      },
+      required: [],
+    })
+  })
+
+  describe.each(['anyOf', 'oneOf'])('%s', (keyword) => {
+    it('ignore additional object logic', () => {
+      expect(simplifyComposedObjectJsonSchemasAndRefs({
+        description: 'animal',
+        [keyword]: [
+          {
+            type: 'object',
+            properties: { type: { const: 'pig' }, weight: { type: 'number' } },
+            required: ['type', 'weight'],
+            additionalProperties: false,
+          },
+          {
+            type: 'object',
+            properties: { type: { const: 'dog' }, barkVolume: { type: 'number' } },
+            required: ['type', 'barkVolume'],
+            patternProperties: {
+              '^S_': { type: 'string' },
+              '^I_': { type: 'integer' },
+            },
+          },
+        ],
+      })).toEqual({
+        type: 'object',
+        properties: {
+          type: { anyOf: [{ const: 'pig' }, { const: 'dog' }] },
+          weight: { type: 'number' },
+          barkVolume: { type: 'number' },
+        },
+        required: ['type'],
+      })
+    })
+
+    it('handles empty', () => {
+      expect(simplifyComposedObjectJsonSchemasAndRefs({
+        description: 'empty',
+        [keyword]: [],
+      })).toEqual({
+        description: 'empty',
+        [keyword]: [],
+      })
+    })
+
+    it('does not merge mixed object and non-object schemas', () => {
+      expect(simplifyComposedObjectJsonSchemasAndRefs({
+        [keyword]: [
+          { type: 'object', properties: { a: { type: 'string' } } },
+          { type: 'boolean' },
+        ],
+      })).toEqual({
+        [keyword]: [
+          { type: 'object', properties: { a: { type: 'string' } } },
+          { type: 'boolean' },
+        ],
+      })
+    })
+
+    it('merges object schemas with discriminated union', () => {
+      expect(simplifyComposedObjectJsonSchemasAndRefs({
+        description: 'animal',
+        [keyword]: [
+          {
+            type: 'object',
+            properties: { type: { const: 'pig' }, weight: { type: 'number' } },
+            required: ['type', 'weight'],
+          },
+          {
+            type: 'object',
+            properties: { type: { const: 'dog' }, barkVolume: { type: 'number' } },
+            required: ['type', 'barkVolume'],
+          },
+        ],
+      })).toEqual({
+        type: 'object',
+        properties: {
+          type: { anyOf: [{ const: 'pig' }, { const: 'dog' }] },
+          weight: { type: 'number' },
+          barkVolume: { type: 'number' },
+        },
+        required: ['type'],
+      })
+    })
+
+    it('handle required & dedupe schemas correctly', () => {
+      expect(simplifyComposedObjectJsonSchemasAndRefs({
+        [keyword]: [
+          { type: 'object', properties: { a: { type: 'string' }, b: { type: 'string' } }, required: ['a'] },
+          { type: 'object', properties: { a: { type: 'string' }, c: { type: 'string' } }, required: ['a', 'c'] },
+        ],
+      })).toEqual({
+        type: 'object',
+        properties: {
+          a: { type: 'string' },
+          b: { type: 'string' },
+          c: { type: 'string' },
+        },
+        required: ['a'],
+      })
+    })
+
+    it('handles nested union recursively', () => {
+      expect(simplifyComposedObjectJsonSchemasAndRefs({
+        [keyword]: [
+          { [keyword]: [{ type: 'string' }, { type: 'number' }] },
+          { type: 'boolean' },
+        ],
+      })).toEqual({
+        [keyword]: [
+          { [keyword]: [{ type: 'string' }, { type: 'number' }] },
+          { type: 'boolean' },
+        ],
+      })
+    })
+  })
+
+  describe('allOf', () => {
+    it('handles empty', () => {
+      expect(simplifyComposedObjectJsonSchemasAndRefs({
+        description: 'empty',
+        allOf: [],
+      })).toEqual({
+        description: 'empty',
+        allOf: [],
+      })
+    })
+
+    it('merges object schemas', () => {
+      expect(simplifyComposedObjectJsonSchemasAndRefs({
+        allOf: [
+          { type: 'object', properties: { a: { type: 'string' } }, required: ['a'] },
+          { type: 'object', properties: { b: { type: 'number' } }, required: ['b'] },
+        ],
+      })).toEqual({
+        type: 'object',
+        properties: {
+          a: { type: 'string' },
+          b: { type: 'number' },
+        },
+        required: ['a', 'b'],
+      })
+    })
+
+    it('merges overlapping properties with allOf', () => {
+      expect(simplifyComposedObjectJsonSchemasAndRefs({
+        allOf: [
+          { type: 'object', properties: { a: { type: 'string', minLength: 1 } }, required: ['a'] },
+          { type: 'object', properties: { a: { type: 'string', maxLength: 10 } }, required: ['a'] },
+        ],
+      })).toEqual({
+        type: 'object',
+        properties: {
+          a: { allOf: [{ type: 'string', minLength: 1 }, { type: 'string', maxLength: 10 }] },
+        },
+        required: ['a'],
+      })
+    })
+
+    it('handle required correctly & dedupe schemas', () => {
+      expect(simplifyComposedObjectJsonSchemasAndRefs({
+        allOf: [
+          { type: 'object', properties: { a: { type: 'string' }, b: { type: 'string' } }, required: ['a'] },
+          { type: 'object', properties: { a: { type: 'string' }, c: { type: 'string' } }, required: ['a', 'c'] },
+        ],
+      })).toEqual({
+        type: 'object',
+        properties: {
+          a: { type: 'string' },
+          b: { type: 'string' },
+          c: { type: 'string' },
+        },
+        required: ['a', 'c'],
+      })
+    })
+
+    it('handle nested compositions', () => {
+      expect(simplifyComposedObjectJsonSchemasAndRefs({
+        allOf: [
+          {
+            allOf: [
+              { type: 'object', properties: { a: { type: 'string' } }, required: ['a'] },
+              { type: 'object', properties: { b: { type: 'number' } } },
+            ],
+          },
+          { type: 'object', properties: { c: { type: 'boolean' } }, required: ['c'] },
+        ],
+      })).toEqual({
+        type: 'object',
+        properties: {
+          a: { type: 'string' },
+          b: { type: 'number' },
+          c: { type: 'boolean' },
+        },
+        required: ['a', 'c'],
+      })
+    })
+  })
+
+  describe('combined compositions', () => {
+    it('recursively simplifies oneOf with nested allOf', () => {
+      expect(simplifyComposedObjectJsonSchemasAndRefs({
+        oneOf: [
+          {
+            allOf: [
+              { type: 'object', properties: { a: { type: 'string' } }, required: ['a'] },
+              { type: 'object', properties: { b: { type: 'number' } }, required: ['b'] },
+            ],
+          },
+          {
+            allOf: [
+              { type: 'object', properties: { a: { type: 'number' } }, required: ['a'] },
+              { type: 'object', properties: { c: { type: 'boolean' } }, required: ['c'] },
+            ],
+          },
+        ],
+      })).toEqual({
+        type: 'object',
+        properties: {
+          a: { anyOf: [{ type: 'string' }, { type: 'number' }] },
+          b: { type: 'number' },
+          c: { type: 'boolean' },
+        },
+        required: ['a'],
+      })
+    })
+
+    it('recursively simplifies anyOf with nested allOf', () => {
+      expect(simplifyComposedObjectJsonSchemasAndRefs({
+        anyOf: [
+          {
+            allOf: [
+              { type: 'object', properties: { a: { type: 'string' } }, required: ['a'] },
+              { type: 'object', properties: { b: { type: 'number' } }, required: ['b'] },
+            ],
+          },
+          {
+            allOf: [
+              { type: 'object', properties: { c: { type: 'boolean' } }, required: ['c'] },
+              { type: 'object', properties: { d: { type: 'string' } }, required: ['d'] },
+            ],
+          },
+        ],
+      })).toEqual({
+        type: 'object',
+        properties: {
+          a: { type: 'string' },
+          b: { type: 'number' },
+          c: { type: 'boolean' },
+          d: { type: 'string' },
+        },
+        required: [],
+      })
+    })
+
+    it('handles deeply nested compositions', () => {
+      expect(simplifyComposedObjectJsonSchemasAndRefs({
+        anyOf: [
+          {
+            allOf: [
+              { type: 'object', properties: { a: { type: 'string' } } },
+            ],
+          },
+        ],
+      })).toEqual({
+        type: 'object',
+        properties: { a: { type: 'string' } },
+        required: [],
+      })
+    })
+
+    it('can simplify composed schemas with many compositions', () => {
+      expect(simplifyComposedObjectJsonSchemasAndRefs({
+        anyOf: [{ type: 'object', properties: { a: { type: 'string' } }, required: ['a'] }],
+        allOf: [{ type: 'object', properties: { b: { type: 'number' } }, required: ['b'] }],
+      })).toEqual({
+        type: 'object',
+        properties: {
+          a: { type: 'string' },
+          b: { type: 'number' },
+        },
+        required: ['a', 'b'],
+      })
+    })
+
+    it('dedupes schemas when anyOf and allOf coexist at the same level', () => {
+      expect(simplifyComposedObjectJsonSchemasAndRefs({
+        allOf: [
+          { type: 'object', properties: { a: { type: 'string' }, b: { type: 'string' } }, required: ['a'] },
+          { type: 'object', properties: { a: { type: 'string' }, c: { type: 'string' } }, required: ['a', 'c'] },
+        ],
+        anyOf: [
+          { type: 'object', properties: { a: { type: 'string' }, b: { type: 'string' } }, required: ['a'] },
+          { type: 'object', properties: { a: { type: 'number' }, d: { type: 'string' } }, required: ['a', 'd'] },
+        ],
+      })).toEqual({
+        type: 'object',
+        properties: {
+          a: {
+            allOf: [
+              { type: 'string' },
+              { anyOf: [{ type: 'string' }, { type: 'number' }] },
+            ],
+          },
+          b: { type: 'string' },
+          c: { type: 'string' },
+          d: { type: 'string' },
+        },
+        required: ['a', 'c'],
+      })
+    })
+  })
+
+  describe('with $ref', () => {
+    const doc = {
+      components: {
+        schemas: {
+          Base: {
+            type: 'object',
+            properties: {
+              id: { type: 'string' },
+            },
+            required: ['id'],
+          },
+          Extended: {
+            allOf: [
+              { $ref: '#/components/schemas/Base' },
+              {
+                type: 'object',
+                properties: {
+                  name: { type: 'string' },
+                },
+                required: ['name'],
+              },
+            ],
+          },
+        },
+      },
+    } as any
+
+    it('resolves $ref before simplifying', () => {
+      expect(simplifyComposedObjectJsonSchemasAndRefs(
+        { $ref: '#/components/schemas/Extended' },
+        doc,
+      )).toEqual({
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' },
+        },
+        required: ['id', 'name'],
+      })
+
+      expect(simplifyComposedObjectJsonSchemasAndRefs({
+        allOf: [
+          { $ref: '#/components/schemas/Base' },
+          {
+            type: 'object',
+            properties: {
+              age: { type: 'number' },
+            },
+            required: ['age'],
+          },
+        ],
+      }, doc)).toEqual({
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          age: { type: 'number' },
+        },
+        required: ['id', 'age'],
+      })
+    })
   })
 })

--- a/packages/openapi/src/openapi-utils.test.ts
+++ b/packages/openapi/src/openapi-utils.test.ts
@@ -755,6 +755,7 @@ describe('simplifyComposedObjectJsonSchemasAndRefs', () => {
 
     it('schema with object and composed schemas in the same level', () => {
       expect(simplifyComposedObjectJsonSchemasAndRefs({
+        type: 'object',
         properties: {
           a: { type: 'string' },
           b: { type: 'string' },

--- a/packages/openapi/src/openapi-utils.ts
+++ b/packages/openapi/src/openapi-utils.ts
@@ -211,16 +211,13 @@ export function simplifyComposedObjectJsonSchemasAndRefs(schema: JSONSchema, doc
       for (const [key, value] of Object.entries(u.properties)) {
         let entry = mergedUnionPropertyMap.get(key)
         if (!entry) {
-          entry = { required: false, schemas: [] }
+          const required = objectUnionSchemas.every(s => s.required?.includes(key))
+
+          entry = { required, schemas: [] }
           mergedUnionPropertyMap.set(key, entry)
         }
         entry.schemas.push(value)
       }
-    }
-  }
-  for (const [key, entry] of mergedUnionPropertyMap) {
-    if (objectUnionSchemas.every(s => s.required?.includes(key))) {
-      entry.required = true
     }
   }
 
@@ -240,17 +237,14 @@ export function simplifyComposedObjectJsonSchemasAndRefs(schema: JSONSchema, doc
       for (const [key, value] of Object.entries(u.properties)) {
         let entry = mergedInteractionPropertyMap.get(key)
         if (!entry) {
-          entry = { required: false, schemas: [] }
+          const required = objectIntersectionSchemas.some(s => s.required?.includes(key))
+
+          entry = { required, schemas: [] }
           mergedInteractionPropertyMap.set(key, entry)
         }
 
         entry.schemas.push(value)
       }
-    }
-  }
-  for (const [key, entry] of mergedInteractionPropertyMap) {
-    if (objectIntersectionSchemas.some(s => s.required?.includes(key))) {
-      entry.required = true
     }
   }
 

--- a/packages/openapi/src/openapi-utils.ts
+++ b/packages/openapi/src/openapi-utils.ts
@@ -231,6 +231,11 @@ export function simplifyComposedObjectJsonSchemasAndRefs(schema: JSONSchema, doc
     objectIntersectionSchemas.push(u)
   }
 
+  // if object schema in the same level with anyOf/oneOf/allOf
+  if (isObjectSchema(schema)) {
+    objectIntersectionSchemas.push(schema)
+  }
+
   const mergedInteractionPropertyMap: Map<string, { required: boolean, schemas: JSONSchema[] }> = new Map()
   for (const u of objectIntersectionSchemas) {
     if (u.properties) {
@@ -244,23 +249,6 @@ export function simplifyComposedObjectJsonSchemasAndRefs(schema: JSONSchema, doc
         }
 
         entry.schemas.push(value)
-      }
-    }
-  }
-
-  // if object schema in the same level with anyOf/oneOf/allOf
-  if (schema.properties) {
-    for (const [key, value] of Object.entries(schema.properties)) {
-      let entry = mergedInteractionPropertyMap.get(key)
-      if (!entry) {
-        entry = { required: false, schemas: [] }
-        mergedInteractionPropertyMap.set(key, entry)
-      }
-
-      entry.schemas.push(value)
-
-      if (!entry.required && schema.required?.includes(key)) {
-        entry.required = true
       }
     }
   }

--- a/packages/openapi/src/openapi-utils.ts
+++ b/packages/openapi/src/openapi-utils.ts
@@ -248,6 +248,23 @@ export function simplifyComposedObjectJsonSchemasAndRefs(schema: JSONSchema, doc
     }
   }
 
+  // if object schema in the same level with anyOf/oneOf/allOf
+  if (schema.properties) {
+    for (const [key, value] of Object.entries(schema.properties)) {
+      let entry = mergedInteractionPropertyMap.get(key)
+      if (!entry) {
+        entry = { required: false, schemas: [] }
+        mergedInteractionPropertyMap.set(key, entry)
+      }
+
+      entry.schemas.push(value)
+
+      if (!entry.required && schema.required?.includes(key)) {
+        entry.required = true
+      }
+    }
+  }
+
   const resultObjectSchema: { type: 'object', properties: Record<string, JSONSchema>, required: string[] } = { type: 'object', properties: {}, required: [] }
   const keys = new Set<string>([
     ...mergedUnionPropertyMap.keys(),

--- a/packages/openapi/src/openapi-utils.ts
+++ b/packages/openapi/src/openapi-utils.ts
@@ -212,17 +212,17 @@ export function simplifyComposedObjectJsonSchemasAndRefs(schema: JSONSchema, doc
       for (const [key, value] of Object.entries(u.properties)) {
         let entry = mergedUnionPropertyMap.get(key)
         if (!entry) {
-          entry = { required: false, schemas: [value] }
+          entry = { required: false, schemas: [] }
           mergedUnionPropertyMap.set(key, entry)
         }
-        else {
-          entry.schemas.push(value)
-        }
-
-        if (!entry.required && objectUnionSchemas.every(s => s.required?.includes(key))) {
-          entry.required = true
-        }
+        entry.schemas.push(value)
       }
+    }
+  }
+
+  for (const [key, entry] of mergedUnionPropertyMap.entries()) {
+    if (objectUnionSchemas.every(s => s.required?.includes(key))) {
+      entry.required = true
     }
   }
 

--- a/packages/openapi/src/openapi-utils.ts
+++ b/packages/openapi/src/openapi-utils.ts
@@ -2,8 +2,8 @@ import type { HTTPMethod, HTTPPath } from '@orpc/client'
 import type { OpenAPI } from '@orpc/contract'
 import type { FileSchema, JSONSchema, ObjectSchema } from './schema'
 import { standardizeHTTPPath } from '@orpc/openapi-client/standard'
-import { findDeepMatches, isObject } from '@orpc/shared'
-import { expandArrayableSchema, filterSchemaBranches, isFileSchema, isPrimitiveSchema } from './schema-utils'
+import { findDeepMatches, isObject, stringifyJSON, toArray } from '@orpc/shared'
+import { expandArrayableSchema, filterSchemaBranches, isFileSchema, isObjectSchema, isPrimitiveSchema } from './schema-utils'
 
 /**
  * @internal
@@ -176,4 +176,141 @@ export function resolveOpenAPIJsonSchemaRef(doc: OpenAPI.Document, schema: JSONS
   const name = schema.$ref.slice(OPENAPI_JSON_SCHEMA_REF_PREFIX.length)
   const resolved = doc.components?.schemas?.[name]
   return resolved as JSONSchema ?? schema
+}
+
+/**
+ * Simplifies composed object JSON Schemas (using anyOf, oneOf, allOf) by flattening nested compositions
+ *
+ * @warning The result is looser than the original schema and may not fully validate the same data.
+ */
+export function simplifyComposedObjectJsonSchemasAndRefs(schema: JSONSchema, doc?: OpenAPI.Document): JSONSchema {
+  if (doc) {
+    schema = resolveOpenAPIJsonSchemaRef(doc, schema)
+  }
+
+  if (typeof schema !== 'object' || (!schema.anyOf && !schema.oneOf && !schema.allOf)) {
+    return schema
+  }
+
+  const unionSchemas = [
+    ...toArray(schema.anyOf?.map(s => simplifyComposedObjectJsonSchemasAndRefs(s, doc))),
+    ...toArray(schema.oneOf?.map(s => simplifyComposedObjectJsonSchemasAndRefs(s, doc))),
+  ]
+
+  const objectUnionSchemas: ObjectSchema[] = []
+  for (const u of unionSchemas) {
+    if (!isObjectSchema(u)) {
+      return schema
+    }
+
+    objectUnionSchemas.push(u)
+  }
+
+  const mergedUnionPropertyMap: Map<string, { required: boolean, schemas: JSONSchema[] }> = new Map()
+  for (const u of objectUnionSchemas) {
+    if (u.properties) {
+      for (const [key, value] of Object.entries(u.properties)) {
+        let entry = mergedUnionPropertyMap.get(key)
+        if (!entry) {
+          entry = { required: false, schemas: [value] }
+          mergedUnionPropertyMap.set(key, entry)
+        }
+        else {
+          entry.schemas.push(value)
+        }
+
+        if (!entry.required && objectUnionSchemas.every(s => s.required?.includes(key))) {
+          entry.required = true
+        }
+      }
+    }
+  }
+
+  const intersectionSchemas = toArray(schema.allOf?.map(s => simplifyComposedObjectJsonSchemasAndRefs(s, doc)))
+  const mergedInteractionPropertyMap: Map<string, { required: boolean, schemas: JSONSchema[] }> = new Map()
+  for (const u of intersectionSchemas) {
+    if (!isObjectSchema(u)) {
+      return schema
+    }
+
+    if (u.properties) {
+      for (const [key, value] of Object.entries(u.properties)) {
+        let entry = mergedInteractionPropertyMap.get(key)
+        if (!entry) {
+          entry = { required: false, schemas: [value] }
+          mergedInteractionPropertyMap.set(key, entry)
+        }
+        else {
+          entry.schemas.push(value)
+        }
+
+        if (u.required?.includes(key)) {
+          entry.required = true
+        }
+      }
+    }
+  }
+
+  const resultObjectSchema: { type: 'object', properties: Record<string, JSONSchema>, required: string[] } = { type: 'object', properties: {}, required: [] }
+
+  const keys = new Set<string>([
+    ...mergedUnionPropertyMap.keys(),
+    ...mergedInteractionPropertyMap.keys(),
+  ])
+
+  if (keys.size === 0) {
+    return schema
+  }
+
+  const deduplicateSchemas = (schemas: JSONSchema[]): JSONSchema[] => {
+    const seen = new Set<string>()
+    const result: JSONSchema[] = []
+    for (const schema of schemas) {
+      const key = stringifyJSON(schema)
+      if (!seen.has(key)) {
+        seen.add(key)
+        result.push(schema)
+      }
+    }
+    return result
+  }
+
+  for (const key of keys) {
+    const unionEntry = mergedUnionPropertyMap.get(key)
+    const intersectionEntry = mergedInteractionPropertyMap.get(key)
+
+    resultObjectSchema.properties[key] = (() => {
+      const dedupedUnionSchemas = unionEntry ? deduplicateSchemas(unionEntry.schemas) : []
+      const dedupedIntersectionSchemas = intersectionEntry ? deduplicateSchemas(intersectionEntry.schemas) : []
+
+      if (!dedupedUnionSchemas.length) {
+        return dedupedIntersectionSchemas.length === 1
+          ? dedupedIntersectionSchemas[0]!
+          : { allOf: dedupedIntersectionSchemas }
+      }
+
+      if (!dedupedIntersectionSchemas.length) {
+        return dedupedUnionSchemas.length === 1
+          ? dedupedUnionSchemas[0]!
+          : { anyOf: dedupedUnionSchemas }
+      }
+
+      const allOf = deduplicateSchemas([
+        ...dedupedIntersectionSchemas,
+        dedupedUnionSchemas.length === 1
+          ? dedupedUnionSchemas[0]!
+          : { anyOf: dedupedUnionSchemas },
+      ])
+
+      return allOf.length === 1
+        ? allOf[0]!
+        : { allOf }
+    })()
+
+    if ((!unionEntry || unionEntry.required) && (!intersectionEntry || intersectionEntry.required)) {
+      resultObjectSchema.required.push(key)
+    }
+  }
+
+  return resultObjectSchema
 }

--- a/packages/openapi/src/openapi-utils.ts
+++ b/packages/openapi/src/openapi-utils.ts
@@ -307,7 +307,7 @@ export function simplifyComposedObjectJsonSchemasAndRefs(schema: JSONSchema, doc
         : { allOf }
     })()
 
-    if ((!unionEntry || unionEntry.required) && (!intersectionEntry || intersectionEntry.required)) {
+    if (unionEntry?.required || intersectionEntry?.required) {
       resultObjectSchema.required.push(key)
     }
   }

--- a/packages/openapi/src/schema-utils.test.ts
+++ b/packages/openapi/src/schema-utils.test.ts
@@ -1,6 +1,16 @@
 import type { JSONSchema, ObjectSchema } from './schema'
 import { isObject } from '@orpc/shared'
-import { applySchemaOptionality, expandArrayableSchema, expandUnionSchema, filterSchemaBranches, isAnySchema, isFileSchema, isObjectSchema, isPrimitiveSchema, separateObjectSchema } from './schema-utils'
+import {
+  applySchemaOptionality,
+  expandArrayableSchema,
+  expandUnionSchema,
+  filterSchemaBranches,
+  isAnySchema,
+  isFileSchema,
+  isObjectSchema,
+  isPrimitiveSchema,
+  separateObjectSchema,
+} from './schema-utils'
 
 it('isFileSchema', () => {
   expect(isFileSchema({ type: 'string', contentMediaType: 'image/png' })).toBe(true)


### PR DESCRIPTION
Fixes #1162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved OpenAPI generation: composed-object schemas and discriminated unions are now simplified earlier, producing clearer path/query/header parameters and request/response bodies across routes and methods; GET/query handling improved for optional fields.

* **Tests**
  * Expanded test coverage for schema simplification, composed-object scenarios, discriminated unions, reference resolution, merging/deduplication and many edge cases.

* **Chores**
  * Exposed a reusable schema-simplification utility for downstream use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->