### PR TITLE
fix(server): stop copying request Vary into CORS responses

### DIFF
--- a/packages/server/src/plugins/cors.test.ts
+++ b/packages/server/src/plugins/cors.test.ts
@@ -27,7 +27,7 @@ describe('corsHandlerPlugin', () => {
     expect(handlerFn).toHaveBeenCalledTimes(0)
     expect(response!.status).toBe(204)
     expect(response!.headers.get('access-control-allow-origin')).toBe('https://example.com')
-    expect(response!.headers.get('vary')).toBe('origin')
+    expect(response!.headers.get('vary')).toBe('Origin')
     expect(response!.headers.get('access-control-allow-methods')).toBe('GET, HEAD, PUT, POST, DELETE, PATCH')
     expect(response!.headers.get('access-control-max-age')).toBeNull()
   })
@@ -52,6 +52,28 @@ describe('corsHandlerPlugin', () => {
     expect(response!.headers.get('access-control-max-age')).toBe('600')
     expect(response!.headers.get('access-control-allow-methods')).toBe('GET, HEAD, PUT, POST, DELETE, PATCH')
     expect(response!.headers.get('access-control-allow-headers')).toBe('Content-Type, Authorization')
+  })
+
+  it('omits allow-methods and allow-headers when configured as empty', async () => {
+    const plugin = new CORSHandlerPlugin({
+      allowMethods: [],
+      allowHeaders: [],
+    })
+
+    const handler = new RPCHandler(router, {
+      plugins: [plugin],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com', {
+      method: 'OPTIONS',
+      headers: {
+        'origin': 'https://example.com',
+        'access-control-request-headers': 'X-Requested-With',
+      },
+    }))
+
+    expect(response!.headers.get('access-control-allow-methods')).toBeNull()
+    expect(response!.headers.get('access-control-allow-headers')).toBeNull()
   })
 
   it('sets allowed origin only when custom origin function approves', async () => {
@@ -211,7 +233,116 @@ describe('corsHandlerPlugin', () => {
     // default origin function `origin => origin` returns '' for empty origin,
     // which is not included in the response as a valid origin
     expect(response!.headers.get('access-control-allow-origin')).toBe('')
-    expect(response!.headers.get('vary')).toBe('origin')
+    expect(response!.headers.get('vary')).toBe('Origin')
+  })
+
+  it('does not copy Vary from the request', async () => {
+    const handler = new RPCHandler(router, {
+      plugins: [new CORSHandlerPlugin()],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com', {
+      method: 'OPTIONS',
+      headers: {
+        origin: 'https://example.com',
+        vary: 'Accept-Encoding',
+      },
+    }))
+
+    expect(response!.headers.get('access-control-allow-origin')).toBe('https://example.com')
+    expect(response!.headers.get('vary')).toBe('Origin')
+  })
+
+  it('appends Origin to an existing response Vary header', async () => {
+    const handler = new RPCHandler(router, {
+      plugins: [
+        {
+          name: 'set-vary',
+          init(options) {
+            return {
+              ...options,
+              routingInterceptors: [
+                async (opts) => {
+                  const result = await opts.next()
+                  if (!result.matched) {
+                    return result
+                  }
+                  return {
+                    ...result,
+                    response: {
+                      ...result.response,
+                      headers: {
+                        ...result.response.headers,
+                        vary: 'Accept-Encoding',
+                      },
+                    },
+                  }
+                },
+                ...options.routingInterceptors ?? [],
+              ],
+            }
+          },
+        },
+        new CORSHandlerPlugin(),
+      ],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/ping', {
+      method: 'POST',
+      headers: {
+        'origin': 'https://example.com',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ json: null }),
+    }))
+
+    expect(response!.headers.get('vary')).toBe('Accept-Encoding, Origin')
+  })
+
+  it('does not duplicate Origin in Vary when already present', async () => {
+    const handler = new RPCHandler(router, {
+      plugins: [
+        {
+          name: 'set-vary',
+          init(options) {
+            return {
+              ...options,
+              routingInterceptors: [
+                async (opts) => {
+                  const result = await opts.next()
+                  if (!result.matched) {
+                    return result
+                  }
+                  return {
+                    ...result,
+                    response: {
+                      ...result.response,
+                      headers: {
+                        ...result.response.headers,
+                        vary: 'Accept-Encoding, origin',
+                      },
+                    },
+                  }
+                },
+                ...options.routingInterceptors ?? [],
+              ],
+            }
+          },
+        },
+        new CORSHandlerPlugin(),
+      ],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/ping', {
+      method: 'POST',
+      headers: {
+        'origin': 'https://example.com',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ json: null }),
+    }))
+
+    expect(response!.headers.get('vary')).toBe('Accept-Encoding, origin')
   })
 
   it('does not add CORS headers when request does not match any procedure', async () => {

--- a/packages/server/src/plugins/cors.ts
+++ b/packages/server/src/plugins/cors.ts
@@ -110,7 +110,10 @@ export class CORSHandlerPlugin<T extends Context> implements StandardHandlerPlug
           resHeaders['access-control-allow-origin'] = origin
         }
 
-        resHeaders.vary = interceptorOptions.request.headers.vary ?? 'origin'
+        const existingVary = flattenStandardHeader(resHeaders.vary)
+        if (!existingVary?.split(',').some(v => v.trim().toLocaleLowerCase() === 'origin')) {
+          resHeaders.vary = existingVary ? `${existingVary}, Origin` : 'Origin'
+        }
       }
 
       const allowedTimingOrigins = toArray(await value(this.options.timingOrigin, origin, interceptorOptions))

--- a/packages/server/src/plugins/cors.ts
+++ b/packages/server/src/plugins/cors.ts
@@ -111,7 +111,7 @@ export class CORSHandlerPlugin<T extends Context> implements StandardHandlerPlug
         }
 
         const existingVary = flattenStandardHeader(resHeaders.vary)
-        if (!existingVary?.split(',').some(v => v.trim().toLocaleLowerCase() === 'origin')) {
+        if (!existingVary?.split(',').some(v => v.trim().toLowerCase() === 'origin')) {
           resHeaders.vary = existingVary ? `${existingVary}, Origin` : 'Origin'
         }
       }


### PR DESCRIPTION
The CORS plugin previously assigned the request's Vary header to the response, letting clients control cache variation. Always set or append Origin on the response Vary instead, preserving any existing response values without duplicates.

Fixes #1661