### PR TITLE
feat(tanstack-query): default query/mutation options

### DIFF
--- a/apps/content/docs/integrations/tanstack-query.md
+++ b/apps/content/docs/integrations/tanstack-query.md
@@ -228,7 +228,7 @@ const query = useQuery(computed(
 
 ## Default Options
 
-You can configure default options for all query/mutation utilities using `experimental_defaults`. This is useful for setting common options like `staleTime`, `retry`, or `context` across your procedures.
+You can configure default options for all query/mutation utilities using `experimental_defaults`. These options are [spread merged](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) with user-provided options, allowing you to set defaults while still enabling customization on a per-call basis.
 
 ```ts
 const orpc = createTanstackQueryUtils(client, {

--- a/apps/content/docs/integrations/tanstack-query.md
+++ b/apps/content/docs/integrations/tanstack-query.md
@@ -226,6 +226,47 @@ const query = useQuery(computed(
 
 :::
 
+## Default Options
+
+You can configure default options for all query/mutation utilities using `experimental_defaults`. This is useful for setting common options like `staleTime`, `retry`, or `context` across your procedures.
+
+```ts
+const orpc = createTanstackQueryUtils(client, {
+  experimental_defaults: {
+    planet: {
+      find: {
+        queryOptions: {
+          staleTime: 60 * 1000, // 1 minute
+          retry: 3,
+        },
+      },
+      list: {
+        infiniteOptions: {
+          staleTime: 30 * 1000,
+        },
+      },
+      create: {
+        mutationOptions: {
+          onSuccess: (output, input, _, ctx) => {
+            ctx.client.invalidateQueries({ queryKey: orpc.planet.key() })
+          },
+        },
+      },
+    },
+  },
+})
+
+// These will automatically use the default options
+const query = useQuery(orpc.planet.find.queryOptions({ input: { id: 123 } }))
+const mutation = useMutation(orpc.planet.create.mutationOptions())
+
+// User-provided options override defaults
+const customQuery = useQuery(orpc.planet.find.queryOptions({
+  input: { id: 123 },
+  staleTime: 0, // overrides the default
+}))
+```
+
 ## Client Context
 
 ::: warning

--- a/packages/tanstack-query/src/procedure-utils.test-d.ts
+++ b/packages/tanstack-query/src/procedure-utils.test-d.ts
@@ -2,7 +2,7 @@ import type { Client } from '@orpc/client'
 import type { ErrorFromErrorMap } from '@orpc/contract'
 import type { GetNextPageParamFunction, InfiniteData, InfiniteQueryObserverOptions, MutationObserverOptions, QueryFunction, QueryKey, QueryObserverOptions } from '@tanstack/query-core'
 import type { baseErrorMap } from '../../contract/tests/shared'
-import type { ProcedureUtils } from './procedure-utils'
+import type { experimental_ProcedureUtilsDefaults, ProcedureUtils } from './procedure-utils'
 import { QueryClient, skipToken } from '@tanstack/query-core'
 
 describe('ProcedureUtils', () => {
@@ -744,5 +744,196 @@ describe('ProcedureUtils', () => {
         onMutate: variables => ({ customContext: true }),
       })).toExtend<MutationObserverOptions<UtilsOutput, UtilsError, UtilsInput, { customContext: boolean }>>()
     })
+  })
+})
+
+describe('ProcedureUtilsDefaults', () => {
+  type TestClientContext = { batch?: boolean }
+  type TestInput = { search?: string }
+  type TestOutput = { title: string }
+  type TestError = Error
+
+  type TestDefaults = experimental_ProcedureUtilsDefaults<TestClientContext, TestInput, TestOutput, TestError>
+
+  it('should have exact same keys as ProcedureUtils excluding call', () => {
+    // Ensures every utility method in ProcedureUtils (except 'call') has a corresponding key in ProcedureUtilsDefaults
+    type ProcedureUtilsKeys = Exclude<keyof ProcedureUtils<any, any, any, any>, 'call'>
+    type DefaultsKeys = keyof experimental_ProcedureUtilsDefaults<any, any, any, any>
+
+    expectTypeOf<DefaultsKeys>().toEqualTypeOf<ProcedureUtilsKeys>()
+  })
+
+  it('all properties should be optional', () => {
+    const emptyDefaults: TestDefaults = {}
+    expectTypeOf(emptyDefaults).toExtend<TestDefaults>()
+  })
+
+  it('queryKey should accept Partial<QueryKeyOptions>', () => {
+    const defaults: TestDefaults = {
+      queryKey: {
+        input: { search: 'test' },
+      },
+    }
+    expectTypeOf(defaults).toExtend<TestDefaults>()
+
+    const _invalid: TestDefaults = {
+      queryKey: {
+        // @ts-expect-error - invalid input type
+        input: { invalid: 'test' },
+      },
+    }
+  })
+
+  it('queryOptions should accept Partial<QueryOptionsIn>', () => {
+    const defaults: TestDefaults = {
+      queryOptions: {
+        input: { search: 'test' },
+        staleTime: 1000,
+        context: { batch: true },
+      },
+    }
+    expectTypeOf(defaults).toExtend<TestDefaults>()
+
+    const _invalid: TestDefaults = {
+      queryOptions: {
+        // @ts-expect-error - invalid input type
+        input: { invalid: 'test' },
+      },
+    }
+  })
+
+  it('experimental_streamedKey should accept Partial<experimental_StreamedKeyOptions>', () => {
+    const defaults: TestDefaults = {
+      experimental_streamedKey: {
+        input: { search: 'test' },
+        queryFnOptions: { maxChunks: 10 },
+      },
+    }
+    expectTypeOf(defaults).toExtend<TestDefaults>()
+
+    const _invalid: TestDefaults = {
+      experimental_streamedKey: {
+        // @ts-expect-error - invalid input type
+        input: { invalid: 'test' },
+      },
+    }
+  })
+
+  it('experimental_streamedOptions should accept Partial<StreamedOptionsIn>', () => {
+    const defaults: TestDefaults = {
+      experimental_streamedOptions: {
+        input: { search: 'test' },
+        staleTime: 1000,
+      },
+    }
+    expectTypeOf(defaults).toExtend<TestDefaults>()
+
+    const _invalid: TestDefaults = {
+      experimental_streamedOptions: {
+        // @ts-expect-error - invalid input type
+        input: { invalid: 'test' },
+      },
+    }
+  })
+
+  it('experimental_liveKey should accept Partial<QueryKeyOptions>', () => {
+    const defaults: TestDefaults = {
+      experimental_liveKey: {
+        input: { search: 'test' },
+      },
+    }
+    expectTypeOf(defaults).toExtend<TestDefaults>()
+
+    const _invalid: TestDefaults = {
+      experimental_liveKey: {
+        // @ts-expect-error - invalid input type
+        input: { invalid: 'test' },
+      },
+    }
+  })
+
+  it('experimental_liveOptions should accept Partial<StreamedOptionsIn>', () => {
+    const defaults: TestDefaults = {
+      experimental_liveOptions: {
+        input: { search: 'test' },
+        staleTime: 1000,
+      },
+    }
+    expectTypeOf(defaults).toExtend<TestDefaults>()
+
+    const _invalid: TestDefaults = {
+      experimental_liveOptions: {
+        // @ts-expect-error - invalid input type
+        input: { invalid: 'test' },
+      },
+    }
+  })
+
+  it('infiniteKey should accept Partial input, initialPageParam, queryKey', () => {
+    const defaults: TestDefaults = {
+      infiniteKey: {
+        initialPageParam: 0,
+        queryKey: ['custom-key'],
+      },
+    }
+    expectTypeOf(defaults).toExtend<TestDefaults>()
+
+    const _invalid: TestDefaults = {
+      infiniteKey: {
+        // @ts-expect-error - invalid input type
+        input: { invalid: 'test' },
+      },
+    }
+  })
+
+  it('infiniteOptions should accept Partial<InfiniteOptionsIn>', () => {
+    const defaults: TestDefaults = {
+      infiniteOptions: {
+        staleTime: 1000,
+      },
+    }
+    expectTypeOf(defaults).toExtend<TestDefaults>()
+
+    const _invalid: TestDefaults = {
+      infiniteOptions: {
+        // @ts-expect-error - invalid input type
+        input: { invalid: 'test' },
+      },
+    }
+  })
+
+  it('mutationKey should accept Partial mutationKey', () => {
+    const defaults: TestDefaults = {
+      mutationKey: {
+        mutationKey: ['custom-mutation-key'],
+      },
+    }
+    expectTypeOf(defaults).toExtend<TestDefaults>()
+
+    const _invalid: TestDefaults = {
+      mutationKey: {
+        // @ts-expect-error - invalid mutationKey type
+        mutationKey: 1,
+      },
+    }
+  })
+
+  it('mutationOptions should accept Partial<MutationOptionsIn>', () => {
+    const defaults: TestDefaults = {
+      mutationOptions: {
+        onSuccess: (output) => {
+          expectTypeOf(output).toEqualTypeOf<TestOutput>()
+        },
+        context: { batch: true },
+      },
+    }
+    expectTypeOf(defaults).toExtend<TestDefaults>()
+
+    const _invalid: TestDefaults = {
+      mutationOptions: {
+        // @ts-expect-error - invalid context type
+        context: { batch: 'invalid' },
+      },
+    }
   })
 })

--- a/packages/tanstack-query/src/procedure-utils.test.ts
+++ b/packages/tanstack-query/src/procedure-utils.test.ts
@@ -346,3 +346,319 @@ describe('createProcedureUtils', () => {
     } })
   })
 })
+
+describe('createProcedureUtils with defaults', () => {
+  const client = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('.queryKey', () => {
+    it('applies defaults when no options provided', () => {
+      const utils = createProcedureUtils(client, {
+        path: ['ping'],
+        experimental_defaults: {
+          queryKey: { input: { defaultInput: true } },
+        },
+      })
+
+      utils.queryKey()
+
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'query', input: { defaultInput: true } })
+    })
+
+    it('user options override defaults', () => {
+      const utils = createProcedureUtils(client, {
+        path: ['ping'],
+        experimental_defaults: {
+          queryKey: { input: { defaultInput: true } },
+        },
+      })
+
+      utils.queryKey({ input: { userInput: true } })
+
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'query', input: { userInput: true } })
+    })
+
+    it('custom queryKey overrides default', () => {
+      const utils = createProcedureUtils(client, {
+        path: ['ping'],
+        experimental_defaults: {
+          queryKey: { queryKey: ['default-key'] },
+        },
+      })
+
+      expect(utils.queryKey()).toEqual(['default-key'])
+      expect(utils.queryKey({ queryKey: ['user-key'] })).toEqual(['user-key'])
+    })
+  })
+
+  describe('.queryOptions', () => {
+    it('applies defaults when no options provided', () => {
+      const utils = createProcedureUtils(client, {
+        path: ['ping'],
+        experimental_defaults: {
+          queryOptions: { input: { defaultInput: true }, staleTime: 1000 },
+        },
+      })
+
+      const options = utils.queryOptions() as any
+
+      expect(options.staleTime).toBe(1000)
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'query', input: { defaultInput: true } })
+    })
+
+    it('user options override defaults', () => {
+      const utils = createProcedureUtils(client, {
+        path: ['ping'],
+        experimental_defaults: {
+          queryOptions: { input: { defaultInput: true }, staleTime: 1000 },
+        },
+      })
+
+      const options = utils.queryOptions({ input: { userInput: true }, staleTime: 2000 }) as any
+
+      expect(options.staleTime).toBe(2000)
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'query', input: { userInput: true } })
+    })
+  })
+
+  describe('.experimental_streamedKey', () => {
+    it('applies defaults when no options provided', () => {
+      const utils = createProcedureUtils(client, {
+        path: ['ping'],
+        experimental_defaults: {
+          experimental_streamedKey: { input: { defaultInput: true } },
+        },
+      })
+
+      utils.experimental_streamedKey()
+
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'streamed', input: { defaultInput: true } })
+    })
+
+    it('user options override defaults', () => {
+      const utils = createProcedureUtils(client, {
+        path: ['ping'],
+        experimental_defaults: {
+          experimental_streamedKey: { input: { defaultInput: true } },
+        },
+      })
+
+      utils.experimental_streamedKey({ input: { userInput: true } })
+
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'streamed', input: { userInput: true } })
+    })
+  })
+
+  describe('.experimental_streamedOptions', () => {
+    it('applies defaults when no options provided', () => {
+      const utils = createProcedureUtils(client, {
+        path: ['ping'],
+        experimental_defaults: {
+          experimental_streamedOptions: { input: { defaultInput: true }, staleTime: 1000 },
+        },
+      })
+
+      const options = utils.experimental_streamedOptions() as any
+
+      expect(options.staleTime).toBe(1000)
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'streamed', input: { defaultInput: true } })
+    })
+
+    it('user options override defaults', () => {
+      const utils = createProcedureUtils(client, {
+        path: ['ping'],
+        experimental_defaults: {
+          experimental_streamedOptions: { input: { defaultInput: true }, staleTime: 1000 },
+        },
+      })
+
+      const options = utils.experimental_streamedOptions({ input: { userInput: true }, staleTime: 2000 }) as any
+
+      expect(options.staleTime).toBe(2000)
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'streamed', input: { userInput: true } })
+    })
+  })
+
+  describe('.experimental_liveKey', () => {
+    it('applies defaults when no options provided', () => {
+      const utils = createProcedureUtils(client, {
+        path: ['ping'],
+        experimental_defaults: {
+          experimental_liveKey: { input: { defaultInput: true } },
+        },
+      })
+
+      utils.experimental_liveKey()
+
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'live', input: { defaultInput: true } })
+    })
+
+    it('user options override defaults', () => {
+      const utils = createProcedureUtils(client, {
+        path: ['ping'],
+        experimental_defaults: {
+          experimental_liveKey: { input: { defaultInput: true } },
+        },
+      })
+
+      utils.experimental_liveKey({ input: { userInput: true } })
+
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'live', input: { userInput: true } })
+    })
+  })
+
+  describe('.experimental_liveOptions', () => {
+    it('applies defaults when no options provided', () => {
+      const utils = createProcedureUtils(client, {
+        path: ['ping'],
+        experimental_defaults: {
+          experimental_liveOptions: { input: { defaultInput: true }, staleTime: 1000 },
+        },
+      })
+
+      const options = utils.experimental_liveOptions() as any
+
+      expect(options.staleTime).toBe(1000)
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'live', input: { defaultInput: true } })
+    })
+
+    it('user options override defaults', () => {
+      const utils = createProcedureUtils(client, {
+        path: ['ping'],
+        experimental_defaults: {
+          experimental_liveOptions: { input: { defaultInput: true }, staleTime: 1000 },
+        },
+      })
+
+      const options = utils.experimental_liveOptions({ input: { userInput: true }, staleTime: 2000 }) as any
+
+      expect(options.staleTime).toBe(2000)
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'live', input: { userInput: true } })
+    })
+  })
+
+  describe('.infiniteKey', () => {
+    it('applies defaults when options provided', () => {
+      const defaultInput = vi.fn().mockReturnValue({ defaultInput: true })
+      const utils = createProcedureUtils(client, {
+        path: ['ping'],
+        experimental_defaults: {
+          infiniteKey: { input: defaultInput, initialPageParam: 0 },
+        },
+      })
+
+      utils.infiniteKey({ input: () => ({}), initialPageParam: 1 })
+
+      // User options override defaults
+      expect(defaultInput).not.toHaveBeenCalled()
+    })
+
+    it('custom queryKey in defaults is used', () => {
+      const utils = createProcedureUtils(client, {
+        path: ['ping'],
+        experimental_defaults: {
+          infiniteKey: { queryKey: ['default-infinite-key'] },
+        },
+      })
+
+      expect(utils.infiniteKey({ input: () => ({}), initialPageParam: 0 })).toEqual(['default-infinite-key'])
+    })
+  })
+
+  describe('.infiniteOptions', () => {
+    it('applies defaults', () => {
+      const getNextPageParam = vi.fn()
+      const utils = createProcedureUtils(client, {
+        path: ['ping'],
+        experimental_defaults: {
+          infiniteOptions: { staleTime: 1000 },
+        },
+      })
+
+      const options = utils.infiniteOptions({
+        input: () => ({}),
+        getNextPageParam,
+        initialPageParam: 0,
+      }) as any
+
+      expect(options.staleTime).toBe(1000)
+    })
+
+    it('user options override defaults', () => {
+      const getNextPageParam = vi.fn()
+      const utils = createProcedureUtils(client, {
+        path: ['ping'],
+        experimental_defaults: {
+          infiniteOptions: { staleTime: 1000 },
+        },
+      })
+
+      const options = utils.infiniteOptions({
+        input: () => ({}),
+        getNextPageParam,
+        initialPageParam: 0,
+        staleTime: 2000,
+      }) as any
+
+      expect(options.staleTime).toBe(2000)
+    })
+  })
+
+  describe('.mutationKey', () => {
+    it('applies defaults when no options provided', () => {
+      const utils = createProcedureUtils(client, {
+        path: ['ping'],
+        experimental_defaults: {
+          mutationKey: { mutationKey: ['default-mutation-key'] },
+        },
+      })
+
+      expect(utils.mutationKey()).toEqual(['default-mutation-key'])
+    })
+
+    it('user options override defaults', () => {
+      const utils = createProcedureUtils(client, {
+        path: ['ping'],
+        experimental_defaults: {
+          mutationKey: { mutationKey: ['default-mutation-key'] },
+        },
+      })
+
+      expect(utils.mutationKey({ mutationKey: ['user-mutation-key'] })).toEqual(['user-mutation-key'])
+    })
+  })
+
+  describe('.mutationOptions', () => {
+    it('applies defaults when no options provided', () => {
+      const onSuccess = vi.fn()
+      const utils = createProcedureUtils(client, {
+        path: ['ping'],
+        experimental_defaults: {
+          mutationOptions: { onSuccess },
+        },
+      })
+
+      const options = utils.mutationOptions()
+
+      expect(options.onSuccess).toBe(onSuccess)
+    })
+
+    it('user options override defaults', () => {
+      const defaultOnSuccess = vi.fn()
+      const userOnSuccess = vi.fn()
+      const utils = createProcedureUtils(client, {
+        path: ['ping'],
+        experimental_defaults: {
+          mutationOptions: { onSuccess: defaultOnSuccess },
+        },
+      })
+
+      const options = utils.mutationOptions({ onSuccess: userOnSuccess })
+
+      expect(options.onSuccess).toBe(userOnSuccess)
+    })
+  })
+})

--- a/packages/tanstack-query/src/procedure-utils.ts
+++ b/packages/tanstack-query/src/procedure-utils.ts
@@ -146,24 +146,133 @@ export interface ProcedureUtils<TClientContext extends ClientContext, TInput, TO
   ): NoInfer<MutationOptions<TInput, TOutput, TError, UMutationContext>>
 }
 
-export interface CreateProcedureUtilsOptions {
+export interface experimental_ProcedureUtilsDefaults<TClientContext extends ClientContext, TInput, TOutput, TError> {
+  /**
+   * Default options for queryKey utility
+   *
+   * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#query-mutation-key Tanstack Query/Mutation Key Docs}
+   */
+  queryKey?: Partial<
+    QueryKeyOptions<TInput>
+  >
+
+  /**
+   * Default options for queryOptions utility
+   *
+   * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#query-options Tanstack Query Options Utility Docs}
+   */
+  queryOptions?: Partial<
+    QueryOptionsIn<TClientContext, TInput, TOutput, TError, unknown>
+  >
+
+  /**
+   * Default options for experimental_streamedKey utility
+   *
+   * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#query-mutation-key Tanstack Query/Mutation Key Docs}
+   */
+  experimental_streamedKey?: Partial<
+    experimental_StreamedKeyOptions<TInput>
+  >
+
+  /**
+   * Default options for experimental_streamedOptions utility
+   *
+   * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#streamed-query-options Tanstack Streamed Query Options Utility Docs}
+   */
+  experimental_streamedOptions?: Partial<
+    StreamedOptionsIn<TClientContext, TInput, experimental_StreamedQueryOutput<TOutput>, TError, unknown>
+  >
+
+  /**
+   * Default options for experimental_liveKey utility
+   *
+   * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#query-mutation-key Tanstack Query/Mutation Key Docs}
+   */
+  experimental_liveKey?: Partial<
+    QueryKeyOptions<TInput>
+  >
+
+  /**
+   * Default options for experimental_liveOptions utility
+   *
+   * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#live-query-options Tanstack Live Query Options Utility Docs}
+   */
+  experimental_liveOptions?: Partial<
+    StreamedOptionsIn<TClientContext, TInput, experimental_LiveQueryOutput<TOutput>, TError, unknown>
+  >
+
+  /**
+   * Default options for infiniteKey utility
+   *
+   * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#query-mutation-key Tanstack Query/Mutation Key Docs}
+   */
+  infiniteKey?: Partial<
+    Pick<
+      InfiniteOptionsIn<TClientContext, TInput, TOutput, TError, InfiniteData<TOutput, unknown>, unknown>,
+      'input' | 'initialPageParam' | 'queryKey'
+    >
+  >
+
+  /**
+   * Default options for infiniteOptions utility
+   *
+   * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#infinite-query-options Tanstack Infinite Query Options Utility Docs}
+   */
+  infiniteOptions?: Partial<
+    InfiniteOptionsIn<TClientContext, TInput, TOutput, TError, unknown, unknown>
+  >
+
+  /**
+   * Default options for mutationKey utility
+   *
+   * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#query-mutation-key Tanstack Query/Mutation Key Docs}
+   */
+  mutationKey?: Partial<
+    Pick<
+      MutationOptionsIn<TClientContext, TInput, TOutput, TError, any>,
+      'mutationKey'
+    >
+  >
+
+  /**
+   * Default options for mutationOptions utility
+   *
+   * @see {@link https://orpc.unnoq.com/docs/integrations/tanstack-query#mutation-options Tanstack Mutation Options Docs}
+   */
+  mutationOptions?: Partial<
+    MutationOptionsIn<TClientContext, TInput, TOutput, TError, unknown>
+  >
+}
+
+/**
+ * @todo remove default generic types on v2
+ */
+export interface CreateProcedureUtilsOptions<
+  TClientContext extends ClientContext = ClientContext,
+  TInput = unknown,
+  TOutput = unknown,
+  TError = unknown,
+> {
   path: readonly string[]
+  experimental_defaults?: experimental_ProcedureUtilsDefaults<TClientContext, TInput, TOutput, TError>
 }
 
 export function createProcedureUtils<TClientContext extends ClientContext, TInput, TOutput, TError>(
   client: Client<TClientContext, TInput, TOutput, TError>,
-  options: CreateProcedureUtilsOptions,
+  options: CreateProcedureUtilsOptions<TClientContext, TInput, TOutput, TError>,
 ): ProcedureUtils<TClientContext, TInput, TOutput, TError> {
   const utils: ProcedureUtils<TClientContext, TInput, TOutput, TError> = {
     call: client,
 
     queryKey(...[optionsIn = {} as any]) {
+      optionsIn = { ...options.experimental_defaults?.queryKey, ...optionsIn }
       const queryKey = optionsIn.queryKey ?? generateOperationKey(options.path, { type: 'query', input: optionsIn.input })
 
       return queryKey
     },
 
     queryOptions(...[optionsIn = {} as any]) {
+      optionsIn = { ...options.experimental_defaults?.queryOptions, ...optionsIn }
       const queryKey = utils.queryKey(optionsIn)
 
       return {
@@ -190,12 +299,14 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
     },
 
     experimental_streamedKey(...[optionsIn = {} as any]) {
+      optionsIn = { ...options.experimental_defaults?.experimental_streamedKey, ...optionsIn }
       const queryKey = optionsIn.queryKey ?? generateOperationKey(options.path, { type: 'streamed', input: optionsIn.input, fnOptions: optionsIn.queryFnOptions })
 
       return queryKey
     },
 
     experimental_streamedOptions(...[optionsIn = {} as any]) {
+      optionsIn = { ...options.experimental_defaults?.experimental_streamedOptions, ...optionsIn }
       const queryKey = utils.experimental_streamedKey(optionsIn)
 
       return {
@@ -231,12 +342,14 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
     },
 
     experimental_liveKey(...[optionsIn = {} as any]) {
+      optionsIn = { ...options.experimental_defaults?.experimental_liveKey, ...optionsIn }
       const queryKey = optionsIn.queryKey ?? generateOperationKey(options.path, { type: 'live', input: optionsIn.input })
 
       return queryKey
     },
 
     experimental_liveOptions(...[optionsIn = {} as any]) {
+      optionsIn = { ...options.experimental_defaults?.experimental_liveOptions, ...optionsIn }
       const queryKey = utils.experimental_liveKey(optionsIn)
 
       return {
@@ -269,6 +382,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
     },
 
     infiniteKey(optionsIn) {
+      optionsIn = { ...options.experimental_defaults?.infiniteKey, ...optionsIn }
       const queryKey = optionsIn.queryKey ?? generateOperationKey(options.path, {
         type: 'infinite',
         input: optionsIn.input === skipToken ? skipToken : optionsIn.input(optionsIn.initialPageParam) as any,
@@ -278,6 +392,7 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
     },
 
     infiniteOptions(optionsIn) {
+      optionsIn = { ...options.experimental_defaults?.infiniteOptions, ...optionsIn }
       const queryKey = utils.infiniteKey(optionsIn as any)
 
       return {
@@ -304,12 +419,14 @@ export function createProcedureUtils<TClientContext extends ClientContext, TInpu
     },
 
     mutationKey(...[optionsIn = {} as any]) {
+      optionsIn = { ...options.experimental_defaults?.mutationKey, ...optionsIn }
       const mutationKey = optionsIn.mutationKey ?? generateOperationKey(options.path, { type: 'mutation' })
 
       return mutationKey
     },
 
     mutationOptions(...[optionsIn = {} as any]) {
+      optionsIn = { ...options.experimental_defaults?.mutationOptions, ...optionsIn }
       const mutationKey = utils.mutationKey(optionsIn)
 
       return {

--- a/packages/tanstack-query/src/router-utils.test-d.ts
+++ b/packages/tanstack-query/src/router-utils.test-d.ts
@@ -3,8 +3,9 @@ import type { RouterClient } from '@orpc/server'
 import type { baseErrorMap } from '../../contract/tests/shared'
 import type { router } from '../../server/tests/shared'
 import type { GeneralUtils } from './general-utils'
-import type { ProcedureUtils } from './procedure-utils'
-import type { RouterUtils } from './router-utils'
+import type { experimental_ProcedureUtilsDefaults, ProcedureUtils } from './procedure-utils'
+import type { experimental_RouterUtilsDefaults, RouterUtils } from './router-utils'
+import { createRouterUtils } from './router-utils'
 
 it('RouterUtils', () => {
   const utils = {} as RouterUtils<RouterClient<typeof router, { batch?: boolean }>>
@@ -35,4 +36,49 @@ it('RouterUtils', () => {
   expectTypeOf(utils.nested.pong).toExtend<
     ProcedureUtils<{ batch?: boolean }, unknown, unknown, Error>
   >()
+})
+
+it('RouterUtilsDefaults', () => {
+  const utils = {} as experimental_RouterUtilsDefaults<RouterClient<typeof router, { batch?: boolean }>>
+
+  expectTypeOf(utils).not.toExtend<
+    undefined | experimental_ProcedureUtilsDefaults<any, any, any, any>
+  >()
+
+  expectTypeOf(utils.nested).not.toExtend<
+    undefined | experimental_ProcedureUtilsDefaults<any, any, any, any>
+  >()
+
+  expectTypeOf(utils.ping).toExtend<
+    undefined | experimental_ProcedureUtilsDefaults<{ batch?: boolean }, { input: number }, { output: string }, ErrorFromErrorMap<typeof baseErrorMap>>
+  >()
+
+  expectTypeOf(utils.nested?.ping).toExtend<
+    undefined | experimental_ProcedureUtilsDefaults<{ batch?: boolean }, { input: number }, { output: string }, ErrorFromErrorMap<typeof baseErrorMap>>
+  >()
+
+  expectTypeOf(utils.pong).toExtend<
+    undefined | experimental_ProcedureUtilsDefaults<{ batch?: boolean }, unknown, unknown, Error>
+  >()
+  expectTypeOf(utils.nested?.pong).toExtend<
+   undefined | experimental_ProcedureUtilsDefaults<{ batch?: boolean }, unknown, unknown, Error>
+  >()
+})
+
+it('createRouterUtils', () => {
+  const utils = createRouterUtils({} as RouterClient<typeof router, { batch?: boolean }>, {
+    experimental_defaults: {
+      nested: {
+        ping: {
+          mutationOptions: {
+            onSuccess: (output) => {
+              expectTypeOf(output).toEqualTypeOf<{ output: string }>()
+            },
+          },
+        },
+      },
+    },
+  })
+
+  expectTypeOf(utils).toEqualTypeOf<RouterUtils<RouterClient<typeof router, { batch?: boolean }>>>()
 })

--- a/packages/tanstack-query/src/router-utils.test.ts
+++ b/packages/tanstack-query/src/router-utils.test.ts
@@ -57,4 +57,38 @@ describe('createRouterUtils', () => {
     const utils = createRouterUtils(client) as any
     expect(utils[Symbol.for('a')]).toBe(undefined)
   })
+
+  it('with defaults', () => {
+    const keyDefaults = {
+      queryOptions: {
+        staleTime: 1000,
+      },
+      mutationOptions: {
+        context: { foo: 'bar' },
+      },
+    }
+
+    const utils = createRouterUtils(client, {
+      experimental_defaults: {
+        key: keyDefaults,
+      },
+    }) as any
+
+    vi.clearAllMocks()
+    const keyUtils = utils.key
+
+    expect(procedureUtilsSpy).toHaveBeenCalledWith(client.key, {
+      path: ['key'],
+      experimental_defaults: keyDefaults,
+    })
+    expect(keyUtils.queryOptions().staleTime).toBeDefined()
+
+    vi.clearAllMocks()
+    const pongUtils = keyUtils.pong
+
+    expect(procedureUtilsSpy).toHaveBeenCalledWith(client.key.pong, {
+      path: ['key', 'pong'],
+    })
+    expect(pongUtils.queryOptions().staleTime).not.toBeDefined()
+  })
 })


### PR DESCRIPTION
Fixes #1051

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experimental centralized default options for procedures and routers, applied to queries, mutations, infinite/streamed/live operations and overridable per call.

* **Tests**
  * Added tests covering default propagation, nested/router-level resolution, and per-call override behavior.

* **Documentation**
  * Added a "Default Options" section to the TanStack Query integration docs (duplicated in two places).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->