### PR TITLE
chore: enfoce anyAbortSignal over native AbortSignal.any

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,6 +32,10 @@ export default antfu({
         name: ['Reflect', 'get'],
         message: 'Use getOrBind instead',
       },
+      {
+        name: ['AbortSignal', 'any'],
+        message: 'Use anyAbortSignal instead',
+      },
     ],
     'no-restricted-imports': ['error', {
       patterns: [{

--- a/packages/shared/src/signal.ts
+++ b/packages/shared/src/signal.ts
@@ -48,6 +48,7 @@ export function anyAbortSignal(signals: readonly (AbortSignal | undefined)[]): A
   }
 
   if (typeof AbortSignal.any === 'function') {
+    // eslint-disable-next-line ban/ban
     return AbortSignal.any(realSignals)
   }
 


### PR DESCRIPTION
Due API is not widely available yet