### PR TITLE
feat(zod): support defs at root level in json schema converter

### DIFF
--- a/packages/zod/src/converter.test.ts
+++ b/packages/zod/src/converter.test.ts
@@ -66,13 +66,34 @@ describe('zodToJsonSchemaConverter', () => {
   })
 
   it('supports $ref & $defs at root level', () => {
-    const schema = z.string().meta({ id: 'root' })
+    const schema = z.object({
+      a: z.string().meta({ id: 'a' }),
+      b: z.number().meta({ id: 'b' }),
+    }).meta({ id: 'root' })
 
     expect(converter.convert(schema, 'input')).toEqual([{
       $ref: '#/$defs/root',
       $defs: {
-        root: {
+        a: {
           type: 'string',
+        },
+        b: {
+          type: 'number',
+        },
+        root: {
+          type: 'object',
+          properties: {
+            a: {
+              $ref: '#/$defs/a',
+            },
+            b: {
+              $ref: '#/$defs/b',
+            },
+          },
+          required: [
+            'a',
+            'b',
+          ],
         },
       },
     }, false],

--- a/packages/zod/src/converter.test.ts
+++ b/packages/zod/src/converter.test.ts
@@ -1,6 +1,15 @@
 import * as v from 'valibot'
 import * as z from 'zod'
+import { $ZodRegistry, toJSONSchema } from 'zod/v4/core'
 import { ZodToJsonSchemaConverter } from './converter'
+
+vi.mock('zod/v4/core', async (original) => {
+  const mod = await original<typeof import('zod/v4/core')>()
+  return {
+    ...mod,
+    toJSONSchema: vi.fn((...args: [any]) => mod.toJSONSchema(...args)),
+  }
+})
 
 describe('zodToJsonSchemaConverter', () => {
   const converter = new ZodToJsonSchemaConverter()
@@ -65,39 +74,98 @@ describe('zodToJsonSchemaConverter', () => {
     expect(converter.convert(schema, 'input')).toEqual([{ type: 'string' }, false])
   })
 
-  it('supports $ref & $defs at root level', () => {
-    const schema = z.object({
-      a: z.string().meta({ id: 'a' }),
-      b: z.number().meta({ id: 'b' }),
-    }).meta({ id: 'root' })
+  describe('supports $ref at root level', () => {
+    it('with the global metadata registry', () => {
+      const schema = z.object({
+        a: z.string().meta({ id: 'a' }),
+        b: z.number().meta({ id: 'b' }),
+      }).meta({ id: 'root' })
 
-    expect(converter.convert(schema, 'input')).toEqual([{
-      $ref: '#/$defs/root',
-      $defs: {
-        a: {
-          type: 'string',
-        },
-        b: {
-          type: 'number',
-        },
-        root: {
-          type: 'object',
-          properties: {
-            a: {
-              $ref: '#/$defs/a',
-            },
-            b: {
-              $ref: '#/$defs/b',
-            },
+      expect(converter.convert(schema, 'input')).toEqual([{
+        $ref: '#/$defs/root',
+        $defs: {
+          a: {
+            type: 'string',
           },
-          required: [
-            'a',
-            'b',
-          ],
+          b: {
+            type: 'number',
+          },
+          root: {
+            type: 'object',
+            properties: {
+              a: {
+                $ref: '#/$defs/a',
+              },
+              b: {
+                $ref: '#/$defs/b',
+              },
+            },
+            required: [
+              'a',
+              'b',
+            ],
+          },
         },
-      },
-    }, false],
-    )
+      }, false],
+      )
+    })
+
+    it('with a custom metadata registry', () => {
+      const registry = new $ZodRegistry()
+      const customConverter = new ZodToJsonSchemaConverter({ metadata: registry as any })
+
+      const schema = z.object({
+        a: z.string(),
+      })
+
+      registry.add(schema, { id: 'root' })
+      registry.add(schema.shape.a, { id: 'a' })
+
+      expect(customConverter.convert(schema, 'input')).toEqual([{
+        $ref: '#/$defs/root',
+        $defs: {
+          a: {
+            type: 'string',
+          },
+          root: {
+            type: 'object',
+            properties: {
+              a: {
+                $ref: '#/$defs/a',
+              },
+            },
+            required: [
+              'a',
+            ],
+          },
+        },
+      }, false])
+    })
+
+    it('avoids overwriting existing $defs when the root id collides', () => {
+      const schema = z.string().meta({ id: 'root' })
+
+      vi.mocked(toJSONSchema).mockReturnValueOnce({
+        $defs: {
+          root: {
+            type: 'number',
+          },
+        },
+        type: 'string',
+      } as any)
+
+      expect(converter.convert(schema, 'input')).toEqual([{
+        $ref: '#/$defs/root__0',
+        $defs: {
+          root: {
+            type: 'number',
+          },
+          root__0: {
+            type: 'string',
+          },
+        },
+      }, false])
+    })
   })
 
   describe('optionality', () => {

--- a/packages/zod/src/converter.test.ts
+++ b/packages/zod/src/converter.test.ts
@@ -75,22 +75,22 @@ describe('zodToJsonSchemaConverter', () => {
   })
 
   describe('supports $ref at root level', () => {
-    it('with the global metadata registry', () => {
+    it('with the global metadata registry and special json pointers', () => {
       const schema = z.object({
         a: z.string().meta({ id: 'a' }),
         b: z.number().meta({ id: 'b' }),
-      }).meta({ id: 'root' })
+      }).meta({ id: 'root~/' })
 
       expect(converter.convert(schema, 'input')).toEqual([{
-        $ref: '#/$defs/root',
+        $ref: '#/$defs/root~0~1',
         $defs: {
-          a: {
+          'a': {
             type: 'string',
           },
-          b: {
+          'b': {
             type: 'number',
           },
-          root: {
+          'root~/': {
             type: 'object',
             properties: {
               a: {

--- a/packages/zod/src/converter.test.ts
+++ b/packages/zod/src/converter.test.ts
@@ -65,6 +65,20 @@ describe('zodToJsonSchemaConverter', () => {
     expect(converter.convert(schema, 'input')).toEqual([{ type: 'string' }, false])
   })
 
+  it('supports $ref & $defs at root level', () => {
+    const schema = z.string().meta({ id: 'root' })
+
+    expect(converter.convert(schema, 'input')).toEqual([{
+      $ref: '#/$defs/root',
+      $defs: {
+        root: {
+          type: 'string',
+        },
+      },
+    }, false],
+    )
+  })
+
   describe('optionality', () => {
     it.each([
       ['defaulted input schema', z.string().default('fallback'), 'input', {

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -1,6 +1,6 @@
 import type { AnySchema, JsonSchema, JsonSchemaConverter, JsonSchemaConverterDirection } from '@orpc/json-schema'
 import type { $ZodType, ToJSONSchemaParams, JSONSchema as ZodJsonSchema } from 'zod/v4/core'
-import { JsonSchemaFormat, JsonSchemaXNativeType } from '@orpc/json-schema'
+import { encodeJsonPointerSegment, JsonSchemaFormat, JsonSchemaXNativeType } from '@orpc/json-schema'
 import { globalRegistry, toJSONSchema } from 'zod/v4/core'
 
 export interface ZodToJsonSchemaConverterOptions extends Omit<ToJSONSchemaParams, 'target' | 'io'> {}
@@ -89,7 +89,7 @@ export class ZodToJsonSchemaConverter implements JsonSchemaConverter {
       }
 
       return {
-        $ref: `#/$defs/${defName}`,
+        $ref: `#/$defs/${encodeJsonPointerSegment(defName)}`,
         $defs: {
           ...$defs,
           [defName]: restWithoutDefs,

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -1,8 +1,7 @@
 import type { AnySchema, JsonSchema, JsonSchemaConverter, JsonSchemaConverterDirection } from '@orpc/json-schema'
-import type { ZodType } from 'zod/v4'
 import type { $ZodType, ToJSONSchemaParams, JSONSchema as ZodJsonSchema } from 'zod/v4/core'
 import { JsonSchemaFormat, JsonSchemaXNativeType } from '@orpc/json-schema'
-import { toJSONSchema } from 'zod/v4/core'
+import { globalRegistry, toJSONSchema } from 'zod/v4/core'
 
 export interface ZodToJsonSchemaConverterOptions extends Omit<ToJSONSchemaParams, 'target' | 'io'> {}
 
@@ -79,12 +78,15 @@ export class ZodToJsonSchemaConverter implements JsonSchemaConverter {
 
     try {
       // workaround until https://github.com/colinhacks/zod/issues/6026 is merged
-      const { id } = (schema as ZodType).meta() || {}
-      if (id) {
+      const registry = this.options.metadata ?? globalRegistry
+      const { id } = registry.get(schema) || {}
+      const { $defs = {}, ...restWithoutDefs } = rest
+      if (id && !(id in $defs)) {
         return {
           $ref: `#/$defs/${id}`,
           $defs: {
-            [id]: rest,
+            ...$defs,
+            [id]: restWithoutDefs,
           },
         }
       }

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -73,6 +73,8 @@ export class ZodToJsonSchemaConverter implements JsonSchemaConverter {
       },
     })
 
+    // Since the default oRPC format is always draft/2020-12,
+    // `$schema` can be safely omitted here.
     const { $schema, ...rest } = jsonSchema
 
     try {

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -76,22 +76,26 @@ export class ZodToJsonSchemaConverter implements JsonSchemaConverter {
     // `$schema` can be safely omitted here.
     const { $schema, ...rest } = jsonSchema
 
-    try {
-      // workaround until https://github.com/colinhacks/zod/issues/6026 is merged
-      const registry = this.options.metadata ?? globalRegistry
-      const { id } = registry.get(schema) || {}
+    // workaround until https://github.com/colinhacks/zod/issues/6026 is merged
+    const registry = this.options.metadata ?? globalRegistry
+    const { id } = registry.get(schema) || {}
+    if (typeof id === 'string' && rest.$ref === undefined) {
       const { $defs = {}, ...restWithoutDefs } = rest
-      if (id && !(id in $defs)) {
-        return {
-          $ref: `#/$defs/${id}`,
-          $defs: {
-            ...$defs,
-            [id]: restWithoutDefs,
-          },
-        }
+
+      let defName = id
+      let index = 0
+      while (defName in $defs) {
+        defName = `${defName}__${index++}`
+      }
+
+      return {
+        $ref: `#/$defs/${defName}`,
+        $defs: {
+          ...$defs,
+          [defName]: restWithoutDefs,
+        },
       }
     }
-    catch {}
 
     return rest
   }

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -1,4 +1,5 @@
 import type { AnySchema, JsonSchema, JsonSchemaConverter, JsonSchemaConverterDirection } from '@orpc/json-schema'
+import type { ZodType } from 'zod/v4'
 import type { $ZodType, ToJSONSchemaParams, JSONSchema as ZodJsonSchema } from 'zod/v4/core'
 import { JsonSchemaFormat, JsonSchemaXNativeType } from '@orpc/json-schema'
 import { toJSONSchema } from 'zod/v4/core'
@@ -72,9 +73,22 @@ export class ZodToJsonSchemaConverter implements JsonSchemaConverter {
       },
     })
 
-    // Since the default oRPC format is always draft/2020-12,
-    // `$schema` can be safely omitted here.
     const { $schema, ...rest } = jsonSchema
+
+    try {
+      // workaround until https://github.com/colinhacks/zod/issues/6026 is merged
+      const { id } = (schema as ZodType).meta() || {}
+      if (id) {
+        return {
+          $ref: `#/$defs/${id}`,
+          $defs: {
+            [id]: rest,
+          },
+        }
+      }
+    }
+    catch {}
+
     return rest
   }
 }


### PR DESCRIPTION
This is a small workaround to support root level `$ref` and `$defs` in `ZodToJsonSchemaConverter` until https://github.com/colinhacks/zod/issues/6026 gets merged eventually.

Note: the `try catch` block is just here as a defensive mechanism to guard against exceptions, but I couldn't encounter any case where an exception was encountered.