### PR TITLE
refactor(interop): remove json-schema-typed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,6 @@ updates:
           - '@antfu/eslint-config'
           - 'eslint-plugin-*'
           - '@hey-api/*'
-          - json-schema-typed # inline
           - compression # inline
         update-types:
           - minor

--- a/packages/interop/README.md
+++ b/packages/interop/README.md
@@ -73,8 +73,6 @@ A compatibility layer that builds & re-exports upstream packages that don't yet 
 
 **Included packages:**
 
-- [json-schema-typed](https://www.npmjs.com/package/json-schema-typed) to address issue [RemyRylan/json-schema-typed#116](https://github.com/RemyRylan/json-schema-typed/issues/116)
-
 - [compression](https://www.npmjs.com/package/compression) for esm compatibility
 
 ## Sponsors

--- a/packages/interop/package.json
+++ b/packages/interop/package.json
@@ -15,26 +15,6 @@
   ],
   "publishConfig": {
     "exports": {
-      "./json-schema-typed": {
-        "types": "./dist/json-schema-typed/index.d.mts",
-        "import": "./dist/json-schema-typed/index.mjs",
-        "default": "./dist/json-schema-typed/index.mjs"
-      },
-      "./json-schema-typed/draft-07": {
-        "types": "./dist/json-schema-typed/draft-07.d.mts",
-        "import": "./dist/json-schema-typed/draft-07.mjs",
-        "default": "./dist/json-schema-typed/draft-07.mjs"
-      },
-      "./json-schema-typed/draft-2019-09": {
-        "types": "./dist/json-schema-typed/draft-2019-09.d.mts",
-        "import": "./dist/json-schema-typed/draft-2019-09.mjs",
-        "default": "./dist/json-schema-typed/draft-2019-09.mjs"
-      },
-      "./json-schema-typed/draft-2020-12": {
-        "types": "./dist/json-schema-typed/draft-2020-12.d.mts",
-        "import": "./dist/json-schema-typed/draft-2020-12.mjs",
-        "default": "./dist/json-schema-typed/draft-2020-12.mjs"
-      },
       "./compression": {
         "types": "./dist/compression/index.d.mts",
         "import": "./dist/compression/index.mjs",
@@ -43,10 +23,6 @@
     }
   },
   "exports": {
-    "./json-schema-typed": "./src/json-schema-typed/index.ts",
-    "./json-schema-typed/draft-07": "./src/json-schema-typed/draft-07.ts",
-    "./json-schema-typed/draft-2019-09": "./src/json-schema-typed/draft-2019-09.ts",
-    "./json-schema-typed/draft-2020-12": "./src/json-schema-typed/draft-2020-12.ts",
     "./compression": "./src/compression/index.ts"
   },
   "files": [
@@ -59,7 +35,6 @@
   },
   "devDependencies": {
     "@types/compression": "^1.8.1",
-    "compression": "^1.8.1",
-    "json-schema-typed": "^8.0.1"
+    "compression": "^1.8.1"
   }
 }

--- a/packages/interop/src/json-schema-typed/draft-07.test.ts
+++ b/packages/interop/src/json-schema-typed/draft-07.test.ts
@@ -1,3 +1,0 @@
-it('exports something', async () => {
-  expect(Object.keys(await import('./draft-07')).length).toBeGreaterThanOrEqual(1)
-})

--- a/packages/interop/src/json-schema-typed/draft-07.ts
+++ b/packages/interop/src/json-schema-typed/draft-07.ts
@@ -1,2 +1,0 @@
-// eslint-disable-next-line no-restricted-imports
-export * from 'json-schema-typed/draft-07'

--- a/packages/interop/src/json-schema-typed/draft-2019-09.test.ts
+++ b/packages/interop/src/json-schema-typed/draft-2019-09.test.ts
@@ -1,3 +1,0 @@
-it('exports something', async () => {
-  expect(Object.keys(await import('./draft-2019-09')).length).toBeGreaterThanOrEqual(1)
-})

--- a/packages/interop/src/json-schema-typed/draft-2019-09.ts
+++ b/packages/interop/src/json-schema-typed/draft-2019-09.ts
@@ -1,2 +1,0 @@
-// eslint-disable-next-line no-restricted-imports
-export * from 'json-schema-typed/draft-2019-09'

--- a/packages/interop/src/json-schema-typed/draft-2020-12.test.ts
+++ b/packages/interop/src/json-schema-typed/draft-2020-12.test.ts
@@ -1,3 +1,0 @@
-it('exports something', async () => {
-  expect(Object.keys(await import('./draft-2020-12')).length).toBeGreaterThanOrEqual(1)
-})

--- a/packages/interop/src/json-schema-typed/draft-2020-12.ts
+++ b/packages/interop/src/json-schema-typed/draft-2020-12.ts
@@ -1,2 +1,0 @@
-// eslint-disable-next-line no-restricted-imports
-export * from 'json-schema-typed/draft-2020-12'

--- a/packages/interop/src/json-schema-typed/index.test.ts
+++ b/packages/interop/src/json-schema-typed/index.test.ts
@@ -1,3 +1,0 @@
-it('exports something', async () => {
-  expect(Object.keys(await import('./index')).length).toBeGreaterThanOrEqual(1)
-})

--- a/packages/interop/src/json-schema-typed/index.ts
+++ b/packages/interop/src/json-schema-typed/index.ts
@@ -1,2 +1,0 @@
-// eslint-disable-next-line no-restricted-imports
-export * from 'json-schema-typed'

--- a/packages/json-schema/package.json
+++ b/packages/json-schema/package.json
@@ -38,7 +38,8 @@
     "@orpc/interop": "workspace:*",
     "@orpc/openapi": "workspace:*",
     "@orpc/server": "workspace:*",
-    "@orpc/shared": "workspace:*"
+    "@orpc/shared": "workspace:*",
+    "json-schema-typed": "^8.0.2"
   },
   "devDependencies": {
     "zod": "^4.1.12"

--- a/packages/json-schema/src/types.ts
+++ b/packages/json-schema/src/types.ts
@@ -1,6 +1,9 @@
-import type * as Draft07 from '@orpc/interop/json-schema-typed/draft-07'
-import type * as Draft2019 from '@orpc/interop/json-schema-typed/draft-2019-09'
-import type * as Draft2020 from '@orpc/interop/json-schema-typed/draft-2020-12'
+// eslint-disable-next-line no-restricted-imports
+import type * as Draft07 from 'json-schema-typed/draft-07'
+// eslint-disable-next-line no-restricted-imports
+import type * as Draft2019 from 'json-schema-typed/draft-2019-09'
+// eslint-disable-next-line no-restricted-imports
+import type * as Draft2020 from 'json-schema-typed/draft-2020-12'
 
 export type JsonSchema
   = | Draft2020.JSONSchema

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -77,6 +77,7 @@
     "@orpc/server": "workspace:*",
     "@orpc/shared": "workspace:*",
     "@orpc/standard-server": "workspace:*",
+    "json-schema-typed": "^8.0.2",
     "rou3": "^0.7.10"
   },
   "devDependencies": {

--- a/packages/openapi/src/schema.ts
+++ b/packages/openapi/src/schema.ts
@@ -1,5 +1,7 @@
-import type { JSONSchema, keywords } from '@orpc/interop/json-schema-typed/draft-2020-12'
-import { ContentEncoding as JSONSchemaContentEncoding, Format as JSONSchemaFormat, TypeName as JSONSchemaTypeName } from '@orpc/interop/json-schema-typed/draft-2020-12'
+// eslint-disable-next-line no-restricted-imports
+import type { JSONSchema, keywords } from 'json-schema-typed/draft-2020-12'
+// eslint-disable-next-line no-restricted-imports
+import { ContentEncoding as JSONSchemaContentEncoding, Format as JSONSchemaFormat, TypeName as JSONSchemaTypeName } from 'json-schema-typed/draft-2020-12'
 
 export { JSONSchemaContentEncoding, JSONSchemaFormat, JSONSchemaTypeName }
 export type { JSONSchema }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -375,9 +375,6 @@ importers:
       compression:
         specifier: ^1.8.1
         version: 1.8.1
-      json-schema-typed:
-        specifier: ^8.0.1
-        version: 8.0.1
 
   packages/json-schema:
     dependencies:
@@ -396,6 +393,9 @@ importers:
       '@orpc/shared':
         specifier: workspace:*
         version: link:../shared
+      json-schema-typed:
+        specifier: ^8.0.2
+        version: 8.0.2
     devDependencies:
       zod:
         specifier: ^4.1.12
@@ -494,6 +494,9 @@ importers:
       '@orpc/standard-server':
         specifier: workspace:*
         version: link:../standard-server
+      json-schema-typed:
+        specifier: ^8.0.2
+        version: 8.0.2
       rou3:
         specifier: ^0.7.10
         version: 0.7.10
@@ -10578,8 +10581,8 @@ packages:
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
-  json-schema-typed@8.0.1:
-    resolution: {integrity: sha512-XQmWYj2Sm4kn4WeTYvmpKEbyPsL7nBsb647c7pMe6l02/yx2+Jfc4dT6UZkEXnIUb5LhD55r2HPsJ1milQ4rDg==}
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -25573,7 +25576,7 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
-  json-schema-typed@8.0.1: {}
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 


### PR DESCRIPTION
json-schema-typed fixed [RemyRylan/json-schema-typed#116](https://github.com/RemyRylan/json-schema-typed/issues/116)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized internal dependency structure by moving json-schema-typed availability to json-schema and openapi packages, removing indirect re-exports from the interop package.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->