### PR TITLE
feat(pinia-colada): contract utils factory

### DIFF
--- a/apps/content/docs/advanced/scaling-large-projects.md
+++ b/apps/content/docs/advanced/scaling-large-projects.md
@@ -122,3 +122,37 @@ const utils = createUtils(router)
 
 const query = useQuery(utils.path.to.procedure.queryOptions({/** options */}))
 ```
+
+## Pinia Colada Integration
+
+[Pinia Colada Integration](/docs/integrations/pinia-colada) also supports this pattern. First, create a factory that accepts a [contract client factory](#contract-client-factory) and options similar to the [Pinia Colada interceptor options](/docs/integrations/pinia-colada#interceptors), but with less type safety because the full contract is not known up front:
+
+```ts
+import { createContractUtilsFactory } from '@orpc/pinia-colada'
+
+export const createUtils = createContractUtilsFactory(createClient, { /** options */})
+```
+
+::: warning
+If you are using [OpenAPI Link](/docs/openapi/link), or any link that requires the client to be wrapped in `JsonifiedClient`, use `createContractJsonifiedUtilsFactory` from `@orpc/pinia-colada` instead of `createContractUtilsFactory`.
+:::
+
+You can then create utilities for each procedure contract:
+
+```ts
+import { procedure } from './path/to/procedure'
+
+const utils = createUtils(procedure)
+
+const query = useQuery(utils.queryOptions({/** options */}))
+```
+
+Like the [contract client factory](#contract-client-factory), it also accepts a [router contract](/docs/contract/router), returning utilities that mirror its shape:
+
+```ts
+import { router } from './path/to/router'
+
+const utils = createUtils(router)
+
+const query = useQuery(utils.path.to.procedure.queryOptions({/** options */}))
+```

--- a/packages/pinia-colada/package.json
+++ b/packages/pinia-colada/package.json
@@ -43,6 +43,8 @@
   },
   "dependencies": {
     "@orpc/client": "workspace:*",
+    "@orpc/contract": "workspace:*",
+    "@orpc/openapi": "workspace:*",
     "@orpc/shared": "workspace:*"
   },
   "devDependencies": {

--- a/packages/pinia-colada/src/contract-utils.test-d.ts
+++ b/packages/pinia-colada/src/contract-utils.test-d.ts
@@ -1,0 +1,179 @@
+import type { ORPCError } from '@orpc/client'
+import type { ContractClientFactory } from '@orpc/contract'
+import type { PromiseWithError } from '@orpc/shared'
+import type { ProcedureUtils } from './procedure-utils'
+import type { SharedRouterUtils } from './router-utils'
+import type { OperationContext } from './types'
+import { meta, oc, type } from '@orpc/contract'
+import { createContractJsonifiedUtilsFactory, createContractUtilsFactory } from './contract-utils'
+
+const contract = {
+  ping: oc.meta(meta.path(['ping'])),
+  nested: {
+    pong: oc
+      .meta(meta.path(['nested', 'pong']))
+      .errors({ BAD_GATEWAY: { data: type<string, RegExp>(vi.fn()) } })
+      .input(type<string, boolean>(vi.fn()))
+      .output(type<number, Date>(vi.fn())),
+  },
+}
+
+describe('createContractUtilsFactory', () => {
+  const clientFactory = {} as ContractClientFactory<{ cache?: boolean }>
+
+  it('infers interceptor input, output, errors types', () => {
+    createContractUtilsFactory(clientFactory, {
+      mutationInterceptors: [
+        async ({ context, next, input }) => {
+          expectTypeOf(input).toEqualTypeOf<unknown>()
+          expectTypeOf(context).toEqualTypeOf<{ cache?: boolean } & OperationContext>()
+
+          const result = next()
+
+          expectTypeOf(result).toEqualTypeOf<
+            PromiseWithError<unknown, unknown>
+          >()
+
+          return result
+        },
+      ],
+      scoped: {
+        ping: {
+          queryInterceptors: [
+            async ({ context, next, input }) => {
+              expectTypeOf(input).toEqualTypeOf<unknown>()
+              expectTypeOf(context).toEqualTypeOf<{ cache?: boolean } & OperationContext>()
+
+              const result = next()
+
+              expectTypeOf(result).toEqualTypeOf<
+                PromiseWithError<unknown, Error | ORPCError<string, unknown>>
+              >()
+
+              return result
+            },
+          ],
+        },
+        nested: {
+          pong: {
+            mutationInterceptors: [
+              async ({ context, next, input }) => {
+                expectTypeOf(input).toEqualTypeOf<unknown>()
+                expectTypeOf(context).toEqualTypeOf<{ cache?: boolean } & OperationContext>()
+
+                const result = next()
+
+                expectTypeOf(result).toEqualTypeOf<
+                  PromiseWithError<unknown, Error | ORPCError<string, unknown>>
+                >()
+
+                return result
+              },
+            ],
+          },
+        },
+      },
+    })
+  })
+
+  it('return general and procedure utils', () => {
+    const createUtils = createContractUtilsFactory(clientFactory, {})
+    const utils = createUtils(contract.nested.pong)
+
+    expectTypeOf(utils).toEqualTypeOf<
+      & Omit<ProcedureUtils<{ cache?: boolean }, string, Date, Error | ORPCError<'BAD_GATEWAY', RegExp>>, 'path' | 'options'>
+      & Omit<SharedRouterUtils<string>, 'path'>
+    >()
+  })
+
+  it('returns router utils when a router contract is passed', () => {
+    const createUtils = createContractUtilsFactory(clientFactory, {})
+    const utils = createUtils(contract)
+
+    expectTypeOf(utils.nested.pong).toEqualTypeOf<
+      & Omit<ProcedureUtils<{ cache?: boolean }, string, Date, Error | ORPCError<'BAD_GATEWAY', RegExp>>, 'path' | 'options'>
+      & Omit<SharedRouterUtils<string>, 'path'>
+    >()
+
+    expectTypeOf(utils.key).toEqualTypeOf<SharedRouterUtils<unknown>['key']>()
+  })
+})
+
+describe('createContractJsonifiedUtilsFactory', () => {
+  const clientFactory = {} as ContractClientFactory<{ cache?: boolean }>
+
+  it('infers interceptor input, output, errors types', () => {
+    createContractJsonifiedUtilsFactory(clientFactory, {
+      mutationInterceptors: [
+        async ({ context, next, input }) => {
+          expectTypeOf(input).toEqualTypeOf<unknown>()
+          expectTypeOf(context).toEqualTypeOf<{ cache?: boolean } & OperationContext>()
+
+          const result = next()
+
+          expectTypeOf(result).toEqualTypeOf<
+            PromiseWithError<unknown, unknown>
+          >()
+
+          return result
+        },
+      ],
+      scoped: {
+        ping: {
+          queryInterceptors: [
+            async ({ context, next, input }) => {
+              expectTypeOf(input).toEqualTypeOf<unknown>()
+              expectTypeOf(context).toEqualTypeOf<{ cache?: boolean } & OperationContext>()
+
+              const result = next()
+
+              expectTypeOf(result).toEqualTypeOf<
+                PromiseWithError<unknown, Error | ORPCError<string, unknown>>
+              >()
+
+              return result
+            },
+          ],
+        },
+        nested: {
+          pong: {
+            mutationInterceptors: [
+              async ({ context, next, input }) => {
+                expectTypeOf(input).toEqualTypeOf<unknown>()
+                expectTypeOf(context).toEqualTypeOf<{ cache?: boolean } & OperationContext>()
+
+                const result = next()
+
+                expectTypeOf(result).toEqualTypeOf<
+                  PromiseWithError<unknown, Error | ORPCError<string, unknown>>
+                >()
+
+                return result
+              },
+            ],
+          },
+        },
+      },
+    })
+  })
+
+  it('return jsonified general and procedure utils', () => {
+    const createUtils = createContractJsonifiedUtilsFactory(clientFactory, {})
+    const utils = createUtils(contract.nested.pong)
+
+    expectTypeOf(utils).toEqualTypeOf<
+      & Omit<ProcedureUtils<{ cache?: boolean }, string, string, Error | ORPCError<'BAD_GATEWAY', string>>, 'path' | 'options'>
+      & Omit<SharedRouterUtils<string>, 'path'>
+    >()
+  })
+
+  it('returns jsonified router utils when a router contract is passed', () => {
+    const createUtils = createContractJsonifiedUtilsFactory(clientFactory, {})
+    const utils = createUtils(contract)
+
+    expectTypeOf(utils.nested.pong).toEqualTypeOf<
+      & Omit<ProcedureUtils<{ cache?: boolean }, string, string, Error | ORPCError<'BAD_GATEWAY', string>>, 'path' | 'options'>
+      & Omit<SharedRouterUtils<string>, 'path'>
+    >()
+  })
+})

--- a/packages/pinia-colada/src/contract-utils.test.ts
+++ b/packages/pinia-colada/src/contract-utils.test.ts
@@ -1,0 +1,165 @@
+import { ProcedureContract } from '@orpc/contract'
+import { createContractJsonifiedUtilsFactory, createContractUtilsFactory } from './contract-utils'
+import * as routerUtilsModule from './router-utils'
+
+const createRouterUtilsSpy = vi.spyOn(routerUtilsModule, 'createRouterUtils')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+function createContract(path?: string[]) {
+  return new ProcedureContract({
+    errorMap: {},
+    meta: path ? { '~path': path } : {},
+    inputSchemas: [],
+    outputSchemas: [],
+  })
+}
+
+describe('createContractUtilsFactory', () => {
+  const clientFactory = vi.fn()
+
+  it('throws when no procedure contract defines meta.path', () => {
+    const factory = createContractUtilsFactory(clientFactory as any, {})
+
+    expect(() => factory(createContract() as any)).toThrow(
+      'ContractUtilsFactory: procedure contract must define `meta.path` that matches its path in the root router contract.',
+    )
+
+    expect(() => factory({ users: { list: createContract() } } as any)).toThrow(
+      'ContractUtilsFactory: procedure contract must define `meta.path` that matches its path in the root router contract.',
+    )
+
+    expect(createRouterUtilsSpy).not.toHaveBeenCalled()
+  })
+
+  it('passes the created client and resolved path to createRouterUtils', () => {
+    const delegatedUtils = { queryOptions: vi.fn() }
+    const queryInterceptor = vi.fn()
+    const mutationInterceptor = vi.fn()
+    const plugin = {
+      name: 'test-plugin',
+      init: vi.fn((options: unknown) => options),
+      initProcedureOptions: vi.fn((_: string[], options: unknown) => options),
+    }
+    const scopedOptions = {
+      queryOptions: {
+        staleTime: 1000,
+      },
+    }
+    const options = {
+      prefix: '__prefix__',
+      queryInterceptors: [queryInterceptor],
+      mutationInterceptors: [mutationInterceptor],
+      plugins: [plugin],
+      scoped: {
+        users: {
+          list: scopedOptions,
+        },
+      },
+    }
+    const procedure = createContract(['users', 'list'])
+    const delegatedClient = vi.fn()
+
+    clientFactory.mockReturnValueOnce(delegatedClient)
+    createRouterUtilsSpy.mockReturnValueOnce(delegatedUtils as any)
+
+    const factory = createContractUtilsFactory(clientFactory as any, options as any)
+    const result = factory(procedure as any)
+
+    expect(result).toBe(delegatedUtils)
+    expect(clientFactory).toHaveBeenCalledTimes(1)
+    expect(clientFactory).toHaveBeenCalledWith(procedure)
+
+    expect(createRouterUtilsSpy).toHaveBeenCalledTimes(1)
+    expect(createRouterUtilsSpy).toHaveBeenCalledWith(delegatedClient, {
+      ...options,
+      path: ['users', 'list'],
+      scoped: scopedOptions,
+    })
+  })
+
+  it('resolves the base path when a router contract is passed', () => {
+    const delegatedUtils = { queryOptions: vi.fn() }
+    const delegatedClient = { list: vi.fn(), find: vi.fn() }
+    const scopedListOptions = {
+      queryOptions: {
+        staleTime: 1000,
+      },
+    }
+    const options = {
+      prefix: '__prefix__',
+      scoped: {
+        users: {
+          list: scopedListOptions,
+        },
+      },
+    }
+    const router = {
+      list: createContract(['users', 'list']),
+      find: createContract(['users', 'find']),
+    }
+
+    clientFactory.mockReturnValueOnce(delegatedClient)
+    createRouterUtilsSpy.mockReturnValueOnce(delegatedUtils as any)
+
+    const factory = createContractUtilsFactory(clientFactory as any, options as any)
+    const result = factory(router as any)
+
+    expect(result).toBe(delegatedUtils)
+    expect(clientFactory).toHaveBeenCalledTimes(1)
+    expect(clientFactory).toHaveBeenCalledWith(router)
+
+    expect(createRouterUtilsSpy).toHaveBeenCalledTimes(1)
+    expect(createRouterUtilsSpy).toHaveBeenCalledWith(delegatedClient, {
+      ...options,
+      path: ['users'],
+      scoped: {
+        list: scopedListOptions,
+      },
+    })
+  })
+})
+
+describe('createContractJsonifiedUtilsFactory', () => {
+  const clientFactory = vi.fn()
+
+  it('delegates to createRouterUtils with the resolved path', () => {
+    const delegatedUtils = { mutationOptions: vi.fn() }
+    const scopedOptions = {
+      mutationOptions: {
+        meta: {
+          feature: 'jsonified',
+        },
+      },
+    }
+    const options = {
+      prefix: '__json__',
+      scoped: {
+        nested: {
+          pong: scopedOptions,
+        },
+      },
+    }
+    const procedure = createContract(['nested', 'pong'])
+    const delegatedClient = vi.fn()
+
+    clientFactory.mockReturnValueOnce(delegatedClient)
+    createRouterUtilsSpy.mockReturnValueOnce(delegatedUtils as any)
+
+    const factory = createContractJsonifiedUtilsFactory(clientFactory as any, options as any)
+    const result = factory(procedure as any)
+
+    expect(result).toBe(delegatedUtils)
+    expect(clientFactory).toHaveBeenCalledTimes(1)
+    expect(clientFactory).toHaveBeenCalledWith(procedure)
+
+    expect(createRouterUtilsSpy).toHaveBeenCalledTimes(1)
+    expect(createRouterUtilsSpy).toHaveBeenCalledWith(delegatedClient, {
+      ...options,
+      path: ['nested', 'pong'],
+      scoped: scopedOptions,
+    })
+  })
+})

--- a/packages/pinia-colada/src/contract-utils.ts
+++ b/packages/pinia-colada/src/contract-utils.ts
@@ -1,0 +1,56 @@
+import type { ClientContext } from '@orpc/client'
+import type { ContractClientFactory, RouterContract, RouterContractClient } from '@orpc/contract'
+import type { JsonifiedClient } from '@orpc/openapi'
+import type { RouterUtils, RouterUtilsOptions } from './router-utils'
+import { resolveBasePathMeta } from '@orpc/contract'
+import { get } from '@orpc/shared'
+import { createRouterUtils } from './router-utils'
+
+export interface ContractUtilsFactory<TClientContext extends ClientContext> {
+  <T extends RouterContract>(contract: T): RouterUtils<RouterContractClient<T, TClientContext>>
+}
+
+export interface ContractUtilsFactoryOptions<
+  TClientContext extends ClientContext,
+> extends Omit<RouterUtilsOptions<RouterContractClient<RouterContract, TClientContext>>, 'path'> {
+}
+
+export function createContractUtilsFactory<
+  TClientContext extends ClientContext,
+>(
+  clientFactory: ContractClientFactory<TClientContext>,
+  options: ContractUtilsFactoryOptions<TClientContext>,
+): ContractUtilsFactory<TClientContext> {
+  const factory: ContractUtilsFactory<TClientContext> = (contract) => {
+    const client = clientFactory(contract)
+    const path = resolveBasePathMeta(contract)
+
+    if (path === undefined) {
+      throw new TypeError(
+        'ContractUtilsFactory: procedure contract must define `meta.path` that matches its path in the root router contract.',
+      )
+    }
+
+    return createRouterUtils(client, { ...options as any, path, scoped: get(options.scoped, path) })
+  }
+
+  return factory
+}
+
+export interface ContractJsonifiedUtilsFactory<TClientContext extends ClientContext> {
+  <T extends RouterContract>(contract: T): RouterUtils<JsonifiedClient<RouterContractClient<T, TClientContext>>>
+}
+
+export interface ContractJsonifiedUtilsFactoryOptions<
+  TClientContext extends ClientContext,
+> extends Omit<RouterUtilsOptions<JsonifiedClient<RouterContractClient<RouterContract, TClientContext>>>, 'path'> {
+}
+
+export function createContractJsonifiedUtilsFactory<
+  TClientContext extends ClientContext,
+>(
+  clientFactory: ContractClientFactory<TClientContext>,
+  options: ContractJsonifiedUtilsFactoryOptions<TClientContext>,
+): ContractJsonifiedUtilsFactory<TClientContext> {
+  return createContractUtilsFactory(clientFactory, options) as ContractJsonifiedUtilsFactory<TClientContext>
+}

--- a/packages/pinia-colada/src/index.ts
+++ b/packages/pinia-colada/src/index.ts
@@ -1,3 +1,4 @@
+export * from './contract-utils'
 export * from './key'
 export * from './live-query'
 export * from './plugin'

--- a/packages/pinia-colada/src/router-utils.test-d.ts
+++ b/packages/pinia-colada/src/router-utils.test-d.ts
@@ -82,11 +82,6 @@ it('RouterUtils', () => {
 })
 
 it('createRouterUtils', () => {
-  createRouterUtils({} as RouterClient<typeof router, { batch?: boolean }>, {
-    // @ts-expect-error path option was replaced by prefix
-    path: ['base'],
-  })
-
   const utils = createRouterUtils({} as RouterClient<typeof router, { batch?: boolean }>, {
     prefix: '__prefix__',
     queryInterceptors: [

--- a/packages/pinia-colada/src/router-utils.ts
+++ b/packages/pinia-colada/src/router-utils.ts
@@ -42,6 +42,13 @@ export type RouterUtilsScoped<T extends AnyNestedClient>
 
 export interface RouterUtilsOptions<T extends AnyNestedClient> extends BuildKeyPrefixOptions {
   /**
+   * Base path for all query keys.
+   *
+   * @internal
+   */
+  path?: string[] | undefined
+
+  /**
    * Interceptors that intercept query inside .queryOptions
    */
   queryInterceptors?: ProcedureUtilsQueryInterceptor<InferClientContext<T>, unknown, unknown, InferClientError<T>>[]
@@ -92,15 +99,15 @@ export function createRouterUtils<T extends AnyNestedClient>(
   const plugin = new CompositeRouterUtilsPlugin<T>(options.plugins)
   options = plugin.init(options)
 
-  return createRouterUtilsInternal(client, [], options, plugin)
+  return createRouterUtilsInternal(client, options, plugin)
 }
 
 function createRouterUtilsInternal<T extends AnyNestedClient>(
   client: T,
-  path: string[],
   options: RouterUtilsOptions<T>,
   plugin: CompositeRouterUtilsPlugin<any>,
 ): RouterUtils<T> {
+  const path = toArray(options.path)
   const sharedUtils = bindMethods(new SharedRouterUtils(path, options))
 
   const procedureUtils = typeof client === 'function' && (options.scoped === undefined || isProcedureUtilsOptions(options.scoped))
@@ -131,8 +138,9 @@ function createRouterUtilsInternal<T extends AnyNestedClient>(
         return value
       }
 
-      const nextUtils = createRouterUtilsInternal(nextClient as any, [...path, prop], {
+      const nextUtils = createRouterUtilsInternal(nextClient as any, {
         ...options,
+        path: [...path, prop],
         scoped: get(options.scoped, [prop]) as any,
       }, plugin)
 

--- a/packages/pinia-colada/tsconfig.json
+++ b/packages/pinia-colada/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../../tsconfig.lib.json",
   "references": [
     { "path": "../client" },
+    { "path": "../contract" },
+    { "path": "../openapi" },
     { "path": "../shared" }
   ],
   "include": ["package.json", "src"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -614,6 +614,12 @@ importers:
       '@orpc/client':
         specifier: workspace:*
         version: link:../client
+      '@orpc/contract':
+        specifier: workspace:*
+        version: link:../contract
+      '@orpc/openapi':
+        specifier: workspace:*
+        version: link:../openapi
       '@orpc/shared':
         specifier: workspace:*
         version: link:../shared


### PR DESCRIPTION
Ports `createContractUtilsFactory` and `createContractJsonifiedUtilsFactory` from `@orpc/tanstack-query` to `@orpc/pinia-colada`, so the [Scaling Large Projects](https://orpc.dev/docs/advanced/scaling-large-projects) pattern works with Pinia Colada too.

```ts
import { createContractUtilsFactory } from '@orpc/pinia-colada'

export const createUtils = createContractUtilsFactory(createClient, { /** options */ })

const utils = createUtils(procedure)
const query = useQuery(utils.queryOptions({ /** options */ }))
```

- `RouterUtilsOptions` now carries the internal `path` option (aligned with `@orpc/tanstack-query`)
- Docs: added a Pinia Colada section to the Scaling Large Projects guide