### PR TITLE
fix(tanstack-query): narrow live options defaults type

### DIFF
--- a/packages/tanstack-query/src/procedure-utils.test-d.ts
+++ b/packages/tanstack-query/src/procedure-utils.test-d.ts
@@ -852,7 +852,7 @@ describe('ProcedureUtilsDefaults', () => {
     }
   })
 
-  it('experimental_liveOptions should accept Partial<StreamedOptionsIn>', () => {
+  it('experimental_liveOptions should accept Partial<QueryOptionsIn>', () => {
     const defaults: TestDefaults = {
       experimental_liveOptions: {
         input: { search: 'test' },
@@ -865,6 +865,13 @@ describe('ProcedureUtilsDefaults', () => {
       experimental_liveOptions: {
         // @ts-expect-error - invalid input type
         input: { invalid: 'test' },
+      },
+    }
+
+    const _invalidStreamedOption: TestDefaults = {
+      experimental_liveOptions: {
+        // @ts-expect-error - queryFnOptions is only supported by experimental_streamedOptions
+        queryFnOptions: { maxChunks: 10 },
       },
     }
   })

--- a/packages/tanstack-query/src/procedure-utils.ts
+++ b/packages/tanstack-query/src/procedure-utils.ts
@@ -198,7 +198,7 @@ export interface experimental_ProcedureUtilsDefaults<TClientContext extends Clie
    * @see {@link https://orpc.dev/docs/integrations/tanstack-query#live-query-options Tanstack Live Query Options Utility Docs}
    */
   experimental_liveOptions?: Partial<
-    StreamedOptionsIn<TClientContext, TInput, experimental_LiveQueryOutput<TOutput>, TError, unknown>
+    QueryOptionsIn<TClientContext, TInput, experimental_LiveQueryOutput<TOutput>, TError, unknown>
   >
 
   /**


### PR DESCRIPTION
## Summary

- Narrow experimental_liveOptions defaults to QueryOptionsIn instead of StreamedOptionsIn
- Add a type test ensuring streamed-only queryFnOptions is rejected for live defaults

## Tests

- pnpm --filter @orpc/tanstack-query type:check
- pnpm vitest run packages/tanstack-query/src/procedure-utils.test.ts
- pnpm run type:check
- pnpm exec eslint --max-warnings=0 packages/tanstack-query/src/procedure-utils.ts packages/tanstack-query/src/procedure-utils.test-d.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type validation for the experimental live query feature to use correct type definitions and enforce requirements properly.

* **Tests**
  * Added type assertions to ensure the experimental live query options correctly validate input and reject incompatible configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/middleapi/orpc/pull/1568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->