### PR TITLE
fix(client): reject calls when websocket is not open instead of sending into a closed socket

### DIFF
--- a/packages/client/src/adapters/websocket/link-client.ts
+++ b/packages/client/src/adapters/websocket/link-client.ts
@@ -11,26 +11,26 @@ const WEBSOCKET_CONNECTING = 0 satisfies WebSocket['CONNECTING']
 const WEBSOCKET_OPEN = 1 satisfies WebSocket['OPEN']
 
 export interface LinkWebsocketClientOptions {
-  websocket: Pick<WebSocket, 'addEventListener' | 'send' | 'readyState'>
+  websocket: Pick<WebSocket, 'addEventListener' | 'removeEventListener' | 'send' | 'readyState'>
 }
 
 export class LinkWebsocketClient<T extends ClientContext> implements StandardLinkClient<T> {
   private readonly peer: ClientPeer
 
   constructor(options: LinkWebsocketClientOptions) {
-    const untilOpen = new Promise<void>((resolve) => {
-      if (options.websocket.readyState === WEBSOCKET_CONNECTING) {
-        options.websocket.addEventListener('open', () => {
-          resolve()
-        }, { once: true })
-      }
-      else {
-        resolve()
-      }
-    })
-
     this.peer = new ClientPeer(async (message) => {
-      await untilOpen
+      if (options.websocket.readyState === WEBSOCKET_CONNECTING) {
+        await new Promise<void>((resolve) => {
+          const settle = () => {
+            options.websocket.removeEventListener('open', settle)
+            options.websocket.removeEventListener('close', settle)
+            resolve()
+          }
+
+          options.websocket.addEventListener('open', settle, { once: true })
+          options.websocket.addEventListener('close', settle, { once: true })
+        })
+      }
 
       if (options.websocket.readyState !== WEBSOCKET_OPEN) {
         throw new Error('Cannot send message, WebSocket is not open.')

--- a/packages/client/src/adapters/websocket/link-client.ts
+++ b/packages/client/src/adapters/websocket/link-client.ts
@@ -8,6 +8,7 @@ import { ClientPeer } from '@orpc/standard-server-peer'
  * Some env maybe not available WebSocket global
  */
 const WEBSOCKET_CONNECTING = 0 satisfies WebSocket['CONNECTING']
+const WEBSOCKET_OPEN = 1 satisfies WebSocket['OPEN']
 
 export interface LinkWebsocketClientOptions {
   websocket: Pick<WebSocket, 'addEventListener' | 'send' | 'readyState'>
@@ -30,6 +31,11 @@ export class LinkWebsocketClient<T extends ClientContext> implements StandardLin
 
     this.peer = new ClientPeer(async (message) => {
       await untilOpen
+
+      if (options.websocket.readyState !== WEBSOCKET_OPEN) {
+        throw new Error('Cannot send message, WebSocket is not open.')
+      }
+
       return options.websocket.send(message)
     })
 

--- a/packages/client/src/adapters/websocket/rpc-link.test.ts
+++ b/packages/client/src/adapters/websocket/rpc-link.test.ts
@@ -18,6 +18,7 @@ describe('rpcLink', () => {
       if (event === 'close')
         onClose = callback
     }),
+    removeEventListener: vi.fn(),
     send: vi.fn(),
   }
 
@@ -88,6 +89,7 @@ describe('rpcLink', () => {
         if (event === 'open')
           onOpen = callback
       }),
+      removeEventListener: vi.fn(),
       send: vi.fn(),
     }
     const orpc = createORPCClient(new RPCLink({
@@ -109,42 +111,99 @@ describe('rpcLink', () => {
     await promise
   })
 
-  it('rejects instead of sending when socket is not open', async () => {
-    const websocket = {
-      readyState: 3,
-      addEventListener: vi.fn(),
-      send: vi.fn(),
+  describe('non-open sockets', () => {
+    function createWebSocket(readyState: number) {
+      const listeners = new Map<string, Set<(event?: any) => void>>()
+
+      return {
+        readyState,
+        addEventListener: vi.fn((event: string, callback: (event?: any) => void) => {
+          if (!listeners.has(event)) {
+            listeners.set(event, new Set())
+          }
+          listeners.get(event)!.add(callback)
+        }),
+        removeEventListener: vi.fn((event: string, callback: (event?: any) => void) => {
+          listeners.get(event)?.delete(callback)
+        }),
+        send: vi.fn(),
+        emit: (event: string, payload?: any) => {
+          [...listeners.get(event) ?? []].forEach(callback => callback(payload))
+        },
+      }
     }
-    const orpc = createORPCClient(new RPCLink({
-      websocket,
-    })) as any
 
-    await expect(orpc.ping('input')).rejects.toThrow('WebSocket is not open')
-    expect(websocket.send).toHaveBeenCalledTimes(0)
-  })
+    it('rejects instead of sending when socket is not open', async () => {
+      const websocket = createWebSocket(3)
+      const orpc = createORPCClient(new RPCLink({
+        websocket,
+      })) as any
 
-  it('rejects instead of sending when socket closes between requests (reconnecting wrappers)', async () => {
-    const websocket = {
-      readyState: 1,
-      addEventListener: vi.fn((event, callback) => {
-        if (event === 'message')
-          onMessage = callback
-      }),
-      send: vi.fn(),
-    }
-    const orpc = createORPCClient(new RPCLink({
-      websocket,
-    })) as any
+      await expect(orpc.ping('input')).rejects.toThrow('WebSocket is not open')
+      expect(websocket.send).toHaveBeenCalledTimes(0)
+    })
 
-    const promise = expect(orpc.ping('input')).resolves.toEqual('pong')
-    await vi.waitFor(() => expect(websocket.send).toHaveBeenCalledTimes(1))
-    const [id] = (await decodeRequestMessage(websocket.send.mock.calls[0]![0]))
-    onMessage({ data: await encodeResponseMessage(id, MessageType.RESPONSE, { body: { json: 'pong' }, status: 200, headers: {} }) })
-    await promise
+    it('rejects instead of sending when socket closes between requests (reconnecting wrappers)', async () => {
+      const websocket = createWebSocket(1)
+      const orpc = createORPCClient(new RPCLink({
+        websocket,
+      })) as any
 
-    websocket.readyState = 3
+      const promise = expect(orpc.ping('input')).resolves.toEqual('pong')
+      await vi.waitFor(() => expect(websocket.send).toHaveBeenCalledTimes(1))
+      const [id] = (await decodeRequestMessage(websocket.send.mock.calls[0]![0]))
+      websocket.emit('message', { data: await encodeResponseMessage(id, MessageType.RESPONSE, { body: { json: 'pong' }, status: 200, headers: {} }) })
+      await promise
 
-    await expect(orpc.ping('input')).rejects.toThrow('WebSocket is not open')
-    expect(websocket.send).toHaveBeenCalledTimes(1)
+      websocket.readyState = 3
+
+      await expect(orpc.ping('input')).rejects.toThrow('WebSocket is not open')
+      expect(websocket.send).toHaveBeenCalledTimes(1)
+    })
+
+    it('waits during a reconnect window and sends once reopened', async () => {
+      const websocket = createWebSocket(1)
+      const orpc = createORPCClient(new RPCLink({
+        websocket,
+      })) as any
+
+      websocket.readyState = 0
+
+      const promise = expect(orpc.ping('input')).resolves.toEqual('pong')
+
+      await new Promise(resolve => setTimeout(resolve, 10))
+      expect(websocket.send).toHaveBeenCalledTimes(0)
+
+      websocket.readyState = 1
+      websocket.emit('open')
+      await vi.waitFor(() => expect(websocket.send).toHaveBeenCalledTimes(1))
+
+      const [id] = (await decodeRequestMessage(websocket.send.mock.calls[0]![0]))
+      websocket.emit('message', { data: await encodeResponseMessage(id, MessageType.RESPONSE, { body: { json: 'pong' }, status: 200, headers: {} }) })
+
+      await promise
+    })
+
+    it('rejects without sending when a reconnect attempt fails', async () => {
+      const websocket = createWebSocket(0)
+      const orpc = createORPCClient(new RPCLink({
+        websocket,
+      })) as any
+
+      const promise = expect(orpc.ping('input')).rejects.toThrow(/aborted|not open/)
+
+      await new Promise(resolve => setTimeout(resolve, 10))
+      expect(websocket.send).toHaveBeenCalledTimes(0)
+
+      websocket.readyState = 3
+      websocket.emit('close')
+
+      await promise
+
+      websocket.readyState = 1
+      websocket.emit('open')
+      await new Promise(resolve => setTimeout(resolve, 10))
+      expect(websocket.send).toHaveBeenCalledTimes(0)
+    })
   })
 })

--- a/packages/client/src/adapters/websocket/rpc-link.test.ts
+++ b/packages/client/src/adapters/websocket/rpc-link.test.ts
@@ -99,6 +99,7 @@ describe('rpcLink', () => {
     await new Promise(resolve => setTimeout(resolve, 10))
     expect(websocket.send).toHaveBeenCalledTimes(0)
 
+    websocket.readyState = 1
     onOpen()
     await vi.waitFor(() => expect(websocket.send).toHaveBeenCalledTimes(1))
 
@@ -106,5 +107,44 @@ describe('rpcLink', () => {
     onMessage({ data: await encodeResponseMessage(id, MessageType.RESPONSE, { body: { json: 'pong' }, status: 200, headers: {} }) })
 
     await promise
+  })
+
+  it('rejects instead of sending when socket is not open', async () => {
+    const websocket = {
+      readyState: 3,
+      addEventListener: vi.fn(),
+      send: vi.fn(),
+    }
+    const orpc = createORPCClient(new RPCLink({
+      websocket,
+    })) as any
+
+    await expect(orpc.ping('input')).rejects.toThrow('WebSocket is not open')
+    expect(websocket.send).toHaveBeenCalledTimes(0)
+  })
+
+  it('rejects instead of sending when socket closes between requests (reconnecting wrappers)', async () => {
+    const websocket = {
+      readyState: 1,
+      addEventListener: vi.fn((event, callback) => {
+        if (event === 'message')
+          onMessage = callback
+      }),
+      send: vi.fn(),
+    }
+    const orpc = createORPCClient(new RPCLink({
+      websocket,
+    })) as any
+
+    const promise = expect(orpc.ping('input')).resolves.toEqual('pong')
+    await vi.waitFor(() => expect(websocket.send).toHaveBeenCalledTimes(1))
+    const [id] = (await decodeRequestMessage(websocket.send.mock.calls[0]![0]))
+    onMessage({ data: await encodeResponseMessage(id, MessageType.RESPONSE, { body: { json: 'pong' }, status: 200, headers: {} }) })
+    await promise
+
+    websocket.readyState = 3
+
+    await expect(orpc.ping('input')).rejects.toThrow('WebSocket is not open')
+    expect(websocket.send).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION
## Problem

`LinkWebsocketClient` calls `websocket.send()` without checking the socket state. With a plain WebSocket this doesn't matter, but with reconnecting sockets like partysocket (which the docs recommend) it breaks in two ways:

- Frames sent while disconnected are buffered and replayed onto the next connection. By then the client peer has already rejected those calls and forgotten their ids (the close handler calls `peer.close()`), so the server ends up with ghost requests, e.g. duplicate event-iterator subscriptions streaming everything twice (or N times), and mutations that get re-executed.
- With `maxEnqueuedMessages: 0` on partysocket's side: the frame is silently dropped, but the peer still awaits a response forever. The call never settles, so caller retry logic never runs.

Easy to reproduce: subscribe to an event iterator, kill the server for ~20s while the client retries, bring it back. Each retry leaves one buffered REQUEST frame, and on reconnect they all become live server-side subscriptions.

## Fix

Each send now dispatches on `readyState`:

- **`OPEN`** => send, as before.
- **`CONNECTING`** => wait for the next `open`/`close` event, then re-check. This covers the initial connect (replacing the constructor-level `untilOpen`) and also reconnect windows on reconnecting sockets: a call made while an attempt is in flight is sent once the connection opens, or rejected if the attempt fails, instead of erroring out during a routinely-occurring ~50ms window.
- **`CLOSING`/`CLOSED`** => throw. `peer.request()` already handles a throwing send by rejecting the call, so callers get an immediate error instead of a hang or a ghost frame.

Native WebSocket behavior is unchanged: `CONNECTING` only happens before the first open, and after a close all pending calls are rejected anyway. The guard only turns a send into a dead socket from a silent no-op into a proper rejection.

One behavioral note: frames can no longer be buffered across a reconnect by the socket wrapper. I think that's correct: request ids are connection-scoped, so replaying frames onto a new connection is never safe, and callers already have to handle rejection since close rejects everything in flight. (The wait-during-CONNECTING path is safe for the same reason in reverse: if a call is rejected while its frame is waiting, `ClientPeer`'s id-guard drops the frame instead of sending it.)