### PR TITLE
feat(zod): respect an explicit `type` in schema metadata

### DIFF
--- a/packages/zod/src/converter.test.ts
+++ b/packages/zod/src/converter.test.ts
@@ -227,4 +227,54 @@ describe('zodToJsonSchemaConverter', () => {
       expect(converter.convert(schema, 'input')).toEqual([jsonSchema, false])
     })
   })
+
+  describe('respects an explicit `type` in metadata', () => {
+    it('drops the leftover `anyOf` when a union pins a scalar type', () => {
+      const schema = z.union([z.string(), z.number()]).meta({
+        type: 'string',
+        format: 'date-time',
+        pattern: '^x$',
+      })
+
+      expect(converter.convert(schema, 'input')).toEqual([
+        {
+          type: 'string',
+          format: 'date-time',
+          pattern: '^x$',
+        },
+        false,
+      ])
+    })
+
+    it('applies to unions nested inside an object', () => {
+      const schema = z.object({
+        createdAt: z.union([z.string(), z.number()]).meta({ type: 'string', format: 'date-time' }),
+      })
+
+      expect(converter.convert(schema, 'input')).toEqual([
+        {
+          type: 'object',
+          properties: {
+            createdAt: { type: 'string', format: 'date-time' },
+          },
+          required: ['createdAt'],
+        },
+        false,
+      ])
+    })
+
+    it('leaves object schemas untouched when metadata restates `type`', () => {
+      const schema = z.object({ a: z.string() }).meta({ type: 'object', title: 'Foo' })
+
+      expect(converter.convert(schema, 'input')).toEqual([
+        {
+          type: 'object',
+          properties: { a: { type: 'string' } },
+          required: ['a'],
+          title: 'Foo',
+        },
+        false,
+      ])
+    })
+  })
 })

--- a/packages/zod/src/converter.test.ts
+++ b/packages/zod/src/converter.test.ts
@@ -276,5 +276,25 @@ describe('zodToJsonSchemaConverter', () => {
         false,
       ])
     })
+
+    it('keeps the `anyOf` when a non-scalar `type` is pinned on a union', () => {
+      // `object`/`array` branches carry real structure the metadata does not
+      // restate, so the composition must survive rather than be discarded.
+      const schema = z.union([
+        z.object({ a: z.string() }),
+        z.object({ b: z.number() }),
+      ]).meta({ type: 'object' })
+
+      expect(converter.convert(schema, 'input')).toEqual([
+        {
+          type: 'object',
+          anyOf: [
+            { type: 'object', properties: { a: { type: 'string' } }, required: ['a'] },
+            { type: 'object', properties: { b: { type: 'number' } }, required: ['b'] },
+          ],
+        },
+        false,
+      ])
+    })
   })
 })

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -5,6 +5,13 @@ import { globalRegistry, toJSONSchema } from 'zod/v4/core'
 
 export interface ZodToJsonSchemaConverterOptions extends Omit<ToJSONSchemaParams, 'target' | 'io'> {}
 
+/**
+ * JSON Schema `type` values that pin a single, non-composite shape. A schema
+ * whose metadata declares one of these types cannot also be a meaningful
+ * `anyOf`/`oneOf`/`allOf`, so those leftover composition keywords are dropped.
+ */
+const SCALAR_JSON_SCHEMA_TYPES = new Set(['string', 'number', 'integer', 'boolean', 'null'])
+
 export class ZodToJsonSchemaConverter implements JsonSchemaConverter {
   constructor(private readonly options: ZodToJsonSchemaConverterOptions = {}) {
   }
@@ -70,18 +77,23 @@ export class ZodToJsonSchemaConverter implements JsonSchemaConverter {
           ctx.jsonSchema['x-native-type'] = JsonSchemaXNativeType.Map
         }
 
-        // Respect an explicit JSON Schema `type` declared through `.meta()`.
+        // Respect an explicit scalar JSON Schema `type` declared through `.meta()`.
         //
         // Zod copies every metadata field on top of the structural conversion but
         // does not reconcile them: `z.union([...]).meta({ type: 'string', ... })`
         // becomes `{ anyOf: [...], type: 'string', ... }` — the intended string
         // schema polluted with a redundant, contradictory `anyOf`. When metadata
-        // pins a concrete `type`, treat it as authoritative and drop the leftover
-        // structural composition keywords. Scalar/object shapes are untouched:
-        // zod already overwrites a structural `type` on merge, and object schemas
-        // keep their `properties`.
+        // pins a scalar `type`, treat it as authoritative and drop the leftover
+        // structural composition keywords.
+        //
+        // Restricted to scalars on purpose. Zod already overwrites a structural
+        // scalar `type` on merge, so the only unreconciled leftover is the
+        // composition wrapper. `object`/`array` are excluded: there the branches
+        // carry real structure the metadata does not restate (e.g. a union of
+        // objects pinned to `type: 'object'`), so stripping them would silently
+        // discard information rather than remove contradictory noise.
         const meta = registry.get(ctx.zodSchema) as { type?: unknown } | undefined
-        if (meta !== undefined && typeof meta.type === 'string') {
+        if (meta !== undefined && SCALAR_JSON_SCHEMA_TYPES.has(meta.type as string)) {
           delete ctx.jsonSchema.anyOf
           delete ctx.jsonSchema.oneOf
           delete ctx.jsonSchema.allOf

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -30,6 +30,8 @@ export class ZodToJsonSchemaConverter implements JsonSchemaConverter {
   }
 
   private convertZod(schema: $ZodType, direction: JsonSchemaConverterDirection): ZodJsonSchema.JSONSchema {
+    const registry = this.options.metadata ?? globalRegistry
+
     const jsonSchema = toJSONSchema(schema, {
       unrepresentable: 'any',
       ...this.options,
@@ -68,6 +70,23 @@ export class ZodToJsonSchemaConverter implements JsonSchemaConverter {
           ctx.jsonSchema['x-native-type'] = JsonSchemaXNativeType.Map
         }
 
+        // Respect an explicit JSON Schema `type` declared through `.meta()`.
+        //
+        // Zod copies every metadata field on top of the structural conversion but
+        // does not reconcile them: `z.union([...]).meta({ type: 'string', ... })`
+        // becomes `{ anyOf: [...], type: 'string', ... }` — the intended string
+        // schema polluted with a redundant, contradictory `anyOf`. When metadata
+        // pins a concrete `type`, treat it as authoritative and drop the leftover
+        // structural composition keywords. Scalar/object shapes are untouched:
+        // zod already overwrites a structural `type` on merge, and object schemas
+        // keep their `properties`.
+        const meta = registry.get(ctx.zodSchema) as { type?: unknown } | undefined
+        if (meta !== undefined && typeof meta.type === 'string') {
+          delete ctx.jsonSchema.anyOf
+          delete ctx.jsonSchema.oneOf
+          delete ctx.jsonSchema.allOf
+        }
+
         this.options.override?.(ctx)
       },
     })
@@ -77,7 +96,6 @@ export class ZodToJsonSchemaConverter implements JsonSchemaConverter {
     const { $schema, ...rest } = jsonSchema
 
     // workaround until https://github.com/colinhacks/zod/issues/6026 is merged
-    const registry = this.options.metadata ?? globalRegistry
     const { id } = registry.get(schema) || {}
     if (typeof id === 'string' && rest.$ref === undefined) {
       const { $defs = {}, ...restWithoutDefs } = rest


### PR DESCRIPTION
## Summary

Make `ZodToJsonSchemaConverter` honor an explicit **scalar** JSON Schema `type` set on a schema's `.meta()`.

Zod copies every `.meta()` field on top of its structural conversion but never **reconciles** them. So a schema like a Temporal validator, which is a `z.union([...])` under the hood with `.meta({ type: 'string', format, pattern })`, converts to:

```jsonc
{ "anyOf": [{ "type": "string" }, ...], "type": "string", "format": "date-time", "pattern": "…" }
```

— the intended string schema polluted with a redundant, contradictory `anyOf` (the non-string branches can never satisfy `type: 'string'`).

This PR: when metadata pins a **scalar** `type`, treat it as authoritative and drop the leftover structural composition keywords (`anyOf`/`oneOf`/`allOf`). The union above now converts to the clean:

```jsonc
{ "type": "string", "format": "date-time", "pattern": "…" }
```

## Why this scope

I checked zod's own `toJSONSchema` behavior first (per the [zod JSON Schema docs](https://zod.dev/json-schema): *"All metadata fields get copied into the resulting JSON Schema"*, and `override` runs **after** the metadata merge). Empirically:

| schema | zod output | needs fix? |
|---|---|---|
| `z.number().meta({ type: 'string' })` | `{ type: 'string' }` | no — zod already overwrites the scalar `type` |
| `z.object({ a }).meta({ type: 'object', title })` | `{ type: 'object', properties, required, title }` | no — properties preserved |
| `z.union([string, number]).meta({ type: 'string' })` | `{ anyOf: [...], type: 'string' }` | **yes** — contradictory leftover `anyOf` |

The only case zod leaves inconsistent is a composition wrapper left next to a pinned type, so the fix strips **only** those keywords — it does not wholesale-replace the schema with the metadata (which would destroy `properties`).

**Restricted to scalar types on purpose.** For `object`/`array`, the composition branches carry real structure the metadata does not restate — e.g. `z.union([{a}, {b}]).meta({ type: 'object' })` is a *consistent* `{ anyOf: [...], type: 'object' }`, not contradictory noise. Stripping there would silently discard the branch shapes, so those types are excluded and keep their `anyOf`.

## Context

This replaces the need for an external converter interceptor. Downstream libraries (e.g. `temporal-zod`, which currently ships a [structural interceptor workaround](https://github.com/macalinao/temporal-utils/pull/70)) can now express a validator's JSON Schema directly through `.meta()` — no converter configuration required. All Temporal validators are ISO strings/durations, i.e. scalar `type: 'string'`, so they are fully covered.

## Test plan

- `pnpm vitest run packages/zod/src/converter.test.ts` — added cases: union pinning a scalar type, nested-in-object, object schema restating `type` (unchanged), and a union of objects pinned to `type: 'object'` that **keeps** its `anyOf`.
- `pnpm --filter @orpc/zod run type:check`
- `pnpm exec eslint packages/zod/src/converter.ts packages/zod/src/converter.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)