### PR TITLE
feat(server,openapi): support ReadableStream<Uint8Array> as handler return value

### DIFF
--- a/apps/content/docs/openapi/openapi-handler.md
+++ b/apps/content/docs/openapi/openapi-handler.md
@@ -27,6 +27,7 @@ The `OpenAPIHandler` enables communication with clients over RESTful APIs, adher
 - **Blob** (unsupported in `AsyncIteratorObject`)
 - **File** (unsupported in `AsyncIteratorObject`)
 - **AsyncIteratorObject** (only at the root level; powers the [Event Iterator](/docs/event-iterator))
+- **ReadableStream\<Uint8Array\>** (supported only at the root level in `OpenAPIHandler`; not supported by client-side `OpenAPILink` until v2)
 
 ::: warning
 If a payload contains `Blob` or `File` outside the root level, it must use `multipart/form-data`. In such cases, oRPC applies [Bracket Notation](/docs/openapi/bracket-notation) and converts other types to strings (exclude `null` and `undefined` will not be represented).

--- a/packages/openapi/src/adapters/standard/openapi-codec.test.ts
+++ b/packages/openapi/src/adapters/standard/openapi-codec.test.ts
@@ -182,6 +182,26 @@ describe('standardOpenAPICodec', () => {
       expect(serializer.serialize).toHaveBeenCalledWith('__output__')
     })
 
+    it('with ReadableStream bypasses serialization and respects successStatus', () => {
+      const procedure = new Procedure({
+        ...ping['~orpc'],
+        route: {
+          successStatus: 202,
+        },
+      })
+      const stream = new ReadableStream<Uint8Array>()
+
+      const response = codec.encode(stream, procedure)
+
+      expect(response).toEqual({
+        status: 202,
+        headers: {},
+        body: stream,
+      })
+
+      expect(serializer.serialize).not.toHaveBeenCalled()
+    })
+
     describe('with detailed structure', async () => {
       const procedure = new Procedure({
         ...ping['~orpc'],
@@ -249,6 +269,24 @@ describe('standardOpenAPICodec', () => {
 
         expect(serializer.serialize).toHaveBeenCalledTimes(1)
         expect(serializer.serialize).toHaveBeenCalledWith('__output__')
+      })
+
+      it('works with ReadableStream body', () => {
+        const stream = new ReadableStream<Uint8Array>()
+        const output = {
+          body: stream,
+          headers: { 'content-type': 'application/zip' },
+        }
+
+        const response = codec.encode(output, procedure)
+
+        expect(response).toEqual({
+          status: 298,
+          headers: { 'content-type': 'application/zip' },
+          body: stream,
+        })
+
+        expect(serializer.serialize).not.toHaveBeenCalled()
       })
 
       it.each([

--- a/packages/openapi/src/adapters/standard/openapi-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-codec.ts
@@ -72,6 +72,14 @@ export class StandardOpenAPICodec implements StandardCodec {
   }
 
   encode(output: unknown, procedure: AnyProcedure): StandardResponse {
+    if (output instanceof ReadableStream) {
+      return {
+        status: 200,
+        headers: {},
+        body: output,
+      }
+    }
+
     const successStatus = fallbackContractConfig('defaultSuccessStatus', procedure['~orpc'].route.successStatus)
     const outputStructure = fallbackContractConfig('defaultOutputStructure', procedure['~orpc'].route.outputStructure)
 

--- a/packages/openapi/src/adapters/standard/openapi-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-codec.ts
@@ -74,17 +74,17 @@ export class StandardOpenAPICodec implements StandardCodec {
   encode(output: unknown, procedure: AnyProcedure): StandardResponse {
     const successStatus = fallbackContractConfig('defaultSuccessStatus', procedure['~orpc'].route.successStatus)
 
-    if (output instanceof ReadableStream) {
-      return {
-        status: successStatus,
-        headers: {},
-        body: output,
-      }
-    }
-
     const outputStructure = fallbackContractConfig('defaultOutputStructure', procedure['~orpc'].route.outputStructure)
 
     if (outputStructure === 'compact') {
+      if (output instanceof ReadableStream) {
+        return {
+          status: successStatus,
+          headers: {},
+          body: output,
+        }
+      }
+
       return {
         status: successStatus,
         headers: {},

--- a/packages/openapi/src/adapters/standard/openapi-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-codec.ts
@@ -72,15 +72,16 @@ export class StandardOpenAPICodec implements StandardCodec {
   }
 
   encode(output: unknown, procedure: AnyProcedure): StandardResponse {
+    const successStatus = fallbackContractConfig('defaultSuccessStatus', procedure['~orpc'].route.successStatus)
+
     if (output instanceof ReadableStream) {
       return {
-        status: 200,
+        status: successStatus,
         headers: {},
         body: output,
       }
     }
 
-    const successStatus = fallbackContractConfig('defaultSuccessStatus', procedure['~orpc'].route.successStatus)
     const outputStructure = fallbackContractConfig('defaultOutputStructure', procedure['~orpc'].route.outputStructure)
 
     if (outputStructure === 'compact') {
@@ -103,6 +104,14 @@ export class StandardOpenAPICodec implements StandardCodec {
         Actual value:
           ${stringifyJSON(output)}
       `)
+    }
+
+    if (output.body instanceof ReadableStream) {
+      return {
+        status: output.status ?? successStatus,
+        headers: output.headers ?? {},
+        body: output.body,
+      }
     }
 
     return {

--- a/packages/openapi/src/openapi-generator.test.ts
+++ b/packages/openapi/src/openapi-generator.test.ts
@@ -1428,7 +1428,6 @@ describe('openAPIGenerator', () => {
                   properties: {
                     parent: { $ref: '#/components/schemas/User' },
                   },
-                  required: [],
                 },
               },
             },
@@ -1707,7 +1706,6 @@ describe('openAPIGenerator', () => {
                 a: { type: 'string' },
                 b: { type: 'number' },
               },
-              required: [],
             },
           },
         },

--- a/packages/openapi/src/openapi-generator.test.ts
+++ b/packages/openapi/src/openapi-generator.test.ts
@@ -137,6 +137,15 @@ const inputTests: TestCase[] = [
     },
   },
   {
+    name: 'dynamic params only (no body)',
+    contract: oc.route({ method: 'POST', path: '/planets/{id}' }).input(z.object({ id: z.string() })),
+    expected: {
+      '/planets/{id}': {
+        post: expect.toSatisfy((v: any) => v.parameters?.length === 1 && !v.requestBody),
+      },
+    },
+  },
+  {
     name: 'query + params',
     contract: oc.route({ path: '/planets/{id}', method: 'GET' }).input(
       z.object({

--- a/packages/openapi/src/openapi-generator.ts
+++ b/packages/openapi/src/openapi-generator.ts
@@ -349,9 +349,15 @@ export class OpenAPIGenerator {
         ref.parameters.push(...toOpenAPIParameters(schema, 'query'))
       }
       else {
-        ref.requestBody = {
-          required,
-          content: toOpenAPIContent(schema),
+        const isEmptyObject = isObjectSchema(schema)
+          && !schema.properties
+          && !schema.required
+
+        if (!isEmptyObject) {
+          ref.requestBody = {
+            required,
+            content: toOpenAPIContent(schema),
+          }
         }
       }
 

--- a/packages/openapi/src/openapi-generator.ts
+++ b/packages/openapi/src/openapi-generator.ts
@@ -307,6 +307,8 @@ export class OpenAPIGenerator {
       },
     )
 
+    let omitResponseBody = false
+
     if (isAnySchema(schema) && !dynamicParams?.length) {
       return
     }
@@ -329,6 +331,7 @@ export class OpenAPIGenerator {
 
         schema = rest
         required = rest.required ? rest.required.length !== 0 : false
+        omitResponseBody = !required && !rest.properties
 
         if (!checkParamsSchema(paramsSchema, dynamicParams)) {
           throw error
@@ -348,16 +351,10 @@ export class OpenAPIGenerator {
         ref.parameters ??= []
         ref.parameters.push(...toOpenAPIParameters(schema, 'query'))
       }
-      else {
-        const isEmptyObject = isObjectSchema(schema)
-          && !schema.properties
-          && !schema.required
-
-        if (!isEmptyObject) {
-          ref.requestBody = {
-            required,
-            content: toOpenAPIContent(schema),
-          }
+      else if (!omitResponseBody) {
+        ref.requestBody = {
+          required,
+          content: toOpenAPIContent(schema),
         }
       }
 

--- a/packages/openapi/src/openapi-utils.test.ts
+++ b/packages/openapi/src/openapi-utils.test.ts
@@ -84,6 +84,19 @@ describe('toOpenAPIContent', () => {
     expect(toOpenAPIContent({ properties: undefined })).toEqual({})
   })
 
+  it('omits application/json when non-file remainder is not: {} (e.g. z.instanceof)', () => {
+    expect(toOpenAPIContent({
+      anyOf: [
+        fileSchema,
+        { not: {} },
+      ],
+    })).toEqual({
+      'image/png': {
+        schema: fileSchema,
+      },
+    })
+  })
+
   it('body contain file schema', () => {
     const schema: JSONSchema = {
       type: 'object',

--- a/packages/openapi/src/openapi-utils.test.ts
+++ b/packages/openapi/src/openapi-utils.test.ts
@@ -69,17 +69,19 @@ describe('toOpenAPIContent', () => {
     })
   })
 
-  it('omits application/json when all non-file branches resolve to false (not: {})', () => {
+  it('omits unconstrained non-file branches', () => {
     expect(toOpenAPIContent({
       anyOf: [
         fileSchema,
-        false,
+        {},
       ],
     })).toEqual({
       'image/png': {
         schema: fileSchema,
       },
     })
+
+    expect(toOpenAPIContent({ properties: undefined })).toEqual({})
   })
 
   it('body contain file schema', () => {

--- a/packages/openapi/src/openapi-utils.test.ts
+++ b/packages/openapi/src/openapi-utils.test.ts
@@ -84,7 +84,7 @@ describe('toOpenAPIContent', () => {
     expect(toOpenAPIContent({ properties: undefined })).toEqual({})
   })
 
-  it('omits application/json when non-file remainder is not: {} (e.g. z.instanceof)', () => {
+  it('omits never non-file branches', () => {
     expect(toOpenAPIContent({
       anyOf: [
         fileSchema,

--- a/packages/openapi/src/openapi-utils.test.ts
+++ b/packages/openapi/src/openapi-utils.test.ts
@@ -69,6 +69,19 @@ describe('toOpenAPIContent', () => {
     })
   })
 
+  it('omits application/json when all non-file branches resolve to false (not: {})', () => {
+    expect(toOpenAPIContent({
+      anyOf: [
+        fileSchema,
+        false,
+      ],
+    })).toEqual({
+      'image/png': {
+        schema: fileSchema,
+      },
+    })
+  })
+
   it('body contain file schema', () => {
     const schema: JSONSchema = {
       type: 'object',

--- a/packages/openapi/src/openapi-utils.ts
+++ b/packages/openapi/src/openapi-utils.ts
@@ -3,7 +3,7 @@ import type { OpenAPI } from '@orpc/contract'
 import type { FileSchema, JSONSchema, ObjectSchema } from './schema'
 import { standardizeHTTPPath } from '@orpc/openapi-client/standard'
 import { findDeepMatches, isObject, stringifyJSON, toArray } from '@orpc/shared'
-import { expandArrayableSchema, filterSchemaBranches, isAnySchema, isFileSchema, isObjectSchema, isPrimitiveSchema } from './schema-utils'
+import { expandArrayableSchema, filterSchemaBranches, isAnySchema, isFileSchema, isNeverSchema, isObjectSchema, isPrimitiveSchema } from './schema-utils'
 
 /**
  * @internal
@@ -33,10 +33,7 @@ export function toOpenAPIContent(schema: JSONSchema): Record<string, OpenAPI.Med
     }
   }
 
-  const isUnsupportedRest = restSchema === false
-    || (isObject(restSchema) && 'not' in restSchema && isObject(restSchema.not) && Object.keys(restSchema.not).length === 0)
-
-  if (restSchema !== undefined && !isAnySchema(restSchema) && !(matches.length > 0 && isUnsupportedRest)) {
+  if (restSchema !== undefined && !isAnySchema(restSchema) && !isNeverSchema(restSchema)) {
     content['application/json'] = {
       schema: toOpenAPISchema(restSchema),
     }

--- a/packages/openapi/src/openapi-utils.ts
+++ b/packages/openapi/src/openapi-utils.ts
@@ -3,7 +3,7 @@ import type { OpenAPI } from '@orpc/contract'
 import type { FileSchema, JSONSchema, ObjectSchema } from './schema'
 import { standardizeHTTPPath } from '@orpc/openapi-client/standard'
 import { findDeepMatches, isObject, stringifyJSON, toArray } from '@orpc/shared'
-import { expandArrayableSchema, filterSchemaBranches, isFileSchema, isObjectSchema, isPrimitiveSchema } from './schema-utils'
+import { expandArrayableSchema, filterSchemaBranches, isAnySchema, isFileSchema, isObjectSchema, isPrimitiveSchema } from './schema-utils'
 
 /**
  * @internal
@@ -33,13 +33,7 @@ export function toOpenAPIContent(schema: JSONSchema): Record<string, OpenAPI.Med
     }
   }
 
-  const isEmptyRest = restSchema === false
-    || (isObject(restSchema) && (
-      (Array.isArray(restSchema.anyOf) && restSchema.anyOf.length === 0)
-      || (Array.isArray(restSchema.oneOf) && restSchema.oneOf.length === 0)
-    ))
-
-  if (restSchema !== undefined && !isEmptyRest) {
+  if (restSchema !== undefined && !isAnySchema(restSchema)) {
     content['application/json'] = {
       schema: toOpenAPISchema(restSchema),
     }

--- a/packages/openapi/src/openapi-utils.ts
+++ b/packages/openapi/src/openapi-utils.ts
@@ -33,7 +33,13 @@ export function toOpenAPIContent(schema: JSONSchema): Record<string, OpenAPI.Med
     }
   }
 
-  if (restSchema !== undefined) {
+  const isEmptyRest = restSchema === false
+    || (isObject(restSchema) && (
+      (Array.isArray(restSchema.anyOf) && restSchema.anyOf.length === 0)
+      || (Array.isArray(restSchema.oneOf) && restSchema.oneOf.length === 0)
+    ))
+
+  if (restSchema !== undefined && !isEmptyRest) {
     content['application/json'] = {
       schema: toOpenAPISchema(restSchema),
     }

--- a/packages/openapi/src/openapi-utils.ts
+++ b/packages/openapi/src/openapi-utils.ts
@@ -33,7 +33,10 @@ export function toOpenAPIContent(schema: JSONSchema): Record<string, OpenAPI.Med
     }
   }
 
-  if (restSchema !== undefined && !isAnySchema(restSchema)) {
+  const isUnsupportedRest = restSchema === false
+    || (isObject(restSchema) && 'not' in restSchema && isObject(restSchema.not) && Object.keys(restSchema.not).length === 0)
+
+  if (restSchema !== undefined && !isAnySchema(restSchema) && !(matches.length > 0 && isUnsupportedRest)) {
     content['application/json'] = {
       schema: toOpenAPISchema(restSchema),
     }

--- a/packages/openapi/src/schema-utils.test.ts
+++ b/packages/openapi/src/schema-utils.test.ts
@@ -36,6 +36,7 @@ it('isAnySchema', () => {
   expect(isAnySchema({})).toBe(true)
   expect(isAnySchema({ type: 'string' })).toBe(false)
   expect(isAnySchema({ description: 'description' })).toBe(true)
+  expect(isAnySchema({ properties: undefined, required: undefined })).toBe(true)
 })
 
 describe('separateObjectSchema', () => {
@@ -121,7 +122,6 @@ describe('separateObjectSchema', () => {
       properties: {
         b: { type: 'string' },
       },
-      required: [],
       additionalProperties: true,
     })
   })
@@ -152,11 +152,28 @@ describe('separateObjectSchema', () => {
 
     const [matched, rest] = separateObjectSchema(schema, ['a'])
 
-    expect(matched).toEqual({
-      ...schema,
-      properties: {},
-    })
+    expect(matched).toEqual(schema)
     expect(rest).toEqual(schema)
+  })
+
+  it('with empty properties & required', () => {
+    const schema: ObjectSchema = {
+      type: 'object',
+      description: 'description',
+      properties: {},
+      required: [],
+    }
+
+    const [matched, rest] = separateObjectSchema(schema, ['a'])
+
+    expect(matched).toEqual({
+      type: 'object',
+      description: 'description',
+    })
+    expect(rest).toEqual({
+      type: 'object',
+      description: 'description',
+    })
   })
 })
 

--- a/packages/openapi/src/schema-utils.test.ts
+++ b/packages/openapi/src/schema-utils.test.ts
@@ -7,6 +7,7 @@ import {
   filterSchemaBranches,
   isAnySchema,
   isFileSchema,
+  isNeverSchema,
   isObjectSchema,
   isPrimitiveSchema,
   separateObjectSchema,
@@ -37,6 +38,58 @@ it('isAnySchema', () => {
   expect(isAnySchema({ type: 'string' })).toBe(false)
   expect(isAnySchema({ description: 'description' })).toBe(true)
   expect(isAnySchema({ properties: undefined, required: undefined })).toBe(true)
+})
+
+describe('isNeverSchema', () => {
+  describe('returns true for never schemas', () => {
+    it('returns true for boolean false', () => {
+      expect(isNeverSchema(false)).toBe(true)
+    })
+
+    it('returns true for { not: true }', () => {
+      expect(isNeverSchema({ not: true })).toBe(true)
+    })
+
+    it('returns true for { not: {} }', () => {
+      expect(isNeverSchema({ not: {} })).toBe(true)
+    })
+  })
+
+  describe('returns false for non-never schemas', () => {
+    it('returns false for boolean true', () => {
+      expect(isNeverSchema(true)).toBe(false)
+    })
+
+    it('returns false for an empty schema {}', () => {
+      expect(isNeverSchema({})).toBe(false)
+    })
+
+    it('returns false for a type constraint', () => {
+      expect(isNeverSchema({ type: 'string' })).toBe(false)
+    })
+
+    it('returns false for { not: false } (double negation = always true)', () => {
+      expect(isNeverSchema({ not: false })).toBe(false)
+    })
+
+    it('returns false for { not: { type: \'string\' } } (only rejects strings)', () => {
+      expect(isNeverSchema({ not: { type: 'string' } })).toBe(false)
+    })
+
+    it('returns false for a schema with only additionalProperties', () => {
+      expect(isNeverSchema({ additionalProperties: false })).toBe(false)
+    })
+
+    it('returns false for a complex schema', () => {
+      expect(
+        isNeverSchema({
+          type: 'object',
+          properties: { id: { type: 'number' } },
+          required: ['id'],
+        }),
+      ).toBe(false)
+    })
+  })
 })
 
 describe('separateObjectSchema', () => {

--- a/packages/openapi/src/schema-utils.ts
+++ b/packages/openapi/src/schema-utils.ts
@@ -24,6 +24,10 @@ export function isAnySchema(schema: JSONSchema): boolean {
     return true
   }
 
+  if (isObject(schema) && 'not' in schema && isObject(schema.not) && Object.keys(schema.not).length === 0) {
+    return true
+  }
+
   if (
     Object
       .keys(schema)

--- a/packages/openapi/src/schema-utils.ts
+++ b/packages/openapi/src/schema-utils.ts
@@ -24,10 +24,6 @@ export function isAnySchema(schema: JSONSchema): boolean {
     return true
   }
 
-  if (isObject(schema) && 'not' in schema && isObject(schema.not) && Object.keys(schema.not).length === 0) {
-    return true
-  }
-
   if (
     Object
       .keys(schema)

--- a/packages/openapi/src/schema-utils.ts
+++ b/packages/openapi/src/schema-utils.ts
@@ -24,7 +24,12 @@ export function isAnySchema(schema: JSONSchema): boolean {
     return true
   }
 
-  if (Object.keys(schema).every(k => !LOGIC_KEYWORDS.includes(k))) {
+  if (
+    Object
+      .keys(schema)
+      .filter(v => schema[v as keyof typeof schema] !== undefined)
+      .every(k => !LOGIC_KEYWORDS.includes(k))
+  ) {
     return true
   }
 
@@ -57,7 +62,15 @@ export function separateObjectSchema(schema: ObjectSchema, separatedProperties: 
       return acc
     }, {})
 
+  if (Object.keys(matched.properties).length === 0) {
+    matched.properties = undefined
+  }
+
   matched.required = schema.required?.filter(key => separatedProperties.includes(key))
+
+  if (matched.required?.length === 0) {
+    matched.required = undefined
+  }
 
   matched.examples = schema.examples?.map((example) => {
     if (!isObject(example)) {
@@ -75,12 +88,16 @@ export function separateObjectSchema(schema: ObjectSchema, separatedProperties: 
 
   rest.properties = schema.properties && Object.entries(schema.properties)
     .filter(([key]) => !separatedProperties.includes(key))
-    .reduce((acc, [key, value]) => {
+    .reduce((acc: Record<string, JSONSchema> = {}, [key, value]) => {
       acc[key] = value
       return acc
-    }, {} as Record<string, JSONSchema>)
+    }, undefined)
 
   rest.required = schema.required?.filter(key => !separatedProperties.includes(key))
+
+  if (rest.required?.length === 0) {
+    rest.required = undefined
+  }
 
   rest.examples = schema.examples?.map((example) => {
     if (!isObject(example)) {

--- a/packages/openapi/src/schema-utils.ts
+++ b/packages/openapi/src/schema-utils.ts
@@ -36,6 +36,27 @@ export function isAnySchema(schema: JSONSchema): boolean {
   return false
 }
 
+export function isNeverSchema(schema: JSONSchema): boolean {
+  // Boolean `false` is the shorthand never-schema
+  if (schema === false) {
+    return true
+  }
+
+  if (typeof schema === 'object' && schema.not !== undefined) {
+    // `{ not: true }` — negation of the boolean catch-all
+    if (schema.not === true) {
+      return true
+    }
+
+    // `{ not: {} }` — negation of the empty object, which accepts everything
+    if (typeof schema.not === 'object' && Object.keys(schema.not).length === 0) {
+      return true
+    }
+  }
+
+  return false
+}
+
 /**
  * @internal
  */

--- a/packages/server/src/adapters/standard/rpc-codec.test.ts
+++ b/packages/server/src/adapters/standard/rpc-codec.test.ts
@@ -76,6 +76,20 @@ describe('standardRPCCodec', () => {
     expect(serializer.serialize).toHaveBeenCalledWith('__output__')
   })
 
+  it('.encode with ReadableStream bypasses serialization', () => {
+    const stream = new ReadableStream<Uint8Array>()
+
+    const response = codec.encode(stream, ping)
+
+    expect(response).toEqual({
+      status: 200,
+      headers: {},
+      body: stream,
+    })
+
+    expect(serializer.serialize).not.toHaveBeenCalled()
+  })
+
   it('.encodeError', async () => {
     serializer.serialize.mockReturnValueOnce('__serialized__')
 

--- a/packages/server/src/adapters/standard/rpc-codec.ts
+++ b/packages/server/src/adapters/standard/rpc-codec.ts
@@ -20,6 +20,14 @@ export class StandardRPCCodec implements StandardCodec {
   }
 
   encode(output: unknown, _procedure: AnyProcedure): StandardResponse {
+    if (output instanceof ReadableStream) {
+      return {
+        status: 200,
+        headers: {},
+        body: output,
+      }
+    }
+
     return {
       status: 200,
       headers: {},

--- a/packages/standard-server-fetch/src/body.test.ts
+++ b/packages/standard-server-fetch/src/body.test.ts
@@ -279,6 +279,8 @@ describe('toFetchBody', () => {
 
   it('readable stream', async () => {
     const headers = new Headers(baseHeaders)
+    headers.set('content-type', 'application/zip')
+    headers.set('content-disposition', 'attachment; filename="archive.zip"')
     const stream = new ReadableStream<Uint8Array>({
       start(controller) {
         controller.enqueue(new TextEncoder().encode('hello'))
@@ -290,6 +292,8 @@ describe('toFetchBody', () => {
 
     expect(body).toBe(stream)
     expect([...headers]).toEqual([
+      ['content-disposition', 'attachment; filename="archive.zip"'],
+      ['content-type', 'application/zip'],
       ['x-custom-header', 'custom-value'],
     ])
 

--- a/packages/standard-server-fetch/src/body.test.ts
+++ b/packages/standard-server-fetch/src/body.test.ts
@@ -277,6 +277,26 @@ describe('toFetchBody', () => {
     expect(generateContentDispositionSpy).toHaveBeenCalledTimes(0)
   })
 
+  it('readable stream', async () => {
+    const headers = new Headers(baseHeaders)
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('hello'))
+        controller.close()
+      },
+    })
+
+    const body = toFetchBody(stream, headers, {})
+
+    expect(body).toBe(stream)
+    expect([...headers]).toEqual([
+      ['x-custom-header', 'custom-value'],
+    ])
+
+    const text = await new Response(body).text()
+    expect(text).toBe('hello')
+  })
+
   it('async generator', async () => {
     async function* gen() {
       yield 123

--- a/packages/standard-server-fetch/src/body.ts
+++ b/packages/standard-server-fetch/src/body.ts
@@ -67,6 +67,10 @@ export function toFetchBody(
   headers: Headers,
   options: ToFetchBodyOptions = {},
 ): string | Blob | FormData | URLSearchParams | undefined | ReadableStream<Uint8Array> {
+  if (body instanceof ReadableStream) {
+    return body
+  }
+
   const currentContentDisposition = headers.get('content-disposition')
 
   headers.delete('content-type')
@@ -92,10 +96,6 @@ export function toFetchBody(
   }
 
   if (body instanceof URLSearchParams) {
-    return body
-  }
-
-  if (body instanceof ReadableStream) {
     return body
   }
 

--- a/packages/standard-server-fetch/src/body.ts
+++ b/packages/standard-server-fetch/src/body.ts
@@ -95,6 +95,10 @@ export function toFetchBody(
     return body
   }
 
+  if (body instanceof ReadableStream) {
+    return body
+  }
+
   if (isAsyncIteratorObject(body)) {
     headers.set('content-type', 'text/event-stream')
 

--- a/packages/standard-server-node/src/body.test.ts
+++ b/packages/standard-server-node/src/body.test.ts
@@ -405,6 +405,26 @@ describe('toNodeHttpBody', () => {
     expect(await resBlob.text()).toBe('foo')
   })
 
+  it('readable stream', async () => {
+    const headers = { ...baseHeaders }
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('hello'))
+        controller.close()
+      },
+    })
+
+    const body = toNodeHttpBody(stream, headers, {})
+
+    expect(body).toBeInstanceOf(Readable)
+    expect(headers).toEqual({
+      'x-custom-header': 'custom-value',
+    })
+
+    const text = await new Response(body).text()
+    expect(text).toBe('hello')
+  })
+
   it('async generator', async () => {
     async function* gen() {
       yield 123

--- a/packages/standard-server-node/src/body.test.ts
+++ b/packages/standard-server-node/src/body.test.ts
@@ -406,7 +406,11 @@ describe('toNodeHttpBody', () => {
   })
 
   it('readable stream', async () => {
-    const headers = { ...baseHeaders }
+    const headers = {
+      ...baseHeaders,
+      'content-type': 'application/zip',
+      'content-disposition': 'attachment; filename="archive.zip"',
+    }
     const stream = new ReadableStream<Uint8Array>({
       start(controller) {
         controller.enqueue(new TextEncoder().encode('hello'))
@@ -418,6 +422,8 @@ describe('toNodeHttpBody', () => {
 
     expect(body).toBeInstanceOf(Readable)
     expect(headers).toEqual({
+      'content-disposition': 'attachment; filename="archive.zip"',
+      'content-type': 'application/zip',
       'x-custom-header': 'custom-value',
     })
 

--- a/packages/standard-server-node/src/body.ts
+++ b/packages/standard-server-node/src/body.ts
@@ -92,6 +92,10 @@ export function toNodeHttpBody(
     return body.toString()
   }
 
+  if (body instanceof ReadableStream) {
+    return Readable.fromWeb(body)
+  }
+
   if (isAsyncIteratorObject(body)) {
     headers['content-type'] = 'text/event-stream'
 

--- a/packages/standard-server-node/src/body.ts
+++ b/packages/standard-server-node/src/body.ts
@@ -62,6 +62,10 @@ export function toNodeHttpBody(
   headers: StandardHeaders,
   options: ToNodeHttpBodyOptions = {},
 ): Readable | undefined | string {
+  if (body instanceof ReadableStream) {
+    return Readable.fromWeb(body)
+  }
+
   const currentContentDisposition = flattenHeader(headers['content-disposition'])
 
   delete headers['content-type']
@@ -90,10 +94,6 @@ export function toNodeHttpBody(
     headers['content-type'] = 'application/x-www-form-urlencoded'
 
     return body.toString()
-  }
-
-  if (body instanceof ReadableStream) {
-    return Readable.fromWeb(body)
   }
 
   if (isAsyncIteratorObject(body)) {

--- a/packages/standard-server/src/types.ts
+++ b/packages/standard-server/src/types.ts
@@ -9,6 +9,7 @@ export type StandardBody
     | URLSearchParams
     | FormData
     | AsyncIterator<unknown | void, unknown | void, undefined>
+    | ReadableStream<Uint8Array>
 
 export interface StandardRequest {
   method: string

--- a/packages/standard-server/src/utils.ts
+++ b/packages/standard-server/src/utils.ts
@@ -1,7 +1,7 @@
 import type { StandardHeaders, StandardLazyResponse } from './types'
 import { isAsyncIteratorObject, once, replicateAsyncIterator, toArray, tryDecodeURIComponent } from '@orpc/shared'
 
-export function generateContentDisposition(filename: string): string {
+export function generateContentDisposition(filename: string, disposition: 'inline' | 'attachment' = 'inline'): string {
   const encodedFileName = filename.replace(/[^\x20-\x7E]/g, '_').replace(/"/g, '\\"')
 
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#encoding_for_content-disposition_and_link_headers
@@ -9,7 +9,7 @@ export function generateContentDisposition(filename: string): string {
     .replace(/['()*]/g, c => `%${c.charCodeAt(0).toString(16).toUpperCase()}`)
     .replace(/%(7C|60|5E)/g, (str, hex) => String.fromCharCode(Number.parseInt(hex, 16)))
 
-  return `inline; filename="${encodedFileName}"; filename*=utf-8\'\'${encodedFilenameStar}`
+  return `${disposition}; filename="${encodedFileName}"; filename*=utf-8\'\'${encodedFilenameStar}`
 }
 
 export function getFilenameFromContentDisposition(contentDisposition: string): string | undefined {


### PR DESCRIPTION
## Summary

Adds **partial** support for returning a `ReadableStream<Uint8Array>` directly from an oRPC handler (OpenAPIHandler only), bypassing JSON serialization. This enables streaming binary responses (ZIP archives, large file downloads, chunked transfer) without buffering the full response in memory.

> **Note:** Full ecosystem support (RPCHandler/Link, OpenAPILink, WebSocket adapters, etc.) is planned for v2 — see [#1058](https://github.com/middleapi/orpc/issues/1058#issuecomment-3499519557). This PR intentionally does **not** close #1058.

### Stream passthrough

- **`@orpc/standard-server`** — adds `ReadableStream<Uint8Array>` to the `StandardBody` union type
- **`@orpc/server`** — `StandardRPCCodec.encode()` detects `ReadableStream` and passes it through without serializing
- **`@orpc/openapi`** — `StandardOpenAPICodec.encode()` detects `ReadableStream` (both as direct return and inside `{ body: stream, headers }` detailed output), respects the contract's `successStatus`, and bypasses serialization
- **`@orpc/standard-server-fetch`** — `toFetchBody()` returns the stream directly; the `ReadableStream` branch runs before header cleanup so caller-set `content-type`/`content-disposition` are preserved
- **`@orpc/standard-server-node`** — `toNodeHttpBody()` converts via `Readable.fromWeb()`; same header-preservation fix
- **`@orpc/standard-server`** — `generateContentDisposition()` gets an optional `disposition` parameter (defaults to `'inline'`, fully backward-compatible)

### OpenAPI spec cleanup (fixes #1536)

- **`@orpc/openapi`** — `separateObjectSchema` no longer leaves empty `properties: {}` / `required: []` on extracted schemas (replaces them with `undefined`)
- **`@orpc/openapi`** — new `isNeverSchema()` helper identifies `false` / `{ not: true }` / `{ not: {} }` schemas; `toOpenAPIContent()` now skips the spurious `application/json: { schema: { not: {} } }` entry that used to appear alongside binary content (e.g. when using `oz.openapi(z.instanceof(ReadableStream), { contentMediaType: 'application/zip' })`)
- **`@orpc/openapi`** — generator skips emitting an empty `requestBody` for POST routes whose input consists only of path parameters

Tests added for all new paths including header preservation, detailed-output streaming, never-schema detection, and the empty-requestBody case.

## Backward compatibility

This is a non-breaking change.

- Previously, returning a `ReadableStream` from a handler would result in it being serialized as `{}` (or a runtime error), which is not useful behaviour anyone would rely on.
- `generateContentDisposition()`'s new `disposition` parameter defaults to `'inline'`, preserving existing output.
- The OpenAPI spec cleanups only suppress output that was previously noise (empty bodies, `not: {}` alongside real content).

Existing handlers and generated specs are unaffected.

## Motivation

We are migrating a service from Hapi.js to Hono + oRPC. One endpoint streams a ZIP archive on-the-fly using `archiver` — the archive must be piped directly to the response. All existing workarounds (returning `new Response(stream)`, `oz.blob()`, casting) either fail at runtime or require bypassing oRPC entirely, losing auth middleware and client-library support.

Relates to #1058 (partial — OpenAPIHandler only)
Closes #1536

## Test plan

- [ ] `pnpm --filter @orpc/standard-server test`
- [ ] `pnpm --filter @orpc/server test`
- [ ] `pnpm --filter @orpc/openapi test`
- [ ] `pnpm --filter @orpc/standard-server-fetch test`
- [ ] `pnpm --filter @orpc/standard-server-node test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)