### PR TITLE
chore: add CLAUDE.md and Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; ./node_modules/.bin/eslint --no-warn-ignored --max-warnings=0 --fix \"$f\"; } 2>/dev/null || true",
+            "timeout": 30,
+            "statusMessage": "Running eslint --fix"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 !.vscode/
 !.github/
 !.vitepress/
+!.claude/
 
 # Common generated folders
 logs/
@@ -28,3 +29,4 @@ vitest.config.ts.timestamp-*
 # Common manual ignore files
 *.local
 *.pem
+*.local.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository
+
+oRPC — typesafe API framework. pnpm monorepo (Node 22+, `pnpm` workspaces) with packages in `packages/*`, docs/website in `apps/content` (VitePress), example apps in `playgrounds/*`, root-level e2e tests in `tests/`, and benchmarks in `benches/`.
+
+## Commands
+
+```bash
+pnpm install                 # setup
+pnpm test                    # all tests: per-package tests + root vitest
+pnpm vitest run <path>       # single test file (from repo root), e.g. pnpm vitest run packages/server/src/builder.test.ts
+pnpm type:check              # tsc across all packages — this is also what runs the *.test-d.ts type tests
+pnpm lint                    # eslint (also the formatter — @antfu/eslint-config)
+pnpm lint:fix
+pnpm bench                   # vitest bench
+pnpm --filter @orpc/server build   # build one package (unbuild); builds are NOT needed for dev/tests
+```
+
+- Root vitest config (`vitest.config.ts`) runs all `*.test.ts` with `globals: true`, plus a jsdom project for `*.test.tsx` in `packages/next` and `packages/tanstack-query`.
+- Exceptions: `packages/bun` runs with `bun test`, `packages/cloudflare` with its own vitest (workerd) — both are excluded from the root vitest and root tsconfig, as is `packages/nest`. Run their tests via `pnpm --filter <pkg> test`.
+- Docs site: `cd apps/content && pnpm dev`.
+- PR titles follow Conventional Commits with the package as scope (e.g. `feat(server): ...`).


### PR DESCRIPTION
## What

- **CLAUDE.md** — repo guidance for Claude Code: common commands (install, test, single-test, type-check, lint, bench, per-package build) plus notes on the test-runner layout (root vitest with jsdom project; `bun`/`cloudflare`/`nest` run separately) and PR title conventions.
- **.claude/settings.json** — shared PostToolUse hook that runs `eslint --fix` after every file edit, matching the repo's lint-staged setup.
- **.gitignore** — track `.claude/` while ignoring `*.local.*` (keeps `settings.local.json` out of the repo).

## Why

Gives Claude Code sessions immediate context on how to build, test, and lint in this monorepo without rediscovering it each time, and keeps machine-edited files auto-formatted via the eslint hook.

## Notes for reviewers

- CLAUDE.md facts were derived from the actual configs (`package.json`, `vitest.config.ts`, tsconfigs); the single-test command was verified to work.
- No source code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)