### PR TITLE
feat(publisher): change cloudflare durable object cleanup

### DIFF
--- a/apps/content/docs/helpers/publisher.md
+++ b/apps/content/docs/helpers/publisher.md
@@ -235,7 +235,7 @@ export class PublisherDO extends PublisherDurableObject {
     super(ctx, env, {
       resume: {
         retentionSeconds: 60 * 2, // Retain events for 2 minutes to support resume
-        cleanupIntervalSeconds: 12 * 60 * 60, // How regularly to check for cleanup (default: 12 hours)
+        cleanupIntervalSeconds: 12 * 60 * 60, // Interval for inactivity checks; if inactive, the DO is cleaned up (default: 12 hours)
       },
     })
   }

--- a/apps/content/docs/helpers/publisher.md
+++ b/apps/content/docs/helpers/publisher.md
@@ -235,6 +235,7 @@ export class PublisherDO extends PublisherDurableObject {
     super(ctx, env, {
       resume: {
         retentionSeconds: 60 * 2, // Retain events for 2 minutes to support resume
+        cleanupIntervalSeconds: 12 * 60 * 60, // How regularly to check for cleanup (default: 12 hours)
       },
     })
   }

--- a/packages/publisher-durable-object/src/resume-storage.test.ts
+++ b/packages/publisher-durable-object/src/resume-storage.test.ts
@@ -293,22 +293,22 @@ describe('resumeStorage', () => {
       expect(ctx.storage.setAlarm).toHaveBeenCalledOnce()
     })
 
-    it('uses custom inactiveDataRetentionTime for alarm scheduling', async () => {
+    it('uses custom cleanupIntervalSeconds for alarm scheduling', async () => {
       const ctx = createDurableObjectState()
       const storage = new ResumeStorage(ctx, {
         retentionSeconds: 60,
-        inactiveDataRetentionTime: 120,
+        cleanupIntervalSeconds: 120,
       })
 
       await storage.store(JSON.stringify({ data: 'test' }))
 
-      // Alarm should be scheduled at retentionSeconds + inactiveDataRetentionTime
+      // Alarm should be scheduled at cleanupIntervalSeconds
       expect(ctx.storage.setAlarm).toHaveBeenCalledWith(
         expect.any(Number),
       )
 
       const alarmTime = ctx.storage.setAlarm.mock.calls[0]![0]
-      const expectedDelay = (60 + 120) * 1000
+      const expectedDelay = 120 * 1000
       expect(alarmTime).toBeGreaterThanOrEqual(Date.now() + expectedDelay - 1000)
       expect(alarmTime).toBeLessThanOrEqual(Date.now() + expectedDelay + 1000)
     })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Renamed the inactive cleanup option to a clearer name and increased the default cleanup scheduling interval from 6 hours to 12 hours.
* **Tests**
  * Updated tests to reflect the renamed option and the revised scheduling expectations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->