### PR TITLE
feat(client, server): add keep-alive for streaming batch responses

### DIFF
--- a/apps/content/docs/plugins/batch.md
+++ b/apps/content/docs/plugins/batch.md
@@ -76,6 +76,54 @@ const link = new RPCLink({
 })
 ```
 
+### Keep-Alive Timer
+
+In **streaming** mode, long-running batch responses may remain idle for extended periods. The server plugin can send keep-alive frames to keep the connection alive.
+
+```ts
+const handler = new RPCHandler(router, {
+  plugins: [
+    new BatchHandlerPlugin({
+      keepAlive: {
+        /**
+         * If true, a keep-alive frame is sent periodically while the stream is idle.
+         *
+         * @default true
+         */
+        enabled: true,
+        /**
+         * Interval (in milliseconds) between keep-alive frames after the last message.
+         *
+         * @default 15000
+         */
+        interval: 15000,
+      },
+    }),
+  ],
+})
+```
+
+## Filtering Requests
+
+Use `filter` to skip batching for specific requests before group matching runs. Requests for which `filter` returns `false` continue through the link chain individually.
+
+```ts
+const link = new RPCLink({
+  url: '/rpc',
+  plugins: [
+    new BatchLinkPlugin({
+      filter: ({ path }) => !path.includes('upload'),
+      groups: [
+        {
+          condition: () => true,
+          context: {},
+        },
+      ],
+    }),
+  ],
+})
+```
+
 ## Groups
 
 Only requests in the same group are batched together. Each group also defines a context, as described in [client context](/docs/rpc/link#client-context).
@@ -119,27 +167,6 @@ const link = new RPCLink<ClientContext>({
 ```
 
 Now, calls made with `cache = 'force-cache'` use that cache setting whether they are batched or sent individually.
-
-## Filtering Requests
-
-Use `filter` to skip batching for specific requests before group matching runs. Requests for which `filter` returns `false` continue through the link chain individually.
-
-```ts
-const link = new RPCLink({
-  url: '/rpc',
-  plugins: [
-    new BatchLinkPlugin({
-      filter: ({ path }) => !path.includes('upload'),
-      groups: [
-        {
-          condition: () => true,
-          context: {},
-        },
-      ],
-    }),
-  ],
-})
-```
 
 ## Learn More
 

--- a/apps/content/docs/plugins/batch.md
+++ b/apps/content/docs/plugins/batch.md
@@ -103,27 +103,6 @@ const handler = new RPCHandler(router, {
 })
 ```
 
-## Filtering Requests
-
-Use `filter` to skip batching for specific requests before group matching runs. Requests for which `filter` returns `false` continue through the link chain individually.
-
-```ts
-const link = new RPCLink({
-  url: '/rpc',
-  plugins: [
-    new BatchLinkPlugin({
-      filter: ({ path }) => !path.includes('upload'),
-      groups: [
-        {
-          condition: () => true,
-          context: {},
-        },
-      ],
-    }),
-  ],
-})
-```
-
 ## Groups
 
 Only requests in the same group are batched together. Each group also defines a context, as described in [client context](/docs/rpc/link#client-context).
@@ -167,6 +146,27 @@ const link = new RPCLink<ClientContext>({
 ```
 
 Now, calls made with `cache = 'force-cache'` use that cache setting whether they are batched or sent individually.
+
+## Filtering Requests
+
+Use `filter` to skip batching for specific requests before group matching runs. Requests for which `filter` returns `false` continue through the link chain individually.
+
+```ts
+const link = new RPCLink({
+  url: '/rpc',
+  plugins: [
+    new BatchLinkPlugin({
+      filter: ({ path }) => !path.includes('upload'),
+      groups: [
+        {
+          condition: () => true,
+          context: {},
+        },
+      ],
+    }),
+  ],
+})
+```
 
 ## Learn More
 

--- a/packages/client/src/plugins/batch.test.ts
+++ b/packages/client/src/plugins/batch.test.ts
@@ -626,46 +626,6 @@ describe('batchLinkPlugin', () => {
       ])
     })
 
-    it('ignores zero-length keep-alive frames in blob batch responses', async () => {
-      const codec = makeCodec()
-      const transport = makeTransport()
-
-      vi.mocked(transport.send).mockImplementation(async (request) => {
-        if (!request.headers['orpc-batch']) {
-          return { status: 200, headers: {}, resolveBody: async () => 'direct' }
-        }
-
-        const rawMessages = Array.isArray(request.body) ? request.body : []
-        const responseMessages = rawMessages.map((msg: any, i: number) => ({
-          kind: 'response',
-          id: msg.id,
-          json: { status: 200, headers: {}, body: `blob-ka-${i}` },
-        }))
-
-        const bytes = await toLengthPrefixedBytes(responseMessages)
-        const keepAlive = new Uint8Array([0, 0, 0, 0])
-        const withKeepAlives = new Uint8Array(keepAlive.length + bytes.length + keepAlive.length)
-        withKeepAlives.set(keepAlive, 0)
-        withKeepAlives.set(bytes, keepAlive.length)
-        withKeepAlives.set(keepAlive, keepAlive.length + bytes.length)
-
-        return {
-          status: 207,
-          headers: {},
-          resolveBody: async () => new Blob([withKeepAlives], { type: 'application/octet-stream' }),
-        }
-      })
-
-      const link = new StandardLink(codec, transport, {
-        plugins: [new BatchLinkPlugin({ groups: [defaultGroup], mode: 'buffered' })],
-      })
-
-      await Promise.all([
-        expect(link.call(['a'], {}, { context: {} })).resolves.toBe('blob-ka-0'),
-        expect(link.call(['b'], {}, { context: {} })).resolves.toBe('blob-ka-1'),
-      ])
-    })
-
     it('decodes streamed responses when length header and payload arrive in separate chunks', async () => {
       const codec = makeCodec()
       const transport = makeTransport()

--- a/packages/client/src/plugins/batch.test.ts
+++ b/packages/client/src/plugins/batch.test.ts
@@ -579,6 +579,93 @@ describe('batchLinkPlugin', () => {
       ])
     })
 
+    it('ignores zero-length keep-alive frames in stream batch responses', async () => {
+      const codec = makeCodec()
+      const transport = makeTransport()
+
+      vi.mocked(transport.send).mockImplementation(async (request) => {
+        if (!request.headers['orpc-batch']) {
+          return { status: 200, headers: {}, resolveBody: async () => 'direct' }
+        }
+
+        const rawMessages = Array.isArray(request.body) ? request.body : []
+        const responseMessages = rawMessages.map((msg: any, i: number) => ({
+          kind: 'response',
+          id: msg.id,
+          json: { status: 200, headers: {}, body: `keepalive-${i}` },
+        }))
+
+        const bytes = await toLengthPrefixedBytes(responseMessages)
+        const keepAlive = new Uint8Array([0, 0, 0, 0])
+
+        // Keep-alive frames only appear between complete length-prefixed messages
+        // (never between a length header and its payload).
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(keepAlive)
+            controller.enqueue(bytes)
+            controller.enqueue(keepAlive)
+            controller.close()
+          },
+        })
+
+        return {
+          status: 207,
+          headers: {},
+          resolveBody: async () => stream,
+        }
+      })
+
+      const link = new StandardLink(codec, transport, {
+        plugins: [new BatchLinkPlugin({ groups: [defaultGroup], mode: 'streaming' })],
+      })
+
+      await Promise.all([
+        expect(link.call(['a'], {}, { context: {} })).resolves.toBe('keepalive-0'),
+        expect(link.call(['b'], {}, { context: {} })).resolves.toBe('keepalive-1'),
+      ])
+    })
+
+    it('ignores zero-length keep-alive frames in blob batch responses', async () => {
+      const codec = makeCodec()
+      const transport = makeTransport()
+
+      vi.mocked(transport.send).mockImplementation(async (request) => {
+        if (!request.headers['orpc-batch']) {
+          return { status: 200, headers: {}, resolveBody: async () => 'direct' }
+        }
+
+        const rawMessages = Array.isArray(request.body) ? request.body : []
+        const responseMessages = rawMessages.map((msg: any, i: number) => ({
+          kind: 'response',
+          id: msg.id,
+          json: { status: 200, headers: {}, body: `blob-ka-${i}` },
+        }))
+
+        const bytes = await toLengthPrefixedBytes(responseMessages)
+        const keepAlive = new Uint8Array([0, 0, 0, 0])
+        const withKeepAlives = new Uint8Array(keepAlive.length + bytes.length + keepAlive.length)
+        withKeepAlives.set(keepAlive, 0)
+        withKeepAlives.set(bytes, keepAlive.length)
+        withKeepAlives.set(keepAlive, keepAlive.length + bytes.length)
+
+        return {
+          status: 207,
+          headers: {},
+          resolveBody: async () => new Blob([withKeepAlives], { type: 'application/octet-stream' }),
+        }
+      })
+
+      const link = new StandardLink(codec, transport, {
+        plugins: [new BatchLinkPlugin({ groups: [defaultGroup], mode: 'buffered' })],
+      })
+
+      await Promise.all([
+        expect(link.call(['a'], {}, { context: {} })).resolves.toBe('blob-ka-0'),
+        expect(link.call(['b'], {}, { context: {} })).resolves.toBe('blob-ka-1'),
+      ])
+    })
+
     it('decodes streamed responses when length header and payload arrive in separate chunks', async () => {
       const codec = makeCodec()
       const transport = makeTransport()

--- a/packages/client/src/plugins/batch.ts
+++ b/packages/client/src/plugins/batch.ts
@@ -363,6 +363,11 @@ async function decodeLengthPrefixedBlob(blob: Blob, peer: ClientPeer): Promise<v
     const length = view.getUint32(0, false)
     offset += 4
 
+    // Zero-length frame is a keep-alive ping; skip it.
+    if (length === 0) {
+      continue
+    }
+
     if (offset + length > buffer.length) {
       throw new BatchLinkPluginError('Invalid batch response: incomplete message.')
     }
@@ -397,6 +402,12 @@ async function decodeLengthPrefixedStream(stream: ReadableStream<Uint8Array>, pe
       while (buffer.length >= 4) {
         const view = new DataView(buffer.buffer, buffer.byteOffset, 4)
         const length = view.getUint32(0, false)
+
+        // Zero-length frame is a keep-alive ping; skip it.
+        if (length === 0) {
+          buffer = buffer.subarray(4)
+          continue
+        }
 
         if (buffer.length < 4 + length) {
           break

--- a/packages/client/src/plugins/batch.ts
+++ b/packages/client/src/plugins/batch.ts
@@ -363,11 +363,6 @@ async function decodeLengthPrefixedBlob(blob: Blob, peer: ClientPeer): Promise<v
     const length = view.getUint32(0, false)
     offset += 4
 
-    // Zero-length frame is a keep-alive ping; skip it.
-    if (length === 0) {
-      continue
-    }
-
     if (offset + length > buffer.length) {
       throw new BatchLinkPluginError('Invalid batch response: incomplete message.')
     }

--- a/packages/server/src/plugins/batch.test.ts
+++ b/packages/server/src/plugins/batch.test.ts
@@ -1,4 +1,5 @@
 import type { AnyRouter } from '../router'
+import { promiseWithResolvers } from '@orpc/shared'
 import { RPCHandler } from '../adapters/fetch/rpc-handler'
 import { os } from '../builder'
 import { BatchHandlerPlugin } from './batch'
@@ -317,6 +318,194 @@ describe('batchHandlerPlugin', () => {
       }))
 
       expect(response!.status).toBe(200)
+    })
+  })
+
+  describe('keepAlive', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('sends zero-length keep-alive frames while the stream is idle', async () => {
+      const { promise: gate, resolve } = promiseWithResolvers<void>()
+
+      const slowRouter = {
+        ping: os.handler(async () => {
+          await gate
+          return 'pong'
+        }),
+      }
+
+      const handler = createHandler(new BatchHandlerPlugin({
+        keepAlive: { enabled: true, interval: 100 },
+      }), slowRouter)
+
+      const { response } = await handler.handle(createBatchRequest({
+        mode: 'streaming',
+        messages: [makePeerRequestMessage(0, '/ping')],
+      }))
+
+      expect(response!.body).toBeInstanceOf(ReadableStream)
+
+      const reader = (response!.body as ReadableStream<Uint8Array>).getReader()
+      const frames: Uint8Array[] = []
+
+      const readNext = async () => {
+        const { done, value } = await reader.read()
+        if (!done && value) {
+          frames.push(value)
+        }
+        return done
+      }
+
+      // First keep-alive after interval with no real message yet.
+      const firstKeepAlive = readNext()
+      await vi.advanceTimersByTimeAsync(100)
+      await firstKeepAlive
+
+      expect(frames).toHaveLength(1)
+      expect(frames[0]).toEqual(new Uint8Array([0, 0, 0, 0]))
+
+      // Another keep-alive while still idle.
+      const secondKeepAlive = readNext()
+      await vi.advanceTimersByTimeAsync(100)
+      await secondKeepAlive
+
+      expect(frames).toHaveLength(2)
+      expect(frames[1]).toEqual(new Uint8Array([0, 0, 0, 0]))
+
+      resolve()
+      while (!(await readNext())) {
+        // keep reading until closed
+      }
+
+      expect(vi.getTimerCount()).toBe(0)
+    })
+
+    it('does not schedule a keep-alive timer when disabled', async () => {
+      const handler = createHandler(new BatchHandlerPlugin({
+        keepAlive: { enabled: false },
+      }))
+
+      const { response } = await handler.handle(createBatchRequest({
+        mode: 'streaming',
+        messages: [makePeerRequestMessage(0, '/ping')],
+      }))
+
+      expect(response!.body).toBeInstanceOf(ReadableStream)
+      expect(vi.getTimerCount()).toBe(0)
+
+      // Drain so the stream can complete cleanly.
+      await response!.arrayBuffer()
+      expect(vi.getTimerCount()).toBe(0)
+    })
+
+    it('stops keep-alive after the stream is cancelled', async () => {
+      const gate = new Promise<void>(() => {})
+
+      const slowRouter = {
+        ping: os.handler(async () => {
+          await gate
+          return 'pong'
+        }),
+      }
+
+      const handler = createHandler(new BatchHandlerPlugin({
+        keepAlive: { enabled: true, interval: 50 },
+      }), slowRouter)
+
+      const { response } = await handler.handle(createBatchRequest({
+        mode: 'streaming',
+        messages: [makePeerRequestMessage(0, '/ping')],
+      }))
+
+      expect(vi.getTimerCount()).toBeGreaterThan(0)
+
+      const reader = (response!.body as ReadableStream<Uint8Array>).getReader()
+
+      const first = reader.read()
+      await vi.advanceTimersByTimeAsync(50)
+      await first
+
+      await reader.cancel()
+
+      expect(vi.getTimerCount()).toBe(0)
+    })
+
+    it('clears keep-alive timer when keep-alive enqueue fails', async ({ onTestFinished }) => {
+      const gate = new Promise<void>(() => {})
+
+      const slowRouter = {
+        ping: os.handler(async () => {
+          await gate
+          return 'pong'
+        }),
+      }
+
+      const originalEnqueue = ReadableStreamDefaultController.prototype.enqueue
+      const enqueueSpy = vi.spyOn(ReadableStreamDefaultController.prototype, 'enqueue')
+        .mockImplementation(function (this: ReadableStreamDefaultController<Uint8Array>, chunk: Uint8Array) {
+          // Keep-alive frame is a zero-length length prefix: [0, 0, 0, 0]
+          if (
+            chunk instanceof Uint8Array
+            && chunk.byteLength === 4
+            && chunk[0] === 0
+            && chunk[1] === 0
+            && chunk[2] === 0
+            && chunk[3] === 0
+          ) {
+            throw new Error('keep-alive enqueue failed')
+          }
+
+          return originalEnqueue.call(this, chunk)
+        })
+
+      onTestFinished(() => {
+        enqueueSpy.mockRestore()
+      })
+
+      const handler = createHandler(new BatchHandlerPlugin({
+        keepAlive: { enabled: true, interval: 50 },
+      }), slowRouter)
+
+      await handler.handle(createBatchRequest({
+        mode: 'streaming',
+        messages: [makePeerRequestMessage(0, '/ping')],
+      }))
+
+      // One keep-alive setInterval is scheduled while the stream is idle.
+      expect(vi.getTimerCount()).toBe(1)
+
+      await vi.advanceTimersByTimeAsync(50)
+
+      // catch path should clear the interval after enqueue throws
+      expect(vi.getTimerCount()).toBe(0)
+    })
+
+    it('clears keep-alive timer when peer-message enqueue throws', async ({ onTestFinished }) => {
+      const enqueueSpy = vi.spyOn(ReadableStreamDefaultController.prototype, 'enqueue')
+        .mockThrow(new Error('enqueue failed'))
+
+      onTestFinished(() => {
+        enqueueSpy.mockRestore()
+      })
+
+      const handler = createHandler(new BatchHandlerPlugin({
+        keepAlive: { enabled: false },
+      }))
+
+      const { response } = await handler.handle(createBatchRequest({
+        mode: 'streaming',
+        messages: [makePeerRequestMessage(0, '/ping')],
+      }))
+
+      const reader = (response!.body as ReadableStream<Uint8Array>).getReader()
+      await expect(reader.read()).rejects.toThrow('enqueue failed')
+      expect(vi.getTimerCount()).toBe(0)
     })
   })
 })

--- a/packages/server/src/plugins/batch.ts
+++ b/packages/server/src/plugins/batch.ts
@@ -36,6 +36,30 @@ export interface BatchHandlerPluginOptions<T extends Context> {
    * @default {}
    */
   headers?: Value<Promisable<StandardHeaders>, [batchOptions: StandardHandlerRoutingInterceptorOptions<T>]>
+
+  /**
+   * Keep-alive settings for streaming batch responses.
+   *
+   * When enabled, a zero-length length-prefixed frame is sent periodically while the
+   * stream is idle (no message sent for `interval` ms). Clients ignore these frames.
+   * Only applies to streaming mode.
+   *
+   * @default { enabled: true, interval: 15000 }
+   */
+  keepAlive?: undefined | {
+    /**
+     * If true, a keep-alive frame is sent periodically while the stream is idle.
+     *
+     * @default true
+     */
+    enabled: boolean
+    /**
+     * Interval (in milliseconds) between keep-alive frames after the last message.
+     *
+     * @default 15000
+     */
+    interval?: number
+  }
 }
 
 export class BatchHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
@@ -51,6 +75,8 @@ export class BatchHandlerPlugin<T extends Context> implements StandardHandlerPlu
   private readonly mapSubrequest: Exclude<BatchHandlerPluginOptions<T>['mapSubrequest'], undefined>
   private readonly successStatus: Exclude<BatchHandlerPluginOptions<T>['successStatus'], undefined>
   private readonly headers: Exclude<BatchHandlerPluginOptions<T>['headers'], undefined>
+  private readonly keepAliveEnabled: boolean
+  private readonly keepAliveInterval: number
 
   constructor(options: BatchHandlerPluginOptions<T> = {}) {
     this.maxSize = options.maxSize ?? 10
@@ -66,6 +92,8 @@ export class BatchHandlerPlugin<T extends Context> implements StandardHandlerPlu
 
     this.successStatus = options.successStatus ?? 207
     this.headers = options.headers ?? {}
+    this.keepAliveEnabled = options.keepAlive?.enabled ?? true
+    this.keepAliveInterval = options.keepAlive?.interval ?? 15_000
   }
 
   init(options: StandardHandlerOptions<T>): StandardHandlerOptions<T> {
@@ -201,9 +229,42 @@ export class BatchHandlerPlugin<T extends Context> implements StandardHandlerPlu
 
       // streaming mode — binary length-prefixed ReadableStream
       let streamController: ReadableStreamDefaultController<Uint8Array>
+      let keepAliveTimer: ReturnType<typeof setInterval> | undefined
+
+      const clearKeepAlive = () => {
+        if (keepAliveTimer !== undefined) {
+          clearInterval(keepAliveTimer)
+          keepAliveTimer = undefined
+        }
+      }
+
+      const scheduleKeepAlive = () => {
+        if (!this.keepAliveEnabled) {
+          return
+        }
+
+        clearKeepAlive()
+        keepAliveTimer = setInterval(() => {
+          try {
+            // Zero-length length-prefixed frame = keep-alive (ignored by clients)
+            const lengthBuffer = new ArrayBuffer(4)
+            new DataView(lengthBuffer).setUint32(0, 0, false)
+            streamController.enqueue(new Uint8Array(lengthBuffer))
+          }
+          catch {
+            // Stream may already be closed or errored.
+            clearKeepAlive()
+          }
+        }, this.keepAliveInterval)
+      }
+
       const stream = new ReadableStream<Uint8Array<ArrayBuffer>>({
         start(controller) {
           streamController = controller
+          scheduleKeepAlive()
+        },
+        cancel() {
+          clearKeepAlive()
         },
       })
 
@@ -215,15 +276,18 @@ export class BatchHandlerPlugin<T extends Context> implements StandardHandlerPlu
         new DataView(lengthBuffer).setUint32(0, bytes.byteLength, false)
         streamController.enqueue(new Uint8Array(lengthBuffer))
         streamController.enqueue(bytes)
+        scheduleKeepAlive() // reset idle timer
       })
 
       // DO NOT await here to block streaming response
       Promise.all(messages.map(msg => peer.message(msg, handleIndividualRequest)))
         .then(async () => {
+          clearKeepAlive()
           streamController.close()
           await peer.close()
         })
         .catch(async (error) => {
+          clearKeepAlive()
           streamController.error(error)
           await peer.close(error)
         })


### PR DESCRIPTION
Send zero-length length-prefixed frames while streaming batch responses are idle (default 15s, configurable).