### PR TITLE
fix(contract): missing `.$input` builder method

### DIFF
--- a/packages/contract/src/builder-variants.test-d.ts
+++ b/packages/contract/src/builder-variants.test-d.ts
@@ -14,7 +14,7 @@ describe('ContractProcedureBuilder', () => {
   const builder = {} as ContractProcedureBuilder<typeof inputSchema, typeof outputSchema, typeof baseErrorMap, BaseMeta>
 
   it('backward compatibility', () => {
-    const expected = {} as OmitChainMethodDeep<typeof generalBuilder, '$meta' | '$route' | 'prefix' | 'tag' | 'router'>
+    const expected = {} as OmitChainMethodDeep<typeof generalBuilder, '$meta' | '$route' | '$input' | 'prefix' | 'tag' | 'router'>
 
     expectTypeOf(builder).toMatchTypeOf(expected)
     expectTypeOf<keyof typeof builder>().toEqualTypeOf<keyof typeof expected>()
@@ -95,7 +95,7 @@ describe('ContractProcedureBuilderWithInput', () => {
   const builder = {} as ContractProcedureBuilderWithInput<typeof inputSchema, typeof outputSchema, typeof baseErrorMap, BaseMeta>
 
   it('backward compatibility', () => {
-    const expected = {} as OmitChainMethodDeep<typeof generalBuilder, '$meta' | '$route' | 'prefix' | 'tag' | 'router' | 'input'>
+    const expected = {} as OmitChainMethodDeep<typeof generalBuilder, '$meta' | '$route' | '$input' | 'prefix' | 'tag' | 'router' | 'input'>
 
     expectTypeOf(builder).toMatchTypeOf(expected)
     expectTypeOf<keyof typeof builder>().toEqualTypeOf<keyof typeof expected>()
@@ -162,7 +162,7 @@ describe('ContractProcedureBuilderWithOutput', () => {
   const builder = {} as ContractProcedureBuilderWithOutput<typeof inputSchema, typeof outputSchema, typeof baseErrorMap, BaseMeta>
 
   it('backward compatibility', () => {
-    const expected = {} as OmitChainMethodDeep<typeof generalBuilder, '$meta' | '$route' | 'prefix' | 'tag' | 'router' | 'output'>
+    const expected = {} as OmitChainMethodDeep<typeof generalBuilder, '$meta' | '$route' | '$input' | 'prefix' | 'tag' | 'router' | 'output'>
 
     expectTypeOf(builder).toMatchTypeOf(expected)
     expectTypeOf<keyof typeof builder>().toEqualTypeOf<keyof typeof expected>()
@@ -229,7 +229,7 @@ it('ContractProcedureBuilderWithInputOutput', () => {
   const builder = {} as ContractProcedureBuilderWithInputOutput<typeof inputSchema, typeof outputSchema, typeof baseErrorMap, BaseMeta>
 
   it('backward compatibility', () => {
-    const expected = {} as OmitChainMethodDeep<typeof generalBuilder, '$meta' | '$route' | 'prefix' | 'tag' | 'router' | 'input' | 'output'>
+    const expected = {} as OmitChainMethodDeep<typeof generalBuilder, '$meta' | '$route' | '$input' | 'prefix' | 'tag' | 'router' | 'input' | 'output'>
 
     expectTypeOf(builder).toMatchTypeOf(expected)
     expectTypeOf<keyof typeof builder>().toEqualTypeOf<keyof typeof expected>()
@@ -282,7 +282,7 @@ describe('ContractRouterBuilder', () => {
   const builder = {} as ContractRouterBuilder<typeof baseErrorMap, BaseMeta>
 
   it('backward compatibility', () => {
-    const expected = {} as OmitChainMethodDeep<typeof generalBuilder, '$meta' | '$route' | 'route' | 'meta' | 'input' | 'output'>
+    const expected = {} as OmitChainMethodDeep<typeof generalBuilder, '$meta' | '$route' | '$input' | 'route' | 'meta' | 'input' | 'output'>
 
     // expectTypeOf(builder).toMatchTypeOf(expected)
     expectTypeOf<keyof typeof builder>().toEqualTypeOf<keyof typeof expected>()

--- a/packages/contract/src/builder.test-d.ts
+++ b/packages/contract/src/builder.test-d.ts
@@ -41,6 +41,15 @@ describe('ContractBuilder', () => {
     builder.$route({ method: 'INVALID' })
   })
 
+  it('.$input', () => {
+    expectTypeOf(builder.$input(generalSchema)).toEqualTypeOf<
+      ContractBuilder<typeof generalSchema, typeof outputSchema, typeof baseErrorMap, BaseMeta>
+    >()
+
+    // @ts-expect-error - schema is invalid
+    builder.$input({})
+  })
+
   it('.errors', () => {
     expectTypeOf(builder.errors({ INVALID: { message: 'invalid' }, OVERRIDE: { message: 'override' } })).toEqualTypeOf<
       ContractBuilder<

--- a/packages/contract/src/builder.test.ts
+++ b/packages/contract/src/builder.test.ts
@@ -49,6 +49,15 @@ describe('contractBuilder', () => {
     })
   })
 
+  it('.$input', () => {
+    const applied = builder.$input(generalSchema)
+    expect(applied).toBeInstanceOf(ContractBuilder)
+    expect(applied['~orpc']).toEqual({
+      ...def,
+      inputSchema: generalSchema,
+    })
+  })
+
   it('.errors', () => {
     const errors = { BAD_GATEWAY: { data: outputSchema }, OVERRIDE: { message: 'override' } } as const
 

--- a/packages/contract/src/builder.test.ts
+++ b/packages/contract/src/builder.test.ts
@@ -43,6 +43,7 @@ describe('contractBuilder', () => {
 
     const applied = builder.$route(route)
     expect(applied).toBeInstanceOf(ContractBuilder)
+    expect(applied).not.toBe(builder)
     expect(applied['~orpc']).toEqual({
       ...def,
       route,
@@ -52,6 +53,7 @@ describe('contractBuilder', () => {
   it('.$input', () => {
     const applied = builder.$input(generalSchema)
     expect(applied).toBeInstanceOf(ContractBuilder)
+    expect(applied).not.toBe(builder)
     expect(applied['~orpc']).toEqual({
       ...def,
       inputSchema: generalSchema,

--- a/packages/contract/src/builder.ts
+++ b/packages/contract/src/builder.ts
@@ -74,6 +74,20 @@ export class ContractBuilder<
   }
 
   /**
+   * Sets or overrides the initial input schema.
+   *
+   * @see {@link https://orpc.dev/docs/procedure#initial-configuration Initial Procedure Configuration Docs}
+   */
+  $input<U extends AnySchema>(
+    initialInputSchema?: U,
+  ): ContractBuilder<U, TOutputSchema, TErrorMap, TMeta> {
+    return new ContractBuilder({
+      ...this['~orpc'],
+      inputSchema: initialInputSchema,
+    })
+  }
+
+  /**
    * Adds type-safe custom errors to the contract.
    * The provided errors are spared-merged with any existing errors in the contract.
    *


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new $input method on ContractBuilder to set/configure input schemas with type-safe behavior.

* **Tests**
  * Added runtime and type-level tests for $input, updated type expectations across builder variants, and extended existing tests to assert chaining/instance behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->