### PR TITLE
docs(openapi): fix `path` JSDoc to describe `{param}` syntax

### DIFF
--- a/packages/openapi/src/meta.ts
+++ b/packages/openapi/src/meta.ts
@@ -14,9 +14,10 @@ export interface OpenAPIMeta {
   method?: 'HEAD' | 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | undefined
 
   /**
-   * URL path for this procedure. Supports dynamic segments via `${}` syntax.
+   * URL path for this procedure. Supports dynamic parameters via `{param}` syntax,
+   * and `{+param}` to allow slashes in the matched value.
    *
-   * @example `/users`, `/users/${id}`
+   * @example `/users`, `/users/{id}`, `/files/{+path}`
    * @default Router segments joined by `'/`
    */
   path?: `/${string}` | undefined


### PR DESCRIPTION
## Summary

The JSDoc for `OpenAPIMeta.path` in `packages/openapi/src/meta.ts` said dynamic segments use `${}` syntax (`/users/${id}`), but the actual parser (`getDynamicPathParams` in `packages/openapi/src/utils.ts`) and the docs (`apps/content/docs/openapi/routing.md`) use `{param}` / `{+param}` syntax.

This updates the JSDoc to describe the correct `{param}` syntax, including the `{+param}` variant that allows slashes in the matched value, and fixes the examples accordingly.

Docs-only change — no runtime behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)