### PR TITLE
fix: OpenAPISerializerOptions should not extend OpenAPISerializerSerializeOptions

### DIFF
--- a/packages/openapi/src/openapi-serializer.ts
+++ b/packages/openapi/src/openapi-serializer.ts
@@ -24,7 +24,7 @@ export interface OpenAPISerializerSerializeOptions {
   asFormData?: boolean | undefined
 }
 
-export interface OpenAPISerializerOptions extends OpenAPIJsonSerializerOptions, OpenAPISerializerSerializeOptions {
+export interface OpenAPISerializerOptions extends OpenAPIJsonSerializerOptions {
   /**
    * Options for bracket notation serializer, like maxExplicitDeserializingArrayIndex
    */


### PR DESCRIPTION
I believe the `OpenAPISerializerOptions` interface should not extend `OpenAPISerializerSerializeOptions` since it has a `serialize` field which is of type `OpenAPISerializerSerializeOptions`.