### PR TITLE
feat: async-serializer for OpenApiSerializer

### DIFF
--- a/packages/openapi/src/adapters/standard/openapi-handler-codec.test.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler-codec.test.ts
@@ -699,7 +699,7 @@ describe('openAPIHandlerCodec', () => {
         const procedure = os.meta(openapi({ outputStructure: 'detailed' })).handler(vi.fn())
         const codec = new OpenAPIHandlerCodec(procedure)
 
-        expect(async () => await codec.encodeOutput(output, procedure, [])).rejects.toThrow('Invalid "detailed" output structure')
+        await expect(codec.encodeOutput(output, procedure, [])).rejects.toThrow('Invalid "detailed" output structure')
       })
     })
   })

--- a/packages/openapi/src/adapters/standard/openapi-handler-codec.test.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler-codec.test.ts
@@ -578,7 +578,7 @@ describe('openAPIHandlerCodec', () => {
 
   describe('.encodeOutput', () => {
     describe('outputStructure=compact', () => {
-      it('uses default 200 success status if successStatus is not defined', () => {
+      it('uses default 200 success status if successStatus is not defined', async () => {
         const serializer = {
           serialize: vi.fn().mockReturnValueOnce('__serialized__'),
           deserialize: vi.fn(),
@@ -587,7 +587,7 @@ describe('openAPIHandlerCodec', () => {
         const procedure = os.handler(vi.fn())
         const codec = new OpenAPIHandlerCodec(procedure, { serializer })
 
-        const response = codec.encodeOutput('__output__', procedure, [])
+        const response = await codec.encodeOutput('__output__', procedure, [])
 
         expect(response).toEqual({
           status: 200,
@@ -599,7 +599,7 @@ describe('openAPIHandlerCodec', () => {
         expect(serializer.serialize).toHaveBeenCalledWith('__output__')
       })
 
-      it('uses successStatus if defined', () => {
+      it('uses successStatus if defined', async () => {
         const serializer = {
           serialize: vi.fn().mockReturnValueOnce('__serialized__'),
           deserialize: vi.fn(),
@@ -608,7 +608,7 @@ describe('openAPIHandlerCodec', () => {
         const procedure = os.meta(openapi({ successStatus: 201 })).handler(vi.fn())
         const codec = new OpenAPIHandlerCodec(procedure, { serializer })
 
-        const response = codec.encodeOutput('__output__', procedure, [])
+        const response = await codec.encodeOutput('__output__', procedure, [])
 
         expect(response).toEqual({
           status: 201,
@@ -622,7 +622,7 @@ describe('openAPIHandlerCodec', () => {
     })
 
     describe('outputStructure=detailed', () => {
-      it('uses default 200 success status meta when output not contain status', () => {
+      it('uses default 200 success status meta when output not contain status', async () => {
         const serializer = {
           serialize: vi.fn().mockReturnValueOnce('__serialized_body__'),
           deserialize: vi.fn(),
@@ -631,7 +631,7 @@ describe('openAPIHandlerCodec', () => {
         const procedure = os.meta(openapi({ outputStructure: 'detailed' })).handler(vi.fn())
         const codec = new OpenAPIHandlerCodec(procedure, { serializer })
 
-        const response = codec.encodeOutput({
+        const response = await codec.encodeOutput({
           body: { ok: true },
         }, procedure, ['detailed'] as any)
 
@@ -645,7 +645,7 @@ describe('openAPIHandlerCodec', () => {
         expect(serializer.serialize).toHaveBeenCalledWith({ ok: true })
       })
 
-      it('uses the successStatus meta when output not contain status', () => {
+      it('uses the successStatus meta when output not contain status', async () => {
         const serializer = {
           serialize: vi.fn().mockReturnValueOnce('__serialized_body__'),
           deserialize: vi.fn(),
@@ -654,7 +654,7 @@ describe('openAPIHandlerCodec', () => {
         const procedure = os.meta(openapi({ outputStructure: 'detailed', successStatus: 201 })).handler(vi.fn())
         const codec = new OpenAPIHandlerCodec(procedure, { serializer })
 
-        const response = codec.encodeOutput({
+        const response = await codec.encodeOutput({
           body: { ok: true },
         }, procedure, ['detailed'] as any)
 
@@ -668,7 +668,7 @@ describe('openAPIHandlerCodec', () => {
         expect(serializer.serialize).toHaveBeenCalledWith({ ok: true })
       })
 
-      it('uses explicit status and headers from output', () => {
+      it('uses explicit status and headers from output', async () => {
         const serializer = {
           serialize: vi.fn().mockReturnValueOnce('__serialized_body__'),
           deserialize: vi.fn(),
@@ -677,7 +677,7 @@ describe('openAPIHandlerCodec', () => {
         const procedure = os.meta(openapi({ outputStructure: 'detailed' })).handler(vi.fn())
         const codec = new OpenAPIHandlerCodec(procedure, { serializer })
 
-        const response = codec.encodeOutput({
+        const response = await codec.encodeOutput({
           status: 202,
           headers: { 'x-custom': 'value' },
           body: { ok: true },
@@ -695,17 +695,17 @@ describe('openAPIHandlerCodec', () => {
         ['status outside the allowed range', { status: 500 }],
         ['extra keys', { body: 'ok', extra: true }],
         ['invalid headers', { headers: { 'x-invalid': 123 } }],
-      ])('throws for invalid output: %s', (_, output) => {
+      ])('throws for invalid output: %s', async (_, output) => {
         const procedure = os.meta(openapi({ outputStructure: 'detailed' })).handler(vi.fn())
         const codec = new OpenAPIHandlerCodec(procedure)
 
-        expect(() => codec.encodeOutput(output, procedure, [])).toThrow('Invalid "detailed" output structure')
+        expect(() => codec.encodeOutput(output, procedure, [])).rejects.toThrow('Invalid "detailed" output structure')
       })
     })
   })
 
   describe('.encodeError', () => {
-    it('maps known error codes to HTTP status via COMMON_ERROR_STATUS_MAP', () => {
+    it('maps known error codes to HTTP status via COMMON_ERROR_STATUS_MAP', async () => {
       const serializer = {
         serialize: vi.fn().mockReturnValueOnce('__serialized_error__'),
         deserialize: vi.fn(),
@@ -715,7 +715,7 @@ describe('openAPIHandlerCodec', () => {
       const codec = new OpenAPIHandlerCodec(procedure, { serializer })
       const error = new ORPCError('BAD_GATEWAY')
 
-      const response = codec.encodeError(error)
+      const response = await codec.encodeError(error)
 
       expect(response).toEqual({
         status: 502,
@@ -727,7 +727,7 @@ describe('openAPIHandlerCodec', () => {
       expect(serializer.serialize).toHaveBeenCalledWith(error.toJSON())
     })
 
-    it('uses customErrorResponseBodyEncoder and falls back on null', () => {
+    it('uses customErrorResponseBodyEncoder and falls back on null', async () => {
       let attempt = 1
       const customErrorResponseBodyEncoder = vi.fn(() => {
         if (attempt++ === 2) {
@@ -753,7 +753,7 @@ describe('openAPIHandlerCodec', () => {
       })
 
       const firstError = new ORPCError('BAD_GATEWAY', { data: '__data1__' })
-      const firstResponse = codec.encodeError(firstError)
+      const firstResponse = await codec.encodeError(firstError)
 
       expect(firstResponse).toEqual({
         status: 502,
@@ -762,7 +762,7 @@ describe('openAPIHandlerCodec', () => {
       })
 
       const secondError = new ORPCError('UNKNOWN_CODE' as any, { data: '__data2__' })
-      const secondResponse = codec.encodeError(secondError)
+      const secondResponse = await codec.encodeError(secondError)
 
       expect(secondResponse).toEqual({
         status: DEFAULT_ERROR_STATUS,
@@ -779,7 +779,7 @@ describe('openAPIHandlerCodec', () => {
       expect(serializer.serialize).toHaveBeenNthCalledWith(2, secondError.toJSON())
     })
 
-    it('can custom error status via errorStatuses option', () => {
+    it('can custom error status via errorStatuses option', async () => {
       const serializer = {
         serialize: vi.fn().mockReturnValueOnce('__serialized_override__'),
         deserialize: vi.fn(),
@@ -792,7 +792,7 @@ describe('openAPIHandlerCodec', () => {
       })
 
       const error = new ORPCError('BAD_GATEWAY')
-      const response = codec.encodeError(error)
+      const response = await codec.encodeError(error)
 
       expect(response).toEqual({
         status: 599,
@@ -801,7 +801,7 @@ describe('openAPIHandlerCodec', () => {
       })
     })
 
-    it('fallback unknown error code to DEFAULT_ERROR_STATUS', () => {
+    it('fallback unknown error code to DEFAULT_ERROR_STATUS', async () => {
       const serializer = {
         serialize: vi.fn()
           .mockReturnValueOnce('__serialized_unknown__'),
@@ -815,7 +815,7 @@ describe('openAPIHandlerCodec', () => {
       })
 
       const unknownError = new ORPCError('UNKNOWN_CODE' as any)
-      const unknownResponse = codec.encodeError(unknownError)
+      const unknownResponse = await codec.encodeError(unknownError)
 
       expect(unknownResponse).toEqual({
         status: DEFAULT_ERROR_STATUS,

--- a/packages/openapi/src/adapters/standard/openapi-handler-codec.test.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler-codec.test.ts
@@ -699,7 +699,7 @@ describe('openAPIHandlerCodec', () => {
         const procedure = os.meta(openapi({ outputStructure: 'detailed' })).handler(vi.fn())
         const codec = new OpenAPIHandlerCodec(procedure)
 
-        expect(() => codec.encodeOutput(output, procedure, [])).rejects.toThrow('Invalid "detailed" output structure')
+        expect(async () => await codec.encodeOutput(output, procedure, [])).rejects.toThrow('Invalid "detailed" output structure')
       })
     })
   })

--- a/packages/openapi/src/adapters/standard/openapi-handler-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler-codec.ts
@@ -1,7 +1,6 @@
 import type { AnyORPCError } from '@orpc/client'
 import type { AnyProcedure, AnyRouter, Context } from '@orpc/server'
 import type { StandardHandlerCodec, StandardHandlerCodecResolvedProcedure, StandardHandlerHandleOptions } from '@orpc/server/standard'
-import type { Promisable } from '@orpc/shared'
 import type { StandardHeaders, StandardLazyRequest, StandardResponse } from '@standardserver/core'
 import type { OpenAPIMeta } from '../../meta'
 import type { OpenAPIMatcherOptions } from './openapi-matcher'
@@ -100,7 +99,7 @@ export class OpenAPIHandlerCodecCore<T extends Context> {
   /**
    * @throws {TypeError} If `outputStructure` is "detailed" and the output doesn't match the expected structure.
    */
-  encodeOutput(output: unknown, procedure: AnyProcedure, path: string[]): Promisable<StandardResponse> {
+  async encodeOutput(output: unknown, procedure: AnyProcedure, path: string[]): Promise<StandardResponse> {
     const meta = getOpenAPIMeta(procedure)
     const successStatus = meta?.successStatus ?? DEFAULT_SUCCESS_STATUS
     const outputStructure = meta?.outputStructure ?? DEFAULT_OPENAPI_OUTPUT_STRUCTURE
@@ -109,7 +108,7 @@ export class OpenAPIHandlerCodecCore<T extends Context> {
       return {
         status: successStatus,
         headers: {},
-        body: this.serializer.serialize(output),
+        body: await this.serializer.serialize(output),
       }
     }
 
@@ -130,17 +129,17 @@ export class OpenAPIHandlerCodecCore<T extends Context> {
     return {
       status: output.status ?? successStatus,
       headers: output.headers ?? {},
-      body: this.serializer.serialize(output.body),
+      body: await this.serializer.serialize(output.body),
     }
   }
 
-  encodeError(error: AnyORPCError): Promisable<StandardResponse> {
+  async encodeError(error: AnyORPCError): Promise<StandardResponse> {
     const status = this.errorStatusMap[error.code] ?? DEFAULT_ERROR_STATUS
 
     return {
       status,
       headers: {},
-      body: this.serializer.serialize(this.customErrorResponseBodySerializer?.(error) ?? error.toJSON()),
+      body: await this.serializer.serialize(this.customErrorResponseBodySerializer?.(error) ?? error.toJSON()),
     }
   }
 

--- a/packages/openapi/src/adapters/standard/openapi-link-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-link-codec.ts
@@ -102,7 +102,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
 
         for (let i = dynamicParams.length - 1; i >= 0; i--) {
           const param = dynamicParams[i]!
-          const encoded = this.encodePathParam(input[param.parameterName], param, meta?.paramsStyles?.[param.parameterName], path)
+          const encoded = await this.encodePathParam(input[param.parameterName], param, meta?.paramsStyles?.[param.parameterName], path)
           pathname = `${pathname.slice(0, param.startIndex)}${encoded}${pathname.slice(param.startIndex + param.segment.length)}` as `/${string}`
           delete remaining[param.parameterName]
         }
@@ -113,7 +113,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
       pathname = `${basePathname.replace(END_SLASH_REGEX, '')}${pathname}` as `/${string}`
 
       if (method === 'GET') {
-        const queryString = this.serializeQueryString(data, meta?.queryStyles)
+        const queryString = await this.serializeQueryString(data, meta?.queryStyles)
         const search = combineSearch(baseSearch, queryString)
         const url = `${pathname}${search ?? ''}${baseHash ?? ''}` as StandardUrl
 
@@ -132,7 +132,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
         url,
         method,
         headers,
-        body: this.serializer.serialize(data),
+        body: await this.serializer.serialize(data),
         signal: options.signal,
       }
     }
@@ -161,7 +161,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
       for (let i = dynamicParams.length - 1; i >= 0; i--) {
         const param = dynamicParams[i]!
         const val = input.params[param.parameterName]
-        const encoded = this.encodePathParam(val, param, meta?.paramsStyles?.[param.parameterName], path)
+        const encoded = await this.encodePathParam(val, param, meta?.paramsStyles?.[param.parameterName], path)
         pathname = `${pathname.slice(0, param.startIndex)}${encoded}${pathname.slice(param.startIndex + param.segment.length)}` as `/${string}`
       }
     }
@@ -171,7 +171,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
     }
 
     pathname = `${basePathname.replace(END_SLASH_REGEX, '')}${pathname}` as `/${string}`
-    const queryString = this.serializeQueryString(input?.query, meta?.queryStyles)
+    const queryString = await this.serializeQueryString(input?.query, meta?.queryStyles)
     const search = combineSearch(baseSearch, queryString)
     const url = `${pathname}${search ?? ''}${baseHash ?? ''}` as StandardUrl
 
@@ -189,35 +189,34 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
       url,
       method,
       headers,
-      body: this.serializer.serialize(input?.body),
+      body: await this.serializer.serialize(input?.body),
       signal: options.signal,
     }
   }
 
-  private encodePathParam(
+  private async encodePathParam(
     val: unknown,
     param: { parameterName: string, allowsSlash: boolean, segment: string },
     style: Exclude<OpenAPIMeta['paramsStyles'], undefined>[string],
     path: string[],
-  ): string {
+  ): Promise<string> {
     let encoded: string | undefined
 
     if (style === 'comma-delimited-array' && Array.isArray(val)) {
-      encoded = val
-        .map(val => this.serializer.serialize(val))
+      encoded = (await Promise.all(val
+        .map(val => this.serializer.serialize(val))))
         .filter(val => val !== undefined && val !== null)
         .map(val => encodeURIComponent(String(val)))
         .join(',')
     }
     else if (style === 'comma-delimited-object' && isTypescriptObject(val)) {
-      encoded = Object.entries(val)
-        .map(([key, val]) => [key, this.serializer.serialize(val)])
+      encoded = (await resolveEntries(Object.entries(val).map(([key, val]) => [key, this.serializer.serialize(val)])))
         .filter(([, val]) => val !== undefined && val !== null)
         .map(([key, val]) => `${encodeURIComponent(String(key))},${encodeURIComponent(String(val))}`)
         .join(',')
     }
     else {
-      const serialized = this.serializer.serialize(val)
+      const serialized = await this.serializer.serialize(val)
 
       if (serialized !== undefined && serialized !== null) {
         if (param.allowsSlash) {
@@ -236,26 +235,30 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
     return encoded
   }
 
-  private serializeQueryString(data: unknown, queryStyles: OpenAPIMeta['queryStyles']): string | undefined {
+  private async serializeQueryString(data: unknown, queryStyles: OpenAPIMeta['queryStyles']): Promise<string | undefined> {
     if (!queryStyles || !isTypescriptObject(data)) {
       return toURLSearchParams(
-        this.serializer.serialize(data, { asFormData: true }) as FormData,
+        await this.serializer.serialize(data, { asFormData: true }) as FormData,
       ).toString()
     }
 
     const remaining = { ...data }
     let query = ''
 
-    Object.entries(queryStyles).forEach(([key, style]) => {
+    const entries = Object.entries(queryStyles)
+
+    for (const entry of entries) {
+      const [key, style] = entry
+
       if (style === undefined) {
-        return
+        continue
       }
 
       const value = remaining[key]
       delete remaining[key]
 
       if (style === 'primitive') {
-        const serialized = this.serializer.serialize(value)
+        const serialized = await this.serializer.serialize(value)
         if (serialized !== undefined && serialized !== null) {
           query += `&${encodeURLSearchParamComponent(key)}=${encodeURLSearchParamComponent(String(serialized))}`
         }
@@ -264,16 +267,16 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
       else if (style === 'array' && Array.isArray(value)) {
         const encodedKey = encodeURLSearchParamComponent(key)
 
-        value.forEach((v) => {
-          const s = this.serializer.serialize(v)
+        for (const v of value) {
+          const s = await this.serializer.serialize(v)
           if (s !== undefined && s !== null) {
             query += `&${encodedKey}=${encodeURLSearchParamComponent(String(s))}`
           }
-        })
+        }
       }
 
       else if (style === 'json') {
-        const serialized = this.serializer.serialize(value)
+        const serialized = await this.serializer.serialize(value)
 
         if (serialized !== undefined) {
           query += `&${encodeURLSearchParamComponent(key)}=${encodeURLSearchParamComponent(stringifyJSON(serialized))}`
@@ -282,7 +285,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
 
       else if (style === 'comma-delimited-array' && Array.isArray(value)) {
         const encodedValue = encodeDelimitedArray(
-          value.map(v => this.serializer.serialize(v)),
+          await Promise.all(value.map(v => this.serializer.serialize(v))),
           ',',
         )
 
@@ -293,7 +296,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
 
       else if (style === 'comma-delimited-object' && isTypescriptObject(value)) {
         const encodedValue = encodeDelimitedObject(
-          Object.entries(value).map(([key, value]) => [key, this.serializer.serialize(value)]),
+          (await resolveEntries(Object.entries(value).map(([key, val]) => [key, this.serializer.serialize(val)]))),
           ',',
         )
 
@@ -304,7 +307,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
 
       else if (style === 'pipe-delimited-array' && Array.isArray(value)) {
         const encodedValue = encodeDelimitedArray(
-          value.map(v => this.serializer.serialize(v)),
+          await Promise.all(value.map(v => this.serializer.serialize(v))),
           '%7C' /* '/' */,
         )
 
@@ -315,7 +318,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
 
       else if (style === 'pipe-delimited-object' && isTypescriptObject(value)) {
         const encodedValue = encodeDelimitedObject(
-          Object.entries(value).map(([key, value]) => [key, this.serializer.serialize(value)]),
+          (await resolveEntries(Object.entries(value).map(([key, val]) => [key, this.serializer.serialize(val)]))),
           '%7C' /* '/' */,
         )
 
@@ -326,7 +329,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
 
       else if (style === 'space-delimited-array' && Array.isArray(value)) {
         const encodedValue = encodeDelimitedArray(
-          value.map(v => this.serializer.serialize(v)),
+          await Promise.all(value.map(v => this.serializer.serialize(v))),
           '%20' /* ' ' */,
         )
 
@@ -337,7 +340,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
 
       else if (style === 'space-delimited-object' && isTypescriptObject(value)) {
         const encodedValue = encodeDelimitedObject(
-          Object.entries(value).map(([key, value]) => [key, this.serializer.serialize(value)]),
+          (await resolveEntries(Object.entries(value).map(([key, val]) => [key, this.serializer.serialize(val)]))),
           '%20' /* ' ' */,
         )
 
@@ -347,14 +350,14 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
       }
 
       else {
-        const serialized = this.serializer.serialize(value)
+        const serialized = await this.serializer.serialize(value)
         if (serialized !== undefined && serialized !== null) {
           query += `&${encodeURLSearchParamComponent(key)}=${encodeURLSearchParamComponent(String(serialized))}`
         }
       }
-    })
+    }
 
-    const form = this.serializer.serialize(remaining, { asFormData: true }) as FormData
+    const form = await this.serializer.serialize(remaining, { asFormData: true }) as FormData
     query = `${toURLSearchParams(form).toString()}${query}`
 
     if (query.startsWith('&')) {
@@ -531,4 +534,14 @@ function encodeDelimitedObject(entries: [string, unknown][], encodedDelimiter: s
       ([key, value]) => `${encodeURLSearchParamComponent(key)}${encodedDelimiter}${encodeURLSearchParamComponent(value)}`,
     )
     .join(encodedDelimiter)
+}
+
+async function resolveEntries(entries: [PropertyKey, Promise<unknown>][]): Promise<[string, unknown][]> {
+  return (await Promise.all(entries.map(([, val]) => val))).map((val, i) => {
+    const entry = entries[i]
+    if (!entry) {
+      return null
+    }
+    return [entry[0], val] as const
+  }).filter(entry => entry !== null) as [string, unknown][]
 }

--- a/packages/openapi/src/openapi-generator.ts
+++ b/packages/openapi/src/openapi-generator.ts
@@ -169,7 +169,7 @@ export class OpenAPIGenerator {
       )
     }
 
-    return this.serializer.serialize(doc, { asFormData: false, useFormDataForBlobFields: false }) as OpenAPIDocument
+    return await this.serializer.serialize(doc, { asFormData: false, useFormDataForBlobFields: false }) as OpenAPIDocument
   }
 
   private async convertSchema(schema: AnySchema | undefined, direction: JsonSchemaConverterDirection): Promise<[JsonSchema, boolean]> {

--- a/packages/openapi/src/openapi-json-serializer.test.ts
+++ b/packages/openapi/src/openapi-json-serializer.test.ts
@@ -18,83 +18,83 @@ describe('openAPIJsonSerializer', () => {
   const serializer = new OpenAPIJsonSerializer()
 
   describe('serialize', () => {
-    it('passes through primitives unchanged', () => {
-      expect(serializer.serialize(1).json).toBe(1)
-      expect(serializer.serialize('hello').json).toBe('hello')
-      expect(serializer.serialize(true).json).toBe(true)
-      expect(serializer.serialize(null).json).toBe(null)
+    it('passes through primitives unchanged', async () => {
+      expect((await serializer.serialize(1)).json).toBe(1)
+      expect((await serializer.serialize('hello')).json).toBe('hello')
+      expect((await serializer.serialize(true)).json).toBe(true)
+      expect((await serializer.serialize(null)).json).toBe(null)
     })
 
-    it('serializes nested undefined values to null', () => {
-      expect(serializer.serialize([undefined]).json).toEqual([null])
+    it('serializes nested undefined values to null', async () => {
+      expect((await serializer.serialize([undefined])).json).toEqual([null])
     })
 
-    it('serializes NaN to null', () => {
-      expect(serializer.serialize(Number.NaN).json).toBeNull()
+    it('serializes NaN to null', async () => {
+      expect((await serializer.serialize(Number.NaN)).json).toBeNull()
     })
 
-    it('serializes Date to ISO string', () => {
-      expect(serializer.serialize(new Date('2023-01-01')).json).toBe('2023-01-01T00:00:00.000Z')
+    it('serializes Date to ISO string', async () => {
+      expect((await serializer.serialize(new Date('2023-01-01'))).json).toBe('2023-01-01T00:00:00.000Z')
     })
 
-    it('serializes invalid Date to null', () => {
-      expect(serializer.serialize(new Date('invalid')).json).toBeNull()
+    it('serializes invalid Date to null', async () => {
+      expect((await serializer.serialize(new Date('invalid'))).json).toBeNull()
     })
 
-    it('serializes bigint to string', () => {
-      expect(serializer.serialize(42n).json).toBe('42')
+    it('serializes bigint to string', async () => {
+      expect((await serializer.serialize(42n)).json).toBe('42')
     })
 
-    it('serializes URL to string', () => {
-      expect(serializer.serialize(new URL('https://dinwwwh.com')).json).toBe('https://dinwwwh.com/')
+    it('serializes URL to string', async () => {
+      expect((await serializer.serialize(new URL('https://dinwwwh.com'))).json).toBe('https://dinwwwh.com/')
     })
 
-    it('serializes RegExp to string', () => {
-      expect(serializer.serialize(/uic/gi).json).toBe('/uic/gi')
+    it('serializes RegExp to string', async () => {
+      expect((await serializer.serialize(/uic/gi)).json).toBe('/uic/gi')
     })
 
-    it('serializes Set to array', () => {
-      expect(serializer.serialize(new Set([1, 2, 3])).json).toEqual([1, 2, 3])
+    it('serializes Set to array', async () => {
+      expect((await serializer.serialize(new Set([1, 2, 3]))).json).toEqual([1, 2, 3])
     })
 
-    it('serializes Map to entries array', () => {
-      expect(serializer.serialize(new Map([['a', 1]])).json).toEqual([['a', 1]])
+    it('serializes Map to entries array', async () => {
+      expect((await serializer.serialize(new Map([['a', 1]]))).json).toEqual([['a', 1]])
     })
 
-    it('serializes nested objects', () => {
-      expect(serializer.serialize({
+    it('serializes nested objects', async () => {
+      expect((await serializer.serialize({
         date: new Date('2023-01-01'),
         count: 1n,
         flag: true,
-      }).json).toEqual({
+      })).json).toEqual({
         date: '2023-01-01T00:00:00.000Z',
         count: '1',
         flag: true,
       })
     })
 
-    it('serializes nested arrays', () => {
-      expect(serializer.serialize([new Date('2023-01-01'), 42n]).json).toEqual([
+    it('serializes nested arrays', async () => {
+      expect((await serializer.serialize([new Date('2023-01-01'), 42n])).json).toEqual([
         '2023-01-01T00:00:00.000Z',
         '42',
       ])
     })
 
-    it('omits undefined object properties by default', () => {
-      expect(serializer.serialize({ a: 1, b: undefined }).json).not.toHaveProperty('b')
+    it('omits undefined object properties by default', async () => {
+      expect((await serializer.serialize({ a: 1, b: undefined })).json).not.toHaveProperty('b')
     })
 
-    it('skips toJSON methods', () => {
-      expect(serializer.serialize({ value: { toJSON: () => 'hello' } }).json).toEqual({ value: {} })
+    it('skips toJSON methods', async () => {
+      expect((await serializer.serialize({ value: { toJSON: () => 'hello' } })).json).toEqual({ value: {} })
     })
 
-    it('keeps non-function toJSON properties', () => {
-      expect(serializer.serialize({ value: { toJSON: 'hello' } }).json).toEqual({ value: { toJSON: 'hello' } })
+    it('keeps non-function toJSON properties', async () => {
+      expect((await serializer.serialize({ value: { toJSON: 'hello' } })).json).toEqual({ value: { toJSON: 'hello' } })
     })
 
-    it('collects blobs and maps', () => {
+    it('collects blobs and maps', async () => {
       const blob = new Blob(['hello'])
-      const { maps, blobs } = serializer.serialize({ file: blob })
+      const { maps, blobs } = await serializer.serialize({ file: blob })
       expect(blobs).toEqual([blob])
       expect(maps).toEqual([['file']])
     })
@@ -115,20 +115,20 @@ describe('openAPIJsonSerializer', () => {
     it.each(['doesNotExist', '__proto__', 'constructor'])('throws on invalid segment "%s" to prevent prototype pollution', (segment) => {
       expect(
         () => serializer.deserialize({ json: { o: {} }, blobs: [new Blob()], maps: [[segment]] }),
-      ).toThrowError(`Security error: Invalid serialized data. Segment "${segment}" does not exist.`)
+      ).toThrow(`Security error: Invalid serialized data. Segment "${segment}" does not exist.`)
 
       expect(
         () => serializer.deserialize({ json: { o: {} }, blobs: [new Blob()], maps: [['o', segment]] }),
-      ).toThrowError(`Security error: Invalid serialized data. Segment "${segment}" does not exist.`)
+      ).toThrow(`Security error: Invalid serialized data. Segment "${segment}" does not exist.`)
 
       expect(
         () => serializer.deserialize({ json: { o: {} }, blobs: [new Blob()], maps: [[segment, 'o']] }),
-      ).toThrowError(`Security error: Invalid serialized data. Segment "${segment}" does not exist.`)
+      ).toThrow(`Security error: Invalid serialized data. Segment "${segment}" does not exist.`)
     })
   })
 
   describe('options', () => {
-    it('supports overriding default handlers', () => {
+    it('supports overriding default handlers', async () => {
       const custom = new OpenAPIJsonSerializer({
         handlers: {
           date: {
@@ -139,16 +139,16 @@ describe('openAPIJsonSerializer', () => {
       })
 
       const date = new Date('2023-01-01')
-      expect(custom.serialize({ value: date }).json).toEqual({ value: `___TEST___${date.getTime()}` })
+      expect((await custom.serialize({ value: date })).json).toEqual({ value: `___TEST___${date.getTime()}` })
     })
 
-    it('supports disabling default handlers', () => {
+    it('supports disabling default handlers', async () => {
       const custom = new OpenAPIJsonSerializer({ handlers: { date: undefined } })
       const date = new Date('2023-01-01')
-      expect(custom.serialize({ value: date }).json).toEqual({ value: date })
+      expect((await custom.serialize({ value: date })).json).toEqual({ value: date })
     })
 
-    it('supports custom handlers', () => {
+    it('supports custom handlers', async () => {
       const custom = new OpenAPIJsonSerializer({
         handlers: {
           person: {
@@ -158,15 +158,15 @@ describe('openAPIJsonSerializer', () => {
         },
       })
 
-      expect(custom.serialize(new Person('dinwwwh', new Date('2023-01-01'))).json).toEqual({
+      expect((await custom.serialize(new Person('dinwwwh', new Date('2023-01-01')))).json).toEqual({
         name: 'dinwwwh',
         date: '2023-01-01T00:00:00.000Z',
       })
     })
 
-    it('can disable omitting undefined properties', () => {
+    it('can disable omitting undefined properties', async () => {
       const custom = new OpenAPIJsonSerializer({ omitUndefinedProperties: false })
-      expect(custom.serialize({ a: 1, b: undefined }).json).toEqual({ a: 1, b: null })
+      expect((await custom.serialize({ a: 1, b: undefined })).json).toEqual({ a: 1, b: null })
     })
   })
 })

--- a/packages/openapi/src/openapi-json-serializer.ts
+++ b/packages/openapi/src/openapi-json-serializer.ts
@@ -1,4 +1,4 @@
-import type { Segment } from '@orpc/shared'
+import type { Promisable, Segment } from '@orpc/shared'
 import { isPlainObject } from '@orpc/shared'
 
 export type OpenAPIJsonSerialization
@@ -6,8 +6,16 @@ export type OpenAPIJsonSerialization
     | { json: unknown, maps: Segment[][], blobs: Blob[] }
 
 export interface OpenAPIJsonSerializerHandler {
-  condition(value: unknown): boolean
-  serialize(value: any): unknown
+  /**
+   * The condition which has to be satisfied for the `serialize` function to run.
+   * @param value The value to be serialized.
+   */
+  condition(value: unknown): Promisable<boolean>
+  /**
+   * Function which serializes the given value.
+   * @param value The value to be serialized.
+   */
+  serialize(value: any): Promisable<unknown>
   /**
    * If false, the result of this serializer will not be further processed by other serializers,
    * even if it matches their conditions and treat it as final serialized value.
@@ -155,24 +163,24 @@ export class OpenAPIJsonSerializer {
     this.omitUndefinedProperties = options.omitUndefinedProperties !== false
   }
 
-  serialize(data: unknown): OpenAPIJsonSerialization {
-    const [json, maps, blobs] = this.serializeValue(data, [], [], [])
+  async serialize(data: unknown): Promise<OpenAPIJsonSerialization> {
+    const [json, maps, blobs] = await this.serializeValue(data, [], [], [])
 
     return { json, maps, blobs }
   }
 
-  private serializeValue(data: unknown, segments: Segment[], maps: Segment[][], blobs: Blob[]): [unknown, Segment[][], Blob[]] {
+  private async serializeValue(data: unknown, segments: Segment[], maps: Segment[][], blobs: Blob[]): Promise<[unknown, Segment[][], Blob[]]> {
     for (const key in this.handlers) {
       const handler = this.handlers[key]
 
-      if (handler && handler.condition(data)) {
-        const serialized = handler.serialize(data)
+      if (handler && (await handler.condition(data))) {
+        const serialized = await handler.serialize(data)
 
         if (handler.isTerminal) {
           return [serialized, maps, blobs]
         }
 
-        const result = this.serializeValue(serialized, segments, maps, blobs)
+        const result = await this.serializeValue(serialized, segments, maps, blobs)
         return result
       }
     }
@@ -184,9 +192,9 @@ export class OpenAPIJsonSerializer {
     }
 
     if (Array.isArray(data)) {
-      const json = data.map((v, i) => {
-        return this.serializeValue(v, [...segments, i], maps, blobs)[0]
-      })
+      const json = await Promise.all(data.map((v, i) => {
+        return this.serializeValue(v, [...segments, i], maps, blobs).then(result => result[0])
+      }))
 
       return [json, maps, blobs]
     }
@@ -209,7 +217,7 @@ export class OpenAPIJsonSerializer {
           continue
         }
 
-        json[k] = this.serializeValue(v, [...segments, k], maps, blobs)[0]
+        json[k] = (await this.serializeValue(v, [...segments, k], maps, blobs))[0]
       }
 
       return [json, maps, blobs]

--- a/packages/openapi/src/openapi-serializer.test.ts
+++ b/packages/openapi/src/openapi-serializer.test.ts
@@ -7,23 +7,23 @@ describe('openAPISerializer', () => {
   const serializer = new OpenAPISerializer()
 
   describe('serialize', () => {
-    it('uses OpenAPIJsonSerializer for serialization', () => {
-      expect(serializer.serialize({ date: new Date('2023-01-01'), count: 1n })).toEqual({
+    it('uses OpenAPIJsonSerializer for serialization', async () => {
+      expect(await serializer.serialize({ date: new Date('2023-01-01'), count: 1n })).toEqual({
         date: '2023-01-01T00:00:00.000Z',
         count: '1',
       })
     })
 
-    it('returns a root-level undefined as-is', () => {
-      expect(serializer.serialize(undefined)).toBe(undefined)
+    it('returns a root-level undefined as-is', async () => {
+      expect(await serializer.serialize(undefined)).toBe(undefined)
     })
 
-    it('returns a root-level Blob as-is without wrapping in FormData', () => {
+    it('returns a root-level Blob as-is without wrapping in FormData', async () => {
       const blob = new Blob(['hello'])
-      expect(serializer.serialize(blob)).toBe(blob)
+      expect(await serializer.serialize(blob)).toBe(blob)
     })
 
-    it('returns a root-level ReadableStream as-is', () => {
+    it('returns a root-level ReadableStream as-is', async () => {
       const stream = new ReadableStream<Uint8Array>({
         start(controller) {
           controller.enqueue(new TextEncoder().encode('hello'))
@@ -31,12 +31,12 @@ describe('openAPISerializer', () => {
         },
       })
 
-      expect(serializer.serialize(stream)).toBe(stream)
+      expect(await serializer.serialize(stream)).toBe(stream)
     })
 
-    it('converts object with blob fields to FormData', () => {
+    it('converts object with blob fields to FormData', async () => {
       const blob = new Blob(['hello'], { type: 'text/plain' })
-      const result = serializer.serialize({ file: blob, date: new Date('2023-01-01') }) as FormData
+      const result = (await serializer.serialize({ file: blob, date: new Date('2023-01-01') })) as FormData
 
       expect(result).toBeInstanceOf(FormData)
       const file = result.get('file') as Blob
@@ -46,21 +46,21 @@ describe('openAPISerializer', () => {
       expect(result.get('date')).toBe('2023-01-01T00:00:00.000Z')
     })
 
-    it('omits null and undefined fields from FormData', () => {
-      const result = serializer.serialize({ file: new Blob(['data']), empty: null }) as FormData
+    it('omits null and undefined fields from FormData', async () => {
+      const result = (await serializer.serialize({ file: new Blob(['data']), empty: null })) as FormData
       expect(result.has('empty')).toBe(false)
     })
 
-    it('skips useFormDataForBlobFields when false', () => {
+    it('skips useFormDataForBlobFields when false', async () => {
       const blob = new Blob(['hello'])
-      expect(serializer.serialize({ file: blob }, { useFormDataForBlobFields: false })).not.toBeInstanceOf(FormData)
+      expect(await serializer.serialize({ file: blob }, { useFormDataForBlobFields: false })).not.toBeInstanceOf(FormData)
     })
 
-    it('always returns FormData when asFormData is true, using bracket notation', () => {
-      const result = serializer.serialize(
+    it('always returns FormData when asFormData is true, using bracket notation', async () => {
+      const result = (await serializer.serialize(
         { user: { name: 'test' }, tags: ['a', 'b'] },
         { asFormData: true },
-      ) as FormData
+      )) as FormData
 
       expect(result).toBeInstanceOf(FormData)
       expect(result.get('user[name]')).toBe('test')
@@ -68,23 +68,23 @@ describe('openAPISerializer', () => {
       expect(result.get('tags[1]')).toBe('b')
     })
 
-    it('serializes root-level arrays to numeric FormData keys', () => {
-      const result = serializer.serialize(['a', 'b'], { asFormData: true }) as FormData
+    it('serializes root-level arrays to numeric FormData keys', async () => {
+      const result = (await serializer.serialize(['a', 'b'], { asFormData: true })) as FormData
 
       expect(result).toBeInstanceOf(FormData)
       expect(result.get('0')).toBe('a')
       expect(result.get('1')).toBe('b')
     })
 
-    it('call-site options override constructor defaults', () => {
+    it('call-site options override constructor defaults', async () => {
       const s = new OpenAPISerializer({ serialize: { asFormData: true, useFormDataForBlobFields: false } })
 
-      expect(s.serialize({ name: 'test' })).toBeInstanceOf(FormData)
-      expect(s.serialize({ name: 'test' }, { asFormData: false })).not.toBeInstanceOf(FormData)
+      expect(await s.serialize({ name: 'test' })).toBeInstanceOf(FormData)
+      expect(await s.serialize({ name: 'test' }, { asFormData: false })).not.toBeInstanceOf(FormData)
 
       const blob = new Blob(['hello'])
-      expect(s.serialize({ file: blob }, { asFormData: false })).not.toBeInstanceOf(FormData)
-      expect(s.serialize({ file: blob }, { asFormData: false, useFormDataForBlobFields: true })).toBeInstanceOf(FormData)
+      expect(await s.serialize({ file: blob }, { asFormData: false })).not.toBeInstanceOf(FormData)
+      expect(await s.serialize({ file: blob }, { asFormData: false, useFormDataForBlobFields: true })).toBeInstanceOf(FormData)
     })
 
     describe('asyncIteratorObject', () => {
@@ -93,7 +93,7 @@ describe('openAPISerializer', () => {
       }
 
       it('returns an AsyncIteratorObject and serializes yielded values', async () => {
-        const result = serializer.serialize(toAsyncIter([new Date('2023-01-01'), 42n])) as AsyncIteratorObject<unknown>
+        const result = (await serializer.serialize(toAsyncIter([new Date('2023-01-01'), 42n]))) as AsyncIteratorObject<unknown>
         expect(result).toSatisfy(isAsyncIteratorObject)
 
         const collected: unknown[] = []
@@ -102,7 +102,7 @@ describe('openAPISerializer', () => {
       })
 
       it('passes through undefined yielded values as-is', async () => {
-        const result = serializer.serialize(toAsyncIter([undefined, 'value'])) as AsyncIteratorObject<unknown>
+        const result = (await serializer.serialize(toAsyncIter([undefined, 'value']))) as AsyncIteratorObject<unknown>
         expect(result).toSatisfy(isAsyncIteratorObject)
 
         const collected: unknown[] = []
@@ -112,7 +112,7 @@ describe('openAPISerializer', () => {
 
       it('ignores asFormData default option and never wraps yielded values', async () => {
         const s = new OpenAPISerializer({ serialize: { asFormData: true } })
-        const result = s.serialize(toAsyncIter([{ name: 'test' }])) as AsyncIteratorObject<unknown>
+        const result = (await s.serialize(toAsyncIter([{ name: 'test' }]))) as AsyncIteratorObject<unknown>
         expect(result).toSatisfy(isAsyncIteratorObject)
 
         const collected: unknown[] = []
@@ -122,9 +122,9 @@ describe('openAPISerializer', () => {
 
       it('converts thrown ORPC errors into ErrorEvent payloads', async () => {
         const error = new ORPCError('BAD_GATEWAY', { data: { reason: 'upstream' } })
-        const result = serializer.serialize((async function* () {
+        const result = (await serializer.serialize((async function* () {
           throw error
-        })()) as AsyncIteratorObject<unknown>
+        })())) as AsyncIteratorObject<unknown>
 
         await expect(result.next()).rejects.toSatisfy((e: any) => {
           expect(e).toBeInstanceOf(ErrorEvent)
@@ -139,9 +139,9 @@ describe('openAPISerializer', () => {
 
       it('maps unknown iterator errors into INTERNAL_SERVER_ERROR payloads', async () => {
         const error = new Error('unexpected')
-        const result = serializer.serialize((async function* () {
+        const result = (await serializer.serialize((async function* () {
           throw error
-        })()) as AsyncIteratorObject<unknown>
+        })())) as AsyncIteratorObject<unknown>
 
         await expect(result.next()).rejects.toSatisfy((e: any) => {
           expect(e).toBeInstanceOf(ErrorEvent)
@@ -227,7 +227,7 @@ describe('openAPISerializer', () => {
       }
 
       it('returns an AsyncIteratorObject and passes through yielded values', async () => {
-        const result = serializer.deserialize(toAsyncIter([{ a: 1 }, { b: 2 }])) as AsyncIterable<unknown>
+        const result = (await serializer.deserialize(toAsyncIter([{ a: 1 }, { b: 2 }]))) as AsyncIterable<unknown>
         expect(result).toSatisfy(isAsyncIteratorObject)
 
         const collected: unknown[] = []
@@ -236,7 +236,7 @@ describe('openAPISerializer', () => {
       })
 
       it('passes through undefined yielded values as-is', async () => {
-        const result = serializer.deserialize(toAsyncIter([undefined, { a: 1 }])) as AsyncIterable<unknown>
+        const result = (await serializer.deserialize(toAsyncIter([undefined, { a: 1 }]))) as AsyncIterable<unknown>
         expect(result).toSatisfy(isAsyncIteratorObject)
 
         const collected: unknown[] = []
@@ -248,9 +248,9 @@ describe('openAPISerializer', () => {
         const error = new ErrorEvent(
           new ORPCError('BAD_GATEWAY', { data: { reason: 'upstream' } }).toJSON(),
         )
-        const result = serializer.deserialize((async function* () {
+        const result = (await serializer.deserialize((async function* () {
           throw error
-        })()) as AsyncIteratorObject<unknown>
+        })())) as AsyncIteratorObject<unknown>
 
         await expect(result.next()).rejects.toSatisfy((e: any) => {
           expect(e).toBeInstanceOf(ORPCError)
@@ -264,18 +264,18 @@ describe('openAPISerializer', () => {
 
       it('passes through ErrorEvent instances with non-ORPC payloads', async () => {
         const error = new ErrorEvent({ reason: 'upstream' })
-        const result = serializer.deserialize((async function* () {
+        const result = (await serializer.deserialize((async function* () {
           throw error
-        })()) as AsyncIteratorObject<unknown>
+        })())) as AsyncIteratorObject<unknown>
 
         await expect(result.next()).rejects.toBe(error)
       })
 
       it('passes through non-ErrorEvent errors', async () => {
         const error = new Error('unexpected')
-        const result = serializer.deserialize((async function* () {
+        const result = (await serializer.deserialize((async function* () {
           throw error
-        })()) as AsyncIteratorObject<unknown>
+        })())) as AsyncIteratorObject<unknown>
 
         await expect(result.next()).rejects.toBe(error)
       })
@@ -283,33 +283,52 @@ describe('openAPISerializer', () => {
   })
 
   describe('options', () => {
-    it('passes OpenAPIJsonSerializerOptions to OpenAPIJsonSerializer', () => {
+    it('passes OpenAPIJsonSerializerOptions to OpenAPIJsonSerializer', async () => {
       const s = new OpenAPISerializer({
         handlers: {
           date: {
             condition: v => v instanceof Date,
             serialize: (v: Date) => `___TEST___${v.getTime()}`,
           },
+          cryptoKey: {
+            condition: v => v instanceof CryptoKey,
+            serialize: async (v: CryptoKey) => {
+              return await crypto.subtle.exportKey('jwk', v)
+            },
+          },
         },
       })
 
       const date = new Date('2023-01-01')
-      expect(s.serialize({ value: date })).toEqual({ value: `___TEST___${date.getTime()}` })
+      expect((await s.serialize({ value: date }))).toEqual({ value: `___TEST___${date.getTime()}` })
+
+      const keyPair = await crypto.subtle.generateKey(
+        {
+          name: 'RSA-OAEP',
+          modulusLength: 4096,
+          publicExponent: new Uint8Array([1, 0, 1]),
+          hash: 'SHA-256',
+        },
+        true,
+        ['encrypt', 'decrypt'],
+      )
+      const serialized = await crypto.subtle.exportKey('jwk', keyPair.publicKey)
+      expect((await s.serialize({ value: keyPair.publicKey }))).toEqual({ value: serialized })
     })
 
-    it('passes omitUndefinedProperties to OpenAPIJsonSerializer', () => {
+    it('passes omitUndefinedProperties to OpenAPIJsonSerializer', async () => {
       const s = new OpenAPISerializer({ omitUndefinedProperties: false })
-      expect(s.serialize({ a: 1, b: undefined })).toEqual({ a: 1, b: null })
+      expect((await s.serialize({ a: 1, b: undefined }))).toEqual({ a: 1, b: null })
     })
 
-    it('passes BracketNotationSerializerOptions to BracketNotationSerializer', () => {
+    it('passes BracketNotationSerializerOptions to BracketNotationSerializer', async () => {
       const s = new OpenAPISerializer({ bracketNotation: { maxExplicitDeserializingArrayIndex: 0 } })
 
       // index 1 exceeds the limit of 0, so the array should be deserialized as an object
       const form = new FormData()
       form.append('tags[0]', 'a')
       form.append('tags[1]', 'b')
-      const result = s.deserialize(form) as any
+      const result = await s.deserialize(form) as any
       expect(Array.isArray(result.tags)).toBe(false)
       expect(result.tags['0']).toBe('a')
       expect(result.tags['1']).toBe('b')

--- a/packages/openapi/src/openapi-serializer.ts
+++ b/packages/openapi/src/openapi-serializer.ts
@@ -24,7 +24,7 @@ export interface OpenAPISerializerSerializeOptions {
   asFormData?: boolean | undefined
 }
 
-export interface OpenAPISerializerOptions extends OpenAPIJsonSerializerOptions, OpenAPISerializerSerializeOptions {
+export interface OpenAPISerializerOptions extends OpenAPIJsonSerializerOptions {
   /**
    * Options for bracket notation serializer, like maxExplicitDeserializingArrayIndex
    */
@@ -49,7 +49,7 @@ export class OpenAPISerializer {
     this.defaultSerializeOptions = serialize
   }
 
-  serialize(data: unknown, options: OpenAPISerializerSerializeOptions = {}): StandardBody {
+  async serialize(data: unknown, options: OpenAPISerializerSerializeOptions = {}): Promise<StandardBody> {
     const useFormDataForBlobFields = options.useFormDataForBlobFields ?? this.defaultSerializeOptions?.useFormDataForBlobFields ?? true
     const asFormData = options.asFormData ?? this.defaultSerializeOptions?.asFormData ?? false
 
@@ -61,17 +61,17 @@ export class OpenAPISerializer {
 
       if (isAsyncIteratorObject(data)) {
         return wrapAsyncIteratorPreservingEventMeta(data, {
-          mapResult: (result) => {
+          mapResult: async (result) => {
             // standard event stream data already supports these types without additional serialization.
             if (result.value === undefined) {
               return result
             }
 
-            return { done: result.done, value: this.serializeValue(result.value, { asFormData: false, useFormDataForBlobFields: false }) }
+            return { done: result.done, value: await this.serializeValue(result.value, { asFormData: false, useFormDataForBlobFields: false }) }
           },
-          mapError: (e) => {
+          mapError: async (e) => {
             return new ErrorEvent({
-              data: this.serializeValue(toORPCError(e).toJSON(), { asFormData: false, useFormDataForBlobFields: false }),
+              data: await this.serializeValue(toORPCError(e).toJSON(), { asFormData: false, useFormDataForBlobFields: false }),
               cause: e,
             })
           },
@@ -82,8 +82,8 @@ export class OpenAPISerializer {
     return this.serializeValue(data, { useFormDataForBlobFields, asFormData })
   }
 
-  private serializeValue(value: unknown, options: Required<OpenAPISerializerSerializeOptions>): unknown {
-    const { json, blobs } = this.jsonSerializer.serialize(value)
+  private async serializeValue(value: unknown, options: Required<OpenAPISerializerSerializeOptions>): Promise<unknown> {
+    const { json, blobs } = await this.jsonSerializer.serialize(value)
 
     if (!options.asFormData && (json instanceof Blob || json === undefined || !blobs?.length || !options.useFormDataForBlobFields)) {
       return json
@@ -110,14 +110,14 @@ export class OpenAPISerializer {
 
     if (isAsyncIteratorObject(data)) {
       return wrapAsyncIteratorPreservingEventMeta(data, {
-        mapResult: (result) => {
+        mapResult: async (result) => {
           if (result.value === undefined) {
             return result
           }
 
           return { done: result.done, value: this.jsonSerializer.deserialize({ json: result.value }) }
         },
-        mapError: (e) => {
+        mapError: async (e) => {
           if (e instanceof ErrorEvent) {
             const deserialized = this.jsonSerializer.deserialize({ json: e.data })
 


### PR DESCRIPTION
Makes the `serialize` function of the `OpenApiSerializer` async. Resolves the `OpenApi` part of https://github.com/middleapi/orpc/issues/1654 

If this gets merged I can make a separate PR for the `RPCSerializer` or add it to this PR.