### PR TITLE
feat: add HTTP Gone error

### DIFF
--- a/apps/content/docs/openapi/error-handling.md
+++ b/apps/content/docs/openapi/error-handling.md
@@ -21,6 +21,7 @@ By default, oRPC maps common error codes to standard HTTP status codes:
 | NOT_ACCEPTABLE         |              406 | Not Acceptable         |
 | TIMEOUT                |              408 | Request Timeout        |
 | CONFLICT               |              409 | Conflict               |
+| GONE                   |              410 | Gone                   |
 | PRECONDITION_FAILED    |              412 | Precondition Failed    |
 | PAYLOAD_TOO_LARGE      |              413 | Payload Too Large      |
 | UNSUPPORTED_MEDIA_TYPE |              415 | Unsupported Media Type |

--- a/packages/client/src/error.ts
+++ b/packages/client/src/error.ts
@@ -35,6 +35,10 @@ export const COMMON_ORPC_ERROR_DEFS = {
     status: 409,
     message: 'Conflict',
   },
+  GONE: {
+    status: 410,
+    message: 'Gone',
+  },
   PRECONDITION_FAILED: {
     status: 412,
     message: 'Precondition Failed',


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/410

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GONE (HTTP 410) error status to supported error responses.

* **Documentation**
  * Updated error handling documentation to reflect the new GONE error mapping in default error set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->