### PR TITLE
feat(nest)!: add plugin support and global context interface

### DIFF
--- a/packages/nest/src/implement.test.ts
+++ b/packages/nest/src/implement.test.ts
@@ -434,7 +434,7 @@ describe('@Implement', async () => {
       customJsonSerializers,
     }))
     // make sure the config object is cloned internally
-    expect(vi.mocked(StandardOpenAPIClientModule.StandardOpenAPIJsonSerializer).mock.calls[0][0]?.customJsonSerializers).not.toBe(customJsonSerializers)
+    expect(vi.mocked(StandardOpenAPIClientModule.StandardOpenAPIJsonSerializer).mock.calls[0]![0]?.customJsonSerializers).not.toBe(customJsonSerializers)
 
     expect(StandardOpenAPIClientModule.StandardBracketNotationSerializer).toHaveBeenCalledWith(expect.objectContaining({
       maxBracketNotationArrayIndex: 9404,
@@ -490,7 +490,7 @@ describe('@Implement', async () => {
       customJsonSerializers,
     }))
     // make sure the config object is cloned internally
-    expect(vi.mocked(StandardOpenAPIClientModule.StandardOpenAPIJsonSerializer).mock.calls[0][0]?.customJsonSerializers).not.toBe(customJsonSerializers)
+    expect(vi.mocked(StandardOpenAPIClientModule.StandardOpenAPIJsonSerializer).mock.calls[0]![0]?.customJsonSerializers).not.toBe(customJsonSerializers)
 
     expect(StandardOpenAPIClientModule.StandardBracketNotationSerializer).toHaveBeenCalledWith(expect.objectContaining({
       maxBracketNotationArrayIndex: 23979,

--- a/packages/nest/src/index.test.ts
+++ b/packages/nest/src/index.test.ts
@@ -1,0 +1,21 @@
+import * as ServerModule from '@orpc/server'
+import { expect, it, vi } from 'vitest'
+import { implement } from './index'
+
+vi.mock('@orpc/server', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@orpc/server')>()
+  return {
+    ...original,
+    implement: vi.fn(original.implement),
+  }
+})
+
+it('implement is aliased', () => {
+  const contract = { nested: {} }
+  const options = { dedupeLeadingMiddlewares: false }
+  const impl = implement(contract, options)
+
+  expect(ServerModule.implement).toHaveBeenCalledTimes(1)
+  expect(ServerModule.implement).toHaveBeenCalledWith(contract, options)
+  expect(impl).toBe(vi.mocked(ServerModule.implement).mock.results[0].value)
+})

--- a/packages/nest/src/index.test.ts
+++ b/packages/nest/src/index.test.ts
@@ -17,5 +17,5 @@ it('implement is aliased', () => {
 
   expect(ServerModule.implement).toHaveBeenCalledTimes(1)
   expect(ServerModule.implement).toHaveBeenCalledWith(contract, options)
-  expect(impl).toBe(vi.mocked(ServerModule.implement).mock.results[0].value)
+  expect(impl).toBe(vi.mocked(ServerModule.implement).mock.results[0]!.value)
 })

--- a/packages/nest/src/index.ts
+++ b/packages/nest/src/index.ts
@@ -1,9 +1,14 @@
+import type { AnyContractRouter } from '@orpc/contract'
+import type { BuilderConfig, Context, Implementer } from '@orpc/server'
+import type { ORPCGlobalContext } from './module'
+import { implement as baseImplement } from '@orpc/server'
+
 export * from './implement'
 export { Implement as Impl } from './implement'
 export * from './module'
 export * from './utils'
 
-export { implement, onError, onFinish, onStart, onSuccess, ORPCError } from '@orpc/server'
+export { onError, onFinish, onStart, onSuccess, ORPCError } from '@orpc/server'
 export type {
   ImplementedProcedure,
   Implementer,
@@ -13,3 +18,13 @@ export type {
   RouterImplementer,
   RouterImplementerWithMiddlewares,
 } from '@orpc/server'
+
+/**
+ * Alias for `implement` from `@orpc/server` with default context set to `ORPCGlobalContext`
+ */
+export function implement<T extends AnyContractRouter, TContext extends Context = ORPCGlobalContext>(
+  contract: T,
+  config: BuilderConfig = {},
+): Implementer<T, TContext, TContext> {
+  return baseImplement(contract, config)
+}

--- a/packages/nest/src/module.ts
+++ b/packages/nest/src/module.ts
@@ -1,15 +1,33 @@
 import type { DynamicModule } from '@nestjs/common'
-import type { AnySchema } from '@orpc/contract'
-import type { CreateProcedureClientOptions } from '@orpc/server'
+import type { StandardBracketNotationSerializerOptions, StandardOpenAPIJsonSerializerOptions } from '@orpc/openapi-client/standard'
+import type { StandardHandlerOptions } from '@orpc/server/standard'
 import type { SendStandardResponseOptions } from '@orpc/standard-server-node'
 import { Module } from '@nestjs/common'
 import { ImplementInterceptor } from './implement'
 
 export const ORPC_MODULE_CONFIG_SYMBOL = Symbol('ORPC_MODULE_CONFIG')
 
+/**
+ * You can extend this interface to add global context properties.
+ * @example
+ * ```ts
+ * declare module '@orpc/nest' {
+ *   interface ORPCGlobalContext {
+ *     user: { id: string; name: string }
+ *   }
+ * }
+ * ```
+ */
+export interface ORPCGlobalContext {
+
+}
+
 export interface ORPCModuleConfig extends
-  CreateProcedureClientOptions<object, AnySchema, object, object, object>,
-  SendStandardResponseOptions {
+  StandardHandlerOptions<ORPCGlobalContext>,
+  SendStandardResponseOptions,
+  StandardOpenAPIJsonSerializerOptions,
+  StandardBracketNotationSerializerOptions {
+  context?: ORPCGlobalContext
 }
 
 @Module({})

--- a/packages/shared/src/object.test.ts
+++ b/packages/shared/src/object.test.ts
@@ -76,13 +76,17 @@ it('isTypescriptObject', () => {
 it('clone', () => {
   expect(clone(null)).toBeNull()
 
-  const obj = { a: 1, arr: [2, 3], nested: { arr: [{ b: 4 }] } }
+  const symbol = Symbol('a')
+  const obj = { a: 1, arr: [2, 3], nested: { arr: [{ b: 4 }], [symbol]: { [symbol]: 5 } } }
   const cloned = clone(obj)
 
   expect(cloned).toEqual(obj)
   expect(cloned).not.toBe(obj)
   expect(cloned.arr).not.toBe(obj.arr)
   expect(cloned.nested.arr).not.toBe(obj.nested.arr)
+  expect(cloned.nested[symbol]).toEqual(obj.nested[symbol])
+  expect(cloned.nested[symbol]).not.toBe(obj.nested[symbol])
+  expect(cloned.nested[symbol][symbol]).toBe(5)
 })
 
 it('get', () => {

--- a/packages/shared/src/object.ts
+++ b/packages/shared/src/object.ts
@@ -70,6 +70,10 @@ export function clone<T>(value: T): T {
       result[key] = clone(value[key])
     }
 
+    for (const sym of Object.getOwnPropertySymbols(value)) {
+      result[sym] = clone(value[sym])
+    }
+
     return result as any
   }
 

--- a/playgrounds/nest/package.json
+++ b/playgrounds/nest/package.json
@@ -15,6 +15,7 @@
     "@nestjs/schematics": "^11.0.9",
     "@orpc/client": "next",
     "@orpc/contract": "next",
+    "@orpc/json-schema": "next",
     "@orpc/nest": "next",
     "@orpc/openapi": "next",
     "@orpc/openapi-client": "next",

--- a/playgrounds/nest/src/app.module.ts
+++ b/playgrounds/nest/src/app.module.ts
@@ -6,16 +6,32 @@ import { PlanetService } from './planet/planet.service'
 import { ReferenceController } from './reference/reference.controller'
 import { ReferenceService } from './reference/reference.service'
 import { onError, ORPCModule } from '@orpc/nest'
+import { experimental_SmartCoercionPlugin as SmartCoercionPlugin } from '@orpc/json-schema'
+import { ZodToJsonSchemaConverter } from '@orpc/zod/zod4'
+
+declare module '@orpc/nest' {
+  interface ORPCGlobalContext {
+    someCustomContext?: string
+  }
+}
 
 @Module({
   imports: [
     ORPCModule.forRoot({
+      eventIteratorKeepAliveInterval: 5000, // 5 seconds
+      context: { someCustomContext: 'Hello, World!' },
       interceptors: [
         onError((error) => {
           console.error(error)
         }),
       ],
-      eventIteratorKeepAliveInterval: 5000, // 5 seconds
+      plugins: [
+        new SmartCoercionPlugin({
+          schemaConverters: [
+            new ZodToJsonSchemaConverter(),
+          ],
+        }),
+      ],
     }),
   ],
   controllers: [AuthController, PlanetController, ReferenceController, OtherController],

--- a/playgrounds/next/tsconfig.json
+++ b/playgrounds/next/tsconfig.json
@@ -2,12 +2,18 @@
   "compilerOptions": {
     "incremental": true,
     "target": "ES2017",
-    "jsx": "preserve",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "jsx": "react-jsx",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "module": "esnext",
     "moduleResolution": "bundler",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     },
     "resolveJsonModule": true,
     "allowJs": true,
@@ -22,6 +28,14 @@
       }
     ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1384,6 +1384,9 @@ importers:
       '@orpc/contract':
         specifier: next
         version: link:../../packages/contract
+      '@orpc/json-schema':
+        specifier: next
+        version: link:../../packages/json-schema
       '@orpc/nest':
         specifier: next
         version: link:../../packages/nest


### PR DESCRIPTION
FEATURES:
- Add plugin support for NestJS integration
- Introduce ORPCGlobalContext interface for type-safe context

TODO:
- [ ] improve plugin system and remove `clone` in `ORPCModule` (v2)

BREAKING CHANGES:
- ORPCModule config changed and removed some options:`interceptors` now become `clientInterceptors`