### PR TITLE
fix(standard-server): filter out undefined headers for node:http adapters compatibility

### DIFF
--- a/packages/standard-server-fastify/src/response.test.ts
+++ b/packages/standard-server-fastify/src/response.test.ts
@@ -6,6 +6,7 @@ import request from 'supertest'
 import { sendStandardResponse } from './response'
 
 const toNodeHttpBodySpy = vi.spyOn(StandardServerNode, 'toNodeHttpBody')
+const toNodeHttpHeadersSpy = vi.spyOn(StandardServerNode, 'toNodeHttpHeaders')
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -39,11 +40,16 @@ describe('sendStandardResponse', () => {
       'x-custom-header': 'custom-value',
     }, options)
 
+    expect(toNodeHttpHeadersSpy).toBeCalledTimes(1)
+    expect(toNodeHttpHeadersSpy).toBeCalledWith({
+      'x-custom-header': 'custom-value',
+    })
+
     expect(sendSpy).toBeCalledTimes(1)
     expect(sendSpy).toBeCalledWith(undefined)
 
     expect(res.status).toBe(207)
-    expect(res.headers['content-type']).toEqual(undefined)
+    expect(res.headers).not.toHaveProperty('content-type')
     expect(res.headers['x-custom-header']).toEqual('custom-value')
 
     expect(res.text).toEqual('')
@@ -76,6 +82,12 @@ describe('sendStandardResponse', () => {
       'content-type': 'application/json',
       'x-custom-header': 'custom-value',
     }, options)
+
+    expect(toNodeHttpHeadersSpy).toBeCalledTimes(1)
+    expect(toNodeHttpHeadersSpy).toBeCalledWith({
+      'content-type': 'application/json',
+      'x-custom-header': 'custom-value',
+    })
 
     expect(sendSpy).toBeCalledTimes(1)
     expect(sendSpy).toBeCalledWith(toNodeHttpBodySpy.mock.results[0]!.value)
@@ -119,6 +131,14 @@ describe('sendStandardResponse', () => {
       'content-type': 'text/plain',
       'x-custom-header': 'custom-value',
     }, options)
+
+    expect(toNodeHttpHeadersSpy).toBeCalledTimes(1)
+    expect(toNodeHttpHeadersSpy).toBeCalledWith({
+      'content-disposition': 'inline; filename="blob"; filename*=utf-8\'\'blob',
+      'content-length': '3',
+      'content-type': 'text/plain',
+      'x-custom-header': 'custom-value',
+    })
 
     expect(sendSpy).toBeCalledTimes(1)
     expect(sendSpy).toBeCalledWith(toNodeHttpBodySpy.mock.results[0]!.value)
@@ -169,6 +189,12 @@ describe('sendStandardResponse', () => {
       'content-type': 'text/event-stream',
       'x-custom-header': 'custom-value',
     }, options)
+
+    expect(toNodeHttpHeadersSpy).toBeCalledTimes(1)
+    expect(toNodeHttpHeadersSpy).toBeCalledWith({
+      'content-type': 'text/event-stream',
+      'x-custom-header': 'custom-value',
+    })
 
     expect(sendSpy).toBeCalledTimes(1)
     expect(sendSpy).toBeCalledWith(toNodeHttpBodySpy.mock.results[0]!.value)

--- a/packages/standard-server-fastify/src/response.ts
+++ b/packages/standard-server-fastify/src/response.ts
@@ -1,7 +1,7 @@
 import type { StandardHeaders, StandardResponse } from '@orpc/standard-server'
 import type { ToNodeHttpBodyOptions } from '@orpc/standard-server-node'
 import type { FastifyReply } from 'fastify'
-import { toNodeHttpBody } from '@orpc/standard-server-node'
+import { toNodeHttpBody, toNodeHttpHeaders } from '@orpc/standard-server-node'
 
 export interface SendStandardResponseOptions extends ToNodeHttpBodyOptions { }
 
@@ -19,7 +19,9 @@ export function sendStandardResponse(
     const resBody = toNodeHttpBody(standardResponse.body, resHeaders, options)
 
     reply.status(standardResponse.status)
-    reply.headers(resHeaders)
+    // fastify treat undefined headers as empty string, so remember to use toNodeHttpHeaders
+    // to filter out undefined headers
+    reply.headers(toNodeHttpHeaders(resHeaders))
     reply.send(resBody)
   })
 }

--- a/packages/standard-server-fastify/src/response.ts
+++ b/packages/standard-server-fastify/src/response.ts
@@ -19,7 +19,7 @@ export function sendStandardResponse(
     const resBody = toNodeHttpBody(standardResponse.body, resHeaders, options)
 
     reply.status(standardResponse.status)
-    // fastify treat undefined headers as empty string, so remember to use toNodeHttpHeaders
+    // Fastify treats undefined headers as empty string, so remember to use toNodeHttpHeaders
     // to filter out undefined headers
     reply.headers(toNodeHttpHeaders(resHeaders))
     reply.send(resBody)

--- a/packages/standard-server-node/src/headers.test.ts
+++ b/packages/standard-server-node/src/headers.test.ts
@@ -1,0 +1,17 @@
+import { toNodeHttpHeaders } from './headers'
+
+describe('toNodeHttpHeaders', () => {
+  it('filters out undefined values', () => {
+    const headers = toNodeHttpHeaders({
+      'x-custom': 'value',
+      'x-undefined': undefined,
+      'set-cookie': ['cookie1=value1', 'cookie2=value2'],
+    })
+
+    expect(headers).toEqual({
+      'x-custom': 'value',
+      'set-cookie': ['cookie1=value1', 'cookie2=value2'],
+    })
+    expect(headers).not.toHaveProperty('x-undefined')
+  })
+})

--- a/packages/standard-server-node/src/headers.ts
+++ b/packages/standard-server-node/src/headers.ts
@@ -1,0 +1,16 @@
+import type { StandardHeaders } from '@orpc/standard-server'
+import type { OutgoingHttpHeaders } from 'node:http'
+
+export function toNodeHttpHeaders(headers: StandardHeaders): OutgoingHttpHeaders {
+  const nodeHttpHeaders: OutgoingHttpHeaders = {}
+
+  for (const key in headers) {
+    const value = headers[key]
+    // nodejs not allow header is undefined
+    if (value !== undefined) {
+      nodeHttpHeaders[key] = value
+    }
+  }
+
+  return nodeHttpHeaders
+}

--- a/packages/standard-server-node/src/headers.ts
+++ b/packages/standard-server-node/src/headers.ts
@@ -4,9 +4,8 @@ import type { OutgoingHttpHeaders } from 'node:http'
 export function toNodeHttpHeaders(headers: StandardHeaders): OutgoingHttpHeaders {
   const nodeHttpHeaders: OutgoingHttpHeaders = {}
 
-  for (const key in headers) {
-    const value = headers[key]
-    // nodejs does not allow headers to be undefined
+  for (const [key, value] of Object.entries(headers)) {
+    // Node.js does not allow headers to be undefined
     if (value !== undefined) {
       nodeHttpHeaders[key] = value
     }

--- a/packages/standard-server-node/src/headers.ts
+++ b/packages/standard-server-node/src/headers.ts
@@ -6,7 +6,7 @@ export function toNodeHttpHeaders(headers: StandardHeaders): OutgoingHttpHeaders
 
   for (const key in headers) {
     const value = headers[key]
-    // nodejs not allow header is undefined
+    // nodejs does not allow headers to be undefined
     if (value !== undefined) {
       nodeHttpHeaders[key] = value
     }

--- a/packages/standard-server-node/src/index.ts
+++ b/packages/standard-server-node/src/index.ts
@@ -1,5 +1,6 @@
 export * from './body'
 export * from './event-iterator'
+export * from './headers'
 export * from './method'
 export * from './request'
 export * from './response'

--- a/packages/standard-server-node/src/response.test.ts
+++ b/packages/standard-server-node/src/response.test.ts
@@ -4,9 +4,11 @@ import { Buffer } from 'node:buffer'
 import Stream from 'node:stream'
 import request from 'supertest'
 import * as Body from './body'
+import * as Headers from './headers'
 import { sendStandardResponse } from './response'
 
 const toNodeHttpBodySpy = vi.spyOn(Body, 'toNodeHttpBody')
+const toNodeHttpHeadersSpy = vi.spyOn(Headers, 'toNodeHttpHeaders')
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -34,11 +36,16 @@ describe('sendStandardResponse', () => {
       'x-custom-header': 'custom-value',
     }, options)
 
+    expect(toNodeHttpHeadersSpy).toBeCalledTimes(1)
+    expect(toNodeHttpHeadersSpy).toBeCalledWith({
+      'x-custom-header': 'custom-value',
+    })
+
     expect(endSpy).toBeCalledTimes(1)
     expect(endSpy).toBeCalledWith()
 
     expect(res.status).toBe(207)
-    expect(res.headers['content-type']).toEqual(undefined)
+    expect(res.headers).not.toHaveProperty('content-type')
     expect(res.headers['x-custom-header']).toEqual('custom-value')
 
     expect(res.text).toEqual('')
@@ -65,6 +72,12 @@ describe('sendStandardResponse', () => {
       'content-type': 'application/json',
       'x-custom-header': 'custom-value',
     }, options)
+
+    expect(toNodeHttpHeadersSpy).toBeCalledTimes(1)
+    expect(toNodeHttpHeadersSpy).toBeCalledWith({
+      'content-type': 'application/json',
+      'x-custom-header': 'custom-value',
+    })
 
     expect(endSpy).toBeCalledTimes(1)
     expect(endSpy).toBeCalledWith(toNodeHttpBodySpy.mock.results[0]!.value)
@@ -102,6 +115,14 @@ describe('sendStandardResponse', () => {
       'content-type': 'text/plain',
       'x-custom-header': 'custom-value',
     }, options)
+
+    expect(toNodeHttpHeadersSpy).toBeCalledTimes(1)
+    expect(toNodeHttpHeadersSpy).toBeCalledWith({
+      'content-disposition': 'inline; filename="blob"; filename*=utf-8\'\'blob',
+      'content-length': '3',
+      'content-type': 'text/plain',
+      'x-custom-header': 'custom-value',
+    })
 
     expect(endSpy).toBeCalledTimes(1)
     expect(endSpy).toBeCalledWith()
@@ -147,6 +168,12 @@ describe('sendStandardResponse', () => {
       'content-type': 'text/event-stream',
       'x-custom-header': 'custom-value',
     }, options)
+
+    expect(toNodeHttpHeadersSpy).toBeCalledTimes(1)
+    expect(toNodeHttpHeadersSpy).toBeCalledWith({
+      'content-type': 'text/event-stream',
+      'x-custom-header': 'custom-value',
+    })
 
     expect(endSpy).toBeCalledTimes(1)
     expect(endSpy).toBeCalledWith()

--- a/packages/standard-server-node/src/response.ts
+++ b/packages/standard-server-node/src/response.ts
@@ -19,7 +19,7 @@ export function sendStandardResponse(
 
     const resBody = toNodeHttpBody(standardResponse.body, resHeaders, options)
 
-    // nodejs throws error when header is undefined, so remember to use toNodeHttpHeaders
+    // Node.js throws an error when a header is undefined, so remember to use toNodeHttpHeaders
     // to filter out undefined headers
     res.writeHead(standardResponse.status, toNodeHttpHeaders(resHeaders))
 

--- a/packages/standard-server-node/src/response.ts
+++ b/packages/standard-server-node/src/response.ts
@@ -2,6 +2,7 @@ import type { StandardHeaders, StandardResponse } from '@orpc/standard-server'
 import type { ToNodeHttpBodyOptions } from './body'
 import type { NodeHttpResponse } from './types'
 import { toNodeHttpBody } from './body'
+import { toNodeHttpHeaders } from './headers'
 
 export interface SendStandardResponseOptions extends ToNodeHttpBodyOptions {}
 
@@ -18,7 +19,9 @@ export function sendStandardResponse(
 
     const resBody = toNodeHttpBody(standardResponse.body, resHeaders, options)
 
-    res.writeHead(standardResponse.status, resHeaders)
+    // nodejs throws error when header is undefined, so remember to use toNodeHttpHeaders
+    // to filter out undefined headers
+    res.writeHead(standardResponse.status, toNodeHttpHeaders(resHeaders))
 
     if (resBody === undefined) {
       res.end()


### PR DESCRIPTION
Node.js http module throws an error when headers contain undefined values. Additionally, Fastify treats undefined headers as empty strings, which differs from oRPC's expected behavior of omitting them from the response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP response header handling to filter out undefined values, ensuring consistent and correct headers (including intentional omission of content-type) across Fastify and Node.js responses.

* **Tests**
  * Added unit tests validating header transformation and that undefined headers are omitted, plus coverage for multiple response scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->