### PR TITLE
docs(playgrounds): prevent server-side execution of SSE query in Nuxt

### DIFF
--- a/playgrounds/nuxt/app/components/orpc-stream.vue
+++ b/playgrounds/nuxt/app/components/orpc-stream.vue
@@ -5,14 +5,17 @@ const { $orpc } = useNuxtApp()
 
 const query = useQuery($orpc.sse.experimental_streamedOptions({
   queryFnOptions: { maxChunks: 3 },
+  enabled: import.meta.client,
 }))
 </script>
 
 <template>
   <div>
     <h2>oRPC and Tanstack Query | Event Iterator example</h2>
-    <pre>
+    <ClientOnly>
+      <pre>
 {{ JSON.stringify(query.data.value, null, 2) }}
-    </pre>
+      </pre>
+    </ClientOnly>
   </div>
 </template>


### PR DESCRIPTION
This PR fixes an issue in the Nuxt example that uses `useQuery` with oRPC's SSE (`experimental_streamedOptions`).  
Previously, the query would run during server-side rendering, leading to hydration errors  because SSE requires a persistent client-side connection.
<img width="790" height="308" alt="image" src="https://github.com/user-attachments/assets/bc1ddfe5-1ff7-4f73-9eda-b2b73527f95f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streamed data output to ensure it displays correctly across all rendering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->