### PR TITLE
refactor(rpc, openapi): treat any status code below 400 as a successful response

### DIFF
--- a/apps/content/docs/openapi/handler.md
+++ b/apps/content/docs/openapi/handler.md
@@ -190,6 +190,9 @@ By default, `OpenAPIHandler` determines response status codes using `COMMON_ERRO
 import { COMMON_ERROR_STATUS_MAP } from '@orpc/openapi'
 
 const handler = new OpenAPIHandler(router, {
+  /**
+   * The status code should be in the `4xx` or `5xx` range (must be greater than or equal to `400`).
+   */
   errorStatusMap: {
     ...COMMON_ERROR_STATUS_MAP,
     CUSTOM_ERROR: 599,

--- a/apps/content/docs/openapi/input-and-output-mapping.md
+++ b/apps/content/docs/openapi/input-and-output-mapping.md
@@ -144,7 +144,7 @@ When using delimited styles, do not use delimiter characters like `,`, ` `, or `
 
 ## Output Mapping
 
-By default, oRPC uses `compact` mode. The procedure's return value becomes the response body, and the status code comes from `successStatus`, which defaults to `200`.
+By default, oRPC uses `compact` mode. The procedure's return value becomes the response body, and the status code comes from `successStatus`, which defaults to `200` (should be in the `2xx` range and must be less than `400`).
 
 ```ts
 const getPlanet = os
@@ -158,7 +158,7 @@ const getPlanet = os
 
 In `detailed` mode, return an object with the following fields:
 
-- `status`: optional success status code _(defaults to `successStatus`)_
+- `status`: optional success status code _(defaults to `successStatus`, should be in the `2xx` range and must be less than `400`)_
 - `headers`: optional response headers in lower-case keys
 - `body`: optional response body
 

--- a/apps/content/docs/rpc/handler.md
+++ b/apps/content/docs/rpc/handler.md
@@ -203,6 +203,9 @@ By default, `RPCHandler` uses `COMMON_ERROR_STATUS_MAP` to determine response st
 import { COMMON_ERROR_STATUS_MAP } from '@orpc/server'
 
 const handler = new RPCHandler(router, {
+  /**
+   * The status code should be in the `4xx` or `5xx` range (must be greater than or equal to `400`).
+   */
   errorStatusMap: {
     ...COMMON_ERROR_STATUS_MAP,
     CUSTOM_ERROR: 599,

--- a/apps/content/docs/rpc/protocol.md
+++ b/apps/content/docs/rpc/protocol.md
@@ -103,7 +103,7 @@ Content-Type: application/json
 }
 ```
 
-A successful response uses an HTTP status code in the `200-299` range and returns the procedure output.
+A successful response should use an HTTP status code in the `2xx` range (must be less than `400`) and return the procedure output.
 
 ::: info
 Response bodies depend on the serializer and are not plain JSON. Learn more in [RPC Serializer Format](/docs/rpc/serializer#serialization-format).
@@ -129,7 +129,7 @@ Content-Type: application/json
 }
 ```
 
-An error response uses an HTTP status code in the `400-599` range and returns an `ORPCError` object.
+An error response should use an HTTP status code in the `4xx` or `5xx` range (must be greater than or equal to `400`) and return an [ORPCError](/docs/rpc/error) object.
 
 ::: info
 Response bodies depend on the serializer and are not plain JSON. Learn more in [RPC Serializer Format](/docs/rpc/serializer#serialization-format).

--- a/packages/client/src/adapters/standard/rpc-link-codec.test.ts
+++ b/packages/client/src/adapters/standard/rpc-link-codec.test.ts
@@ -231,7 +231,7 @@ describe('rpcLinkCodec', () => {
   describe('.decodeResponse', () => {
     const codec = new RPCLinkCodec({ url: '/api', serializer })
 
-    it.each([200, 201, 399])('decodes successful output (status %i)', async (status) => {
+    it.each([100, 199, 200, 204, 301, 302, 399])('treats status %i as success', async (status) => {
       const serialized = serializer.serialize({ data: 'hello' })
 
       const result = await codec.decodeResponse({
@@ -241,6 +241,19 @@ describe('rpcLinkCodec', () => {
       })
 
       expect(result).toEqual({ kind: 'output', output: deserializeSpy.mock.results[0]!.value })
+    })
+
+    it.each([400, 401, 403, 404, 500, 599, 600])('treats status %i as error', async (status) => {
+      const error = new ORPCError('BAD_REQUEST')
+      const serialized = serializer.serialize(error.toJSON())
+
+      const result = await codec.decodeResponse({
+        status,
+        headers: {},
+        resolveBody: () => Promise.resolve(serialized),
+      })
+
+      expect(result.kind).toBe('error')
     })
 
     it('decodes ORPCError JSON from error response', async () => {
@@ -278,19 +291,6 @@ describe('rpcLinkCodec', () => {
           body: { something: 'unexpected' },
         }))
       }
-    })
-
-    it.each([400, 500, 100])('treats status %i as error', async (status) => {
-      const error = new ORPCError('BAD_REQUEST')
-      const serialized = serializer.serialize(error.toJSON())
-
-      const result = await codec.decodeResponse({
-        status,
-        headers: {},
-        resolveBody: () => Promise.resolve(serialized),
-      })
-
-      expect(result.kind).toBe('error')
     })
 
     it('throws on invalid RPC response format', async () => {

--- a/packages/client/src/adapters/standard/rpc-link-codec.ts
+++ b/packages/client/src/adapters/standard/rpc-link-codec.ts
@@ -123,7 +123,7 @@ export class RPCLinkCodec<T extends ClientContext> implements StandardLinkCodec<
   }
 
   async decodeResponse(response: StandardLazyResponse): Promise<StandardLinkCodecDecodedResponse> {
-    const isOk = response.status >= 200 && response.status < 400
+    const isOk = response.status < 400
 
     const body = await response.resolveBody()
 

--- a/packages/openapi/src/adapters/standard/openapi-handler-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler-codec.ts
@@ -25,6 +25,7 @@ export interface OpenAPIHandlerCodecCoreOptions<_T extends Context> {
 
   /**
    * Mapping ORPCError Code -> HTTP Status Code
+   * The status code should be in the `4xx` or `5xx` range (must be greater than or equal to `400`).
    *
    * @default COMMON_ERROR_STATUS_MAP, DEFAULT_ERROR_STATUS
    */

--- a/packages/openapi/src/adapters/standard/openapi-link-codec.test.ts
+++ b/packages/openapi/src/adapters/standard/openapi-link-codec.test.ts
@@ -742,5 +742,39 @@ describe('openAPILinkCodec', () => {
         'Expected a procedure or contract at path (not-exists)',
       )
     })
+
+    it.each([100, 199, 200, 204, 301, 302, 399])('treats status %i as success', async (status) => {
+      const codec = new OpenAPILinkCodec({
+        ping: oc.meta(openapi({ outputStructure: 'compact', responseBodyHint: 'json' })),
+      }, { serializer })
+
+      const resolveBody = vi.fn(async () => ({ ok: true }))
+      const result = await codec.decodeResponse({
+        status,
+        headers: {},
+        resolveBody,
+      }, ['ping'], { context: {} })
+
+      expect(result).toEqual({
+        kind: 'output',
+        output: { ok: true },
+      })
+    })
+
+    it.each([400, 401, 403, 404, 500, 599, 600])('treats status %i as error', async (status) => {
+      const codec = new OpenAPILinkCodec({
+        ping: oc.meta(openapi({})),
+      }, { serializer })
+
+      const error = new ORPCError('BAD_REQUEST')
+
+      const result = await codec.decodeResponse({
+        status,
+        headers: {},
+        resolveBody: async () => error.toJSON(),
+      }, ['ping'], { context: {} })
+
+      expect(result.kind).toBe('error')
+    })
   })
 })

--- a/packages/openapi/src/adapters/standard/openapi-link-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-link-codec.ts
@@ -369,7 +369,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
     path: string[],
     _options: ClientOptions<T>,
   ): Promise<StandardLinkCodecDecodedResponse> {
-    const isOk = response.status >= 200 && response.status < 400
+    const isOk = response.status < 400
     const procedure = await this.resolveProcedure(path)
     const meta = getOpenAPIMeta(procedure)
 

--- a/packages/openapi/src/meta.ts
+++ b/packages/openapi/src/meta.ts
@@ -51,7 +51,8 @@ export interface OpenAPIMeta {
   tags?: string[] | undefined
 
   /**
-   * HTTP status code returned on success. Must be in the 200–399 range.
+   * HTTP status code returned on success.
+   * Should be in the `2xx` range and must be less than `400`.
    *
    * @default 200
    */

--- a/packages/openapi/src/openapi-generator.ts
+++ b/packages/openapi/src/openapi-generator.ts
@@ -424,16 +424,16 @@ export class OpenAPIGenerator {
       if (!objectSchemaEntries) {
         throw new OpenAPIGeneratorError(
           `Procedure at path "${path.join('.')}" has outputStructure "detailed" but its output schema is not an object.\n`
-          + `  Expected shape: { status: number (200-299), headers?: Record<string, unknown>, body?: unknown }`,
+          + `  Expected shape: { status?: number (less than 400), headers?: Record<string, string | string[]>, body?: unknown }`,
         )
       }
 
       const statusSchema = objectSchemaEntries?.find(([name]) => name === 'status')?.[1]
 
-      if (statusSchema !== undefined && (typeof statusSchema !== 'object' || !Number.isInteger(statusSchema.const) || statusSchema.const < 200 || statusSchema.const >= 300)) {
+      if (statusSchema !== undefined && (typeof statusSchema !== 'object' || !Number.isInteger(statusSchema.const) || statusSchema.const >= 400)) {
         throw new OpenAPIGeneratorError(
           `Procedure at path "${path.join('.')}" has an invalid "status" field in its outputStructure "detailed" schema.\n`
-          + `  Expected: a const integer in the 200-299 range\n`
+          + `  Expected: a const integer less than 400\n`
           + `  Received: ${stringifyJSON(statusSchema)}`,
 
         )

--- a/packages/server/src/adapters/standard/rpc-handler-codec.ts
+++ b/packages/server/src/adapters/standard/rpc-handler-codec.ts
@@ -21,15 +21,16 @@ export interface RPCHandlerCodecOptions<T extends Context> extends RPCMatcherOpt
   /**
    * Resolve HTTP status for encoded successful outputs.
    *
-   * Value should be in range `200-299`
+   * Value should be in the `2xx` range and must be less than `400`.
    * Return `undefined` or `null` to fallback to default
    *
-   * @default DEFAULT_ERROR_STATUS, DEFAULT_ERROR_STATUS
+   * @default DEFAULT_SUCCESS_STATUS (200)
    */
   outputStatus?: Value<number | undefined | null, [output: unknown, procedure: AnyProcedure, path: string[], options: StandardHandlerHandleOptions<T>]>
 
   /**
    * Mapping ORPCError Code -> HTTP Status Code
+   * The status code should be in the `4xx` or `5xx` range (must be greater than or equal to `400`).
    *
    * @default COMMON_ERROR_STATUS_MAP
    */


### PR DESCRIPTION
Instead of only treating status codes in the 200–399 range as successful responses.