### PR TITLE
feat(tanstack-query,pinia-colada): support back option in key utils

### DIFF
--- a/apps/content/docs/integrations/pinia-colada.md
+++ b/apps/content/docs/integrations/pinia-colada.md
@@ -171,6 +171,11 @@ queryCache.invalidateQueries({
   key: orpc.planet.find.key({ input: { id: 123 } })
 })
 
+// Walk back the key path with `back` — this equals orpc.planet.key()
+queryCache.invalidateQueries({
+  key: orpc.planet.find.key({ back: 1 })
+})
+
 // Update the planet find query with id 123
 queryCache.setQueryData(orpc.planet.find.queryKey({ input: { id: 123 } }), (old) => {
   return { ...old, id: 123, name: 'Earth' }

--- a/apps/content/docs/integrations/tanstack-query.md
+++ b/apps/content/docs/integrations/tanstack-query.md
@@ -190,6 +190,11 @@ queryClient.invalidateQueries({
   queryKey: orpc.planet.find.key({ input: { id: 123 } })
 })
 
+// Walk back the key path with `back` — this equals orpc.planet.key()
+queryClient.invalidateQueries({
+  queryKey: orpc.planet.find.key({ back: 1 })
+})
+
 // Update the planet find query with id 123
 queryClient.setQueryData(orpc.planet.find.queryKey({ input: { id: 123 } }), (old) => {
   return { ...old, id: 123, name: 'Earth' }

--- a/packages/pinia-colada/src/key.test.ts
+++ b/packages/pinia-colada/src/key.test.ts
@@ -12,6 +12,11 @@ it('generateOperationKey', () => {
   const date = new Date()
   expect(generateOperationKey(['path', 'path2'], { input: { a: date } })).toEqual([['path', 'path2'], { input: { a: date.toISOString() } }])
 
+  expect(generateOperationKey(['planet', 'find'], { back: 1 })).toEqual([['planet'], {}])
+  expect(generateOperationKey(['planet', 'find'], { back: 10 })).toEqual([[], {}])
+  expect(generateOperationKey(['planet', 'find'], { back: 0 })).toEqual([['planet', 'find'], {}])
+  expect(generateOperationKey(['planet', 'find'], { prefix: '__prefix__', back: 1, type: 'query' })).toEqual(['__prefix__', ['planet'], { type: 'query' }])
+
   expect(generateOperationKey(['path'], { prefix: '__prefix__' })).toEqual(['__prefix__', ['path'], {}])
   expect(generateOperationKey(['path'], { prefix: undefined })).toEqual([['path'], {}])
   expect(generateOperationKey(['path'], { prefix: '__prefix__', type: 'query', input: { a: 1 } })).toEqual(['__prefix__', ['path'], { type: 'query', input: { a: 1 } }])

--- a/packages/pinia-colada/src/key.test.ts
+++ b/packages/pinia-colada/src/key.test.ts
@@ -15,6 +15,9 @@ it('generateOperationKey', () => {
   expect(generateOperationKey(['planet', 'find'], { back: 1 })).toEqual([['planet'], {}])
   expect(generateOperationKey(['planet', 'find'], { back: 10 })).toEqual([[], {}])
   expect(generateOperationKey(['planet', 'find'], { back: 0 })).toEqual([['planet', 'find'], {}])
+  expect(generateOperationKey(['planet', 'find'], { back: 0.5 })).toEqual([['planet', 'find'], {}])
+  expect(generateOperationKey(['planet', 'find'], { back: 1.5 })).toEqual([['planet'], {}])
+  expect(generateOperationKey(['planet', 'find'], { back: -1 })).toEqual([['planet', 'find'], {}])
   expect(generateOperationKey(['planet', 'find'], { prefix: '__prefix__', back: 1, type: 'query' })).toEqual(['__prefix__', ['planet'], { type: 'query' }])
 
   expect(generateOperationKey(['path'], { prefix: '__prefix__' })).toEqual(['__prefix__', ['path'], {}])

--- a/packages/pinia-colada/src/key.test.ts
+++ b/packages/pinia-colada/src/key.test.ts
@@ -15,9 +15,6 @@ it('generateOperationKey', () => {
   expect(generateOperationKey(['planet', 'find'], { back: 1 })).toEqual([['planet'], {}])
   expect(generateOperationKey(['planet', 'find'], { back: 10 })).toEqual([[], {}])
   expect(generateOperationKey(['planet', 'find'], { back: 0 })).toEqual([['planet', 'find'], {}])
-  expect(generateOperationKey(['planet', 'find'], { back: 0.5 })).toEqual([['planet', 'find'], {}])
-  expect(generateOperationKey(['planet', 'find'], { back: 1.5 })).toEqual([['planet'], {}])
-  expect(generateOperationKey(['planet', 'find'], { back: -1 })).toEqual([['planet', 'find'], {}])
   expect(generateOperationKey(['planet', 'find'], { prefix: '__prefix__', back: 1, type: 'query' })).toEqual(['__prefix__', ['planet'], { type: 'query' }])
 
   expect(generateOperationKey(['path'], { prefix: '__prefix__' })).toEqual(['__prefix__', ['path'], {}])

--- a/packages/pinia-colada/src/key.ts
+++ b/packages/pinia-colada/src/key.ts
@@ -16,12 +16,18 @@ export type OperationKeyOptions<TType extends OperationType, TInput> = Operation
   type?: TType
   input?: PartialDeep<TInput>
   fnOptions?: TType extends 'streamed' ? SerializableStreamedQueryOptions : never
+
+  /**
+   * Number of trailing path segments to drop before generating the key.
+   * Use this to target a parent path, e.g. `orpc.planet.find.key({ back: 1 })` equals `orpc.planet.key()`.
+   */
+  back?: number
 }
 
 export type OperationKey<TType extends OperationType, TInput>
   = EntryKey & (
-    | [path: string[], options: Omit<OperationKeyOptions<TType, TInput>, 'prefix'>]
-    | [prefix: string, path: string[], options: Omit<OperationKeyOptions<TType, TInput>, 'prefix'>]
+    | [path: string[], options: Omit<OperationKeyOptions<TType, TInput>, 'prefix' | 'back'>]
+    | [prefix: string, path: string[], options: Omit<OperationKeyOptions<TType, TInput>, 'prefix' | 'back'>]
   )
 
 const serializer = new RPCJsonSerializer()
@@ -40,7 +46,7 @@ export function generateOperationKey<TType extends OperationType, TInput>(
 ): OperationKey<TType, TInput> {
   return [
     ...options.prefix !== undefined ? [options.prefix] : [],
-    path,
+    options.back ? path.slice(0, -options.back) : path,
     {
       ...options.input !== undefined ? { input: serializer.serialize(options.input).json } : {},
       ...options.type !== undefined ? { type: options.type } : {},

--- a/packages/pinia-colada/src/key.ts
+++ b/packages/pinia-colada/src/key.ts
@@ -46,7 +46,9 @@ export function generateOperationKey<TType extends OperationType, TInput>(
 ): OperationKey<TType, TInput> {
   return [
     ...options.prefix !== undefined ? [options.prefix] : [],
-    options.back ? path.slice(0, -options.back) : path,
+    options.back
+      ? path.slice(0, Math.max(0, path.length - Math.trunc(options.back)))
+      : path,
     {
       ...options.input !== undefined ? { input: serializer.serialize(options.input).json } : {},
       ...options.type !== undefined ? { type: options.type } : {},

--- a/packages/pinia-colada/src/key.ts
+++ b/packages/pinia-colada/src/key.ts
@@ -46,9 +46,7 @@ export function generateOperationKey<TType extends OperationType, TInput>(
 ): OperationKey<TType, TInput> {
   return [
     ...options.prefix !== undefined ? [options.prefix] : [],
-    options.back
-      ? path.slice(0, Math.max(0, path.length - Math.trunc(options.back)))
-      : path,
+    options.back ? path.slice(0, -options.back) : path,
     {
       ...options.input !== undefined ? { input: serializer.serialize(options.input).json } : {},
       ...options.type !== undefined ? { type: options.type } : {},

--- a/packages/pinia-colada/src/router-utils.test-d.ts
+++ b/packages/pinia-colada/src/router-utils.test-d.ts
@@ -46,6 +46,11 @@ describe('SharedRouterUtils', () => {
     utils.key({ input: { a: {} } })
     utils.key({ input: { a: { b: {} } } })
     utils.key({ input: { a: { b: { c: 1 } } } })
+    utils.key({ back: 1 })
+    utils.key({ back: 1, type: 'query' })
+
+    // @ts-expect-error invalid back
+    utils.key({ back: '1' })
 
     // @ts-expect-error invalid input
     utils.key({ input: 123 })

--- a/packages/pinia-colada/src/router-utils.test.ts
+++ b/packages/pinia-colada/src/router-utils.test.ts
@@ -47,6 +47,15 @@ describe('sharedRouterUtils', () => {
     expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
     expect(generateOperationKeySpy).toHaveBeenCalledWith(['path'], { type: 'query', prefix: '__prefix__' })
   })
+
+  it('.key with back', () => {
+    const nestedUtils = new SharedRouterUtils(['planet', 'find'], {})
+
+    expect(nestedUtils.key({ back: 1, type: 'query' })).toBe(generateOperationKeySpy.mock.results[0]!.value)
+    expect(generateOperationKeySpy).toHaveBeenCalledWith(['planet', 'find'], { back: 1, type: 'query', prefix: undefined })
+
+    expect(nestedUtils.key({ back: 1 })).toEqual(new SharedRouterUtils(['planet'], {}).key())
+  })
 })
 
 describe('createRouterUtils', () => {

--- a/packages/tanstack-query/src/key.test.ts
+++ b/packages/tanstack-query/src/key.test.ts
@@ -12,6 +12,9 @@ it('generateOperationKey', () => {
   expect(generateOperationKey(['planet', 'find'], { back: 1 })).toEqual([['planet'], {}])
   expect(generateOperationKey(['planet', 'find'], { back: 10 })).toEqual([[], {}])
   expect(generateOperationKey(['planet', 'find'], { back: 0 })).toEqual([['planet', 'find'], {}])
+  expect(generateOperationKey(['planet', 'find'], { back: 0.5 })).toEqual([['planet', 'find'], {}])
+  expect(generateOperationKey(['planet', 'find'], { back: 1.5 })).toEqual([['planet'], {}])
+  expect(generateOperationKey(['planet', 'find'], { back: -1 })).toEqual([['planet', 'find'], {}])
   expect(generateOperationKey(['planet', 'find'], { prefix: '__prefix__', back: 1, type: 'query' })).toEqual(['__prefix__', ['planet'], { type: 'query' }])
 
   expect(generateOperationKey(['path'], { prefix: '__prefix__' })).toEqual(['__prefix__', ['path'], {}])

--- a/packages/tanstack-query/src/key.test.ts
+++ b/packages/tanstack-query/src/key.test.ts
@@ -12,9 +12,6 @@ it('generateOperationKey', () => {
   expect(generateOperationKey(['planet', 'find'], { back: 1 })).toEqual([['planet'], {}])
   expect(generateOperationKey(['planet', 'find'], { back: 10 })).toEqual([[], {}])
   expect(generateOperationKey(['planet', 'find'], { back: 0 })).toEqual([['planet', 'find'], {}])
-  expect(generateOperationKey(['planet', 'find'], { back: 0.5 })).toEqual([['planet', 'find'], {}])
-  expect(generateOperationKey(['planet', 'find'], { back: 1.5 })).toEqual([['planet'], {}])
-  expect(generateOperationKey(['planet', 'find'], { back: -1 })).toEqual([['planet', 'find'], {}])
   expect(generateOperationKey(['planet', 'find'], { prefix: '__prefix__', back: 1, type: 'query' })).toEqual(['__prefix__', ['planet'], { type: 'query' }])
 
   expect(generateOperationKey(['path'], { prefix: '__prefix__' })).toEqual(['__prefix__', ['path'], {}])

--- a/packages/tanstack-query/src/key.test.ts
+++ b/packages/tanstack-query/src/key.test.ts
@@ -9,6 +9,11 @@ it('generateOperationKey', () => {
   expect(generateOperationKey(['planet', 'stream'], { type: 'streamed', input: { cursor: 0 }, fnOptions: { refetchMode: 'append' } }))
     .toEqual([['planet', 'stream'], { type: 'streamed', input: { cursor: 0 }, fnOptions: { refetchMode: 'append' } }])
 
+  expect(generateOperationKey(['planet', 'find'], { back: 1 })).toEqual([['planet'], {}])
+  expect(generateOperationKey(['planet', 'find'], { back: 10 })).toEqual([[], {}])
+  expect(generateOperationKey(['planet', 'find'], { back: 0 })).toEqual([['planet', 'find'], {}])
+  expect(generateOperationKey(['planet', 'find'], { prefix: '__prefix__', back: 1, type: 'query' })).toEqual(['__prefix__', ['planet'], { type: 'query' }])
+
   expect(generateOperationKey(['path'], { prefix: '__prefix__' })).toEqual(['__prefix__', ['path'], {}])
   expect(generateOperationKey(['path'], { prefix: undefined })).toEqual([['path'], {}])
   expect(generateOperationKey(['path'], { prefix: '__prefix__', type: 'query', input: { a: 1 } })).toEqual(['__prefix__', ['path'], { type: 'query', input: { a: 1 } }])

--- a/packages/tanstack-query/src/key.ts
+++ b/packages/tanstack-query/src/key.ts
@@ -32,7 +32,9 @@ export function generateOperationKey<TType extends OperationType, TInput>(
 ): OperationKey<TType, TInput> {
   return [
     ...options.prefix !== undefined ? [options.prefix] : [],
-    options.back ? path.slice(0, -options.back) : path,
+    options.back
+      ? path.slice(0, Math.max(0, path.length - Math.trunc(options.back)))
+      : path,
     {
       ...options.input !== undefined ? { input: options.input } : {},
       ...options.type !== undefined ? { type: options.type } : {},

--- a/packages/tanstack-query/src/key.ts
+++ b/packages/tanstack-query/src/key.ts
@@ -14,11 +14,17 @@ export type OperationKeyOptions<TType extends OperationType, TInput> = Operation
   type?: TType
   input?: TType extends 'mutation' ? never : PartialDeep<TInput>
   fnOptions?: TType extends 'streamed' ? SerializableStreamedQueryOptions : never
+
+  /**
+   * Number of trailing path segments to drop before generating the key.
+   * Use this to target a parent path, e.g. `orpc.planet.find.key({ back: 1 })` equals `orpc.planet.key()`.
+   */
+  back?: number
 }
 
 export type OperationKey<TType extends OperationType, TInput>
-  = | [path: string[], options: Omit<OperationKeyOptions<TType, TInput>, 'prefix'>]
-    | [prefix: string, path: string[], options: Omit<OperationKeyOptions<TType, TInput>, 'prefix'>]
+  = | [path: string[], options: Omit<OperationKeyOptions<TType, TInput>, 'prefix' | 'back'>]
+    | [prefix: string, path: string[], options: Omit<OperationKeyOptions<TType, TInput>, 'prefix' | 'back'>]
 
 export function generateOperationKey<TType extends OperationType, TInput>(
   path: string[],
@@ -26,7 +32,7 @@ export function generateOperationKey<TType extends OperationType, TInput>(
 ): OperationKey<TType, TInput> {
   return [
     ...options.prefix !== undefined ? [options.prefix] : [],
-    path,
+    options.back ? path.slice(0, -options.back) : path,
     {
       ...options.input !== undefined ? { input: options.input } : {},
       ...options.type !== undefined ? { type: options.type } : {},

--- a/packages/tanstack-query/src/key.ts
+++ b/packages/tanstack-query/src/key.ts
@@ -32,9 +32,7 @@ export function generateOperationKey<TType extends OperationType, TInput>(
 ): OperationKey<TType, TInput> {
   return [
     ...options.prefix !== undefined ? [options.prefix] : [],
-    options.back
-      ? path.slice(0, Math.max(0, path.length - Math.trunc(options.back)))
-      : path,
+    options.back ? path.slice(0, -options.back) : path,
     {
       ...options.input !== undefined ? { input: options.input } : {},
       ...options.type !== undefined ? { type: options.type } : {},

--- a/packages/tanstack-query/src/router-utils.test-d.ts
+++ b/packages/tanstack-query/src/router-utils.test-d.ts
@@ -42,6 +42,11 @@ describe('SharedRouterUtils', () => {
     utils.key({ input: { a: {} } })
     utils.key({ input: { a: { b: {} } } })
     utils.key({ input: { a: { b: { c: 1 } } } })
+    utils.key({ back: 1 })
+    utils.key({ back: 1, type: 'query' })
+
+    // @ts-expect-error invalid back
+    utils.key({ back: '1' })
 
     // @ts-expect-error invalid input
     utils.key({ input: 123 })

--- a/packages/tanstack-query/src/router-utils.test.ts
+++ b/packages/tanstack-query/src/router-utils.test.ts
@@ -47,6 +47,15 @@ describe('sharedRouterUtils', () => {
     expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
     expect(generateOperationKeySpy).toHaveBeenCalledWith(['path'], { type: 'query', prefix: '__prefix__' })
   })
+
+  it('.key with back', () => {
+    const nestedUtils = new SharedRouterUtils(['planet', 'find'], {})
+
+    expect(nestedUtils.key({ back: 1, type: 'query' })).toBe(generateOperationKeySpy.mock.results[0]!.value)
+    expect(generateOperationKeySpy).toHaveBeenCalledWith(['planet', 'find'], { back: 1, type: 'query', prefix: undefined })
+
+    expect(nestedUtils.key({ back: 1 })).toEqual(new SharedRouterUtils(['planet'], {}).key())
+  })
 })
 
 describe('createRouterUtils', () => {


### PR DESCRIPTION
## Summary

Key utils now accept a `back` option that drops trailing path segments, making it easy to target a parent path from a nested util:

```ts
orpc.planet.find.key({ back: 1 }) // equals orpc.planet.key()

queryClient.invalidateQueries({
  queryKey: orpc.planet.find.key({ back: 1 }),
})
```

- Supported in both `@orpc/tanstack-query` and `@orpc/pinia-colada`, including `generateOperationKey`
- `back` only shapes the key path — like `prefix`, it never appears inside the generated key
- A `back` larger than the path depth resolves to the root key