### PR TITLE
feat(tanstack-query): support defaults factory

### DIFF
--- a/apps/content/docs/integrations/tanstack-query.md
+++ b/apps/content/docs/integrations/tanstack-query.md
@@ -245,20 +245,12 @@ const orpc = createTanstackQueryUtils(client, {
           staleTime: 30 * 1000,
         },
       },
-      create: {
-        mutationOptions: {
-          onSuccess: (output, input, _, ctx) => {
-            ctx.client.invalidateQueries({ queryKey: orpc.planet.key() })
-          },
-        },
-      },
     },
   },
 })
 
 // These will automatically use the default options
 const query = useQuery(orpc.planet.find.queryOptions({ input: { id: 123 } }))
-const mutation = useMutation(orpc.planet.create.mutationOptions())
 
 // User-provided options override defaults
 const customQuery = useQuery(orpc.planet.find.queryOptions({
@@ -266,6 +258,30 @@ const customQuery = useQuery(orpc.planet.find.queryOptions({
   staleTime: 0, // overrides the default
 }))
 ```
+
+When defaults need to reference generated query or mutation keys, use the function form. The function receives the same typed utils returned by `createTanstackQueryUtils`, avoiding self-references when configuring mutation side effects:
+
+```ts
+const orpc = createTanstackQueryUtils(client, {
+  experimental_defaults: utils => ({
+    planet: {
+      create: {
+        mutationOptions: {
+          onSuccess: (_, __, ___, ctx) => {
+            ctx.client.invalidateQueries({
+              queryKey: utils.planet.key(),
+            })
+          },
+        },
+      },
+    },
+  }),
+})
+```
+
+::: info
+Default options are still shallow spread merged. If a call provides the same lifecycle callback, such as `onSuccess`, it overrides the default callback instead of composing both callbacks.
+:::
 
 ## Client Context
 

--- a/packages/tanstack-query/src/router-utils.test-d.ts
+++ b/packages/tanstack-query/src/router-utils.test-d.ts
@@ -4,7 +4,7 @@ import type { baseErrorMap } from '../../contract/tests/shared'
 import type { router } from '../../server/tests/shared'
 import type { GeneralUtils } from './general-utils'
 import type { experimental_ProcedureUtilsDefaults, ProcedureUtils } from './procedure-utils'
-import type { experimental_RouterUtilsDefaults, RouterUtils } from './router-utils'
+import type { experimental_RouterUtilsDefaults, experimental_RouterUtilsDefaultsOption, RouterUtils } from './router-utils'
 import { createRouterUtils } from './router-utils'
 
 it('RouterUtils', () => {
@@ -78,6 +78,37 @@ it('createRouterUtils', () => {
         },
       },
     },
+  })
+
+  expectTypeOf(utils).toEqualTypeOf<RouterUtils<RouterClient<typeof router, { batch?: boolean }>>>()
+})
+
+it('createRouterUtils with defaults factory', () => {
+  const defaults = ((utils) => {
+    utils.nested.ping.key({ input: { input: 123 } })
+    // @ts-expect-error - invalid input type
+    utils.nested.ping.key({ input: { input: '123' } })
+
+    return {
+      nested: {
+        ping: {
+          mutationOptions: {
+            onSuccess: (output, input, _, ctx) => {
+              expectTypeOf(output).toEqualTypeOf<{ output: string }>()
+              expectTypeOf(input).toEqualTypeOf<{ input: number }>()
+
+              ctx.client.invalidateQueries({
+                queryKey: utils.nested.ping.key(),
+              })
+            },
+          },
+        },
+      },
+    }
+  }) satisfies experimental_RouterUtilsDefaultsOption<RouterClient<typeof router, { batch?: boolean }>>
+
+  const utils = createRouterUtils({} as RouterClient<typeof router, { batch?: boolean }>, {
+    experimental_defaults: defaults,
   })
 
   expectTypeOf(utils).toEqualTypeOf<RouterUtils<RouterClient<typeof router, { batch?: boolean }>>>()

--- a/packages/tanstack-query/src/router-utils.test.ts
+++ b/packages/tanstack-query/src/router-utils.test.ts
@@ -91,4 +91,34 @@ describe('createRouterUtils', () => {
     })
     expect(pongUtils.queryOptions().staleTime).not.toBeDefined()
   })
+
+  it('with defaults factory', () => {
+    const appClient = vi.fn() as any
+    appClient.planet = vi.fn()
+
+    const defaultsFactory = vi.fn((utils: any) => ({
+      planet: {
+        mutationOptions: {
+          mutationKey: utils.planet.mutationKey(),
+        },
+      },
+    }))
+
+    const utils = createRouterUtils(appClient, {
+      experimental_defaults: defaultsFactory,
+    }) as any
+
+    expect(defaultsFactory).toHaveBeenCalledTimes(1)
+
+    const planetDefaults = defaultsFactory.mock.results[0]!.value.planet
+
+    vi.clearAllMocks()
+    const planetUtils = utils.planet
+
+    expect(procedureUtilsSpy).toHaveBeenCalledWith(appClient.planet, {
+      path: ['planet'],
+      experimental_defaults: planetDefaults,
+    })
+    expect(planetUtils.mutationOptions().mutationKey).toEqual(planetUtils.mutationKey())
+  })
 })

--- a/packages/tanstack-query/src/router-utils.ts
+++ b/packages/tanstack-query/src/router-utils.ts
@@ -19,12 +19,16 @@ export type experimental_RouterUtilsDefaults<T extends NestedClient<any>>
         [K in keyof T]?: T[K] extends NestedClient<any> ? experimental_RouterUtilsDefaults<T[K]> : never
       }
 
+export type experimental_RouterUtilsDefaultsOption<T extends NestedClient<any>>
+  = | experimental_RouterUtilsDefaults<T>
+    | ((utils: RouterUtils<T>) => experimental_RouterUtilsDefaults<T>)
+
 /**
  * @todo remove default generic types on v2
  */
 export interface CreateRouterUtilsOptions<T extends NestedClient<any> = NestedClient<any>> {
   path?: readonly string[]
-  experimental_defaults?: experimental_RouterUtilsDefaults<T>
+  experimental_defaults?: experimental_RouterUtilsDefaultsOption<T>
 }
 
 /**
@@ -38,11 +42,14 @@ export function createRouterUtils<T extends NestedClient<any>>(
   options: CreateRouterUtilsOptions<T> = {},
 ): RouterUtils<T> {
   const path = toArray(options.path)
+  const experimental_defaults = typeof options.experimental_defaults === 'function'
+    ? options.experimental_defaults(createRouterUtils(client, { path }))
+    : options.experimental_defaults
 
   const generalUtils = createGeneralUtils(path)
   const procedureUtils = createProcedureUtils(client as any, {
     path,
-    experimental_defaults: options.experimental_defaults,
+    experimental_defaults,
   })
 
   const recursive = new Proxy({
@@ -57,9 +64,8 @@ export function createRouterUtils<T extends NestedClient<any>>(
       }
 
       const nextUtils = createRouterUtils((client as any)[prop], {
-        ...options,
         path: [...path, prop],
-        experimental_defaults: get(options.experimental_defaults, [prop]) as any,
+        experimental_defaults: get(experimental_defaults, [prop]) as any,
       })
 
       if (typeof value !== 'function') {


### PR DESCRIPTION
Fixes #1569.

This lets `experimental_defaults` take a function in addition to the existing object form:

```ts
createTanstackQueryUtils(client, {
  experimental_defaults: utils => ({
    planet: {
      create: {
        mutationOptions: {
          onSuccess: (_, __, ___, ctx) => {
            ctx.client.invalidateQueries({
              queryKey: utils.planet.key(),
            })
          },
        },
      },
    },
  }),
})
```

The goal is to keep procedure-level server-state defaults close to the router while avoiding a self-reference to the outer `orpc` variable. The object form keeps working, and defaults still use the existing shallow merge behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * experimental_defaults parameter now accepts either an object or a factory function for dynamic configuration.

* **Documentation**
  * Updated integration guide with expanded guidance on using defaults with mutation side effects, including examples using generated query keys. Added clarification on shallow merge behavior and callback override semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/middleapi/orpc/pull/1570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->