### PR TITLE
refactor(pinia-colada): align key utils with tanstack-query

### DIFF
--- a/packages/pinia-colada/src/index.test.ts
+++ b/packages/pinia-colada/src/index.test.ts
@@ -2,7 +2,7 @@ it('exports createPiniaColadaUtils, PINIA_COLADA_OPERATION_CONTEXT_SYMBOL', asyn
   await expect(import('./index')).resolves.toMatchObject({
     createPiniaColadaUtils: expect.any(Function),
     createRouterUtils: expect.any(Function),
-    buildKey: expect.any(Function),
+    generateOperationKey: expect.any(Function),
     serializableStreamedQuery: expect.any(Function),
     liveQuery: expect.any(Function),
     CompositeRouterUtilsPlugin: expect.any(Function),

--- a/packages/pinia-colada/src/key.test.ts
+++ b/packages/pinia-colada/src/key.test.ts
@@ -1,18 +1,18 @@
-import { buildKey } from './key'
+import { generateOperationKey } from './key'
 
-it('buildKey', () => {
-  expect(buildKey(['path'])).toEqual([['path'], {}])
-  expect(buildKey(['path', 'path2'], { input: { a: 1 } })).toEqual([['path', 'path2'], { input: { a: 1 } }])
-  expect(buildKey(['path'], { input: undefined })).toEqual([['path'], {}])
-  expect(buildKey(['path', 'path2'], { type: 'query' })).toEqual([['path', 'path2'], { type: 'query' }])
-  expect(buildKey(['path'], { type: undefined })).toEqual([['path'], {}])
-  expect(buildKey(['path', 'path2'], { type: 'query', input: { a: 1 } })).toEqual([['path', 'path2'], { type: 'query', input: { a: 1 } }])
-  expect(buildKey(['path'], { type: 'mutation' })).toEqual([['path'], { type: 'mutation' }])
+it('generateOperationKey', () => {
+  expect(generateOperationKey(['path'])).toEqual([['path'], {}])
+  expect(generateOperationKey(['path', 'path2'], { input: { a: 1 } })).toEqual([['path', 'path2'], { input: { a: 1 } }])
+  expect(generateOperationKey(['path'], { input: undefined })).toEqual([['path'], {}])
+  expect(generateOperationKey(['path', 'path2'], { type: 'query' })).toEqual([['path', 'path2'], { type: 'query' }])
+  expect(generateOperationKey(['path'], { type: undefined })).toEqual([['path'], {}])
+  expect(generateOperationKey(['path', 'path2'], { type: 'query', input: { a: 1 } })).toEqual([['path', 'path2'], { type: 'query', input: { a: 1 } }])
+  expect(generateOperationKey(['path'], { type: 'mutation' })).toEqual([['path'], { type: 'mutation' }])
 
   const date = new Date()
-  expect(buildKey(['path', 'path2'], { input: { a: date } })).toEqual([['path', 'path2'], { input: { a: date.toISOString() } }])
+  expect(generateOperationKey(['path', 'path2'], { input: { a: date } })).toEqual([['path', 'path2'], { input: { a: date.toISOString() } }])
 
-  expect(buildKey(['path'], { prefix: '__prefix__' })).toEqual(['__prefix__', ['path'], {}])
-  expect(buildKey(['path'], { prefix: undefined })).toEqual([['path'], {}])
-  expect(buildKey(['path'], { prefix: '__prefix__', type: 'query', input: { a: 1 } })).toEqual(['__prefix__', ['path'], { type: 'query', input: { a: 1 } }])
+  expect(generateOperationKey(['path'], { prefix: '__prefix__' })).toEqual(['__prefix__', ['path'], {}])
+  expect(generateOperationKey(['path'], { prefix: undefined })).toEqual([['path'], {}])
+  expect(generateOperationKey(['path'], { prefix: '__prefix__', type: 'query', input: { a: 1 } })).toEqual(['__prefix__', ['path'], { type: 'query', input: { a: 1 } }])
 })

--- a/packages/pinia-colada/src/key.ts
+++ b/packages/pinia-colada/src/key.ts
@@ -4,7 +4,7 @@ import type { SerializableStreamedQueryOptions } from './stream-query'
 import type { OperationType } from './types'
 import { RPCJsonSerializer } from '@orpc/client'
 
-export interface BuildKeyPrefixOptions {
+export interface OperationKeyPrefixOptions {
   /**
    * Prepended as the first element of the key when present.
    * Use this to avoid key conflicts when multiple router utils share the same client.
@@ -12,26 +12,32 @@ export interface BuildKeyPrefixOptions {
   prefix?: string
 }
 
-export interface BuildKeyOptions<TInput> extends BuildKeyPrefixOptions {
-  type?: OperationType
+export type OperationKeyOptions<TType extends OperationType, TInput> = OperationKeyPrefixOptions & {
+  type?: TType
   input?: PartialDeep<TInput>
-  fnOptions?: SerializableStreamedQueryOptions
+  fnOptions?: TType extends 'streamed' ? SerializableStreamedQueryOptions : never
 }
+
+export type OperationKey<TType extends OperationType, TInput>
+  = EntryKey & (
+    | [path: string[], options: Omit<OperationKeyOptions<TType, TInput>, 'prefix'>]
+    | [prefix: string, path: string[], options: Omit<OperationKeyOptions<TType, TInput>, 'prefix'>]
+  )
 
 const serializer = new RPCJsonSerializer()
 
 /**
- * Build a Pinia Colada entry key for a procedure.
+ * Generate a Pinia Colada entry key for a procedure.
  *
  * The input is serialized to JSON-compatible values because Pinia Colada
  * requires entry keys to be serializable.
  *
  * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key Pinia Colada Query/Mutation Key Docs}
  */
-export function buildKey<TInput>(
+export function generateOperationKey<TType extends OperationType, TInput>(
   path: string[],
-  options: BuildKeyOptions<TInput> = {},
-): EntryKey {
+  options: OperationKeyOptions<TType, TInput> = {},
+): OperationKey<TType, TInput> {
   return [
     ...options.prefix !== undefined ? [options.prefix] : [],
     path,
@@ -40,5 +46,5 @@ export function buildKey<TInput>(
       ...options.type !== undefined ? { type: options.type } : {},
       ...options.fnOptions !== undefined ? { fnOptions: options.fnOptions } : {},
     },
-  ] as EntryKey
+  ] as OperationKey<TType, TInput>
 }

--- a/packages/pinia-colada/src/procedure-utils.test.ts
+++ b/packages/pinia-colada/src/procedure-utils.test.ts
@@ -4,7 +4,7 @@ import { ProcedureUtils } from './procedure-utils'
 import * as StreamQueryModule from './stream-query'
 import { OPERATION_CONTEXT_SYMBOL } from './types'
 
-const buildKeySpy = vi.spyOn(KeyModule, 'buildKey')
+const generateOperationKeySpy = vi.spyOn(KeyModule, 'generateOperationKey')
 const streamedQuerySpy = vi.spyOn(StreamQueryModule, 'serializableStreamedQuery')
 const liveQuerySpy = vi.spyOn(LiveQueryModule, 'liveQuery')
 
@@ -24,15 +24,15 @@ describe('procedureUtils', () => {
 
   describe('.queryKey', () => {
     it('works', () => {
-      expect(utils.queryKey({ input: { search: '__search__' } } as any)).toBe(buildKeySpy.mock.results[0]!.value)
-      expect(buildKeySpy).toHaveBeenCalledTimes(1)
-      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { type: 'query', input: { search: '__search__' } })
+      expect(utils.queryKey({ input: { search: '__search__' } } as any)).toBe(generateOperationKeySpy.mock.results[0]!.value)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'query', input: { search: '__search__' } })
 
-      expect(utils.queryKey()).toBe(buildKeySpy.mock.results[1]!.value)
-      expect(buildKeySpy).toHaveBeenNthCalledWith(2, ['ping'], { type: 'query', input: undefined })
+      expect(utils.queryKey()).toBe(generateOperationKeySpy.mock.results[1]!.value)
+      expect(generateOperationKeySpy).toHaveBeenNthCalledWith(2, ['ping'], { type: 'query', input: undefined })
 
       expect(utils.queryKey({ key: ['__custom__'] } as any)).toEqual(['__custom__'])
-      expect(buildKeySpy).toHaveBeenCalledTimes(2)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(2)
     })
 
     it('applies object modifier with per-call options taking precedence', () => {
@@ -41,10 +41,10 @@ describe('procedureUtils', () => {
       })
 
       modifiedUtils.queryKey()
-      expect(buildKeySpy).toHaveBeenNthCalledWith(1, ['ping'], { type: 'query', input: 1 })
+      expect(generateOperationKeySpy).toHaveBeenNthCalledWith(1, ['ping'], { type: 'query', input: 1 })
 
       modifiedUtils.queryKey({ input: 2 } as any)
-      expect(buildKeySpy).toHaveBeenNthCalledWith(2, ['ping'], { type: 'query', input: 2 })
+      expect(generateOperationKeySpy).toHaveBeenNthCalledWith(2, ['ping'], { type: 'query', input: 2 })
     })
 
     it('applies function modifier', () => {
@@ -56,18 +56,18 @@ describe('procedureUtils', () => {
       modifiedUtils.queryKey({ input: 1 } as any)
       expect(modifier).toHaveBeenCalledTimes(1)
       expect(modifier).toHaveBeenCalledWith({ input: 1 })
-      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { type: 'query', input: 9 })
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'query', input: 9 })
     })
   })
 
   describe('.streamedKey', () => {
     it('works', () => {
-      expect(utils.streamedKey({ input: { search: '__search__' }, fnOptions: { refetchMode: 'append' } } as any)).toBe(buildKeySpy.mock.results[0]!.value)
-      expect(buildKeySpy).toHaveBeenCalledTimes(1)
-      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { prefix: undefined, type: 'streamed', input: { search: '__search__' }, fnOptions: { refetchMode: 'append' } })
+      expect(utils.streamedKey({ input: { search: '__search__' }, fnOptions: { refetchMode: 'append' } } as any)).toBe(generateOperationKeySpy.mock.results[0]!.value)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { prefix: undefined, type: 'streamed', input: { search: '__search__' }, fnOptions: { refetchMode: 'append' } })
 
       expect(utils.streamedKey({ key: ['__custom__'] } as any)).toEqual(['__custom__'])
-      expect(buildKeySpy).toHaveBeenCalledTimes(1)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
     })
 
     it('applies object modifier with per-call options taking precedence', () => {
@@ -76,10 +76,10 @@ describe('procedureUtils', () => {
       })
 
       modifiedUtils.streamedKey()
-      expect(buildKeySpy).toHaveBeenNthCalledWith(1, ['ping'], { prefix: undefined, type: 'streamed', input: undefined, fnOptions: { maxChunks: 1 } })
+      expect(generateOperationKeySpy).toHaveBeenNthCalledWith(1, ['ping'], { prefix: undefined, type: 'streamed', input: undefined, fnOptions: { maxChunks: 1 } })
 
       modifiedUtils.streamedKey({ fnOptions: { maxChunks: 2 } } as any)
-      expect(buildKeySpy).toHaveBeenNthCalledWith(2, ['ping'], { prefix: undefined, type: 'streamed', input: undefined, fnOptions: { maxChunks: 2 } })
+      expect(generateOperationKeySpy).toHaveBeenNthCalledWith(2, ['ping'], { prefix: undefined, type: 'streamed', input: undefined, fnOptions: { maxChunks: 2 } })
     })
 
     it('applies function modifier', () => {
@@ -91,7 +91,7 @@ describe('procedureUtils', () => {
       modifiedUtils.streamedKey({ input: 1 } as any)
       expect(modifier).toHaveBeenCalledTimes(1)
       expect(modifier).toHaveBeenCalledWith({ input: 1 })
-      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { prefix: undefined, type: 'streamed', input: 9, fnOptions: undefined })
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { prefix: undefined, type: 'streamed', input: 9, fnOptions: undefined })
     })
   })
 
@@ -107,9 +107,9 @@ describe('procedureUtils', () => {
     it('works', async () => {
       const options = utils.streamedOptions({ input: 1, fnOptions: { maxChunks: 3 } } as any) as any
 
-      expect(options.key).toBe(buildKeySpy.mock.results[0]!.value)
-      expect(buildKeySpy).toHaveBeenCalledTimes(1)
-      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { prefix: undefined, type: 'streamed', input: 1, fnOptions: { maxChunks: 3 } })
+      expect(options.key).toBe(generateOperationKeySpy.mock.results[0]!.value)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { prefix: undefined, type: 'streamed', input: 1, fnOptions: { maxChunks: 3 } })
       expect(options.fnOptions).toBeUndefined() // consumed, not forwarded to pinia colada
 
       client.mockResolvedValueOnce(stream('a', 'b'))
@@ -217,12 +217,12 @@ describe('procedureUtils', () => {
 
   describe('.liveKey', () => {
     it('works', () => {
-      expect(utils.liveKey({ input: { search: '__search__' } } as any)).toBe(buildKeySpy.mock.results[0]!.value)
-      expect(buildKeySpy).toHaveBeenCalledTimes(1)
-      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { prefix: undefined, type: 'live', input: { search: '__search__' } })
+      expect(utils.liveKey({ input: { search: '__search__' } } as any)).toBe(generateOperationKeySpy.mock.results[0]!.value)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { prefix: undefined, type: 'live', input: { search: '__search__' } })
 
       expect(utils.liveKey({ key: ['__custom__'] } as any)).toEqual(['__custom__'])
-      expect(buildKeySpy).toHaveBeenCalledTimes(1)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
     })
 
     it('applies object modifier with per-call options taking precedence', () => {
@@ -231,10 +231,10 @@ describe('procedureUtils', () => {
       })
 
       modifiedUtils.liveKey()
-      expect(buildKeySpy).toHaveBeenNthCalledWith(1, ['ping'], { prefix: undefined, type: 'live', input: 1 })
+      expect(generateOperationKeySpy).toHaveBeenNthCalledWith(1, ['ping'], { prefix: undefined, type: 'live', input: 1 })
 
       modifiedUtils.liveKey({ input: 2 } as any)
-      expect(buildKeySpy).toHaveBeenNthCalledWith(2, ['ping'], { prefix: undefined, type: 'live', input: 2 })
+      expect(generateOperationKeySpy).toHaveBeenNthCalledWith(2, ['ping'], { prefix: undefined, type: 'live', input: 2 })
     })
 
     it('applies function modifier', () => {
@@ -246,7 +246,7 @@ describe('procedureUtils', () => {
       modifiedUtils.liveKey({ input: 1 } as any)
       expect(modifier).toHaveBeenCalledTimes(1)
       expect(modifier).toHaveBeenCalledWith({ input: 1 })
-      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { prefix: undefined, type: 'live', input: 9 })
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { prefix: undefined, type: 'live', input: 9 })
     })
   })
 
@@ -262,9 +262,9 @@ describe('procedureUtils', () => {
     it('works', async () => {
       const options = utils.liveOptions({ input: 1 } as any) as any
 
-      expect(options.key).toBe(buildKeySpy.mock.results[0]!.value)
-      expect(buildKeySpy).toHaveBeenCalledTimes(1)
-      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { prefix: undefined, type: 'live', input: 1 })
+      expect(options.key).toBe(generateOperationKeySpy.mock.results[0]!.value)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { prefix: undefined, type: 'live', input: 1 })
 
       client.mockResolvedValueOnce(stream('a', 'b'))
       await expect(options.query({ signal, entry })).resolves.toEqual('b')
@@ -370,15 +370,15 @@ describe('procedureUtils', () => {
 
   describe('.infiniteKey', () => {
     it('works', () => {
-      expect(utils.infiniteKey({ input: (cursor: number) => ({ cursor }), initialPageParam: 0 } as any)).toBe(buildKeySpy.mock.results[0]!.value)
-      expect(buildKeySpy).toHaveBeenCalledTimes(1)
-      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { type: 'infinite', input: { cursor: 0 } })
+      expect(utils.infiniteKey({ input: (cursor: number) => ({ cursor }), initialPageParam: 0 } as any)).toBe(generateOperationKeySpy.mock.results[0]!.value)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'infinite', input: { cursor: 0 } })
 
-      expect(utils.infiniteKey({ input: (cursor: number) => ({ cursor }), initialPageParam: () => 5 } as any)).toBe(buildKeySpy.mock.results[1]!.value)
-      expect(buildKeySpy).toHaveBeenNthCalledWith(2, ['ping'], { type: 'infinite', input: { cursor: 5 } })
+      expect(utils.infiniteKey({ input: (cursor: number) => ({ cursor }), initialPageParam: () => 5 } as any)).toBe(generateOperationKeySpy.mock.results[1]!.value)
+      expect(generateOperationKeySpy).toHaveBeenNthCalledWith(2, ['ping'], { type: 'infinite', input: { cursor: 5 } })
 
       expect(utils.infiniteKey({ key: ['__custom__'] } as any)).toEqual(['__custom__'])
-      expect(buildKeySpy).toHaveBeenCalledTimes(2)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(2)
     })
 
     it('applies object modifier with per-call options taking precedence', () => {
@@ -387,10 +387,10 @@ describe('procedureUtils', () => {
       })
 
       modifiedUtils.infiniteKey({ input: (cursor: number) => ({ cursor }) } as any)
-      expect(buildKeySpy).toHaveBeenNthCalledWith(1, ['ping'], { type: 'infinite', input: { cursor: 1 } })
+      expect(generateOperationKeySpy).toHaveBeenNthCalledWith(1, ['ping'], { type: 'infinite', input: { cursor: 1 } })
 
       modifiedUtils.infiniteKey({ input: (cursor: number) => ({ cursor }), initialPageParam: 2 } as any)
-      expect(buildKeySpy).toHaveBeenNthCalledWith(2, ['ping'], { type: 'infinite', input: { cursor: 2 } })
+      expect(generateOperationKeySpy).toHaveBeenNthCalledWith(2, ['ping'], { type: 'infinite', input: { cursor: 2 } })
     })
 
     it('applies function modifier', () => {
@@ -401,7 +401,7 @@ describe('procedureUtils', () => {
 
       modifiedUtils.infiniteKey({ input: (cursor: number) => ({ cursor }), initialPageParam: 1 } as any)
       expect(modifier).toHaveBeenCalledTimes(1)
-      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { type: 'infinite', input: { cursor: 9 } })
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'infinite', input: { cursor: 9 } })
     })
   })
 
@@ -409,12 +409,12 @@ describe('procedureUtils', () => {
     it('works', () => {
       const key = utils.mutationKey() as any
 
-      expect(key('__input__')).toBe(buildKeySpy.mock.results[0]!.value)
-      expect(buildKeySpy).toHaveBeenCalledTimes(1)
-      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { type: 'mutation', input: '__input__' })
+      expect(key('__input__')).toBe(generateOperationKeySpy.mock.results[0]!.value)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'mutation', input: '__input__' })
 
       expect(utils.mutationKey({ key: ['__custom__'] } as any)).toEqual(['__custom__'])
-      expect(buildKeySpy).toHaveBeenCalledTimes(1)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
     })
 
     it('applies object modifier with per-call options taking precedence', () => {
@@ -424,7 +424,7 @@ describe('procedureUtils', () => {
 
       expect(modifiedUtils.mutationKey()).toEqual(['__modifier__'])
       expect(modifiedUtils.mutationKey({ key: ['__call__'] } as any)).toEqual(['__call__'])
-      expect(buildKeySpy).toHaveBeenCalledTimes(0)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(0)
     })
 
     it('applies function modifier', () => {
@@ -444,14 +444,14 @@ describe('procedureUtils', () => {
 
     it('includes prefix in generated keys', () => {
       prefixedUtils.queryKey({ input: 1 } as any)
-      expect(buildKeySpy).toHaveBeenNthCalledWith(1, ['ping'], { prefix: '__prefix__', type: 'query', input: 1 })
+      expect(generateOperationKeySpy).toHaveBeenNthCalledWith(1, ['ping'], { prefix: '__prefix__', type: 'query', input: 1 })
 
       prefixedUtils.infiniteKey({ input: (cursor: number) => ({ cursor }), initialPageParam: 0 } as any)
-      expect(buildKeySpy).toHaveBeenNthCalledWith(2, ['ping'], { prefix: '__prefix__', type: 'infinite', input: { cursor: 0 } })
+      expect(generateOperationKeySpy).toHaveBeenNthCalledWith(2, ['ping'], { prefix: '__prefix__', type: 'infinite', input: { cursor: 0 } })
 
       const mutationKey = prefixedUtils.mutationKey() as any
       mutationKey('__input__')
-      expect(buildKeySpy).toHaveBeenNthCalledWith(3, ['ping'], { prefix: '__prefix__', type: 'mutation', input: '__input__' })
+      expect(generateOperationKeySpy).toHaveBeenNthCalledWith(3, ['ping'], { prefix: '__prefix__', type: 'mutation', input: '__input__' })
     })
   })
 
@@ -459,9 +459,9 @@ describe('procedureUtils', () => {
     it('works', async () => {
       const options = utils.queryOptions({ input: 1 }) as any
 
-      expect(options.key).toBe(buildKeySpy.mock.results[0]!.value)
-      expect(buildKeySpy).toHaveBeenCalledTimes(1)
-      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { type: 'query', input: 1 })
+      expect(options.key).toBe(generateOperationKeySpy.mock.results[0]!.value)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'query', input: 1 })
 
       client.mockResolvedValueOnce('__mocked__')
       await expect(options.query({ signal })).resolves.toEqual('__mocked__')
@@ -477,9 +477,9 @@ describe('procedureUtils', () => {
     it('works without options', async () => {
       const options = utils.queryOptions() as any
 
-      expect(options.key).toBe(buildKeySpy.mock.results[0]!.value)
-      expect(buildKeySpy).toHaveBeenCalledTimes(1)
-      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { type: 'query', input: undefined })
+      expect(options.key).toBe(generateOperationKeySpy.mock.results[0]!.value)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'query', input: undefined })
 
       client.mockResolvedValueOnce('__mocked__')
       await expect(options.query({ signal })).resolves.toEqual('__mocked__')
@@ -517,7 +517,7 @@ describe('procedureUtils', () => {
       const options = utils.queryOptions({ key: ['__custom__'] } as any) as any
 
       expect(options.key).toEqual(['__custom__'])
-      expect(buildKeySpy).toHaveBeenCalledTimes(0)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(0)
 
       client.mockResolvedValueOnce('__mocked__')
       await expect(options.query({ signal })).resolves.toEqual('__mocked__')
@@ -624,9 +624,9 @@ describe('procedureUtils', () => {
     it('works', async () => {
       const options = utils.infiniteOptions(baseOptions as any) as any
 
-      expect(options.key).toBe(buildKeySpy.mock.results[0]!.value)
-      expect(buildKeySpy).toHaveBeenCalledTimes(1)
-      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { type: 'infinite', input: { cursor: 0 } })
+      expect(options.key).toBe(generateOperationKeySpy.mock.results[0]!.value)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'infinite', input: { cursor: 0 } })
       expect(options.initialPageParam).toEqual(0)
       expect(options.getNextPageParam).toBe(baseOptions.getNextPageParam)
 
@@ -644,9 +644,9 @@ describe('procedureUtils', () => {
     it('works with initialPageParam as function', () => {
       const options = utils.infiniteOptions({ ...baseOptions, initialPageParam: () => 5 } as any) as any
 
-      expect(options.key).toBe(buildKeySpy.mock.results[0]!.value)
-      expect(buildKeySpy).toHaveBeenCalledTimes(1)
-      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { type: 'infinite', input: { cursor: 5 } })
+      expect(options.key).toBe(generateOperationKeySpy.mock.results[0]!.value)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'infinite', input: { cursor: 5 } })
     })
 
     it('works with client context', async () => {
@@ -675,7 +675,7 @@ describe('procedureUtils', () => {
       const options = utils.infiniteOptions({ ...baseOptions, key: ['__custom__'] } as any) as any
 
       expect(options.key).toEqual(['__custom__'])
-      expect(buildKeySpy).toHaveBeenCalledTimes(0)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(0)
 
       client.mockResolvedValueOnce('__mocked__')
       await expect(options.query({ signal, pageParam: 0 })).resolves.toEqual('__mocked__')
@@ -774,28 +774,28 @@ describe('procedureUtils', () => {
     it('works', async () => {
       const options = utils.mutationOptions() as any
 
-      expect(options.key('__input__')).toBe(buildKeySpy.mock.results[0]!.value)
-      expect(buildKeySpy).toHaveBeenCalledTimes(1)
-      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { type: 'mutation', input: '__input__' })
+      expect(options.key('__input__')).toBe(generateOperationKeySpy.mock.results[0]!.value)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'mutation', input: '__input__' })
 
       client.mockResolvedValueOnce('__mocked__')
       await expect(options.mutation(1, {})).resolves.toEqual('__mocked__')
       expect(client).toHaveBeenCalledTimes(1)
       expect(client).toHaveBeenCalledWith(1, { context: {
         [OPERATION_CONTEXT_SYMBOL]: {
-          key: buildKeySpy.mock.results[1]!.value,
+          key: generateOperationKeySpy.mock.results[1]!.value,
           type: 'mutation',
         },
       } })
-      expect(buildKeySpy).toHaveBeenNthCalledWith(2, ['ping'], { type: 'mutation', input: 1 })
+      expect(generateOperationKeySpy).toHaveBeenNthCalledWith(2, ['ping'], { type: 'mutation', input: 1 })
     })
 
     it('works with client context', async () => {
       const options = utils.mutationOptions({ context: { batch: true } }) as any
 
-      expect(options.key('__input__')).toBe(buildKeySpy.mock.results[0]!.value)
-      expect(buildKeySpy).toHaveBeenCalledTimes(1)
-      expect(buildKeySpy).toHaveBeenCalledWith(['ping'], { type: 'mutation', input: '__input__' })
+      expect(options.key('__input__')).toBe(generateOperationKeySpy.mock.results[0]!.value)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+      expect(generateOperationKeySpy).toHaveBeenCalledWith(['ping'], { type: 'mutation', input: '__input__' })
 
       client.mockResolvedValueOnce('__mocked__')
       await expect(options.mutation(1, {})).resolves.toEqual('__mocked__')
@@ -803,7 +803,7 @@ describe('procedureUtils', () => {
       expect(client).toHaveBeenCalledWith(1, { context: {
         batch: true,
         [OPERATION_CONTEXT_SYMBOL]: {
-          key: buildKeySpy.mock.results[1]!.value,
+          key: generateOperationKeySpy.mock.results[1]!.value,
           type: 'mutation',
         },
       } })
@@ -820,7 +820,7 @@ describe('procedureUtils', () => {
       const options = utils.mutationOptions({ key: ['__custom__'] } as any) as any
 
       expect(options.key).toEqual(['__custom__'])
-      expect(buildKeySpy).toHaveBeenCalledTimes(0)
+      expect(generateOperationKeySpy).toHaveBeenCalledTimes(0)
 
       client.mockResolvedValueOnce('__mocked__')
       await expect(options.mutation(1, {})).resolves.toEqual('__mocked__')
@@ -872,7 +872,7 @@ describe('procedureUtils', () => {
         context: {
           batch: true,
           [OPERATION_CONTEXT_SYMBOL]: {
-            key: buildKeySpy.mock.results[0]!.value,
+            key: generateOperationKeySpy.mock.results[0]!.value,
             type: 'mutation',
           },
         },
@@ -884,7 +884,7 @@ describe('procedureUtils', () => {
       expect(client).toHaveBeenCalledWith('__override__', { context: {
         batch: true,
         [OPERATION_CONTEXT_SYMBOL]: {
-          key: buildKeySpy.mock.results[0]!.value,
+          key: generateOperationKeySpy.mock.results[0]!.value,
           type: 'mutation',
         },
       } })

--- a/packages/pinia-colada/src/procedure-utils.ts
+++ b/packages/pinia-colada/src/procedure-utils.ts
@@ -1,10 +1,10 @@
 import type { Client, ClientContext } from '@orpc/client'
 import type { Interceptor, MaybeOptionalOptions, PromiseWithError } from '@orpc/shared'
 import type { _EmptyObject, EntryKeyTagged, UseInfiniteQueryData, UseInfiniteQueryFnContext } from '@pinia/colada'
-import type { BuildKeyPrefixOptions } from './key'
+import type { OperationKeyPrefixOptions } from './key'
 import type { InferLiveQueryOutput, InferStreamedQueryOutput, InfiniteKeyOptions, InfiniteOptionsIn, InfiniteOptionsOut, MutationKeyOptions, MutationOptionsIn, MutationOptionsOut, OperationContext, QueryKeyOptions, QueryOptionsIn, QueryOptionsOut, StreamedKeyOptions, StreamedOptionsIn, StreamedOptionsOut, UseMutationFnContext, UseQueryFnContext } from './types'
 import { intercept, isAsyncIteratorObject, resolveMaybeOptionalOptions } from '@orpc/shared'
-import { buildKey } from './key'
+import { generateOperationKey } from './key'
 import { liveQuery } from './live-query'
 import { serializableStreamedQuery } from './stream-query'
 import { OPERATION_CONTEXT_SYMBOL } from './types'
@@ -52,7 +52,7 @@ export type ProcedureUtilsMutationInterceptor<TClientContext extends ClientConte
  */
 export type ProcedureUtilsModifier<T extends object> = Partial<T> | ((options: T) => T)
 
-export interface ProcedureUtilsOptions<TClientContext extends ClientContext, TInput, TOutput, TError> extends BuildKeyPrefixOptions {
+export interface ProcedureUtilsOptions<TClientContext extends ClientContext, TInput, TOutput, TError> extends OperationKeyPrefixOptions {
   /**
    * Key options modifier for .queryKey and .queryOptions
    * Can be partial options or a function that receives per-call options and returns override this.options.
@@ -193,7 +193,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
     }
 
     const key = (optionsIn as any).key
-      ?? buildKey(this.path, { prefix: this.options.prefix, type: 'query', input: (optionsIn as any).input })
+      ?? generateOperationKey(this.path, { prefix: this.options.prefix, type: 'query', input: (optionsIn as any).input })
 
     return key as EntryKeyTagged<TOutput, TError>
   }
@@ -269,7 +269,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
     }
 
     const key = (optionsIn as any).key
-      ?? buildKey(this.path, { prefix: this.options.prefix, type: 'streamed', input: (optionsIn as any).input, fnOptions: (optionsIn as any).fnOptions })
+      ?? generateOperationKey(this.path, { prefix: this.options.prefix, type: 'streamed', input: (optionsIn as any).input, fnOptions: (optionsIn as any).fnOptions })
 
     return key as EntryKeyTagged<InferStreamedQueryOutput<TOutput>, TError>
   }
@@ -356,7 +356,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
     }
 
     const key = (optionsIn as any).key
-      ?? buildKey(this.path, { prefix: this.options.prefix, type: 'live', input: (optionsIn as any).input })
+      ?? generateOperationKey(this.path, { prefix: this.options.prefix, type: 'live', input: (optionsIn as any).input })
 
     return key as EntryKeyTagged<InferLiveQueryOutput<TOutput>, TError>
   }
@@ -438,7 +438,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
     }
 
     const key = (optionsIn as any).key
-      ?? buildKey(this.path, {
+      ?? generateOperationKey(this.path, {
         prefix: this.options.prefix,
         type: 'infinite',
         input: (optionsIn as any).input(
@@ -518,7 +518,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
     }
 
     const key = optionsIn.key
-      ?? ((input: TInput) => buildKey(this.path, { prefix: this.options.prefix, type: 'mutation', input: input as any }))
+      ?? ((input: TInput) => generateOperationKey(this.path, { prefix: this.options.prefix, type: 'mutation', input: input as any }))
 
     return key as MutationOptionsOut<TInput, TOutput, TError, _EmptyObject>['key']
   }

--- a/packages/pinia-colada/src/router-utils.test-d.ts
+++ b/packages/pinia-colada/src/router-utils.test-d.ts
@@ -38,7 +38,10 @@ describe('SharedRouterUtils', () => {
     utils.key()
     utils.key({})
     utils.key({ type: 'mutation' })
+    // unlike tanstack-query, mutation keys can contain input
+    utils.key({ type: 'mutation', input: {} })
     utils.key({ input: {}, type: 'query' })
+    utils.key({ input: {}, type: 'streamed', fnOptions: { refetchMode: 'append' } })
     utils.key({ input: {} })
     utils.key({ input: { a: {} } })
     utils.key({ input: { a: { b: {} } } })
@@ -54,6 +57,9 @@ describe('SharedRouterUtils', () => {
 
     // @ts-expect-error invalid type
     utils.key({ type: 'ddd' })
+
+    // @ts-expect-error fnOptions is only allowed for streamed type
+    utils.key({ type: 'infinite', fnOptions: { refetchMode: 'append' } })
   })
 })
 

--- a/packages/pinia-colada/src/router-utils.test.ts
+++ b/packages/pinia-colada/src/router-utils.test.ts
@@ -11,7 +11,7 @@ vi.mock('./procedure-utils', async () => ({
   }),
 }))
 
-const buildKeySpy = vi.spyOn(KeyModule, 'buildKey')
+const generateOperationKeySpy = vi.spyOn(KeyModule, 'generateOperationKey')
 
 const emptyInterceptors = {
   queryInterceptors: [],
@@ -31,10 +31,10 @@ describe('sharedRouterUtils', () => {
   it('.key', () => {
     expect(
       utils.key({ input: { search: '__search__' }, type: 'query' }),
-    ).toBe(buildKeySpy.mock.results[0]!.value)
+    ).toBe(generateOperationKeySpy.mock.results[0]!.value)
 
-    expect(buildKeySpy).toHaveBeenCalledTimes(1)
-    expect(buildKeySpy).toHaveBeenCalledWith(['path'], { input: { search: '__search__' }, type: 'query', prefix: undefined })
+    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+    expect(generateOperationKeySpy).toHaveBeenCalledWith(['path'], { input: { search: '__search__' }, type: 'query', prefix: undefined })
   })
 
   it('.key with prefix', () => {
@@ -42,10 +42,10 @@ describe('sharedRouterUtils', () => {
 
     expect(
       prefixedUtils.key({ type: 'query' }),
-    ).toBe(buildKeySpy.mock.results[0]!.value)
+    ).toBe(generateOperationKeySpy.mock.results[0]!.value)
 
-    expect(buildKeySpy).toHaveBeenCalledTimes(1)
-    expect(buildKeySpy).toHaveBeenCalledWith(['path'], { type: 'query', prefix: '__prefix__' })
+    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+    expect(generateOperationKeySpy).toHaveBeenCalledWith(['path'], { type: 'query', prefix: '__prefix__' })
   })
 })
 
@@ -61,8 +61,8 @@ describe('createRouterUtils', () => {
 
     expect(ProcedureUtils).toHaveBeenCalledTimes(1)
     expect(ProcedureUtils).toHaveBeenCalledWith([], client, { ...emptyInterceptors, prefix: '__prefix__' })
-    expect(utils.key({ type: 'query' })).toBe(buildKeySpy.mock.results[0]?.value)
-    expect(buildKeySpy).toHaveBeenNthCalledWith(1, [], { type: 'query', prefix: '__prefix__' })
+    expect(utils.key({ type: 'query' })).toBe(generateOperationKeySpy.mock.results[0]?.value)
+    expect(generateOperationKeySpy).toHaveBeenNthCalledWith(1, [], { type: 'query', prefix: '__prefix__' })
     expect(utils.queryOptions()).toBe(vi.mocked(ProcedureUtils).mock.results[0]?.value.queryOptions.mock.results[0]?.value)
 
     vi.clearAllMocks()
@@ -70,8 +70,8 @@ describe('createRouterUtils', () => {
 
     expect(ProcedureUtils).toHaveBeenCalledTimes(1)
     expect(ProcedureUtils).toHaveBeenCalledWith(['key'], client.key, { ...emptyInterceptors, prefix: '__prefix__' })
-    expect(keyUtils.key({ type: 'mutation' })).toBe(buildKeySpy.mock.results[0]?.value)
-    expect(buildKeySpy).toHaveBeenNthCalledWith(1, ['key'], { type: 'mutation', prefix: '__prefix__' })
+    expect(keyUtils.key({ type: 'mutation' })).toBe(generateOperationKeySpy.mock.results[0]?.value)
+    expect(generateOperationKeySpy).toHaveBeenNthCalledWith(1, ['key'], { type: 'mutation', prefix: '__prefix__' })
     expect(keyUtils.queryOptions()).toBe(vi.mocked(ProcedureUtils).mock.results[0]?.value.queryOptions.mock.results[0]?.value)
 
     vi.clearAllMocks()
@@ -79,8 +79,8 @@ describe('createRouterUtils', () => {
 
     expect(ProcedureUtils).toHaveBeenCalledTimes(1)
     expect(ProcedureUtils).toHaveBeenCalledWith(['key', 'pong'], client.key.pong, { ...emptyInterceptors, prefix: '__prefix__' })
-    expect(pongUtils.key({ type: 'query' })).toBe(buildKeySpy.mock.results[0]?.value)
-    expect(buildKeySpy).toHaveBeenNthCalledWith(1, ['key', 'pong'], { type: 'query', prefix: '__prefix__' })
+    expect(pongUtils.key({ type: 'query' })).toBe(generateOperationKeySpy.mock.results[0]?.value)
+    expect(generateOperationKeySpy).toHaveBeenNthCalledWith(1, ['key', 'pong'], { type: 'query', prefix: '__prefix__' })
     expect(pongUtils.queryOptions()).toBe(vi.mocked(ProcedureUtils).mock.results[0]?.value.queryOptions.mock.results[0]?.value)
   })
 
@@ -90,14 +90,14 @@ describe('createRouterUtils', () => {
 
     expect(ProcedureUtils).toHaveBeenCalledTimes(0)
     expect(utils.queryOptions).toBeUndefined()
-    expect(utils.key()).toBe(buildKeySpy.mock.results[0]?.value)
-    expect(buildKeySpy).toHaveBeenNthCalledWith(1, [], { prefix: undefined })
+    expect(utils.key()).toBe(generateOperationKeySpy.mock.results[0]?.value)
+    expect(generateOperationKeySpy).toHaveBeenNthCalledWith(1, [], { prefix: undefined })
 
     const nestedUtils = utils.nested
 
     expect(ProcedureUtils).toHaveBeenCalledTimes(0)
-    expect(nestedUtils.key()).toBe(buildKeySpy.mock.results[1]?.value)
-    expect(buildKeySpy).toHaveBeenNthCalledWith(2, ['nested'], { prefix: undefined })
+    expect(nestedUtils.key()).toBe(generateOperationKeySpy.mock.results[1]?.value)
+    expect(generateOperationKeySpy).toHaveBeenNthCalledWith(2, ['nested'], { prefix: undefined })
 
     const pingUtils = nestedUtils.ping
 

--- a/packages/pinia-colada/src/router-utils.ts
+++ b/packages/pinia-colada/src/router-utils.ts
@@ -1,28 +1,28 @@
 import type { AnyNestedClient, Client, InferClientContext, InferClientError } from '@orpc/client'
 import type { Public } from '@orpc/shared'
-import type { EntryKey } from '@pinia/colada'
-import type { BuildKeyOptions, BuildKeyPrefixOptions } from './key'
+import type { OperationKey, OperationKeyOptions, OperationKeyPrefixOptions } from './key'
 import type { RouterUtilsPlugin } from './plugin'
 import type { ProcedureUtilsInfiniteInterceptor, ProcedureUtilsLiveInterceptor, ProcedureUtilsMutationInterceptor, ProcedureUtilsOptions, ProcedureUtilsQueryInterceptor, ProcedureUtilsStreamedInterceptor } from './procedure-utils'
+import type { OperationType } from './types'
 import { RECURSIVE_CLIENT_UNWRAP_KEYS } from '@orpc/client'
 import { bindMethods, get, getOrBind, isTypescriptObject, toArray } from '@orpc/shared'
-import { buildKey } from './key'
+import { generateOperationKey } from './key'
 import { CompositeRouterUtilsPlugin } from './plugin'
 import { ProcedureUtils } from './procedure-utils'
 
 export class SharedRouterUtils<TInput> {
   constructor(
     private readonly path: string[],
-    private readonly options: BuildKeyPrefixOptions,
+    private readonly options: OperationKeyPrefixOptions,
   ) {}
 
   /**
-   * Generate a query/mutation key for checking status, invalidate, set, get, etc.
+   * Generate a **partial matching** key for actions like revalidating queries, checking mutation status, etc.
    *
    * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key Pinia Colada Query/Mutation Key Docs}
    */
-  key(options?: Omit<BuildKeyOptions<TInput>, 'prefix'>): EntryKey {
-    return buildKey(this.path, { ...options, prefix: this.options.prefix })
+  key<TType extends OperationType>(options: Omit<OperationKeyOptions<TType, TInput>, 'prefix'> = {}): OperationKey<TType, TInput> {
+    return generateOperationKey(this.path, { ...options, prefix: this.options.prefix })
   }
 }
 
@@ -40,7 +40,7 @@ export type RouterUtilsScoped<T extends AnyNestedClient>
         [K in keyof T]?: T[K] extends AnyNestedClient ? RouterUtilsScoped<T[K]> : never
       }
 
-export interface RouterUtilsOptions<T extends AnyNestedClient> extends BuildKeyPrefixOptions {
+export interface RouterUtilsOptions<T extends AnyNestedClient> extends OperationKeyPrefixOptions {
   /**
    * Base path for all query keys.
    *


### PR DESCRIPTION
## Summary

Renames the Pinia Colada key utilities to match the `@orpc/tanstack-query` package, so both integrations share the same API shape:

- `buildKey` → `generateOperationKey`
- `BuildKeyOptions` → `OperationKeyOptions<TType, TInput>` (`fnOptions` now only allowed for `streamed`)
- `BuildKeyPrefixOptions` → `OperationKeyPrefixOptions`
- adds the `OperationKey<TType, TInput>` type; `utils.key()` now returns it

Pinia Colada specifics are kept: input is still serialized (entry keys must be JSON-serializable) and mutation keys still accept `input` (mutation keys are per-input functions).