### PR TITLE
feat(tanstack-query,pinia-colada): pass corresponding procedure utils to interceptors

### DIFF
--- a/apps/content/docs/integrations/pinia-colada.md
+++ b/apps/content/docs/integrations/pinia-colada.md
@@ -251,7 +251,7 @@ When you configure `queryKey`, it also affects `.queryOptions` because it is use
 
 ## Interceptors
 
-Interceptors let you wrap `query` and `mutation` calls. Unlike [default options](#default-options), which can be overridden by per-call options, interceptors always run for every query and mutation.
+Interceptors let you wrap `query` and `mutation` calls. Unlike [default options](#default-options), which can be overridden by per-call options, interceptors always run for every query and mutation. Each interceptor receives the corresponding procedure utils through the `utils` option, so you can build keys like `utils.key({ back: 1 })` to target a parent scope.
 
 ```ts
 import { isInferableError, safe } from '@orpc/client'

--- a/apps/content/docs/integrations/tanstack-query.md
+++ b/apps/content/docs/integrations/tanstack-query.md
@@ -285,7 +285,7 @@ When you configure `queryKey`, it also affects `.queryOptions` because it is use
 
 ## Interceptors
 
-Interceptors let you wrap `queryFn` and `mutationFn` calls. Unlike [default options](#default-options), which can be overridden by per-call options, interceptors always run for every query and mutation.
+Interceptors let you wrap `queryFn` and `mutationFn` calls. Unlike [default options](#default-options), which can be overridden by per-call options, interceptors always run for every query and mutation. Each interceptor receives the corresponding procedure utils through the `utils` option, so you can build keys like `utils.key({ back: 1 })` to target a parent scope.
 
 ```ts
 import { isInferableError, safe } from '@orpc/client'
@@ -314,9 +314,10 @@ const orpc = createTanstackQueryUtils(client, {
     planet: {
       create: {
         mutationInterceptors: [
-          async ({ next, fnContext }) => {
+          async ({ next, utils, fnContext }) => {
             const result = await next()
-            fnContext.client.invalidateQueries({ queryKey: orpc.planet.key() })
+            // invalidate the parent scope: equals orpc.planet.key()
+            fnContext.client.invalidateQueries({ queryKey: utils.key({ back: 1 }) })
             return result
           },
         ],

--- a/packages/pinia-colada/src/contract-utils.test-d.ts
+++ b/packages/pinia-colada/src/contract-utils.test-d.ts
@@ -2,7 +2,7 @@ import type { ORPCError } from '@orpc/client'
 import type { ContractClientFactory } from '@orpc/contract'
 import type { PromiseWithError } from '@orpc/shared'
 import type { ProcedureUtils } from './procedure-utils'
-import type { SharedRouterUtils } from './router-utils'
+import type { SharedUtils } from './shared-utils'
 import type { OperationContext } from './types'
 import { meta, oc, type } from '@orpc/contract'
 import { createContractJsonifiedUtilsFactory, createContractUtilsFactory } from './contract-utils'
@@ -82,7 +82,6 @@ describe('createContractUtilsFactory', () => {
 
     expectTypeOf(utils).toEqualTypeOf<
       & Omit<ProcedureUtils<{ cache?: boolean }, string, Date, Error | ORPCError<'BAD_GATEWAY', RegExp>>, 'path' | 'options'>
-      & Omit<SharedRouterUtils<string>, 'path'>
     >()
   })
 
@@ -92,10 +91,9 @@ describe('createContractUtilsFactory', () => {
 
     expectTypeOf(utils.nested.pong).toEqualTypeOf<
       & Omit<ProcedureUtils<{ cache?: boolean }, string, Date, Error | ORPCError<'BAD_GATEWAY', RegExp>>, 'path' | 'options'>
-      & Omit<SharedRouterUtils<string>, 'path'>
     >()
 
-    expectTypeOf(utils.key).toEqualTypeOf<SharedRouterUtils<unknown>['key']>()
+    expectTypeOf(utils.key).toEqualTypeOf<SharedUtils<unknown>['key']>()
   })
 })
 
@@ -163,7 +161,6 @@ describe('createContractJsonifiedUtilsFactory', () => {
 
     expectTypeOf(utils).toEqualTypeOf<
       & Omit<ProcedureUtils<{ cache?: boolean }, string, string, Error | ORPCError<'BAD_GATEWAY', string>>, 'path' | 'options'>
-      & Omit<SharedRouterUtils<string>, 'path'>
     >()
   })
 
@@ -173,7 +170,6 @@ describe('createContractJsonifiedUtilsFactory', () => {
 
     expectTypeOf(utils.nested.pong).toEqualTypeOf<
       & Omit<ProcedureUtils<{ cache?: boolean }, string, string, Error | ORPCError<'BAD_GATEWAY', string>>, 'path' | 'options'>
-      & Omit<SharedRouterUtils<string>, 'path'>
     >()
   })
 })

--- a/packages/pinia-colada/src/index.ts
+++ b/packages/pinia-colada/src/index.ts
@@ -7,6 +7,7 @@ export * from './router-utils'
 export {
   createRouterUtils as createPiniaColadaUtils,
 } from './router-utils'
+export * from './shared-utils'
 export * from './stream-query'
 export * from './types'
 export {

--- a/packages/pinia-colada/src/procedure-utils.test.ts
+++ b/packages/pinia-colada/src/procedure-utils.test.ts
@@ -166,6 +166,7 @@ describe('procedureUtils', () => {
       await expect(options.query(fnContext)).resolves.toEqual(['a'])
 
       expect(interceptor1).toHaveBeenCalledTimes(1)
+      expect(interceptor1.mock.calls[0]![0].utils).toBe(interceptedUtils)
       expect(interceptor1).toHaveBeenCalledWith(expect.objectContaining({
         path: ['ping'],
         input: 1,
@@ -319,6 +320,7 @@ describe('procedureUtils', () => {
       await expect(options.query(fnContext)).resolves.toEqual('a')
 
       expect(interceptor1).toHaveBeenCalledTimes(1)
+      expect(interceptor1.mock.calls[0]![0].utils).toBe(interceptedUtils)
       expect(interceptor1).toHaveBeenCalledWith(expect.objectContaining({
         path: ['ping'],
         input: 1,
@@ -563,6 +565,7 @@ describe('procedureUtils', () => {
       await expect(options.query(fnContext)).resolves.toEqual('__mocked__')
 
       expect(interceptor1).toHaveBeenCalledTimes(1)
+      expect(interceptor1.mock.calls[0]![0].utils).toBe(interceptedUtils)
       expect(interceptor1).toHaveBeenCalledWith(expect.objectContaining({
         path: ['ping'],
         input: 1,
@@ -720,6 +723,7 @@ describe('procedureUtils', () => {
       await expect(options.query(fnContext)).resolves.toEqual('__mocked__')
 
       expect(interceptor1).toHaveBeenCalledTimes(1)
+      expect(interceptor1.mock.calls[0]![0].utils).toBe(interceptedUtils)
       expect(interceptor1).toHaveBeenCalledWith(expect.objectContaining({
         path: ['ping'],
         input: { cursor: 1 },
@@ -865,6 +869,7 @@ describe('procedureUtils', () => {
       await expect(options.mutation(1, fnContext)).resolves.toEqual('__mocked__')
 
       expect(interceptor1).toHaveBeenCalledTimes(1)
+      expect(interceptor1.mock.calls[0]![0].utils).toBe(interceptedUtils)
       expect(interceptor1).toHaveBeenCalledWith(expect.objectContaining({
         path: ['ping'],
         input: 1,

--- a/packages/pinia-colada/src/procedure-utils.ts
+++ b/packages/pinia-colada/src/procedure-utils.ts
@@ -6,45 +6,49 @@ import type { InferLiveQueryOutput, InferStreamedQueryOutput, InfiniteKeyOptions
 import { intercept, isAsyncIteratorObject, resolveMaybeOptionalOptions } from '@orpc/shared'
 import { generateOperationKey } from './key'
 import { liveQuery } from './live-query'
+import { SharedUtils } from './shared-utils'
 import { serializableStreamedQuery } from './stream-query'
 import { OPERATION_CONTEXT_SYMBOL } from './types'
 
-export interface ProcedureUtilsQueryInterceptorOptions<TClientContext extends ClientContext, TInput> {
+export interface ProcedureUtilsQueryInterceptorOptions<TClientContext extends ClientContext, TInput, TOutput, TError> {
   path: string[]
+  utils: ProcedureUtils<TClientContext, TInput, TOutput, TError>
   context: TClientContext & OperationContext
   input: TInput
   fnContext: UseQueryFnContext
 }
 export type ProcedureUtilsQueryInterceptor<TClientContext extends ClientContext, TInput, TOutput, TError>
-  = Interceptor<ProcedureUtilsQueryInterceptorOptions<TClientContext, TInput>, PromiseWithError<TOutput, TError>>
+  = Interceptor<ProcedureUtilsQueryInterceptorOptions<TClientContext, TInput, TOutput, TError>, PromiseWithError<TOutput, TError>>
 
-export interface ProcedureUtilsStreamedInterceptorOptions<TClientContext extends ClientContext, TInput> extends ProcedureUtilsQueryInterceptorOptions<TClientContext, TInput> {
+export interface ProcedureUtilsStreamedInterceptorOptions<TClientContext extends ClientContext, TInput, TOutput, TError> extends ProcedureUtilsQueryInterceptorOptions<TClientContext, TInput, TOutput, TError> {
 }
 export type ProcedureUtilsStreamedInterceptor<TClientContext extends ClientContext, TInput, TOutput, TError>
-  = Interceptor<ProcedureUtilsStreamedInterceptorOptions<TClientContext, TInput>, PromiseWithError<InferStreamedQueryOutput<TOutput>, TError>>
+  = Interceptor<ProcedureUtilsStreamedInterceptorOptions<TClientContext, TInput, TOutput, TError>, PromiseWithError<InferStreamedQueryOutput<TOutput>, TError>>
 
-export interface ProcedureUtilsLiveInterceptorOptions<TClientContext extends ClientContext, TInput> extends ProcedureUtilsQueryInterceptorOptions<TClientContext, TInput> {
+export interface ProcedureUtilsLiveInterceptorOptions<TClientContext extends ClientContext, TInput, TOutput, TError> extends ProcedureUtilsQueryInterceptorOptions<TClientContext, TInput, TOutput, TError> {
 }
 export type ProcedureUtilsLiveInterceptor<TClientContext extends ClientContext, TInput, TOutput, TError>
-  = Interceptor<ProcedureUtilsLiveInterceptorOptions<TClientContext, TInput>, PromiseWithError<InferLiveQueryOutput<TOutput>, TError>>
+  = Interceptor<ProcedureUtilsLiveInterceptorOptions<TClientContext, TInput, TOutput, TError>, PromiseWithError<InferLiveQueryOutput<TOutput>, TError>>
 
-export interface ProcedureUtilsInfiniteInterceptorOptions<TClientContext extends ClientContext, TInput> {
+export interface ProcedureUtilsInfiniteInterceptorOptions<TClientContext extends ClientContext, TInput, TOutput, TError> {
   path: string[]
+  utils: ProcedureUtils<TClientContext, TInput, TOutput, TError>
   context: TClientContext & OperationContext
   input: TInput
   fnContext: UseInfiniteQueryFnContext<any, any, any, any>
 }
 export type ProcedureUtilsInfiniteInterceptor<TClientContext extends ClientContext, TInput, TOutput, TError>
-  = Interceptor<ProcedureUtilsInfiniteInterceptorOptions<TClientContext, TInput>, PromiseWithError<TOutput, TError>>
+  = Interceptor<ProcedureUtilsInfiniteInterceptorOptions<TClientContext, TInput, TOutput, TError>, PromiseWithError<TOutput, TError>>
 
-export interface ProcedureUtilsMutationInterceptorOptions<TClientContext extends ClientContext, TInput> {
+export interface ProcedureUtilsMutationInterceptorOptions<TClientContext extends ClientContext, TInput, TOutput, TError> {
   path: string[]
+  utils: ProcedureUtils<TClientContext, TInput, TOutput, TError>
   context: TClientContext & OperationContext
   input: TInput
   fnContext: UseMutationFnContext
 }
 export type ProcedureUtilsMutationInterceptor<TClientContext extends ClientContext, TInput, TOutput, TError>
-  = Interceptor<ProcedureUtilsMutationInterceptorOptions<TClientContext, TInput>, PromiseWithError<TOutput, TError>>
+  = Interceptor<ProcedureUtilsMutationInterceptorOptions<TClientContext, TInput, TOutput, TError>, PromiseWithError<TOutput, TError>>
 
 /**
  * Can be partial options for spread-merged options,
@@ -159,7 +163,9 @@ export interface ProcedureUtilsOptions<TClientContext extends ClientContext, TIn
   >
 }
 
-export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutput, TError> {
+export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutput, TError> extends SharedUtils<TInput> {
+  declare protected readonly options: ProcedureUtilsOptions<TClientContext, TInput, TOutput, TError>
+
   /**
    * Calling corresponding procedure client
    *
@@ -168,10 +174,11 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   call: Client<TClientContext, TInput, TOutput, TError>
 
   constructor(
-    private readonly path: string[],
+    path: string[],
     client: Client<TClientContext, TInput, TOutput, TError>,
-    private readonly options: ProcedureUtilsOptions<TClientContext, TInput, TOutput, TError> = {},
+    options: ProcedureUtilsOptions<TClientContext, TInput, TOutput, TError> = {},
   ) {
+    super(path, options)
     this.call = client
   }
 
@@ -229,6 +236,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
           this.options.queryInterceptors,
           {
             path: this.path,
+            utils: this,
             context: {
               [OPERATION_CONTEXT_SYMBOL]: {
                 key,
@@ -305,6 +313,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
           this.options.streamedInterceptors,
           {
             path: this.path,
+            utils: this,
             context: {
               [OPERATION_CONTEXT_SYMBOL]: {
                 key,
@@ -392,6 +401,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
           this.options.liveInterceptors,
           {
             path: this.path,
+            utils: this,
             context: {
               [OPERATION_CONTEXT_SYMBOL]: {
                 key,
@@ -478,6 +488,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
           this.options.infiniteInterceptors,
           {
             path: this.path,
+            utils: this,
             context: {
               [OPERATION_CONTEXT_SYMBOL]: {
                 key,
@@ -554,6 +565,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
           this.options.mutationInterceptors,
           {
             path: this.path,
+            utils: this,
             context: {
               [OPERATION_CONTEXT_SYMBOL]: {
                 key: typeof key === 'function' ? key(input) : key,

--- a/packages/pinia-colada/src/router-utils.test-d.ts
+++ b/packages/pinia-colada/src/router-utils.test-d.ts
@@ -2,9 +2,9 @@ import type { ORPCErrorFromErrorMap } from '@orpc/contract'
 import type { RouterClient } from '@orpc/server'
 import type { Public } from '@orpc/shared'
 import type { ProcedureUtils } from './procedure-utils'
-import type { RouterUtils, SharedRouterUtils } from './router-utils'
+import type { RouterUtils } from './router-utils'
+import type { SharedUtils } from './shared-utils'
 import { os } from '@orpc/server'
-import { ref } from 'vue'
 import z from 'zod'
 import { createRouterUtils } from './router-utils'
 
@@ -31,51 +31,14 @@ const router = {
   }),
 }
 
-describe('SharedRouterUtils', () => {
-  const utils = {} as Public<SharedRouterUtils<{ a: { b: { c: number } } }>>
-
-  it('.key', () => {
-    utils.key()
-    utils.key({})
-    utils.key({ type: 'mutation' })
-    // unlike tanstack-query, mutation keys can contain input
-    utils.key({ type: 'mutation', input: {} })
-    utils.key({ input: {}, type: 'query' })
-    utils.key({ input: {}, type: 'streamed', fnOptions: { refetchMode: 'append' } })
-    utils.key({ input: {} })
-    utils.key({ input: { a: {} } })
-    utils.key({ input: { a: { b: {} } } })
-    utils.key({ input: { a: { b: { c: 1 } } } })
-    utils.key({ back: 1 })
-    utils.key({ back: 1, type: 'query' })
-
-    // @ts-expect-error invalid back
-    utils.key({ back: '1' })
-
-    // @ts-expect-error invalid input
-    utils.key({ input: 123 })
-    // @ts-expect-error invalid input
-    utils.key({ input: { a: { b: { c: '1' } } } })
-
-    // @ts-expect-error not allow ref
-    utils.key({ input: { a: { b: ref({ c: 1 }) } } })
-
-    // @ts-expect-error invalid type
-    utils.key({ type: 'ddd' })
-
-    // @ts-expect-error fnOptions is only allowed for streamed type
-    utils.key({ type: 'infinite', fnOptions: { refetchMode: 'append' } })
-  })
-})
-
 it('RouterUtils', () => {
   const utils = {} as RouterUtils<RouterClient<typeof router, { batch?: boolean }>>
 
-  expectTypeOf(utils).toExtend<Public<SharedRouterUtils<unknown>>>()
-  expectTypeOf(utils.nested).toExtend<Public<SharedRouterUtils<unknown>>>()
+  expectTypeOf(utils).toExtend<Public<SharedUtils<unknown>>>()
+  expectTypeOf(utils.nested).toExtend<Public<SharedUtils<unknown>>>()
 
-  expectTypeOf(utils.ping).toExtend<Public<SharedRouterUtils<{ input: number }>>>()
-  expectTypeOf(utils.nested.ping).toExtend<Public<SharedRouterUtils<{ input: number }>>>()
+  expectTypeOf(utils.ping).toExtend<Public<SharedUtils<{ input: number }>>>()
+  expectTypeOf(utils.nested.ping).toExtend<Public<SharedUtils<{ input: number }>>>()
 
   expectTypeOf(utils.ping).toExtend<
     Public<ProcedureUtils<{ batch?: boolean }, { input: number }, { output: string }, ORPCErrorFromErrorMap<typeof baseErrorMap> | Error>>

--- a/packages/pinia-colada/src/router-utils.test.ts
+++ b/packages/pinia-colada/src/router-utils.test.ts
@@ -1,15 +1,24 @@
 import type { RouterUtilsPlugin } from './plugin'
 import * as KeyModule from './key'
 import { ProcedureUtils } from './procedure-utils'
-import { createRouterUtils, SharedRouterUtils } from './router-utils'
+import { createRouterUtils } from './router-utils'
 
-vi.mock('./procedure-utils', async () => ({
-  ProcedureUtils: vi.fn(class {
-    call = vi.fn()
-    queryOptions = vi.fn(() => ({ queryOptions: true }))
-    mutationOptions = vi.fn(() => ({ mutationOptions: true }))
-  }),
-}))
+vi.mock('./procedure-utils', async () => {
+  const { SharedUtils } = await import('./shared-utils')
+
+  return {
+    ProcedureUtils: vi.fn(class extends SharedUtils<unknown> {
+      call = vi.fn()
+      override key = SharedUtils.prototype.key
+      queryOptions = vi.fn(() => ({ queryOptions: true }))
+      mutationOptions = vi.fn(() => ({ mutationOptions: true }))
+
+      constructor(path: string[], _client: unknown, options: any = {}) {
+        super(path, options)
+      }
+    }),
+  }
+})
 
 const generateOperationKeySpy = vi.spyOn(KeyModule, 'generateOperationKey')
 
@@ -23,39 +32,6 @@ const emptyInterceptors = {
 
 beforeEach(() => {
   vi.clearAllMocks()
-})
-
-describe('sharedRouterUtils', () => {
-  const utils = new SharedRouterUtils(['path'], {})
-
-  it('.key', () => {
-    expect(
-      utils.key({ input: { search: '__search__' }, type: 'query' }),
-    ).toBe(generateOperationKeySpy.mock.results[0]!.value)
-
-    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
-    expect(generateOperationKeySpy).toHaveBeenCalledWith(['path'], { input: { search: '__search__' }, type: 'query', prefix: undefined })
-  })
-
-  it('.key with prefix', () => {
-    const prefixedUtils = new SharedRouterUtils(['path'], { prefix: '__prefix__' })
-
-    expect(
-      prefixedUtils.key({ type: 'query' }),
-    ).toBe(generateOperationKeySpy.mock.results[0]!.value)
-
-    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
-    expect(generateOperationKeySpy).toHaveBeenCalledWith(['path'], { type: 'query', prefix: '__prefix__' })
-  })
-
-  it('.key with back', () => {
-    const nestedUtils = new SharedRouterUtils(['planet', 'find'], {})
-
-    expect(nestedUtils.key({ back: 1, type: 'query' })).toBe(generateOperationKeySpy.mock.results[0]!.value)
-    expect(generateOperationKeySpy).toHaveBeenCalledWith(['planet', 'find'], { back: 1, type: 'query', prefix: undefined })
-
-    expect(nestedUtils.key({ back: 1 })).toEqual(new SharedRouterUtils(['planet'], {}).key())
-  })
 })
 
 describe('createRouterUtils', () => {

--- a/packages/pinia-colada/src/router-utils.ts
+++ b/packages/pinia-colada/src/router-utils.ts
@@ -1,37 +1,20 @@
 import type { AnyNestedClient, Client, InferClientContext, InferClientError } from '@orpc/client'
 import type { Public } from '@orpc/shared'
-import type { OperationKey, OperationKeyOptions, OperationKeyPrefixOptions } from './key'
+import type { OperationKeyPrefixOptions } from './key'
 import type { RouterUtilsPlugin } from './plugin'
 import type { ProcedureUtilsInfiniteInterceptor, ProcedureUtilsLiveInterceptor, ProcedureUtilsMutationInterceptor, ProcedureUtilsOptions, ProcedureUtilsQueryInterceptor, ProcedureUtilsStreamedInterceptor } from './procedure-utils'
-import type { OperationType } from './types'
 import { RECURSIVE_CLIENT_UNWRAP_KEYS } from '@orpc/client'
 import { bindMethods, get, getOrBind, isTypescriptObject, toArray } from '@orpc/shared'
-import { generateOperationKey } from './key'
 import { CompositeRouterUtilsPlugin } from './plugin'
 import { ProcedureUtils } from './procedure-utils'
-
-export class SharedRouterUtils<TInput> {
-  constructor(
-    private readonly path: string[],
-    private readonly options: OperationKeyPrefixOptions,
-  ) {}
-
-  /**
-   * Generate a **partial matching** key for actions like revalidating queries, checking mutation status, etc.
-   *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key Pinia Colada Query/Mutation Key Docs}
-   */
-  key<TType extends OperationType>(options: Omit<OperationKeyOptions<TType, TInput>, 'prefix'> = {}): OperationKey<TType, TInput> {
-    return generateOperationKey(this.path, { ...options, prefix: this.options.prefix })
-  }
-}
+import { SharedUtils } from './shared-utils'
 
 export type RouterUtils<T extends AnyNestedClient>
   = T extends Client<infer UClientContext, infer UInput, infer UOutput, infer UError>
-    ? Public<ProcedureUtils<UClientContext, UInput, UOutput, UError>> & Public<SharedRouterUtils<UInput>>
+    ? Public<ProcedureUtils<UClientContext, UInput, UOutput, UError>>
     : {
       [K in keyof T]: T[K] extends AnyNestedClient ? RouterUtils<T[K]> : never
-    } & Public<SharedRouterUtils<unknown>>
+    } & Public<SharedUtils<unknown>>
 
 export type RouterUtilsScoped<T extends AnyNestedClient>
   = T extends Client<infer UClientContext, infer UInput, infer UOutput, infer UError>
@@ -108,9 +91,8 @@ function createRouterUtilsInternal<T extends AnyNestedClient>(
   plugin: CompositeRouterUtilsPlugin<any>,
 ): RouterUtils<T> {
   const path = toArray(options.path)
-  const sharedUtils = bindMethods(new SharedRouterUtils(path, options))
 
-  const procedureUtils = typeof client === 'function' && (options.scoped === undefined || isProcedureUtilsOptions(options.scoped))
+  const utils = typeof client === 'function' && (options.scoped === undefined || isProcedureUtilsOptions(options.scoped))
     ? bindMethods(new ProcedureUtils(
         path,
         client,
@@ -124,12 +106,9 @@ function createRouterUtilsInternal<T extends AnyNestedClient>(
           mutationInterceptors: [...toArray(options.mutationInterceptors) as any, ...toArray(options.scoped?.mutationInterceptors)],
         }),
       ))
-    : undefined
+    : bindMethods(new SharedUtils(path, options))
 
-  const recursive = new Proxy({
-    ...sharedUtils,
-    ...procedureUtils,
-  }, {
+  const recursive = new Proxy(utils, {
     get(target, prop) {
       const value = getOrBind(target, prop)
       const nextClient = get(client, [prop])
@@ -141,8 +120,8 @@ function createRouterUtilsInternal<T extends AnyNestedClient>(
       const nextUtils = createRouterUtilsInternal(nextClient as any, {
         ...options,
         path: [...path, prop],
-        scoped: get(options.scoped, [prop]) as any,
-      }, plugin)
+        scoped: get(options.scoped, [prop]),
+      } as any, plugin)
 
       if (typeof value !== 'function') {
         return nextUtils

--- a/packages/pinia-colada/src/shared-utils.test-d.ts
+++ b/packages/pinia-colada/src/shared-utils.test-d.ts
@@ -1,0 +1,40 @@
+import type { Public } from '@orpc/shared'
+import type { SharedUtils } from './shared-utils'
+import { ref } from 'vue'
+
+describe('SharedUtils', () => {
+  const utils = {} as Public<SharedUtils<{ a: { b: { c: number } } }>>
+
+  it('.key', () => {
+    utils.key()
+    utils.key({})
+    utils.key({ type: 'mutation' })
+    // unlike tanstack-query, mutation keys can contain input
+    utils.key({ type: 'mutation', input: {} })
+    utils.key({ input: {}, type: 'query' })
+    utils.key({ input: {}, type: 'streamed', fnOptions: { refetchMode: 'append' } })
+    utils.key({ input: {} })
+    utils.key({ input: { a: {} } })
+    utils.key({ input: { a: { b: {} } } })
+    utils.key({ input: { a: { b: { c: 1 } } } })
+    utils.key({ back: 1 })
+    utils.key({ back: 1, type: 'query' })
+
+    // @ts-expect-error invalid back
+    utils.key({ back: '1' })
+
+    // @ts-expect-error invalid input
+    utils.key({ input: 123 })
+    // @ts-expect-error invalid input
+    utils.key({ input: { a: { b: { c: '1' } } } })
+
+    // @ts-expect-error not allow ref
+    utils.key({ input: { a: { b: ref({ c: 1 }) } } })
+
+    // @ts-expect-error invalid type
+    utils.key({ type: 'ddd' })
+
+    // @ts-expect-error fnOptions is only allowed for streamed type
+    utils.key({ type: 'infinite', fnOptions: { refetchMode: 'append' } })
+  })
+})

--- a/packages/pinia-colada/src/shared-utils.test.ts
+++ b/packages/pinia-colada/src/shared-utils.test.ts
@@ -1,0 +1,41 @@
+import * as KeyModule from './key'
+import { SharedUtils } from './shared-utils'
+
+const generateOperationKeySpy = vi.spyOn(KeyModule, 'generateOperationKey')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('sharedUtils', () => {
+  const utils = new SharedUtils(['path'], {})
+
+  it('.key', () => {
+    expect(
+      utils.key({ input: { search: '__search__' }, type: 'query' }),
+    ).toBe(generateOperationKeySpy.mock.results[0]!.value)
+
+    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+    expect(generateOperationKeySpy).toHaveBeenCalledWith(['path'], { input: { search: '__search__' }, type: 'query', prefix: undefined })
+  })
+
+  it('.key with prefix', () => {
+    const prefixedUtils = new SharedUtils(['path'], { prefix: '__prefix__' })
+
+    expect(
+      prefixedUtils.key({ type: 'query' }),
+    ).toBe(generateOperationKeySpy.mock.results[0]!.value)
+
+    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+    expect(generateOperationKeySpy).toHaveBeenCalledWith(['path'], { type: 'query', prefix: '__prefix__' })
+  })
+
+  it('.key with back', () => {
+    const nestedUtils = new SharedUtils(['planet', 'find'], {})
+
+    expect(nestedUtils.key({ back: 1, type: 'query' })).toBe(generateOperationKeySpy.mock.results[0]!.value)
+    expect(generateOperationKeySpy).toHaveBeenCalledWith(['planet', 'find'], { back: 1, type: 'query', prefix: undefined })
+
+    expect(nestedUtils.key({ back: 1 })).toEqual(new SharedUtils(['planet'], {}).key())
+  })
+})

--- a/packages/pinia-colada/src/shared-utils.ts
+++ b/packages/pinia-colada/src/shared-utils.ts
@@ -1,0 +1,19 @@
+import type { OperationKey, OperationKeyOptions, OperationKeyPrefixOptions } from './key'
+import type { OperationType } from './types'
+import { generateOperationKey } from './key'
+
+export class SharedUtils<TInput> {
+  constructor(
+    protected readonly path: string[],
+    protected readonly options: OperationKeyPrefixOptions,
+  ) {}
+
+  /**
+   * Generate a **partial matching** key for actions like revalidating queries, checking mutation status, etc.
+   *
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key Pinia Colada Query/Mutation Key Docs}
+   */
+  key<TType extends OperationType>(options: Omit<OperationKeyOptions<TType, TInput>, 'prefix'> = {}): OperationKey<TType, TInput> {
+    return generateOperationKey(this.path, { ...options, prefix: this.options.prefix })
+  }
+}

--- a/packages/tanstack-query/src/contract-utils.test-d.ts
+++ b/packages/tanstack-query/src/contract-utils.test-d.ts
@@ -2,7 +2,7 @@ import type { ORPCError } from '@orpc/client'
 import type { ContractClientFactory } from '@orpc/contract'
 import type { PromiseWithError } from '@orpc/shared'
 import type { ProcedureUtils } from './procedure-utils'
-import type { SharedRouterUtils } from './router-utils'
+import type { SharedUtils } from './shared-utils'
 import type { OperationContext } from './types'
 import { meta, oc, type } from '@orpc/contract'
 import { createContractJsonifiedUtilsFactory, createContractUtilsFactory } from './contract-utils'
@@ -82,7 +82,6 @@ describe('createContractUtilsFactory', () => {
 
     expectTypeOf(utils).toEqualTypeOf<
       & Omit<ProcedureUtils<{ cache?: boolean }, string, Date, Error | ORPCError<'BAD_GATEWAY', RegExp>>, 'path' | 'options'>
-      & Omit<SharedRouterUtils<string>, 'path'>
     >()
   })
 
@@ -92,10 +91,9 @@ describe('createContractUtilsFactory', () => {
 
     expectTypeOf(utils.nested.pong).toEqualTypeOf<
       & Omit<ProcedureUtils<{ cache?: boolean }, string, Date, Error | ORPCError<'BAD_GATEWAY', RegExp>>, 'path' | 'options'>
-      & Omit<SharedRouterUtils<string>, 'path'>
     >()
 
-    expectTypeOf(utils.key).toEqualTypeOf<SharedRouterUtils<unknown>['key']>()
+    expectTypeOf(utils.key).toEqualTypeOf<SharedUtils<unknown>['key']>()
   })
 })
 
@@ -163,7 +161,6 @@ describe('createContractJsonifiedUtilsFactory', () => {
 
     expectTypeOf(utils).toEqualTypeOf<
       & Omit<ProcedureUtils<{ cache?: boolean }, string, string, Error | ORPCError<'BAD_GATEWAY', string>>, 'path' | 'options'>
-      & Omit<SharedRouterUtils<string>, 'path'>
     >()
   })
 
@@ -173,7 +170,6 @@ describe('createContractJsonifiedUtilsFactory', () => {
 
     expectTypeOf(utils.nested.pong).toEqualTypeOf<
       & Omit<ProcedureUtils<{ cache?: boolean }, string, string, Error | ORPCError<'BAD_GATEWAY', string>>, 'path' | 'options'>
-      & Omit<SharedRouterUtils<string>, 'path'>
     >()
   })
 })

--- a/packages/tanstack-query/src/index.ts
+++ b/packages/tanstack-query/src/index.ts
@@ -3,6 +3,7 @@ export * from './key'
 export * from './procedure-utils'
 export * from './router-utils'
 export { createRouterUtils as createTanstackQueryUtils } from './router-utils'
+export * from './shared-utils'
 export * from './stream-query'
 export * from './types'
 export {

--- a/packages/tanstack-query/src/procedure-utils.test-d.ts
+++ b/packages/tanstack-query/src/procedure-utils.test-d.ts
@@ -867,7 +867,7 @@ describe('CreateProcedureUtilsOptions', () => {
 
   it('should have all keys that ProcedureUtils provides', () => {
     // Ensures every utility method in ProcedureUtils (except 'call') has a corresponding key in CreateProcedureUtilsOptions
-    type ProcedureUtilsKeys = Exclude<keyof ProcedureUtils<any, any, any, any>, 'call'>
+    type ProcedureUtilsKeys = Exclude<keyof ProcedureUtils<any, any, any, any>, 'call' | 'key'>
     type DefaultsKeys = keyof ProcedureUtilsOptions<any, any, any, any>
 
     expectTypeOf<ProcedureUtilsKeys>().toExtend<DefaultsKeys>()

--- a/packages/tanstack-query/src/procedure-utils.test.ts
+++ b/packages/tanstack-query/src/procedure-utils.test.ts
@@ -894,6 +894,7 @@ describe('createProcedureUtils with interceptors', () => {
     await expect(options.queryFn!({ signal } as any)).resolves.toBe('__output__')
 
     expect(queryInterceptor).toHaveBeenCalledTimes(1)
+    expect(queryInterceptor.mock.calls[0]![0].utils).toBe(utils)
     expect(queryInterceptor.mock.calls[0]![0]).toMatchObject({
       path: ['ping'],
       input: { search: '__search__' },
@@ -944,6 +945,7 @@ describe('createProcedureUtils with interceptors', () => {
     await expect(options.queryFn!({ signal, client: queryClient, queryKey: options.queryKey } as any)).resolves.toEqual(['__1__'])
 
     expect(streamedInterceptor).toHaveBeenCalledTimes(1)
+    expect(streamedInterceptor.mock.calls[0]![0].utils).toBe(utils)
     expect(streamedInterceptor.mock.calls[0]![0]).toMatchObject({
       path: ['ping'],
       input: { search: '__search__' },
@@ -994,6 +996,7 @@ describe('createProcedureUtils with interceptors', () => {
     await expect(options.queryFn!({ signal, client: queryClient, queryKey: options.queryKey } as any)).resolves.toEqual('__1__')
 
     expect(liveInterceptor).toHaveBeenCalledTimes(1)
+    expect(liveInterceptor.mock.calls[0]![0].utils).toBe(utils)
     expect(liveInterceptor.mock.calls[0]![0]).toMatchObject({
       path: ['ping'],
       input: { search: '__search__' },
@@ -1047,6 +1050,7 @@ describe('createProcedureUtils with interceptors', () => {
     await expect(options.queryFn!({ signal, pageParam: '__pageParam__' } as any)).resolves.toBe('__output__')
 
     expect(infiniteInterceptor).toHaveBeenCalledTimes(1)
+    expect(infiniteInterceptor.mock.calls[0]![0].utils).toBe(utils)
     expect(infiniteInterceptor.mock.calls[0]![0]).toMatchObject({
       path: ['ping'],
       input: { search: '__search__', pageParam: '__pageParam__' },
@@ -1095,6 +1099,7 @@ describe('createProcedureUtils with interceptors', () => {
     await expect(options.mutationFn!('__input__', {} as any)).resolves.toBe('__output__')
 
     expect(mutationInterceptor).toHaveBeenCalledTimes(1)
+    expect(mutationInterceptor.mock.calls[0]![0].utils).toBe(utils)
     expect(mutationInterceptor.mock.calls[0]![0]).toMatchObject({
       path: ['ping'],
       input: '__input__',

--- a/packages/tanstack-query/src/procedure-utils.ts
+++ b/packages/tanstack-query/src/procedure-utils.ts
@@ -23,40 +23,42 @@ import { intercept, isAsyncIteratorObject, resolveMaybeOptionalOptions, toArray 
 import { skipToken } from '@tanstack/query-core'
 import { generateOperationKey } from './key'
 import { liveQuery } from './live-query'
+import { SharedUtils } from './shared-utils'
 import { serializableStreamedQuery } from './stream-query'
 import { OPERATION_CONTEXT_SYMBOL } from './types'
 
-export interface ProcedureUtilsQueryInterceptorOptions<TClientContext extends ClientContext, TInput> {
+export interface ProcedureUtilsQueryInterceptorOptions<TClientContext extends ClientContext, TInput, TOutput, TError> {
   path: string[]
+  utils: ProcedureUtils<TClientContext, TInput, TOutput, TError>
   context: TClientContext & OperationContext
   input: TInput | SkipToken
   fnContext: QueryFunctionContext
 }
 export type ProcedureUtilsQueryInterceptor<TClientContext extends ClientContext, TInput, TOutput, TError>
-  = Interceptor<ProcedureUtilsQueryInterceptorOptions<TClientContext, TInput>, PromiseWithError<TOutput, TError>>
+  = Interceptor<ProcedureUtilsQueryInterceptorOptions<TClientContext, TInput, TOutput, TError>, PromiseWithError<TOutput, TError>>
 
-export interface ProcedureUtilsStreamedInterceptorOptions<TClientContext extends ClientContext, TInput> extends ProcedureUtilsQueryInterceptorOptions<TClientContext, TInput> {
+export interface ProcedureUtilsStreamedInterceptorOptions<TClientContext extends ClientContext, TInput, TOutput, TError> extends ProcedureUtilsQueryInterceptorOptions<TClientContext, TInput, TOutput, TError> {
 }
 export type ProcedureUtilsStreamedInterceptor<TClientContext extends ClientContext, TInput, TOutput, TError>
-  = Interceptor<ProcedureUtilsStreamedInterceptorOptions<TClientContext, TInput>, PromiseWithError<InferStreamedQueryOutput<TOutput>, TError>>
+  = Interceptor<ProcedureUtilsStreamedInterceptorOptions<TClientContext, TInput, TOutput, TError>, PromiseWithError<InferStreamedQueryOutput<TOutput>, TError>>
 
-export interface ProcedureUtilsLiveInterceptorOptions<TClientContext extends ClientContext, TInput> extends ProcedureUtilsQueryInterceptorOptions<TClientContext, TInput> {
+export interface ProcedureUtilsLiveInterceptorOptions<TClientContext extends ClientContext, TInput, TOutput, TError> extends ProcedureUtilsQueryInterceptorOptions<TClientContext, TInput, TOutput, TError> {
 }
 export type ProcedureUtilsLiveInterceptor<TClientContext extends ClientContext, TInput, TOutput, TError>
-  = Interceptor<ProcedureUtilsLiveInterceptorOptions<TClientContext, TInput>, PromiseWithError<InferLiveQueryOutput<TOutput>, TError>>
+  = Interceptor<ProcedureUtilsLiveInterceptorOptions<TClientContext, TInput, TOutput, TError>, PromiseWithError<InferLiveQueryOutput<TOutput>, TError>>
 
-export interface ProcedureUtilsInfiniteInterceptorOptions<TClientContext extends ClientContext, TInput> extends ProcedureUtilsQueryInterceptorOptions<TClientContext, TInput> {
+export interface ProcedureUtilsInfiniteInterceptorOptions<TClientContext extends ClientContext, TInput, TOutput, TError> extends ProcedureUtilsQueryInterceptorOptions<TClientContext, TInput, TOutput, TError> {
   fnContext: QueryFunctionContext<QueryKey, any>
 }
 export type ProcedureUtilsInfiniteInterceptor<TClientContext extends ClientContext, TInput, TOutput, TError>
-  = Interceptor<ProcedureUtilsInfiniteInterceptorOptions<TClientContext, TInput>, PromiseWithError<TOutput, TError>>
+  = Interceptor<ProcedureUtilsInfiniteInterceptorOptions<TClientContext, TInput, TOutput, TError>, PromiseWithError<TOutput, TError>>
 
-export interface ProcedureUtilsMutationInterceptorOptions<TClientContext extends ClientContext, TInput> extends Omit<ProcedureUtilsQueryInterceptorOptions<TClientContext, TInput>, 'input' | 'fnContext'> {
+export interface ProcedureUtilsMutationInterceptorOptions<TClientContext extends ClientContext, TInput, TOutput, TError> extends Omit<ProcedureUtilsQueryInterceptorOptions<TClientContext, TInput, TOutput, TError>, 'input' | 'fnContext'> {
   input: TInput
   fnContext: MutationFunctionContext
 }
 export type ProcedureUtilsMutationInterceptor<TClientContext extends ClientContext, TInput, TOutput, TError>
-  = Interceptor<ProcedureUtilsMutationInterceptorOptions<TClientContext, TInput>, PromiseWithError<TOutput, TError>>
+  = Interceptor<ProcedureUtilsMutationInterceptorOptions<TClientContext, TInput, TOutput, TError>, PromiseWithError<TOutput, TError>>
 
 /**
  * Can be partial options for spread-merged options,
@@ -171,17 +173,20 @@ export interface ProcedureUtilsOptions<TClientContext extends ClientContext, TIn
   >
 }
 
-export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutput, TError> {
+export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutput, TError> extends SharedUtils<TInput> {
+  declare protected readonly options: ProcedureUtilsOptions<TClientContext, TInput, TOutput, TError>
+
   /**
    * Calling corresponding procedure client
    */
   call: Client<TClientContext, TInput, TOutput, TError>
 
   constructor(
-    private readonly path: string[],
+    path: string[],
     client: Client<TClientContext, TInput, TOutput, TError>,
-    private readonly options: ProcedureUtilsOptions<TClientContext, TInput, TOutput, TError> = {},
+    options: ProcedureUtilsOptions<TClientContext, TInput, TOutput, TError> = {},
   ) {
+    super(path, options)
     this.call = client
   }
 
@@ -233,6 +238,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
           this.options.queryInterceptors,
           {
             path: this.path,
+            utils: this,
             context: {
               [OPERATION_CONTEXT_SYMBOL]: {
                 key: queryKey,
@@ -310,6 +316,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
           toArray(this.options.streamedInterceptors),
           {
             path: this.path,
+            utils: this,
             context: {
               [OPERATION_CONTEXT_SYMBOL]: {
                 key: queryKey,
@@ -398,6 +405,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
           toArray(this.options.liveInterceptors),
           {
             path: this.path,
+            utils: this,
             context: {
               [OPERATION_CONTEXT_SYMBOL]: {
                 key: queryKey,
@@ -482,6 +490,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
           toArray(this.options.infiniteInterceptors),
           {
             path: this.path,
+            utils: this,
             context: {
               [OPERATION_CONTEXT_SYMBOL]: {
                 key: queryKey,
@@ -553,6 +562,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
           toArray(this.options.mutationInterceptors),
           {
             path: this.path,
+            utils: this,
             context: {
               [OPERATION_CONTEXT_SYMBOL]: {
                 key: mutationKey,

--- a/packages/tanstack-query/src/router-utils.test-d.ts
+++ b/packages/tanstack-query/src/router-utils.test-d.ts
@@ -1,7 +1,8 @@
 import type { ORPCErrorFromErrorMap } from '@orpc/contract'
 import type { RouterClient } from '@orpc/server'
 import type { ProcedureUtils, ProcedureUtilsOptions } from './procedure-utils'
-import type { RouterUtils, RouterUtilsScoped, SharedRouterUtils } from './router-utils'
+import type { RouterUtils, RouterUtilsScoped } from './router-utils'
+import type { SharedUtils } from './shared-utils'
 import { os } from '@orpc/server'
 import z from 'zod'
 import { createRouterUtils } from './router-utils'
@@ -29,60 +30,26 @@ const scopedRouter = {
   }),
 }
 
-describe('SharedRouterUtils', () => {
-  const utils = {} as SharedRouterUtils<{ a: { b: { c: number } } }>
-
-  it('.key', () => {
-    utils.key()
-    utils.key({})
-    utils.key({ type: 'mutation' })
-    utils.key({ input: {}, type: 'query' })
-    utils.key({ input: {}, type: 'streamed', fnOptions: { refetchMode: 'append' } })
-    utils.key({ input: {} })
-    utils.key({ input: { a: {} } })
-    utils.key({ input: { a: { b: {} } } })
-    utils.key({ input: { a: { b: { c: 1 } } } })
-    utils.key({ back: 1 })
-    utils.key({ back: 1, type: 'query' })
-
-    // @ts-expect-error invalid back
-    utils.key({ back: '1' })
-
-    // @ts-expect-error invalid input
-    utils.key({ input: 123 })
-    // @ts-expect-error invalid input
-    utils.key({ input: { a: { b: { c: '1' } } } })
-
-    // @ts-expect-error invalid input
-    utils.key({ type: 'ddd' })
-
-    // @ts-expect-error input is not allowed when type is mutation
-    utils.key({ type: 'mutation', input: {} })
-    // @ts-expect-error fnOptions is not allowed when type not streamed
-    utils.key({ type: 'infinite', fnOptions: { refetchMode: 'append' } })
-  })
-})
-
 it('RouterUtils', () => {
   type G = RouterClient<typeof scopedRouter, { batch?: boolean }>['nested']['ping']
   const utils = {} as RouterUtils<RouterClient<typeof scopedRouter, { batch?: boolean }>>
 
-  expectTypeOf(utils).toExtend<Omit<SharedRouterUtils<unknown>, 'path'>>()
+  expectTypeOf(utils).toExtend<Omit<SharedUtils<unknown>, 'path'>>()
   expectTypeOf<typeof utils>().not.toExtend<
     ProcedureUtils<any, any, any, any>
   >()
 
-  expectTypeOf(utils.nested).toExtend<Omit<SharedRouterUtils<unknown>, 'path'>>()
+  expectTypeOf(utils.nested).toExtend<Omit<SharedUtils<unknown>, 'path'>>()
   expectTypeOf<typeof utils.nested>().not.toExtend<
     ProcedureUtils<any, any, any, any>
   >()
 
-  expectTypeOf(utils.ping).toExtend<Omit<SharedRouterUtils<{ input: number }>, 'path'>>()
+  expectTypeOf(utils.ping).toExtend<Omit<SharedUtils<{ input: number }>, 'path'>>()
   expectTypeOf(utils.ping).toExtend<
     Omit<ProcedureUtils<{ batch?: boolean }, { input: number }, { output: string }, ORPCErrorFromErrorMap<typeof baseErrorMap> | Error>, 'path' | 'options'>
   >()
 
-  expectTypeOf(utils.nested.ping).toExtend<Omit<SharedRouterUtils<{ input: number }>, 'path'>>()
+  expectTypeOf(utils.nested.ping).toExtend<Omit<SharedUtils<{ input: number }>, 'path'>>()
   expectTypeOf(utils.nested.ping).toExtend<
     Omit<ProcedureUtils<{ batch?: boolean }, { input: number }, { output: string }, ORPCErrorFromErrorMap<typeof baseErrorMap> | Error>, 'path' | 'options'>
   >()

--- a/packages/tanstack-query/src/router-utils.test.ts
+++ b/packages/tanstack-query/src/router-utils.test.ts
@@ -1,15 +1,24 @@
 import type { RouterUtilsPlugin } from './plugin'
 import * as KeyModule from './key'
 import { ProcedureUtils } from './procedure-utils'
-import { createRouterUtils, SharedRouterUtils } from './router-utils'
+import { createRouterUtils } from './router-utils'
 
-vi.mock('./procedure-utils', async () => ({
-  ProcedureUtils: vi.fn(class {
-    call = vi.fn()
-    queryOptions = vi.fn(() => ({ queryOptions: true }))
-    mutationOptions = vi.fn(() => ({ mutationOptions: true }))
-  }),
-}))
+vi.mock('./procedure-utils', async () => {
+  const { SharedUtils } = await import('./shared-utils')
+
+  return {
+    ProcedureUtils: vi.fn(class extends SharedUtils<unknown> {
+      call = vi.fn()
+      override key = SharedUtils.prototype.key
+      queryOptions = vi.fn(() => ({ queryOptions: true }))
+      mutationOptions = vi.fn(() => ({ mutationOptions: true }))
+
+      constructor(path: string[], _client: unknown, options: any = {}) {
+        super(path, options)
+      }
+    }),
+  }
+})
 
 const generateOperationKeySpy = vi.spyOn(KeyModule, 'generateOperationKey')
 
@@ -23,39 +32,6 @@ const emptyInterceptors = {
 
 beforeEach(() => {
   vi.clearAllMocks()
-})
-
-describe('sharedRouterUtils', () => {
-  const utils = new SharedRouterUtils(['path'], {})
-
-  it('.key', () => {
-    expect(
-      utils.key({ input: { search: '__search__' }, type: 'infinite' }),
-    ).toBe(generateOperationKeySpy.mock.results[0]!.value)
-
-    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
-    expect(generateOperationKeySpy).toHaveBeenCalledWith(['path'], { input: { search: '__search__' }, type: 'infinite', prefix: undefined })
-  })
-
-  it('.key with prefix', () => {
-    const prefixedUtils = new SharedRouterUtils(['path'], { prefix: '__prefix__' })
-
-    expect(
-      prefixedUtils.key({ type: 'query' }),
-    ).toBe(generateOperationKeySpy.mock.results[0]!.value)
-
-    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
-    expect(generateOperationKeySpy).toHaveBeenCalledWith(['path'], { type: 'query', prefix: '__prefix__' })
-  })
-
-  it('.key with back', () => {
-    const nestedUtils = new SharedRouterUtils(['planet', 'find'], {})
-
-    expect(nestedUtils.key({ back: 1, type: 'query' })).toBe(generateOperationKeySpy.mock.results[0]!.value)
-    expect(generateOperationKeySpy).toHaveBeenCalledWith(['planet', 'find'], { back: 1, type: 'query', prefix: undefined })
-
-    expect(nestedUtils.key({ back: 1 })).toEqual(new SharedRouterUtils(['planet'], {}).key())
-  })
 })
 
 describe('createRouterUtils', () => {

--- a/packages/tanstack-query/src/router-utils.ts
+++ b/packages/tanstack-query/src/router-utils.ts
@@ -1,35 +1,20 @@
 import type { AnyNestedClient, Client, InferClientContext, InferClientError } from '@orpc/client'
 import type { Public } from '@orpc/shared'
-import type { OperationKey, OperationKeyOptions, OperationKeyPrefixOptions } from './key'
+import type { OperationKeyPrefixOptions } from './key'
 import type { RouterUtilsPlugin } from './plugin'
 import type { ProcedureUtilsInfiniteInterceptor, ProcedureUtilsLiveInterceptor, ProcedureUtilsMutationInterceptor, ProcedureUtilsOptions, ProcedureUtilsQueryInterceptor, ProcedureUtilsStreamedInterceptor } from './procedure-utils'
-import type { OperationType } from './types'
 import { RECURSIVE_CLIENT_UNWRAP_KEYS } from '@orpc/client'
 import { bindMethods, get, getOrBind, isTypescriptObject, toArray } from '@orpc/shared'
-import { generateOperationKey } from './key'
 import { CompositeRouterUtilsPlugin } from './plugin'
 import { ProcedureUtils } from './procedure-utils'
-
-export class SharedRouterUtils<TInput> {
-  constructor(
-    private readonly path: string[],
-    private readonly options: OperationKeyPrefixOptions,
-  ) {}
-
-  /**
-   * Generate a **partial matching** key for actions like revalidating queries, checking mutation status, etc.
-   */
-  key<TType extends OperationType>(options: Omit<OperationKeyOptions<TType, TInput>, 'prefix'> = {}): OperationKey<TType, TInput> {
-    return generateOperationKey(this.path, { ...options, prefix: this.options.prefix })
-  }
-}
+import { SharedUtils } from './shared-utils'
 
 export type RouterUtils<T extends AnyNestedClient>
   = T extends Client<infer UClientContext, infer UInput, infer UOutput, infer UError>
-    ? Public<ProcedureUtils<UClientContext, UInput, UOutput, UError>> & Public<SharedRouterUtils<UInput>>
+    ? Public<ProcedureUtils<UClientContext, UInput, UOutput, UError>>
     : {
       [K in keyof T]: T[K] extends AnyNestedClient ? RouterUtils<T[K]> : never
-    } & Public<SharedRouterUtils<unknown>>
+    } & Public<SharedUtils<unknown>>
 
 export type RouterUtilsScoped<T extends AnyNestedClient>
   = T extends Client<infer UClientContext, infer UInput, infer UOutput, infer UError>
@@ -105,9 +90,8 @@ function createRouterUtilsInternal<T extends AnyNestedClient>(
   plugin: CompositeRouterUtilsPlugin<any>,
 ): RouterUtils<T> {
   const path = toArray(options.path)
-  const sharedUtils = bindMethods(new SharedRouterUtils(path, options))
 
-  const procedureUtils = typeof client === 'function' && (options.scoped === undefined || isProcedureUtilsOptions(options.scoped))
+  const utils = typeof client === 'function' && (options.scoped === undefined || isProcedureUtilsOptions(options.scoped))
     ? bindMethods(new ProcedureUtils(
         path,
         client,
@@ -121,12 +105,9 @@ function createRouterUtilsInternal<T extends AnyNestedClient>(
           mutationInterceptors: [...toArray(options.mutationInterceptors) as any, ...toArray(options.scoped?.mutationInterceptors)],
         }),
       ))
-    : undefined
+    : bindMethods(new SharedUtils(path, options))
 
-  const recursive = new Proxy({
-    ...sharedUtils,
-    ...procedureUtils,
-  }, {
+  const recursive = new Proxy(utils, {
     get(target, prop) {
       const value = getOrBind(target, prop)
       const nextClient = get(client, [prop])
@@ -138,8 +119,8 @@ function createRouterUtilsInternal<T extends AnyNestedClient>(
       const nextUtils = createRouterUtilsInternal(nextClient as any, {
         ...options,
         path: [...path, prop],
-        scoped: get(options.scoped, [prop]) as any,
-      }, plugin)
+        scoped: get(options.scoped, [prop]),
+      } as any, plugin)
 
       if (typeof value !== 'function') {
         return nextUtils

--- a/packages/tanstack-query/src/shared-utils.test-d.ts
+++ b/packages/tanstack-query/src/shared-utils.test-d.ts
@@ -1,0 +1,35 @@
+import type { SharedUtils } from './shared-utils'
+
+describe('SharedUtils', () => {
+  const utils = {} as SharedUtils<{ a: { b: { c: number } } }>
+
+  it('.key', () => {
+    utils.key()
+    utils.key({})
+    utils.key({ type: 'mutation' })
+    utils.key({ input: {}, type: 'query' })
+    utils.key({ input: {}, type: 'streamed', fnOptions: { refetchMode: 'append' } })
+    utils.key({ input: {} })
+    utils.key({ input: { a: {} } })
+    utils.key({ input: { a: { b: {} } } })
+    utils.key({ input: { a: { b: { c: 1 } } } })
+    utils.key({ back: 1 })
+    utils.key({ back: 1, type: 'query' })
+
+    // @ts-expect-error invalid back
+    utils.key({ back: '1' })
+
+    // @ts-expect-error invalid input
+    utils.key({ input: 123 })
+    // @ts-expect-error invalid input
+    utils.key({ input: { a: { b: { c: '1' } } } })
+
+    // @ts-expect-error invalid input
+    utils.key({ type: 'ddd' })
+
+    // @ts-expect-error input is not allowed when type is mutation
+    utils.key({ type: 'mutation', input: {} })
+    // @ts-expect-error fnOptions is not allowed when type not streamed
+    utils.key({ type: 'infinite', fnOptions: { refetchMode: 'append' } })
+  })
+})

--- a/packages/tanstack-query/src/shared-utils.test.ts
+++ b/packages/tanstack-query/src/shared-utils.test.ts
@@ -1,0 +1,41 @@
+import * as KeyModule from './key'
+import { SharedUtils } from './shared-utils'
+
+const generateOperationKeySpy = vi.spyOn(KeyModule, 'generateOperationKey')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('sharedUtils', () => {
+  const utils = new SharedUtils(['path'], {})
+
+  it('.key', () => {
+    expect(
+      utils.key({ input: { search: '__search__' }, type: 'infinite' }),
+    ).toBe(generateOperationKeySpy.mock.results[0]!.value)
+
+    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+    expect(generateOperationKeySpy).toHaveBeenCalledWith(['path'], { input: { search: '__search__' }, type: 'infinite', prefix: undefined })
+  })
+
+  it('.key with prefix', () => {
+    const prefixedUtils = new SharedUtils(['path'], { prefix: '__prefix__' })
+
+    expect(
+      prefixedUtils.key({ type: 'query' }),
+    ).toBe(generateOperationKeySpy.mock.results[0]!.value)
+
+    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+    expect(generateOperationKeySpy).toHaveBeenCalledWith(['path'], { type: 'query', prefix: '__prefix__' })
+  })
+
+  it('.key with back', () => {
+    const nestedUtils = new SharedUtils(['planet', 'find'], {})
+
+    expect(nestedUtils.key({ back: 1, type: 'query' })).toBe(generateOperationKeySpy.mock.results[0]!.value)
+    expect(generateOperationKeySpy).toHaveBeenCalledWith(['planet', 'find'], { back: 1, type: 'query', prefix: undefined })
+
+    expect(nestedUtils.key({ back: 1 })).toEqual(new SharedUtils(['planet'], {}).key())
+  })
+})

--- a/packages/tanstack-query/src/shared-utils.ts
+++ b/packages/tanstack-query/src/shared-utils.ts
@@ -1,0 +1,17 @@
+import type { OperationKey, OperationKeyOptions, OperationKeyPrefixOptions } from './key'
+import type { OperationType } from './types'
+import { generateOperationKey } from './key'
+
+export class SharedUtils<TInput> {
+  constructor(
+    protected readonly path: string[],
+    protected readonly options: OperationKeyPrefixOptions,
+  ) {}
+
+  /**
+   * Generate a **partial matching** key for actions like revalidating queries, checking mutation status, etc.
+   */
+  key<TType extends OperationType>(options: Omit<OperationKeyOptions<TType, TInput>, 'prefix'> = {}): OperationKey<TType, TInput> {
+    return generateOperationKey(this.path, { ...options, prefix: this.options.prefix })
+  }
+}


### PR DESCRIPTION
## Summary

Interceptors now receive the corresponding procedure utils via a new `utils` option, so they can build keys without referencing the root utils object — e.g. invalidating a parent scope with `.key({ back: 1 })`:

```ts
const orpc = createTanstackQueryUtils(client, {
  scoped: {
    planet: {
      create: {
        mutationInterceptors: [
          async ({ next, utils, fnContext }) => {
            const result = await next()
            // invalidate the parent scope: equals orpc.planet.key()
            fnContext.client.invalidateQueries({ queryKey: utils.key({ back: 1 }) })
            return result
          },
        ],
      },
    },
  },
})
```

- `utils` is available in all interceptor kinds (query, streamed, live, infinite, mutation) in both `@orpc/tanstack-query` and `@orpc/pinia-colada`
- `ProcedureUtils` now provides `.key()` directly (it extends the renamed `SharedUtils`, moved to a dedicated `shared-utils` module), so procedure-level utils expose the full key helper including `back` and `prefix`