### PR TITLE
feat(tanstack-db): TanStack DB integration

### DIFF
--- a/apps/content/.vitepress/config.ts
+++ b/apps/content/.vitepress/config.ts
@@ -196,6 +196,7 @@ export default withMermaid(defineConfig({
             { text: 'Pinia Colada', link: '/docs/integrations/pinia-colada' },
             { text: 'Pino', link: '/docs/integrations/pino' },
             { text: 'Standard Schema', link: '/docs/integrations/standard-schema' },
+            { text: 'Tanstack DB', link: '/docs/integrations/tanstack-db' },
             { text: 'Tanstack Query', link: '/docs/integrations/tanstack-query' },
             { text: 'tRPC', link: '/docs/integrations/trpc' },
             { text: 'Valibot', link: '/docs/integrations/valibot' },

--- a/apps/content/docs/integrations/tanstack-db.md
+++ b/apps/content/docs/integrations/tanstack-db.md
@@ -11,23 +11,23 @@ This guide assumes you are already familiar with [TanStack DB](https://tanstack.
 ::: code-group
 
 ```sh [npm]
-npm install @orpc/tanstack-db@beta @tanstack/db @tanstack/query-db-collection
+npm install @orpc/experimental-tanstack-db@beta @tanstack/db @tanstack/query-db-collection
 ```
 
 ```sh [yarn]
-yarn add @orpc/tanstack-db@beta @tanstack/db @tanstack/query-db-collection
+yarn add @orpc/experimental-tanstack-db@beta @tanstack/db @tanstack/query-db-collection
 ```
 
 ```sh [pnpm]
-pnpm add @orpc/tanstack-db@beta @tanstack/db @tanstack/query-db-collection
+pnpm add @orpc/experimental-tanstack-db@beta @tanstack/db @tanstack/query-db-collection
 ```
 
 ```sh [bun]
-bun add @orpc/tanstack-db@beta @tanstack/db @tanstack/query-db-collection
+bun add @orpc/experimental-tanstack-db@beta @tanstack/db @tanstack/query-db-collection
 ```
 
 ```sh [deno]
-deno add npm:@orpc/tanstack-db@beta npm:@tanstack/db npm:@tanstack/query-db-collection
+deno add npm:@orpc/experimental-tanstack-db@beta npm:@tanstack/db npm:@tanstack/query-db-collection
 ```
 
 :::
@@ -37,7 +37,7 @@ deno add npm:@orpc/tanstack-db@beta npm:@tanstack/db npm:@tanstack/query-db-coll
 Before you begin, set up either a [server-side client](/docs/client/server-side) or a [client-side client](/docs/client/client-side).
 
 ```ts
-import { createTanstackDBUtils } from '@orpc/tanstack-db'
+import { createTanstackDBUtils } from '@orpc/experimental-tanstack-db'
 
 const orpc = createTanstackDBUtils(client)
 ```

--- a/apps/content/docs/integrations/tanstack-db.md
+++ b/apps/content/docs/integrations/tanstack-db.md
@@ -66,8 +66,8 @@ Use `.collectionOptions` to build [Query Collection](https://tanstack.com/db/lat
 import { createCollection } from '@tanstack/db'
 
 const todosCollection = createCollection(orpc.todo.list.collectionOptions({
-  input: { search: 'orpc' }, // Specify input if needed
-  context: { cache: true }, // Provide client context if needed
+  input: () => ({ search: 'orpc' }), // Resolve procedure input on each fetch
+  context: () => ({ cache: true }), // Provide client context if needed
   queryClient,
   getKey: todo => todo.id,
   onInsert: orpc.todo.create.mutationHandler({
@@ -96,7 +96,7 @@ const { data: todos } = useLiveQuery(q =>
 The query key is generated the same way as in the [Tanstack Query Integration](/docs/integrations/tanstack-query), so both integrations can share a `queryClient` and actions like invalidation work across them.
 :::
 
-The `input` option also accepts a function that resolves the input from the query function context on each fetch. This is useful when the query key is dynamic, such as with [on-demand sync mode](https://tanstack.com/db/latest/docs/collections/query-collection#queryfn-and-predicate-push-down):
+The `input` and `context` options are functions that receive the query function context, so they are resolved on each fetch. This pairs naturally with a dynamic `queryKey`, such as with [on-demand sync mode](https://tanstack.com/db/latest/docs/collections/query-collection#queryfn-and-predicate-push-down):
 
 ```ts
 const todosCollection = createCollection(orpc.todo.list.collectionOptions({
@@ -109,17 +109,17 @@ const todosCollection = createCollection(orpc.todo.list.collectionOptions({
 ```
 
 ::: warning
-When the input is dynamic, the generated query key no longer includes it. Provide a custom `queryKey` that reflects whatever the input depends on, so each variation is cached separately.
+The generated query key does not include the input. If the input varies, provide a custom `queryKey` that reflects whatever it depends on, so each variation is cached separately.
 :::
 
 ## Mutation Handler Utility
 
-Use `.mutationHandler` to build a [persistence handler](https://tanstack.com/db/latest/docs/guides/mutations) for collection options like `onInsert`, `onUpdate`, and `onDelete`. The `input` option maps each mutation in the transaction to the procedure input, and the procedure is called once per mutation.
+Use `.mutationHandler` to build a [persistence handler](https://tanstack.com/db/latest/docs/guides/mutations) for collection options like `onInsert`, `onUpdate`, and `onDelete`. The procedure is called once per mutation in the transaction, with the `input` and `context` options resolved for each mutation.
 
 ```ts
 const onUpdate = orpc.todo.update.mutationHandler({
   input: mutation => ({ id: mutation.key, data: mutation.changes }),
-  context: { cache: true }, // Provide client context if needed
+  context: mutation => ({ cache: true }), // Provide client context if needed
 })
 ```
 

--- a/apps/content/docs/integrations/tanstack-db.md
+++ b/apps/content/docs/integrations/tanstack-db.md
@@ -1,0 +1,139 @@
+# TanStack DB Integration
+
+[TanStack DB](https://tanstack.com/db/latest) integration provides utilities for wiring typed oRPC procedures into TanStack DB collections. It includes helpers for building collection options and persistence handlers.
+
+::: warning
+This guide assumes you are already familiar with [TanStack DB](https://tanstack.com/db/latest). If you need a refresher, review the official TanStack DB documentation before continuing.
+:::
+
+## Installation
+
+::: code-group
+
+```sh [npm]
+npm install @orpc/tanstack-db@beta @tanstack/db @tanstack/query-db-collection
+```
+
+```sh [yarn]
+yarn add @orpc/tanstack-db@beta @tanstack/db @tanstack/query-db-collection
+```
+
+```sh [pnpm]
+pnpm add @orpc/tanstack-db@beta @tanstack/db @tanstack/query-db-collection
+```
+
+```sh [bun]
+bun add @orpc/tanstack-db@beta @tanstack/db @tanstack/query-db-collection
+```
+
+```sh [deno]
+deno add npm:@orpc/tanstack-db@beta npm:@tanstack/db npm:@tanstack/query-db-collection
+```
+
+:::
+
+## Setup
+
+Before you begin, set up either a [server-side client](/docs/client/server-side) or a [client-side client](/docs/client/client-side).
+
+```ts
+import { createTanstackDBUtils } from '@orpc/tanstack-db'
+
+const orpc = createTanstackDBUtils(client)
+```
+
+::: details Avoiding Key Conflicts?
+
+To avoid key conflicts when creating multiple sets of utils, pass a unique `prefix`. It becomes the first element of every key, so keys from different utils never overlap.
+
+```ts
+const userORPC = createTanstackDBUtils(userClient, {
+  prefix: 'user'
+})
+
+const postORPC = createTanstackDBUtils(postClient, {
+  prefix: 'post'
+})
+```
+
+:::
+
+## Collection Options Utility
+
+Use `.collectionOptions` to build [Query Collection](https://tanstack.com/db/latest/docs/collections/query-collection) options for `createCollection`. It is built on top of `queryCollectionOptions` from `@tanstack/query-db-collection` and accepts the same options, except `queryKey` and `queryFn` are wired to the procedure for you.
+
+```ts
+import { createCollection } from '@tanstack/db'
+
+const todosCollection = createCollection(orpc.todo.list.collectionOptions({
+  input: { search: 'orpc' }, // Specify input if needed
+  context: { cache: true }, // Provide client context if needed
+  queryClient,
+  getKey: todo => todo.id,
+  onInsert: orpc.todo.create.mutationHandler({
+    input: mutation => mutation.modified,
+  }),
+  onUpdate: orpc.todo.update.mutationHandler({
+    input: mutation => ({ id: mutation.key, data: mutation.changes }),
+  }),
+  onDelete: orpc.todo.delete.mutationHandler({
+    input: mutation => ({ id: mutation.key }),
+  }),
+  // additional options...
+}))
+```
+
+Everything else stays fully native to TanStack DB, such as [live queries](https://tanstack.com/db/latest/docs/guides/live-queries) and [optimistic mutations](https://tanstack.com/db/latest/docs/guides/mutations):
+
+```ts
+const { data: todos } = useLiveQuery(q =>
+  q.from({ todo: todosCollection })
+    .where(({ todo }) => eq(todo.completed, false))
+)
+```
+
+::: info
+The query key is generated the same way as in the [Tanstack Query Integration](/docs/integrations/tanstack-query), so both integrations can share a `queryClient` and actions like invalidation work across them.
+:::
+
+## Mutation Handler Utility
+
+Use `.mutationHandler` to build a [persistence handler](https://tanstack.com/db/latest/docs/guides/mutations) for collection options like `onInsert`, `onUpdate`, and `onDelete`. The `input` option maps each mutation in the transaction to the procedure input, and the procedure is called once per mutation.
+
+```ts
+const onUpdate = orpc.todo.update.mutationHandler({
+  input: mutation => ({ id: mutation.key, data: mutation.changes }),
+  context: { cache: true }, // Provide client context if needed
+})
+```
+
+The handler resolves with the list of procedure outputs by default. Use the `output` option when a collection expects a specific return shape, such as [Electric Collection](https://tanstack.com/db/latest/docs/collections/electric-collection) transaction matching:
+
+```ts
+const todosCollection = createCollection(electricCollectionOptions({
+  shapeOptions: { url: '/api/todos' },
+  getKey: todo => todo.id,
+  onInsert: orpc.todo.create.mutationHandler({
+    input: mutation => mutation.modified,
+    output: outputs => ({ txid: outputs.map(output => output.txid) }),
+  }),
+}))
+```
+
+## Operation Key Utility
+
+Use `.key` to generate a **partial matching** key for actions like invalidating queries synced by collections:
+
+```ts
+queryClient.invalidateQueries({
+  queryKey: orpc.todo.key()
+})
+```
+
+## Calling Procedure Clients
+
+Use `.call` to call a procedure client directly. It's an alias for corresponding procedure client.
+
+```ts
+const todos = await orpc.todo.list.call({ search: 'orpc' })
+```

--- a/apps/content/docs/integrations/tanstack-db.md
+++ b/apps/content/docs/integrations/tanstack-db.md
@@ -96,6 +96,22 @@ const { data: todos } = useLiveQuery(q =>
 The query key is generated the same way as in the [Tanstack Query Integration](/docs/integrations/tanstack-query), so both integrations can share a `queryClient` and actions like invalidation work across them.
 :::
 
+The `input` option also accepts a function that resolves the input from the query function context on each fetch. This is useful when the query key is dynamic, such as with [on-demand sync mode](https://tanstack.com/db/latest/docs/collections/query-collection#queryfn-and-predicate-push-down):
+
+```ts
+const todosCollection = createCollection(orpc.todo.list.collectionOptions({
+  syncMode: 'on-demand',
+  queryKey: options => ['todos', { limit: options.limit }],
+  input: context => ({ limit: (context.queryKey[1] as any).limit }),
+  queryClient,
+  getKey: todo => todo.id,
+}))
+```
+
+::: warning
+When the input is dynamic, the generated query key no longer includes it. Provide a custom `queryKey` that reflects whatever the input depends on, so each variation is cached separately.
+:::
+
 ## Mutation Handler Utility
 
 Use `.mutationHandler` to build a [persistence handler](https://tanstack.com/db/latest/docs/guides/mutations) for collection options like `onInsert`, `onUpdate`, and `onDelete`. The `input` option maps each mutation in the transaction to the procedure input, and the procedure is called once per mutation.

--- a/apps/content/docs/integrations/tanstack-db.md
+++ b/apps/content/docs/integrations/tanstack-db.md
@@ -123,7 +123,7 @@ const onUpdate = orpc.todo.update.mutationHandler({
 })
 ```
 
-The handler resolves with the list of procedure outputs by default. Use the `output` option when a collection expects a specific return shape, such as [Electric Collection](https://tanstack.com/db/latest/docs/collections/electric-collection) transaction matching:
+The `output` option maps the list of procedure outputs to the handler's return value, and is required when a collection expects a specific return shape, such as [Electric Collection](https://tanstack.com/db/latest/docs/collections/electric-collection) transaction matching:
 
 ```ts
 const todosCollection = createCollection(electricCollectionOptions({

--- a/apps/content/docs/integrations/tanstack-db.md
+++ b/apps/content/docs/integrations/tanstack-db.md
@@ -118,12 +118,25 @@ const onUpdate = orpc.todo.update.mutationHandler({
 })
 ```
 
-By default, [Query Collection](https://tanstack.com/db/latest/docs/collections/query-collection) refetches after a handler completes. Use the `refetch` option to control this behavior, either statically or based on the procedure outputs:
+The `output` option maps the list of procedure outputs to the handler's return value. It is required when a collection expects a specific return shape, and optional otherwise. For example, [Electric Collection](https://tanstack.com/db/latest/docs/collections/electric-collection) transaction matching:
+
+```ts
+const todosCollection = createCollection(electricCollectionOptions({
+  shapeOptions: { url: '/api/todos' },
+  getKey: todo => todo.id,
+  onInsert: orpc.todo.create.mutationHandler({
+    input: mutation => mutation.modified,
+    output: outputs => ({ txid: outputs.map(output => output.txid) }),
+  }),
+}))
+```
+
+Or skipping the [Query Collection](https://tanstack.com/db/latest/docs/collections/query-collection) refetch after a handler completes:
 
 ```ts
 const onUpdate = orpc.todo.update.mutationHandler({
   input: mutation => ({ id: mutation.key, data: mutation.changes }),
-  refetch: false, // or (outputs, params) => boolean
+  output: () => ({ refetch: false }),
 })
 ```
 

--- a/apps/content/docs/integrations/tanstack-db.md
+++ b/apps/content/docs/integrations/tanstack-db.md
@@ -123,17 +123,13 @@ const onUpdate = orpc.todo.update.mutationHandler({
 })
 ```
 
-The `output` option maps the list of procedure outputs to the handler's return value, and is required when a collection expects a specific return shape, such as [Electric Collection](https://tanstack.com/db/latest/docs/collections/electric-collection) transaction matching:
+By default, [Query Collection](https://tanstack.com/db/latest/docs/collections/query-collection) refetches after a handler completes. Use the `refetch` option to control this behavior, either statically or based on the procedure outputs:
 
 ```ts
-const todosCollection = createCollection(electricCollectionOptions({
-  shapeOptions: { url: '/api/todos' },
-  getKey: todo => todo.id,
-  onInsert: orpc.todo.create.mutationHandler({
-    input: mutation => mutation.modified,
-    output: outputs => ({ txid: outputs.map(output => output.txid) }),
-  }),
-}))
+const onUpdate = orpc.todo.update.mutationHandler({
+  input: mutation => ({ id: mutation.key, data: mutation.changes }),
+  refetch: false, // or (outputs, params) => boolean
+})
 ```
 
 ## Operation Key Utility

--- a/apps/content/docs/integrations/tanstack-db.md
+++ b/apps/content/docs/integrations/tanstack-db.md
@@ -66,7 +66,7 @@ Use `.collectionOptions` to build [Query Collection](https://tanstack.com/db/lat
 import { createCollection } from '@tanstack/db'
 
 const todosCollection = createCollection(orpc.todo.list.collectionOptions({
-  input: () => ({ search: 'orpc' }), // Resolve procedure input on each fetch
+  input: () => ({ search: 'orpc' }), // Resolve procedure input for each subset
   context: () => ({ cache: true }), // Provide client context if needed
   queryClient,
   getKey: todo => todo.id,
@@ -96,21 +96,16 @@ const { data: todos } = useLiveQuery(q =>
 The query key is generated the same way as in the [Tanstack Query Integration](/docs/integrations/tanstack-query), so both integrations can share a `queryClient` and actions like invalidation work across them.
 :::
 
-The `input` and `context` options are functions that receive the query function context, so they are resolved on each fetch. This pairs naturally with a dynamic `queryKey`, such as with [on-demand sync mode](https://tanstack.com/db/latest/docs/collections/query-collection#queryfn-and-predicate-push-down):
+The `input` option resolves the procedure input from [load subset options](https://tanstack.com/db/latest/docs/collections/query-collection#queryfn-and-predicate-push-down), and the resolved input becomes part of the generated query key. With [on-demand sync mode](https://tanstack.com/db/latest/docs/collections/query-collection#queryfn-and-predicate-push-down), each subset is fetched and cached with its own input:
 
 ```ts
 const todosCollection = createCollection(orpc.todo.list.collectionOptions({
   syncMode: 'on-demand',
-  queryKey: options => ['todos', { limit: options.limit }],
-  input: context => ({ limit: (context.queryKey[1] as any).limit }),
+  input: options => ({ limit: options.limit }),
   queryClient,
   getKey: todo => todo.id,
 }))
 ```
-
-::: warning
-The generated query key does not include the input. If the input varies, provide a custom `queryKey` that reflects whatever it depends on, so each variation is cached separately.
-:::
 
 ## Mutation Handler Utility
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -45,5 +45,6 @@ export type {
   IsEqual,
   PartialDeep,
   Promisable,
+  SetOptional,
   Writable,
 } from 'type-fest'

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -45,6 +45,5 @@ export type {
   IsEqual,
   PartialDeep,
   Promisable,
-  SetOptional,
   Writable,
 } from 'type-fest'

--- a/packages/shared/src/types.test-d.ts
+++ b/packages/shared/src/types.test-d.ts
@@ -1,4 +1,4 @@
-import type { IntersectPick, PromiseWithError, Public } from './types'
+import type { IntersectPick, PromiseWithError, Public, SetOptional } from './types'
 
 interface Empty {}
 
@@ -6,6 +6,16 @@ it('IntersectPick', () => {
   expectTypeOf<IntersectPick<{ a: number }, { a: number, b: number }>>().toEqualTypeOf<{ a: number }>()
   expectTypeOf<IntersectPick<{ a: number, b: number }, { b: number }>>().toEqualTypeOf<{ b: number }>()
   expectTypeOf<IntersectPick<{ a: number }, { b: number }>>().toEqualTypeOf<Empty>()
+})
+
+it('SetOptional', () => {
+  type A = SetOptional<{ a: number, b: number }, 'a'>
+
+  expectTypeOf<A['a']>().toEqualTypeOf<number | undefined>()
+  expectTypeOf<A['b']>().toEqualTypeOf<number>()
+  expectTypeOf({ b: 1 }).toExtend<A>()
+  expectTypeOf({ a: 1, b: 1 }).toExtend<A>()
+  expectTypeOf({ a: 1 }).not.toExtend<A>()
 })
 
 it('PromiseWithError', () => {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,6 +1,11 @@
 export type IntersectPick<T, U> = Pick<T, keyof T & keyof U>
 
 /**
+ * Make the given keys optional while keeping the rest unchanged.
+ */
+export type SetOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
+
+/**
  * Remove protected/private properties/methods
  */
 export type Public<T> = Pick<T, keyof T>

--- a/packages/tanstack-db/.gitignore
+++ b/packages/tanstack-db/.gitignore
@@ -1,0 +1,26 @@
+# Hidden folders and files
+.*
+!.gitignore
+!.*.example
+
+# Common generated folders
+logs/
+node_modules/
+out/
+dist/
+dist-ssr/
+build/
+coverage/
+temp/
+
+# Common generated files
+*.log
+*.log.*
+*.tsbuildinfo
+*.vitest-temp.json
+vite.config.ts.timestamp-*
+vitest.config.ts.timestamp-*
+
+# Common manual ignore files
+*.local
+*.pem

--- a/packages/tanstack-db/README.md
+++ b/packages/tanstack-db/README.md
@@ -4,8 +4,8 @@
   <a href="https://codecov.io/gh/middleapi/orpc">
     <img alt="codecov" src="https://codecov.io/gh/middleapi/orpc/branch/main/graph/badge.svg">
   </a>
-  <a href="https://www.npmjs.com/package/@orpc/tanstack-db">
-    <img alt="weekly downloads" src="https://img.shields.io/npm/dw/%40orpc%2Ftanstack-db?logo=npm" />
+  <a href="https://www.npmjs.com/package/@orpc/experimental-tanstack-db">
+    <img alt="weekly downloads" src="https://img.shields.io/npm/dw/%40orpc%2Fexperimental-tanstack-db?logo=npm" />
   </a>
   <a href="https://app.codspeed.io/middleapi/orpc?utm_source=badge">
     <img alt="CodSpeed" src="https://img.shields.io/endpoint?url=https://codspeed.io/badge.json" />

--- a/packages/tanstack-db/README.md
+++ b/packages/tanstack-db/README.md
@@ -1,0 +1,196 @@
+<h1 align="center">oRPC - Typesafe APIs Made Simple 🪄</h1>
+
+<div align="center">
+  <a href="https://codecov.io/gh/middleapi/orpc">
+    <img alt="codecov" src="https://codecov.io/gh/middleapi/orpc/branch/main/graph/badge.svg">
+  </a>
+  <a href="https://www.npmjs.com/package/@orpc/tanstack-db">
+    <img alt="weekly downloads" src="https://img.shields.io/npm/dw/%40orpc%2Ftanstack-db?logo=npm" />
+  </a>
+  <a href="https://app.codspeed.io/middleapi/orpc?utm_source=badge">
+    <img alt="CodSpeed" src="https://img.shields.io/endpoint?url=https://codspeed.io/badge.json" />
+  </a>
+  <a href="https://github.com/middleapi/orpc/blob/main/LICENSE">
+    <img alt="MIT License" src="https://img.shields.io/github/license/middleapi/orpc?logo=open-source-initiative" />
+  </a>
+  <a href="https://discord.gg/TXEbwRBvQn">
+    <img alt="Discord" src="https://img.shields.io/discord/1308966753044398161?color=7389D8&label&logo=discord&logoColor=ffffff" />
+  </a>
+  <a href="https://deepwiki.com/middleapi/orpc">
+    <img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki">
+  </a>
+</div>
+
+## Documentation
+
+You can read the documentation [here](https://orpc.dev).
+
+## Packages
+
+**Core**
+
+- [@orpc/contract](https://www.npmjs.com/package/@orpc/contract): Define API contract as the single source of truth.
+- [@orpc/server](https://www.npmjs.com/package/@orpc/server): Build APIs or implement contracts.
+- [@orpc/client](https://www.npmjs.com/package/@orpc/client): Consume APIs with end-to-end type safety.
+- [@orpc/openapi](https://www.npmjs.com/package/@orpc/openapi): Add OpenAPI compatibility to APIs.
+
+**Schema validation**
+
+- [@orpc/zod](https://www.npmjs.com/package/@orpc/zod): Integrate with [Zod](https://zod.dev/).
+- [@orpc/valibot](https://www.npmjs.com/package/@orpc/valibot): Integrate with [Valibot](https://valibot.dev/).
+- [@orpc/arktype](https://www.npmjs.com/package/@orpc/arktype): Integrate with [ArkType](https://arktype.io/).
+
+**Built-in features**
+
+- [@orpc/publisher](https://www.npmjs.com/package/@orpc/publisher): Pub/Sub with memory, Redis, and Upstash adapters.
+- [@orpc/ratelimit](https://www.npmjs.com/package/@orpc/ratelimit): Rate limiting with memory, Redis, and Upstash adapters.
+- [@orpc/json-schema](https://www.npmjs.com/package/@orpc/json-schema): Smart coercion for OpenAPI requests.
+
+**Framework & ecosystem integrations**
+
+- [@orpc/next](https://www.npmjs.com/package/@orpc/next): Integrate with [Next.js Server Functions](https://nextjs.org/docs/app/getting-started/mutating-data).
+- [@orpc/tanstack-query](https://www.npmjs.com/package/@orpc/tanstack-query): Integrate with [TanStack Query](https://tanstack.com/query/latest).
+- [@orpc/experimental-effect](https://www.npmjs.com/package/@orpc/experimental-effect): Integrate with [Effect](https://effect.website/).
+- [@orpc/nest](https://www.npmjs.com/package/@orpc/nest): Implement your contract with [NestJS](https://nestjs.com/).
+- [@orpc/bun](https://www.npmjs.com/package/@orpc/bun): Adapters for [Bun's Redis](https://bun.sh/).
+- [@orpc/cloudflare](https://www.npmjs.com/package/@orpc/cloudflare): Adapters for [Cloudflare's RateLimit and Durable Objects](https://developers.cloudflare.com/workers/).
+- [@orpc/trpc](https://www.npmjs.com/package/@orpc/trpc): Reuse existing [tRPC](https://trpc.io/) routers within oRPC.
+
+**Observability**
+
+- [@orpc/opentelemetry](https://www.npmjs.com/package/@orpc/opentelemetry): Integrate with [OpenTelemetry](https://opentelemetry.io/) for distributed tracing.
+- [@orpc/pino](https://www.npmjs.com/package/@orpc/pino): Integrate with [Pino](https://getpino.io/) for logging.
+- [@orpc/evlog](https://www.npmjs.com/package/@orpc/evlog): Integrate with [Evlog](https://evlog.dev/) for logging.
+
+## Sponsors
+
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+
+### 🏆 Platinum Sponsor
+
+<table>
+  <tr>
+   <td align="center"><a href="https://screenshotone.com/?ref=orpc" target="_blank" rel="noopener" title="ScreenshotOne.com"><img src="https://avatars.githubusercontent.com/u/97035603?v=4" width="279" alt="ScreenshotOne.com"/><br />ScreenshotOne.com</a></td>
+  </tr>
+</table>
+
+### 🥈 Silver Sponsor
+
+<table>
+  <tr>
+   <td align="center"><a href="https://misskey.io/?ref=orpc" target="_blank" rel="noopener" title="村上さん"><img src="https://avatars.githubusercontent.com/u/37681609?u=0dd4c7e4ba937cbb52b068c55914b1d8164dc0c7&amp;v=4" width="209" alt="村上さん"/><br />村上さん</a></td>
+  </tr>
+</table>
+
+### Generous Sponsors
+
+<table>
+  <tr>
+   <td align="center"><a href="https://github.com/ln-markets?ref=orpc" target="_blank" rel="noopener" title="LN Markets"><img src="https://avatars.githubusercontent.com/u/70597625?v=4" width="167" alt="LN Markets"/><br />LN Markets</a></td>
+  </tr>
+</table>
+
+### Sponsors
+
+<table>
+  <tr>
+   <td align="center"><a href="https://github.com/hrmcdonald?ref=orpc" target="_blank" rel="noopener" title="Reece McDonald"><img src="https://avatars.githubusercontent.com/u/39349270?v=4" width="139" alt="Reece McDonald"/><br />Reece McDonald</a></td>
+   <td align="center"><a href="https://github.com/nicognaW?ref=orpc" target="_blank" rel="noopener" title="nk"><img src="https://avatars.githubusercontent.com/u/66731869?u=4699bda3a9092d3ec34fbd959450767bcc8b8b6d&amp;v=4" width="139" alt="nk"/><br />nk</a></td>
+   <td align="center"><a href="https://github.com/supastarter?ref=orpc" target="_blank" rel="noopener" title="supastarter"><img src="https://avatars.githubusercontent.com/u/110960143?v=4" width="139" alt="supastarter"/><br />supastarter</a></td>
+   <td align="center"><a href="https://github.com/divmgl?ref=orpc" target="_blank" rel="noopener" title="Dexter Miguel"><img src="https://avatars.githubusercontent.com/u/5452298?u=645993204be8696c085ecf0d228c3062efe2ed65&amp;v=4" width="139" alt="Dexter Miguel"/><br />Dexter Miguel</a></td>
+   <td align="center"><a href="https://github.com/herrfugbaum?ref=orpc" target="_blank" rel="noopener" title="herrfugbaum"><img src="https://avatars.githubusercontent.com/u/12859776?u=644dc1666d0220bc0468eb0de3c56b919f635b16&amp;v=4" width="139" alt="herrfugbaum"/><br />herrfugbaum</a></td>
+   <td align="center"><a href="https://github.com/ryota-murakami?ref=orpc" target="_blank" rel="noopener" title="Ryota Murakami"><img src="https://avatars.githubusercontent.com/u/5501268?u=599389e03340734325726ca3f8f423c021d47d7f&amp;v=4" width="139" alt="Ryota Murakami"/><br />Ryota Murakami</a></td>
+  </tr>
+  <tr>
+   <td align="center"><a href="https://github.com/dcramer?ref=orpc" target="_blank" rel="noopener" title="David Cramer"><img src="https://avatars.githubusercontent.com/u/23610?v=4" width="139" alt="David Cramer"/><br />David Cramer</a></td>
+   <td align="center"><a href="https://github.com/valerii15298?ref=orpc" target="_blank" rel="noopener" title="Valerii Petryniak"><img src="https://avatars.githubusercontent.com/u/44531564?u=88ac74d9bacd20401518441907acad21063cd397&amp;v=4" width="139" alt="Valerii Petryniak"/><br />Valerii Petryniak</a></td>
+   <td align="center"><a href="https://github.com/letstri?ref=orpc" target="_blank" rel="noopener" title="Valerii Strilets"><img src="https://avatars.githubusercontent.com/u/13253748?u=c7b10399ccc8f8081e24db94ec32cd9858e86ac3&amp;v=4" width="139" alt="Valerii Strilets"/><br />Valerii Strilets</a></td>
+   <td align="center"><a href="https://github.com/K-Mistele?ref=orpc" target="_blank" rel="noopener" title="Kyle Mistele"><img src="https://avatars.githubusercontent.com/u/18430555?u=3afebeb81de666e35aaac3ed46f14159d7603ffb&amp;v=4" width="139" alt="Kyle Mistele"/><br />Kyle Mistele</a></td>
+   <td align="center"><a href="https://github.com/andrewpeters9?ref=orpc" target="_blank" rel="noopener" title="Andrew Peters"><img src="https://avatars.githubusercontent.com/u/36251325?v=4" width="139" alt="Andrew Peters"/><br />Andrew Peters</a></td>
+   <td align="center"><a href="https://github.com/R44VC0RP?ref=orpc" target="_blank" rel="noopener" title="Ryan Vogel"><img src="https://avatars.githubusercontent.com/u/89211796?u=1857347b9787d8d8a7ea5bfc333f96be92d5a683&amp;v=4" width="139" alt="Ryan Vogel"/><br />Ryan Vogel</a></td>
+  </tr>
+  <tr>
+   <td align="center"><a href="https://github.com/christ12938?ref=orpc" target="_blank" rel="noopener" title="christ12938"><img src="https://avatars.githubusercontent.com/u/25758598?v=4" width="139" alt="christ12938"/><br />christ12938</a></td>
+   <td align="center"><a href="https://github.com/Ryanjso?ref=orpc" target="_blank" rel="noopener" title="Ryan Soderberg"><img src="https://avatars.githubusercontent.com/u/39172778?u=5ed913c31d57e7221b75784abcad48c7ebddde27&amp;v=4" width="139" alt="Ryan Soderberg"/><br />Ryan Soderberg</a></td>
+   <td align="center"><a href="https://github.com/itigoore01?ref=orpc" target="_blank" rel="noopener" title="shota"><img src="https://avatars.githubusercontent.com/u/11831107?u=c976a6dc7e055eb026304c46c99100ed22b0c8e0&amp;v=4" width="139" alt="shota"/><br />shota</a></td>
+  </tr>
+</table>
+
+### Backers
+
+<table>
+  <tr>
+   <td align="center"><a href="https://github.com/rhinodavid?ref=orpc" target="_blank" rel="noopener" title="David Walsh"><img src="https://avatars.githubusercontent.com/u/5778036?u=b5521f07d2f88c3db2a0dae62b5f2f8357214af0&amp;v=4" width="119" alt="David Walsh"/><br />David Walsh</a></td>
+   <td align="center"><a href="https://github.com/Nic13Gamer?ref=orpc" target="_blank" rel="noopener" title="Nicholas"><img src="https://avatars.githubusercontent.com/u/54724556?u=56a7ab430ce7a80d648ab6eba051d454a818ed0b&amp;v=4" width="119" alt="Nicholas"/><br />Nicholas</a></td>
+   <td align="center"><a href="https://github.com/Robbe95?ref=orpc" target="_blank" rel="noopener" title="Robbe Vaes"><img src="https://avatars.githubusercontent.com/u/44748019?u=e0232402c045ad4eac7cbd217f1f47e083103b89&amp;v=4" width="119" alt="Robbe Vaes"/><br />Robbe Vaes</a></td>
+   <td align="center"><a href="https://github.com/aidansunbury?ref=orpc" target="_blank" rel="noopener" title="Aidan Sunbury"><img src="https://avatars.githubusercontent.com/u/64103161?v=4" width="119" alt="Aidan Sunbury"/><br />Aidan Sunbury</a></td>
+   <td align="center"><a href="https://github.com/soonoo?ref=orpc" target="_blank" rel="noopener" title="soonoo"><img src="https://avatars.githubusercontent.com/u/5436405?u=5d0b4aa955c87e30e6bda7f0cccae5402da99528&amp;v=4" width="119" alt="soonoo"/><br />soonoo</a></td>
+   <td align="center"><a href="https://github.com/kporten?ref=orpc" target="_blank" rel="noopener" title="Kevin Porten"><img src="https://avatars.githubusercontent.com/u/1839345?u=dc2263d5cfe0d927ce1a0be04a1d55dd6b55405c&amp;v=4" width="119" alt="Kevin Porten"/><br />Kevin Porten</a></td>
+   <td align="center"><a href="https://github.com/pumpkinlink?ref=orpc" target="_blank" rel="noopener" title="Denis"><img src="https://avatars.githubusercontent.com/u/11864620?u=5f47bbe6c65d0f6f5cf011021490238e4b0593d0&amp;v=4" width="119" alt="Denis"/><br />Denis</a></td>
+  </tr>
+  <tr>
+   <td align="center"><a href="https://github.com/christopher-kapic?ref=orpc" target="_blank" rel="noopener" title="Christopher Kapic"><img src="https://avatars.githubusercontent.com/u/59740769?u=e7ad4b72b5bf6c9eb1644c26dbf3332a8f987377&amp;v=4" width="119" alt="Christopher Kapic"/><br />Christopher Kapic</a></td>
+   <td align="center"><a href="https://github.com/thomasballinger?ref=orpc" target="_blank" rel="noopener" title="Tom Ballinger"><img src="https://avatars.githubusercontent.com/u/458879?u=4b045ac75d721b6ac2b42a74d7d37f61f0414031&amp;v=4" width="119" alt="Tom Ballinger"/><br />Tom Ballinger</a></td>
+   <td align="center"><a href="https://github.com/SSam0419?ref=orpc" target="_blank" rel="noopener" title="Sam"><img src="https://avatars.githubusercontent.com/u/102863520?u=3c89611f549d5070be232eb4532f690c8f2e7a65&amp;v=4" width="119" alt="Sam"/><br />Sam</a></td>
+   <td align="center"><a href="https://github.com/Titoine?ref=orpc" target="_blank" rel="noopener" title="Titoine"><img src="https://avatars.githubusercontent.com/u/3514286?u=1bb1e86b0c99c8a1121372e56d51a177eea12191&amp;v=4" width="119" alt="Titoine"/><br />Titoine</a></td>
+   <td align="center"><a href="https://github.com/Mnigos?ref=orpc" target="_blank" rel="noopener" title="Igor Makowski"><img src="https://avatars.githubusercontent.com/u/56691628?u=ee8c879478f7c151b9156aef6c74243fa3e247a8&amp;v=4" width="119" alt="Igor Makowski"/><br />Igor Makowski</a></td>
+   <td align="center"><a href="https://github.com/hanayashiki?ref=orpc" target="_blank" rel="noopener" title="hanayashiki"><img src="https://avatars.githubusercontent.com/u/26056783?u=06c3b9205a16fd41a871e82da1cc2a09306d53f5&amp;v=4" width="119" alt="hanayashiki"/><br />hanayashiki</a></td>
+   <td align="center"><a href="https://github.com/ldub?ref=orpc" target="_blank" rel="noopener" title="Lev Dubinets"><img src="https://avatars.githubusercontent.com/u/3114081?u=f547f5d5012cab54851f1b1ad72d10e537f78fc2&amp;v=4" width="119" alt="Lev Dubinets"/><br />Lev Dubinets</a></td>
+  </tr>
+  <tr>
+   <td align="center"><a href="https://github.com/mr-kelly?ref=orpc" target="_blank" rel="noopener" title="Kelly Peilin Chan"><img src="https://avatars.githubusercontent.com/u/520852?u=6b0f7105f694e7b5cacf410a3f04c7044b469dc8&amp;v=4" width="119" alt="Kelly Peilin Chan"/><br />Kelly Peilin Chan</a></td>
+   <td align="center"><a href="https://github.com/piscis?ref=orpc" target="_blank" rel="noopener" title="Alex"><img src="https://avatars.githubusercontent.com/u/326163?u=b245f368bd940cf51d08c0b6bf55f8257f359437&amp;v=4" width="119" alt="Alex"/><br />Alex</a></td>
+   <td align="center"><a href="https://github.com/finom?ref=orpc" target="_blank" rel="noopener" title="Andrey Gubanov"><img src="https://avatars.githubusercontent.com/u/1082083?u=29e91400dbd4a9c217048a8f59562c4f740498e6&amp;v=4" width="119" alt="Andrey Gubanov"/><br />Andrey Gubanov</a></td>
+  </tr>
+</table>
+
+### Past Sponsors
+
+<p>
+  <a href="https://github.com/MrMaxie?ref=orpc" target="_blank" rel="noopener" title="Maxie"><img src="https://avatars.githubusercontent.com/u/3857836?u=5e6b57973d4385d655663ffdd836e487856f2984&amp;v=4" width="32" height="32" alt="Maxie" /></a>
+  <a href="https://github.com/Stijn-Timmer?ref=orpc" target="_blank" rel="noopener" title="Stijn Timmer"><img src="https://avatars.githubusercontent.com/u/100147665?u=106b2c18e9c98a61861b4ee7fc100f5b9906a6c9&amp;v=4" width="32" height="32" alt="Stijn Timmer" /></a>
+  <a href="https://github.com/u1-liquid?ref=orpc" target="_blank" rel="noopener" title="あわわわとーにゅ"><img src="https://avatars.githubusercontent.com/u/17376330?u=de3353804be889f009f7e0a1582daf04d0ab292d&amp;v=4" width="32" height="32" alt="あわわわとーにゅ" /></a>
+  <a href="https://github.com/zuplo?ref=orpc" target="_blank" rel="noopener" title="Zuplo"><img src="https://avatars.githubusercontent.com/u/85497839?v=4" width="32" height="32" alt="Zuplo" /></a>
+  <a href="https://github.com/motopods?ref=orpc" target="_blank" rel="noopener" title="motopods"><img src="https://avatars.githubusercontent.com/u/58200641?v=4" width="32" height="32" alt="motopods" /></a>
+  <a href="https://github.com/franciscohermida?ref=orpc" target="_blank" rel="noopener" title="Francisco Hermida"><img src="https://avatars.githubusercontent.com/u/483242?u=bbcbc80eb9d8781ff401f7dafc3b59cd7bea0561&amp;v=4" width="32" height="32" alt="Francisco Hermida" /></a>
+  <a href="https://github.com/theoludwig?ref=orpc" target="_blank" rel="noopener" title="Théo LUDWIG"><img src="https://avatars.githubusercontent.com/u/25207499?u=a6a9653725a2f574c07893748806668e0598cdbe&amp;v=4" width="32" height="32" alt="Théo LUDWIG" /></a>
+  <a href="https://github.com/abhay-ramesh?ref=orpc" target="_blank" rel="noopener" title="Abhay Ramesh"><img src="https://avatars.githubusercontent.com/u/66196314?u=c5c2b0327b26606c2efcfaf17046ab18c3d25c57&amp;v=4" width="32" height="32" alt="Abhay Ramesh" /></a>
+  <a href="https://github.com/shr-ink?ref=orpc" target="_blank" rel="noopener" title="shr.ink oü"><img src="https://avatars.githubusercontent.com/u/139700438?v=4" width="32" height="32" alt="shr.ink oü" /></a>
+  <a href="https://github.com/johngerome?ref=orpc" target="_blank" rel="noopener" title="0x4e32"><img src="https://avatars.githubusercontent.com/u/2002000?u=505e54608466ab53754f702973687b04c6424c1f&amp;v=4" width="32" height="32" alt="0x4e32" /></a>
+  <a href="https://github.com/yzuyr?ref=orpc" target="_blank" rel="noopener" title="Ryuz"><img src="https://avatars.githubusercontent.com/u/196539378?u=d38374588d219b6748b16406982f6559411466d4&amp;v=4" width="32" height="32" alt="Ryuz" /></a>
+  <a href="https://github.com/happyboy2022?ref=orpc" target="_blank" rel="noopener" title="happyboy"><img src="https://avatars.githubusercontent.com/u/103669586?u=65b49c4b893ed3703909fbb3a7a22313f3f9c121&amp;v=4" width="32" height="32" alt="happyboy" /></a>
+  <a href="https://github.com/YiCChi?ref=orpc" target="_blank" rel="noopener" title="yicchi"><img src="https://avatars.githubusercontent.com/u/86967274?u=6c2756f09fe15dd94d572f560e979cd157982852&amp;v=4" width="32" height="32" alt="yicchi" /></a>
+  <a href="https://github.com/cloudycotton?ref=orpc" target="_blank" rel="noopener" title="Saksham"><img src="https://avatars.githubusercontent.com/u/168998965?u=9b9634a5aed66a51c1b880663272725b00b92b14&amp;v=4" width="32" height="32" alt="Saksham" /></a>
+  <a href="https://github.com/hrynevychroman?ref=orpc" target="_blank" rel="noopener" title="Roman Hrynevych"><img src="https://avatars.githubusercontent.com/u/82209198?u=1a1d111ab3d589855b9cc8a7fefb1b5c6a4fbbaf&amp;v=4" width="32" height="32" alt="Roman Hrynevych" /></a>
+  <a href="https://github.com/rokitgg?ref=orpc" target="_blank" rel="noopener" title="rokitg"><img src="https://avatars.githubusercontent.com/u/125133357?u=06c74aefaa2236b06a2e5fba5a5c612339f45912&amp;v=4" width="32" height="32" alt="rokitg" /></a>
+  <a href="https://github.com/omarkhatibgg?ref=orpc" target="_blank" rel="noopener" title="Omar Khatib"><img src="https://avatars.githubusercontent.com/u/9054278?u=afbba7331b85c51b8eee4130f5fd31b1017dc919&amp;v=4" width="32" height="32" alt="Omar Khatib" /></a>
+  <a href="https://github.com/YuSabo90002?ref=orpc" target="_blank" rel="noopener" title="Yu-Sabo"><img src="https://avatars.githubusercontent.com/u/13120582?v=4" width="32" height="32" alt="Yu-Sabo" /></a>
+  <a href="https://github.com/bapspatil?ref=orpc" target="_blank" rel="noopener" title="Bapusaheb Patil"><img src="https://avatars.githubusercontent.com/u/16699418?u=6d9d8e0a64a6f91ca1c4d559c72d931172bdcbbd&amp;v=4" width="32" height="32" alt="Bapusaheb Patil" /></a>
+  <a href="https://github.com/ripgrim?ref=orpc" target="_blank" rel="noopener" title="grim"><img src="https://avatars.githubusercontent.com/u/75869731?u=b17c42ec2309552fdb822a86b25a2f99146a4d72&amp;v=4" width="32" height="32" alt="grim" /></a>
+  <a href="https://github.com/nelsonlaidev?ref=orpc" target="_blank" rel="noopener" title="Nelson Lai"><img src="https://avatars.githubusercontent.com/u/75498339?u=2fc0e0b95dd184c5ffb744df977cb15a18b60672&amp;v=4" width="32" height="32" alt="Nelson Lai" /></a>
+  <a href="https://github.com/nguyenlc1993?ref=orpc" target="_blank" rel="noopener" title="Lê Cao Nguyên"><img src="https://avatars.githubusercontent.com/u/13871971?u=83c8b69d9e35b589c4e1f066cc113b1d9461386f&amp;v=4" width="32" height="32" alt="Lê Cao Nguyên" /></a>
+  <a href="https://github.com/wobsoriano?ref=orpc" target="_blank" rel="noopener" title="Robert Soriano"><img src="https://avatars.githubusercontent.com/u/13049130?u=6d72104182e7c9ed25934815313fb69107332111&amp;v=4" width="32" height="32" alt="Robert Soriano" /></a>
+  <a href="https://github.com/SKostyukovich?ref=orpc" target="_blank" rel="noopener" title="SKostyukovich"><img src="https://avatars.githubusercontent.com/u/10700067?v=4" width="32" height="32" alt="SKostyukovich" /></a>
+  <a href="https://github.com/peter-adam-dy?ref=orpc" target="_blank" rel="noopener" title="Peter Adam"><img src="https://avatars.githubusercontent.com/u/132129459?u=4f3dbbb3b443990b56acb7d6a5d11ed2c555f6db&amp;v=4" width="32" height="32" alt="Peter Adam" /></a>
+  <a href="https://github.com/FabworksHQ?ref=orpc" target="_blank" rel="noopener" title="Fabworks"><img src="https://avatars.githubusercontent.com/u/160179500?v=4" width="32" height="32" alt="Fabworks" /></a>
+  <a href="https://github.com/NovakAnton?ref=orpc" target="_blank" rel="noopener" title="Novak Antonijevic"><img src="https://avatars.githubusercontent.com/u/157126729?u=ae49fa22292d55c0434ff0ca008206155b18663b&amp;v=4" width="32" height="32" alt="Novak Antonijevic" /></a>
+  <a href="https://github.com/laduniestu?ref=orpc" target="_blank" rel="noopener" title="Laduni Estu Syalwa"><img src="https://avatars.githubusercontent.com/u/44757637?u=a2fc1ea8f7d827a96721176f79d30592d1c48059&amp;v=4" width="32" height="32" alt="Laduni Estu Syalwa" /></a>
+  <a href="https://github.com/yukimotochern?ref=orpc" target="_blank" rel="noopener" title="Chen, Zhi-Yuan"><img src="https://avatars.githubusercontent.com/u/20896173?u=945c33fc21725e4d566a0d02afc54b136ca1d67a&amp;v=4" width="32" height="32" alt="Chen, Zhi-Yuan" /></a>
+  <a href="https://github.com/illarionvk?ref=orpc" target="_blank" rel="noopener" title="Illarion Koperski"><img src="https://avatars.githubusercontent.com/u/5012724?u=7cfa13652f7ac5fb3c56d880e3eb3fbe40c3ea34&amp;v=4" width="32" height="32" alt="Illarion Koperski" /></a>
+  <a href="https://github.com/steelbrain?ref=orpc" target="_blank" rel="noopener" title="Anees Iqbal"><img src="https://avatars.githubusercontent.com/u/4278113?u=22b80b5399eed68ac76cd58b02961b0481f1db11&amp;v=4" width="32" height="32" alt="Anees Iqbal" /></a>
+  <a href="https://github.com/Scrumplex?ref=orpc" target="_blank" rel="noopener" title="Sefa Eyeoglu"><img src="https://avatars.githubusercontent.com/u/11587657?u=ab503582165c0bbff0cca47ce31c9450bb1553c9&amp;v=4" width="32" height="32" alt="Sefa Eyeoglu" /></a>
+  <a href="https://github.com/nattstack?ref=orpc" target="_blank" rel="noopener" title="natt"><img src="https://avatars.githubusercontent.com/u/31426677?u=fa9dbb8b3e66eb0ea3c88db5dc07f31c8c5418fe&amp;v=4" width="32" height="32" alt="natt" /></a>
+  <a href="https://github.com/ChromeGG?ref=orpc" target="_blank" rel="noopener" title="Adam Tkaczyk"><img src="https://avatars.githubusercontent.com/u/39050595?u=a58ca6042a6950e94e6e92442db76ef584279bc0&amp;v=4" width="32" height="32" alt="Adam Tkaczyk" /></a>
+  <a href="https://github.com/plancraft?ref=orpc" target="_blank" rel="noopener" title="plancraft"><img src="https://avatars.githubusercontent.com/u/46482287?v=4" width="32" height="32" alt="plancraft" /></a>
+</p>
+
+## References
+
+oRPC is inspired by existing solutions that prioritize type safety and developer experience. Special acknowledgments to:
+
+- [tRPC](https://trpc.io): For pioneering the concept of end-to-end type-safe RPC and influencing the development of type-safe APIs.
+- [ts-rest](https://ts-rest.com): For its emphasis on contract-first development and OpenAPI integration, which have greatly inspired oRPC's feature set.
+
+## License
+
+Distributed under the MIT License. See [LICENSE](https://github.com/middleapi/orpc/blob/main/LICENSE) for more information.

--- a/packages/tanstack-db/package.json
+++ b/packages/tanstack-db/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@orpc/tanstack-db",
+  "type": "module",
+  "version": "2.0.0-beta.18",
+  "license": "MIT",
+  "homepage": "https://orpc.dev",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/middleapi/orpc.git",
+    "directory": "packages/tanstack-db"
+  },
+  "keywords": [
+    "orpc",
+    "tanstack db"
+  ],
+  "sideEffects": false,
+  "publishConfig": {
+    "exports": {
+      "./package.json": "./package.json",
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "unbuild",
+    "type:check": "tsc -b"
+  },
+  "peerDependencies": {
+    "@tanstack/db": ">=0.6.13",
+    "@tanstack/query-core": ">=5.80.2",
+    "@tanstack/query-db-collection": ">=1.0.6"
+  },
+  "dependencies": {
+    "@orpc/client": "workspace:*",
+    "@orpc/contract": "workspace:*",
+    "@orpc/shared": "workspace:*",
+    "@orpc/tanstack-query": "workspace:*"
+  },
+  "devDependencies": {
+    "@tanstack/db": "^0.6.16",
+    "@tanstack/query-core": "^5.101.0",
+    "@tanstack/query-db-collection": "^1.1.0",
+    "zod": "^4.4.3"
+  }
+}

--- a/packages/tanstack-db/package.json
+++ b/packages/tanstack-db/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@orpc/tanstack-db",
+  "name": "@orpc/experimental-tanstack-db",
   "type": "module",
   "version": "2.0.0-beta.18",
   "license": "MIT",

--- a/packages/tanstack-db/package.json
+++ b/packages/tanstack-db/package.json
@@ -48,8 +48,10 @@
   },
   "devDependencies": {
     "@tanstack/db": "^0.6.16",
+    "@tanstack/electric-db-collection": "^0.3.14",
     "@tanstack/query-core": "^5.101.0",
     "@tanstack/query-db-collection": "^1.1.0",
+    "@tanstack/react-db": "^0.1.94",
     "zod": "^4.4.3"
   }
 }

--- a/packages/tanstack-db/src/index.ts
+++ b/packages/tanstack-db/src/index.ts
@@ -1,0 +1,6 @@
+export * from './procedure-utils'
+export * from './router-utils'
+export { createRouterUtils as createTanstackDBUtils } from './router-utils'
+export * from './types'
+export { generateOperationKey, SharedRouterUtils } from '@orpc/tanstack-query'
+export type { OperationKey, OperationKeyOptions, OperationKeyPrefixOptions } from '@orpc/tanstack-query'

--- a/packages/tanstack-db/src/procedure-utils.test-d.ts
+++ b/packages/tanstack-db/src/procedure-utils.test-d.ts
@@ -44,16 +44,6 @@ describe('ProcedureUtils', () => {
 
     it('handles `input` correctly', () => {
       listUtils.collectionOptions({ queryClient, getKey: item => item.id })
-      listUtils.collectionOptions({ input: { search: '__search__' }, queryClient, getKey: item => item.id })
-      // @ts-expect-error --- input is invalid
-      listUtils.collectionOptions({ input: { search: 123 }, queryClient, getKey: item => item.id })
-
-      requiredInputListUtils.collectionOptions({ input: { search: '__search__' }, queryClient, getKey: item => item.id })
-      // @ts-expect-error --- input is required
-      requiredInputListUtils.collectionOptions({ queryClient, getKey: item => item.id })
-    })
-
-    it('supports dynamic input', () => {
       listUtils.collectionOptions({
         input: (context) => {
           expectTypeOf(context.queryKey).toEqualTypeOf<QueryKey>()
@@ -63,18 +53,32 @@ describe('ProcedureUtils', () => {
         queryClient,
         getKey: item => item.id,
       })
-
-      // @ts-expect-error --- dynamic input return type is invalid
+      // @ts-expect-error --- static input is not allowed
+      listUtils.collectionOptions({ input: { search: '__search__' }, queryClient, getKey: item => item.id })
+      // @ts-expect-error --- input return type is invalid
       listUtils.collectionOptions({ input: () => ({ search: 123 }), queryClient, getKey: item => item.id })
+
+      requiredInputListUtils.collectionOptions({ input: () => ({ search: '__search__' }), queryClient, getKey: item => item.id })
+      // @ts-expect-error --- input is required
+      requiredInputListUtils.collectionOptions({ queryClient, getKey: item => item.id })
     })
 
     it('handles `context` correctly', () => {
       listUtils.collectionOptions({ queryClient, getKey: item => item.id })
+      listUtils.collectionOptions({
+        context: (context) => {
+          expectTypeOf(context.queryKey).toEqualTypeOf<QueryKey>()
+          return { batch: true }
+        },
+        queryClient,
+        getKey: item => item.id,
+      })
+      // @ts-expect-error --- static context is not allowed
       listUtils.collectionOptions({ context: { batch: true }, queryClient, getKey: item => item.id })
-      // @ts-expect-error --- context is invalid
-      listUtils.collectionOptions({ context: { batch: 'invalid' }, queryClient, getKey: item => item.id })
+      // @ts-expect-error --- context return type is invalid
+      listUtils.collectionOptions({ context: () => ({ batch: 'invalid' }), queryClient, getKey: item => item.id })
 
-      requiredContextListUtils.collectionOptions({ context: { batch: true }, queryClient, getKey: item => item.id })
+      requiredContextListUtils.collectionOptions({ context: () => ({ batch: true }), queryClient, getKey: item => item.id })
       // @ts-expect-error --- context is required
       requiredContextListUtils.collectionOptions({ queryClient, getKey: item => item.id })
     })
@@ -152,7 +156,16 @@ describe('ProcedureUtils', () => {
 
       // @ts-expect-error --- context is required
       requiredContextListUtils.mutationHandler()
+      // @ts-expect-error --- static context is not allowed
       requiredContextListUtils.mutationHandler({ context: { batch: true } })
+      requiredContextListUtils.mutationHandler({ context: () => ({ batch: true }) })
+      requiredContextListUtils.mutationHandler<Todo, 'update'>({
+        context: (mutation, params) => {
+          expectTypeOf(mutation.changes).toEqualTypeOf<Partial<Todo>>()
+          expectTypeOf(params.transaction.mutations[0].type).toEqualTypeOf<'update'>()
+          return { batch: true }
+        },
+      })
     })
 
     it('is assignable to TanStack DB persistence handlers', () => {

--- a/packages/tanstack-db/src/procedure-utils.test-d.ts
+++ b/packages/tanstack-db/src/procedure-utils.test-d.ts
@@ -1,0 +1,186 @@
+import type { Client } from '@orpc/client'
+import type { DeleteMutationFn, InsertMutationFn, UpdateMutationFn } from '@tanstack/db'
+import type { QueryCollectionUtils } from '@tanstack/query-db-collection'
+import type { ProcedureUtils } from './procedure-utils'
+import { QueryClient } from '@tanstack/query-core'
+import z from 'zod'
+
+describe('ProcedureUtils', () => {
+  interface Todo {
+    id: number
+    name: string
+  }
+
+  type ListInput = { search?: string } | undefined
+
+  const queryClient = new QueryClient()
+
+  const listUtils = {} as ProcedureUtils<{ batch?: boolean }, ListInput, Todo[], Error>
+  const requiredInputListUtils = {} as ProcedureUtils<{ batch?: boolean }, { search: string }, Todo[], Error>
+  const requiredContextListUtils = {} as ProcedureUtils<{ batch: boolean }, ListInput, Todo[], Error>
+  const nonArrayListUtils = {} as ProcedureUtils<{ batch?: boolean }, ListInput, { items: Todo[] }, Error>
+  const createUtils = {} as ProcedureUtils<{ batch?: boolean }, Todo, Todo, Error>
+  const updateUtils = {} as ProcedureUtils<{ batch?: boolean }, { id: number, data: Partial<Todo> }, Todo, Error>
+
+  it('.call', () => {
+    expectTypeOf(listUtils.call).toEqualTypeOf<
+      Client<{ batch?: boolean }, ListInput, Todo[], Error>
+    >()
+  })
+
+  describe('.collectionOptions', () => {
+    it('infers item type from procedure output', () => {
+      const options = listUtils.collectionOptions({
+        queryClient,
+        getKey: (item) => {
+          expectTypeOf(item).toEqualTypeOf<Todo>()
+          return item.id
+        },
+      })
+
+      expectTypeOf(options.utils).toEqualTypeOf<QueryCollectionUtils<Todo, number, Todo, Error>>()
+    })
+
+    it('handles `input` correctly', () => {
+      listUtils.collectionOptions({ queryClient, getKey: item => item.id })
+      listUtils.collectionOptions({ input: { search: '__search__' }, queryClient, getKey: item => item.id })
+      // @ts-expect-error --- input is invalid
+      listUtils.collectionOptions({ input: { search: 123 }, queryClient, getKey: item => item.id })
+
+      requiredInputListUtils.collectionOptions({ input: { search: '__search__' }, queryClient, getKey: item => item.id })
+      // @ts-expect-error --- input is required
+      requiredInputListUtils.collectionOptions({ queryClient, getKey: item => item.id })
+    })
+
+    it('handles `context` correctly', () => {
+      listUtils.collectionOptions({ queryClient, getKey: item => item.id })
+      listUtils.collectionOptions({ context: { batch: true }, queryClient, getKey: item => item.id })
+      // @ts-expect-error --- context is invalid
+      listUtils.collectionOptions({ context: { batch: 'invalid' }, queryClient, getKey: item => item.id })
+
+      requiredContextListUtils.collectionOptions({ context: { batch: true }, queryClient, getKey: item => item.id })
+      // @ts-expect-error --- context is required
+      requiredContextListUtils.collectionOptions({ queryClient, getKey: item => item.id })
+    })
+
+    it('infers item type from `select`', () => {
+      const options = nonArrayListUtils.collectionOptions({
+        queryClient,
+        select: (data) => {
+          expectTypeOf(data).toEqualTypeOf<{ items: Todo[] }>()
+          return data.items
+        },
+        getKey: (item) => {
+          expectTypeOf(item).toEqualTypeOf<Todo>()
+          return item.id
+        },
+      })
+
+      expectTypeOf(options.utils).toEqualTypeOf<QueryCollectionUtils<Todo, number, Todo, Error>>()
+    })
+
+    it('requires `select` when output is not an array', () => {
+      // @ts-expect-error --- select is required
+      nonArrayListUtils.collectionOptions({ queryClient, getKey: (item: any) => item.id })
+    })
+
+    it('infers item type from `schema`', () => {
+      const todoSchema = z.object({ id: z.number(), name: z.string() })
+
+      const options = listUtils.collectionOptions({
+        queryClient,
+        schema: todoSchema,
+        getKey: (item) => {
+          expectTypeOf(item).toEqualTypeOf<{ id: number, name: string }>()
+          return item.id
+        },
+      })
+
+      expectTypeOf(options.schema).toEqualTypeOf<typeof todoSchema>()
+      expectTypeOf(options.utils).toEqualTypeOf<QueryCollectionUtils<{ id: number, name: string }, number, { id: number, name: string }, Error>>()
+
+      nonArrayListUtils.collectionOptions({
+        queryClient,
+        schema: todoSchema,
+        select: (data) => {
+          expectTypeOf(data).toEqualTypeOf<{ items: Todo[] }>()
+          return data.items
+        },
+        getKey: item => item.id,
+      })
+    })
+
+    it('supports persistence handlers', () => {
+      listUtils.collectionOptions({
+        queryClient,
+        getKey: item => item.id,
+        onInsert: createUtils.mutationHandler({ input: mutation => mutation.modified }),
+        onUpdate: updateUtils.mutationHandler({ input: mutation => ({ id: mutation.key, data: mutation.changes }) }),
+      })
+    })
+  })
+
+  describe('.mutationHandler', () => {
+    it('enforces input mapper return type', () => {
+      createUtils.mutationHandler({ input: mutation => mutation.modified })
+      // @ts-expect-error --- input is invalid
+      createUtils.mutationHandler({ input: () => ({ id: 'invalid' }) })
+      // @ts-expect-error --- input is required
+      createUtils.mutationHandler()
+    })
+
+    it('optional options when input & context are optional', () => {
+      listUtils.mutationHandler()
+      listUtils.mutationHandler({})
+      listUtils.mutationHandler({ input: () => ({ search: '__search__' }) })
+
+      // @ts-expect-error --- context is required
+      requiredContextListUtils.mutationHandler()
+      requiredContextListUtils.mutationHandler({ context: { batch: true } })
+    })
+
+    it('is assignable to TanStack DB persistence handlers', () => {
+      const handler = createUtils.mutationHandler({ input: mutation => mutation.modified })
+
+      expectTypeOf(handler).toExtend<InsertMutationFn<Todo, number>>()
+      expectTypeOf(handler).toExtend<UpdateMutationFn<Todo, number>>()
+      expectTypeOf(handler).toExtend<DeleteMutationFn<Todo, number>>()
+    })
+
+    it('supports explicit item & operation types', () => {
+      createUtils.mutationHandler<Todo, 'insert'>({
+        input: (mutation) => {
+          expectTypeOf(mutation.modified).toEqualTypeOf<Todo>()
+          expectTypeOf(mutation.type).toEqualTypeOf<'insert'>()
+          return mutation.modified
+        },
+      })
+
+      updateUtils.mutationHandler<Todo, 'update'>({
+        input: (mutation) => {
+          expectTypeOf(mutation.original).toEqualTypeOf<Todo>()
+          expectTypeOf(mutation.changes).toEqualTypeOf<Partial<Todo>>()
+          return { id: mutation.original.id, data: mutation.changes }
+        },
+      })
+    })
+
+    it('infers return type from `output`', () => {
+      const handler = updateUtils.mutationHandler({
+        input: mutation => ({ id: mutation.key, data: mutation.changes }),
+        output: (outputs) => {
+          expectTypeOf(outputs).toEqualTypeOf<Todo[]>()
+          return { txid: outputs.length }
+        },
+      })
+
+      expectTypeOf(handler).returns.resolves.toEqualTypeOf<{ txid: number }>()
+
+      const defaultHandler = updateUtils.mutationHandler({
+        input: mutation => ({ id: mutation.key, data: mutation.changes }),
+      })
+
+      expectTypeOf(defaultHandler).returns.resolves.toEqualTypeOf<Todo[]>()
+    })
+  })
+})

--- a/packages/tanstack-db/src/procedure-utils.test-d.ts
+++ b/packages/tanstack-db/src/procedure-utils.test-d.ts
@@ -209,7 +209,19 @@ describe('ProcedureUtils', () => {
         input: mutation => ({ id: mutation.key, data: mutation.changes }),
       })
 
-      expectTypeOf(defaultHandler).returns.resolves.toEqualTypeOf<Todo[]>()
+      expectTypeOf(defaultHandler).returns.resolves.toEqualTypeOf<undefined>()
+    })
+
+    it('requires `output` when return type does not accept undefined', () => {
+      updateUtils.mutationHandler<Todo, 'update', { txid: number }>({
+        input: mutation => ({ id: mutation.key, data: mutation.changes }),
+        output: outputs => ({ txid: outputs.length }),
+      })
+
+      // @ts-expect-error --- output is required
+      updateUtils.mutationHandler<Todo, 'update', { txid: number }>({
+        input: mutation => ({ id: mutation.key, data: mutation.changes }),
+      })
     })
   })
 })

--- a/packages/tanstack-db/src/procedure-utils.test-d.ts
+++ b/packages/tanstack-db/src/procedure-utils.test-d.ts
@@ -1,5 +1,5 @@
 import type { Client } from '@orpc/client'
-import type { DeleteMutationFn, InsertMutationFn, UpdateMutationFn } from '@tanstack/db'
+import type { DeleteMutationFn, InsertMutationFn, LoadSubsetOptions, UpdateMutationFn } from '@tanstack/db'
 import type { QueryKey } from '@tanstack/query-core'
 import type { QueryCollectionUtils } from '@tanstack/query-db-collection'
 import type { ProcedureUtils } from './procedure-utils'
@@ -45,9 +45,8 @@ describe('ProcedureUtils', () => {
     it('handles `input` correctly', () => {
       listUtils.collectionOptions({ queryClient, getKey: item => item.id })
       listUtils.collectionOptions({
-        input: (context) => {
-          expectTypeOf(context.queryKey).toEqualTypeOf<QueryKey>()
-          expectTypeOf(context.signal).toEqualTypeOf<AbortSignal>()
+        input: (options) => {
+          expectTypeOf(options).toEqualTypeOf<LoadSubsetOptions>()
           return { search: '__search__' }
         },
         queryClient,

--- a/packages/tanstack-db/src/procedure-utils.test-d.ts
+++ b/packages/tanstack-db/src/procedure-utils.test-d.ts
@@ -194,33 +194,32 @@ describe('ProcedureUtils', () => {
       })
     })
 
-    it('infers return type from `output`', () => {
+    it('handles `refetch` correctly', () => {
       const handler = updateUtils.mutationHandler({
         input: mutation => ({ id: mutation.key, data: mutation.changes }),
-        output: (outputs) => {
+        refetch: false,
+      })
+
+      expectTypeOf(handler).returns.resolves.toEqualTypeOf<{ refetch: boolean } | undefined>()
+
+      updateUtils.mutationHandler({
+        input: mutation => ({ id: mutation.key, data: mutation.changes }),
+        refetch: (outputs, params) => {
           expectTypeOf(outputs).toEqualTypeOf<Todo[]>()
-          return { txid: outputs.length }
+          expectTypeOf(params.transaction.mutations[0].modified).toEqualTypeOf<any>()
+          return outputs.length > 0
         },
       })
 
-      expectTypeOf(handler).returns.resolves.toEqualTypeOf<{ txid: number }>()
-
-      const defaultHandler = updateUtils.mutationHandler({
+      updateUtils.mutationHandler({
         input: mutation => ({ id: mutation.key, data: mutation.changes }),
+        refetch: async () => false,
       })
 
-      expectTypeOf(defaultHandler).returns.resolves.toEqualTypeOf<undefined>()
-    })
-
-    it('requires `output` when return type does not accept undefined', () => {
-      updateUtils.mutationHandler<Todo, 'update', { txid: number }>({
+      updateUtils.mutationHandler({
         input: mutation => ({ id: mutation.key, data: mutation.changes }),
-        output: outputs => ({ txid: outputs.length }),
-      })
-
-      // @ts-expect-error --- output is required
-      updateUtils.mutationHandler<Todo, 'update', { txid: number }>({
-        input: mutation => ({ id: mutation.key, data: mutation.changes }),
+        // @ts-expect-error --- refetch is invalid
+        refetch: 'invalid',
       })
     })
   })

--- a/packages/tanstack-db/src/procedure-utils.test-d.ts
+++ b/packages/tanstack-db/src/procedure-utils.test-d.ts
@@ -1,5 +1,6 @@
 import type { Client } from '@orpc/client'
 import type { DeleteMutationFn, InsertMutationFn, UpdateMutationFn } from '@tanstack/db'
+import type { QueryKey } from '@tanstack/query-core'
 import type { QueryCollectionUtils } from '@tanstack/query-db-collection'
 import type { ProcedureUtils } from './procedure-utils'
 import { QueryClient } from '@tanstack/query-core'
@@ -50,6 +51,21 @@ describe('ProcedureUtils', () => {
       requiredInputListUtils.collectionOptions({ input: { search: '__search__' }, queryClient, getKey: item => item.id })
       // @ts-expect-error --- input is required
       requiredInputListUtils.collectionOptions({ queryClient, getKey: item => item.id })
+    })
+
+    it('supports dynamic input', () => {
+      listUtils.collectionOptions({
+        input: (context) => {
+          expectTypeOf(context.queryKey).toEqualTypeOf<QueryKey>()
+          expectTypeOf(context.signal).toEqualTypeOf<AbortSignal>()
+          return { search: '__search__' }
+        },
+        queryClient,
+        getKey: item => item.id,
+      })
+
+      // @ts-expect-error --- dynamic input return type is invalid
+      listUtils.collectionOptions({ input: () => ({ search: 123 }), queryClient, getKey: item => item.id })
     })
 
     it('handles `context` correctly', () => {

--- a/packages/tanstack-db/src/procedure-utils.test-d.ts
+++ b/packages/tanstack-db/src/procedure-utils.test-d.ts
@@ -213,6 +213,7 @@ describe('ProcedureUtils', () => {
 
       updateUtils.mutationHandler({
         input: mutation => ({ id: mutation.key, data: mutation.changes }),
+        // @ts-expect-error --- refetch must be sync
         refetch: async () => false,
       })
 

--- a/packages/tanstack-db/src/procedure-utils.test-d.ts
+++ b/packages/tanstack-db/src/procedure-utils.test-d.ts
@@ -1,8 +1,9 @@
 import type { Client } from '@orpc/client'
-import type { DeleteMutationFn, InsertMutationFn, LoadSubsetOptions, UpdateMutationFn } from '@tanstack/db'
+import type { DeleteMutationFn, InsertMutationFn, InsertMutationFnParams, LoadSubsetOptions, UpdateMutationFn } from '@tanstack/db'
 import type { QueryKey } from '@tanstack/query-core'
 import type { QueryCollectionUtils } from '@tanstack/query-db-collection'
 import type { ProcedureUtils } from './procedure-utils'
+import { electricCollectionOptions } from '@tanstack/electric-db-collection'
 import { QueryClient } from '@tanstack/query-core'
 import z from 'zod'
 
@@ -21,6 +22,7 @@ describe('ProcedureUtils', () => {
   const requiredContextListUtils = {} as ProcedureUtils<{ batch: boolean }, ListInput, Todo[], Error>
   const nonArrayListUtils = {} as ProcedureUtils<{ batch?: boolean }, ListInput, { items: Todo[] }, Error>
   const createUtils = {} as ProcedureUtils<{ batch?: boolean }, Todo, Todo, Error>
+  const createWithTxidUtils = {} as ProcedureUtils<{ batch?: boolean }, Todo, { txid: number }, Error>
   const updateUtils = {} as ProcedureUtils<{ batch?: boolean }, { id: number, data: Partial<Todo> }, Todo, Error>
 
   it('.call', () => {
@@ -193,33 +195,57 @@ describe('ProcedureUtils', () => {
       })
     })
 
-    it('handles `refetch` correctly', () => {
+    it('infers return type from `output`', () => {
       const handler = updateUtils.mutationHandler({
         input: mutation => ({ id: mutation.key, data: mutation.changes }),
-        refetch: false,
-      })
-
-      expectTypeOf(handler).returns.resolves.toEqualTypeOf<{ refetch: boolean } | undefined>()
-
-      updateUtils.mutationHandler({
-        input: mutation => ({ id: mutation.key, data: mutation.changes }),
-        refetch: (outputs, params) => {
+        output: (outputs, params) => {
           expectTypeOf(outputs).toEqualTypeOf<Todo[]>()
           expectTypeOf(params.transaction.mutations[0].modified).toEqualTypeOf<any>()
-          return outputs.length > 0
+          return { refetch: outputs.length > 0 }
         },
       })
 
-      updateUtils.mutationHandler({
+      expectTypeOf(handler).returns.resolves.toEqualTypeOf<{ refetch: boolean }>()
+
+      const defaultHandler = updateUtils.mutationHandler({
         input: mutation => ({ id: mutation.key, data: mutation.changes }),
-        // @ts-expect-error --- refetch must be sync
-        refetch: async () => false,
       })
 
-      updateUtils.mutationHandler({
-        input: mutation => ({ id: mutation.key, data: mutation.changes }),
-        // @ts-expect-error --- refetch is invalid
-        refetch: 'invalid',
+      expectTypeOf(defaultHandler).returns.resolves.toEqualTypeOf<undefined>()
+    })
+
+    it('requires `output` when expected return type does not accept undefined', () => {
+      const _valid: (params: InsertMutationFnParams<Todo>) => Promise<{ txid: number }> = createWithTxidUtils.mutationHandler({
+        input: mutation => mutation.modified,
+        output: outputs => ({ txid: outputs[0]!.txid }),
+      })
+
+      // @ts-expect-error --- output is required
+      const _invalid: (params: InsertMutationFnParams<Todo>) => Promise<{ txid: number }> = createWithTxidUtils.mutationHandler({
+        input: mutation => mutation.modified,
+      })
+    })
+
+    it('works with electric collection options', () => {
+      interface ElectricTodo extends Record<string, unknown> {
+        id: number
+        name: string
+      }
+
+      const electricCreateUtils = {} as ProcedureUtils<{ batch?: boolean }, ElectricTodo, { txid: number }, Error>
+
+      electricCollectionOptions({
+        shapeOptions: { url: 'http://localhost:3000/v1/shape' },
+        getKey: (item: ElectricTodo) => item.id,
+        onInsert: electricCreateUtils.mutationHandler({
+          input: (mutation) => {
+            expectTypeOf(mutation.modified).toEqualTypeOf<ElectricTodo>()
+            return mutation.modified
+          },
+          output: outputs => ({ txid: outputs.map(output => output.txid) }),
+        }),
+        // returning nothing is allowed by electric, so output is optional
+        onDelete: electricCreateUtils.mutationHandler({ input: mutation => mutation.modified }),
       })
     })
   })

--- a/packages/tanstack-db/src/procedure-utils.test.ts
+++ b/packages/tanstack-db/src/procedure-utils.test.ts
@@ -1,0 +1,208 @@
+import { generateOperationKey, TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL } from '@orpc/tanstack-query'
+import { QueryClient } from '@tanstack/query-core'
+import * as QueryDBCollectionModule from '@tanstack/query-db-collection'
+import { ProcedureUtils } from './procedure-utils'
+
+vi.mock('@tanstack/query-db-collection', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/query-db-collection')>()
+
+  return {
+    ...actual,
+    queryCollectionOptions: vi.fn(actual.queryCollectionOptions),
+  }
+})
+
+const queryCollectionOptionsSpy = vi.mocked(QueryDBCollectionModule.queryCollectionOptions)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('procedureUtils', () => {
+  const signal = new AbortController().signal
+  const client = vi.fn()
+  const utils = new ProcedureUtils(['planet', 'list'], client as any)
+
+  it('.call', () => {
+    expect(utils.call).toBe(client)
+  })
+
+  describe('.collectionOptions', () => {
+    const queryClient = new QueryClient()
+    const getKey = vi.fn((item: any) => item.id)
+
+    it('forwards options to queryCollectionOptions with a generated queryKey', () => {
+      const options = utils.collectionOptions({
+        input: { search: '__search__' },
+        queryClient,
+        getKey,
+        startSync: true,
+      } as any)
+
+      expect(queryCollectionOptionsSpy).toHaveBeenCalledTimes(1)
+      const config = queryCollectionOptionsSpy.mock.calls[0]![0] as any
+
+      expect(config.queryKey).toEqual(generateOperationKey(['planet', 'list'], { type: 'query', input: { search: '__search__' } }))
+      expect(config.queryClient).toBe(queryClient)
+      expect(config.getKey).toBe(getKey)
+      expect(config.startSync).toBe(true)
+      expect(config).not.toHaveProperty('input')
+      expect(config).not.toHaveProperty('context')
+
+      expect(options).toBe(queryCollectionOptionsSpy.mock.results[0]!.value)
+    })
+
+    it('queryFn calls client with input, signal, and operation context', async () => {
+      client.mockResolvedValueOnce([{ id: 1 }])
+
+      utils.collectionOptions({
+        input: { search: '__search__' },
+        context: { cache: true },
+        queryClient,
+        getKey,
+      } as any)
+
+      const config = queryCollectionOptionsSpy.mock.calls[0]![0] as any
+
+      await expect(config.queryFn({ signal, queryKey: config.queryKey })).resolves.toEqual([{ id: 1 }])
+
+      expect(client).toHaveBeenCalledTimes(1)
+      expect(client).toHaveBeenCalledWith({ search: '__search__' }, {
+        signal,
+        context: {
+          [TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL]: {
+            key: config.queryKey,
+            type: 'query',
+          },
+          cache: true,
+        },
+      })
+    })
+
+    it('supports custom queryKey', () => {
+      utils.collectionOptions({
+        input: { search: '__search__' },
+        queryKey: ['__custom__'],
+        queryClient,
+        getKey,
+      } as any)
+
+      const config = queryCollectionOptionsSpy.mock.calls[0]![0] as any
+      expect(config.queryKey).toEqual(['__custom__'])
+    })
+
+    it('includes prefix in generated queryKey', () => {
+      const prefixedUtils = new ProcedureUtils(['planet', 'list'], client as any, { prefix: '__prefix__' })
+
+      prefixedUtils.collectionOptions({
+        input: { search: '__search__' },
+        queryClient,
+        getKey,
+      } as any)
+
+      const config = queryCollectionOptionsSpy.mock.calls[0]![0] as any
+      expect(config.queryKey).toEqual(
+        generateOperationKey(['planet', 'list'], { prefix: '__prefix__', type: 'query', input: { search: '__search__' } }),
+      )
+    })
+  })
+
+  describe('.mutationHandler', () => {
+    const params = {
+      transaction: {
+        mutations: [
+          { type: 'update', key: 1, modified: { id: 1, name: '__modified1__' }, changes: { name: '__modified1__' } },
+          { type: 'update', key: 2, modified: { id: 2, name: '__modified2__' }, changes: { name: '__modified2__' } },
+        ],
+      },
+      collection: {},
+    } as any
+
+    it('calls client once per mutation and returns outputs', async () => {
+      client.mockResolvedValueOnce('__output1__').mockResolvedValueOnce('__output2__')
+
+      const inputMapper = vi.fn((mutation: any) => ({ id: mutation.key, data: mutation.changes }))
+      const handler = utils.mutationHandler({ input: inputMapper } as any)
+
+      await expect(handler(params)).resolves.toEqual(['__output1__', '__output2__'])
+
+      expect(inputMapper).toHaveBeenCalledTimes(2)
+      expect(inputMapper).toHaveBeenNthCalledWith(1, params.transaction.mutations[0], params)
+      expect(inputMapper).toHaveBeenNthCalledWith(2, params.transaction.mutations[1], params)
+
+      expect(client).toHaveBeenCalledTimes(2)
+      expect(client).toHaveBeenNthCalledWith(1, { id: 1, data: { name: '__modified1__' } }, {
+        context: {
+          [TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL]: {
+            key: generateOperationKey(['planet', 'list'], { type: 'mutation' }),
+            type: 'mutation',
+          },
+        },
+      })
+      expect(client).toHaveBeenNthCalledWith(2, { id: 2, data: { name: '__modified2__' } }, expect.any(Object))
+    })
+
+    it('calls client sequentially', async () => {
+      let resolveFirst!: (value: string) => void
+      client.mockImplementationOnce(() => new Promise((resolve) => {
+        resolveFirst = resolve
+      }))
+      client.mockResolvedValueOnce('__output2__')
+
+      const handler = utils.mutationHandler({ input: (mutation: any) => mutation.key } as any)
+      const promise = handler(params)
+
+      await new Promise(resolve => setTimeout(resolve, 10))
+      expect(client).toHaveBeenCalledTimes(1)
+
+      resolveFirst('__output1__')
+      await expect(promise).resolves.toEqual(['__output1__', '__output2__'])
+      expect(client).toHaveBeenCalledTimes(2)
+    })
+
+    it('supports output mapper', async () => {
+      client.mockResolvedValueOnce({ txid: 1 }).mockResolvedValueOnce({ txid: 2 })
+
+      const outputMapper = vi.fn((outputs: any[]) => ({ txid: outputs.map(output => output.txid) }))
+      const handler = utils.mutationHandler({
+        input: (mutation: any) => mutation.modified,
+        output: outputMapper,
+      } as any)
+
+      await expect(handler(params)).resolves.toEqual({ txid: [1, 2] })
+      expect(outputMapper).toHaveBeenCalledTimes(1)
+      expect(outputMapper).toHaveBeenCalledWith([{ txid: 1 }, { txid: 2 }], params)
+    })
+
+    it('merges custom context and includes prefix in mutation key', async () => {
+      const prefixedUtils = new ProcedureUtils(['planet', 'list'], client as any, { prefix: '__prefix__' })
+      client.mockResolvedValueOnce('__output1__').mockResolvedValueOnce('__output2__')
+
+      const handler = prefixedUtils.mutationHandler({
+        input: (mutation: any) => mutation.key,
+        context: { cache: true },
+      } as any)
+
+      await handler(params)
+
+      expect(client).toHaveBeenNthCalledWith(1, 1, {
+        context: {
+          [TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL]: {
+            key: generateOperationKey(['planet', 'list'], { prefix: '__prefix__', type: 'mutation' }),
+            type: 'mutation',
+          },
+          cache: true,
+        },
+      })
+    })
+
+    it('works without options', async () => {
+      client.mockResolvedValueOnce('__output1__').mockResolvedValueOnce('__output2__')
+
+      const handler = utils.mutationHandler()
+
+      await expect(handler(params)).resolves.toEqual(['__output1__', '__output2__'])
+      expect(client).toHaveBeenNthCalledWith(1, undefined, expect.any(Object))
+    })
+  })
+})

--- a/packages/tanstack-db/src/procedure-utils.test.ts
+++ b/packages/tanstack-db/src/procedure-utils.test.ts
@@ -196,7 +196,7 @@ describe('procedureUtils', () => {
     it('supports dynamic refetch option', async () => {
       client.mockResolvedValueOnce('__output1__').mockResolvedValueOnce('__output2__')
 
-      const refetchFn = vi.fn(async (outputs: any[]) => outputs.length > 2)
+      const refetchFn = vi.fn((outputs: any[]) => outputs.length > 2)
       const handler = utils.mutationHandler({
         input: (mutation: any) => mutation.modified,
         refetch: refetchFn,

--- a/packages/tanstack-db/src/procedure-utils.test.ts
+++ b/packages/tanstack-db/src/procedure-utils.test.ts
@@ -33,7 +33,7 @@ describe('procedureUtils', () => {
 
     it('forwards options to queryCollectionOptions with a generated queryKey', () => {
       const options = utils.collectionOptions({
-        input: { search: '__search__' },
+        input: () => ({ search: '__search__' }),
         queryClient,
         getKey,
         startSync: true,
@@ -42,7 +42,7 @@ describe('procedureUtils', () => {
       expect(queryCollectionOptionsSpy).toHaveBeenCalledTimes(1)
       const config = queryCollectionOptionsSpy.mock.calls[0]![0] as any
 
-      expect(config.queryKey).toEqual(generateOperationKey(['planet', 'list'], { type: 'query', input: { search: '__search__' } }))
+      expect(config.queryKey).toEqual(generateOperationKey(['planet', 'list'], { type: 'query' }))
       expect(config.queryClient).toBe(queryClient)
       expect(config.getKey).toBe(getKey)
       expect(config.startSync).toBe(true)
@@ -52,40 +52,15 @@ describe('procedureUtils', () => {
       expect(options).toBe(queryCollectionOptionsSpy.mock.results[0]!.value)
     })
 
-    it('queryFn calls client with input, signal, and operation context', async () => {
-      client.mockResolvedValueOnce([{ id: 1 }])
-
-      utils.collectionOptions({
-        input: { search: '__search__' },
-        context: { cache: true },
-        queryClient,
-        getKey,
-      } as any)
-
-      const config = queryCollectionOptionsSpy.mock.calls[0]![0] as any
-
-      await expect(config.queryFn({ signal, queryKey: config.queryKey })).resolves.toEqual([{ id: 1 }])
-
-      expect(client).toHaveBeenCalledTimes(1)
-      expect(client).toHaveBeenCalledWith({ search: '__search__' }, {
-        signal,
-        context: {
-          [TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL]: {
-            key: config.queryKey,
-            type: 'query',
-          },
-          cache: true,
-        },
-      })
-    })
-
-    it('supports dynamic input resolved from queryFn context', async () => {
+    it('queryFn resolves input & context from its context and calls client', async () => {
       client.mockResolvedValueOnce([{ id: 1 }])
 
       const inputFn = vi.fn((fnContext: any) => ({ search: fnContext.queryKey[1].search }))
+      const contextFn = vi.fn(() => ({ cache: true }))
 
       utils.collectionOptions({
         input: inputFn,
+        context: contextFn,
         queryKey: ['__custom__', { search: '__dynamic__' }],
         queryClient,
         getKey,
@@ -99,44 +74,57 @@ describe('procedureUtils', () => {
 
       expect(inputFn).toHaveBeenCalledTimes(1)
       expect(inputFn).toHaveBeenCalledWith({ signal, queryKey: config.queryKey })
-      expect(client).toHaveBeenCalledWith({ search: '__dynamic__' }, expect.any(Object))
+      expect(contextFn).toHaveBeenCalledTimes(1)
+      expect(contextFn).toHaveBeenCalledWith({ signal, queryKey: config.queryKey })
+
+      expect(client).toHaveBeenCalledTimes(1)
+      expect(client).toHaveBeenCalledWith({ search: '__dynamic__' }, {
+        signal,
+        context: {
+          [TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL]: {
+            key: config.queryKey,
+            type: 'query',
+          },
+          cache: true,
+        },
+      })
     })
 
-    it('excludes dynamic input from generated queryKey', () => {
+    it('works without input & context', async () => {
+      client.mockResolvedValueOnce([{ id: 1 }])
+
       utils.collectionOptions({
-        input: () => ({ search: '__dynamic__' }),
         queryClient,
         getKey,
       } as any)
 
       const config = queryCollectionOptionsSpy.mock.calls[0]![0] as any
-      expect(config.queryKey).toEqual(generateOperationKey(['planet', 'list'], { type: 'query' }))
-    })
 
-    it('supports custom queryKey', () => {
-      utils.collectionOptions({
-        input: { search: '__search__' },
-        queryKey: ['__custom__'],
-        queryClient,
-        getKey,
-      } as any)
+      await expect(config.queryFn({ signal, queryKey: config.queryKey })).resolves.toEqual([{ id: 1 }])
 
-      const config = queryCollectionOptionsSpy.mock.calls[0]![0] as any
-      expect(config.queryKey).toEqual(['__custom__'])
+      expect(client).toHaveBeenCalledWith(undefined, {
+        signal,
+        context: {
+          [TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL]: {
+            key: config.queryKey,
+            type: 'query',
+          },
+        },
+      })
     })
 
     it('includes prefix in generated queryKey', () => {
       const prefixedUtils = new ProcedureUtils(['planet', 'list'], client as any, { prefix: '__prefix__' })
 
       prefixedUtils.collectionOptions({
-        input: { search: '__search__' },
+        input: () => ({ search: '__search__' }),
         queryClient,
         getKey,
       } as any)
 
       const config = queryCollectionOptionsSpy.mock.calls[0]![0] as any
       expect(config.queryKey).toEqual(
-        generateOperationKey(['planet', 'list'], { prefix: '__prefix__', type: 'query', input: { search: '__search__' } }),
+        generateOperationKey(['planet', 'list'], { prefix: '__prefix__', type: 'query' }),
       )
     })
   })
@@ -208,16 +196,22 @@ describe('procedureUtils', () => {
       expect(outputMapper).toHaveBeenCalledWith([{ txid: 1 }, { txid: 2 }], params)
     })
 
-    it('merges custom context and includes prefix in mutation key', async () => {
+    it('resolves context per mutation and includes prefix in mutation key', async () => {
       const prefixedUtils = new ProcedureUtils(['planet', 'list'], client as any, { prefix: '__prefix__' })
       client.mockResolvedValueOnce('__output1__').mockResolvedValueOnce('__output2__')
 
+      const contextFn = vi.fn((mutation: any) => ({ cache: mutation.key }))
+
       const handler = prefixedUtils.mutationHandler({
         input: (mutation: any) => mutation.key,
-        context: { cache: true },
+        context: contextFn,
       } as any)
 
       await handler(params)
+
+      expect(contextFn).toHaveBeenCalledTimes(2)
+      expect(contextFn).toHaveBeenNthCalledWith(1, params.transaction.mutations[0], params)
+      expect(contextFn).toHaveBeenNthCalledWith(2, params.transaction.mutations[1], params)
 
       expect(client).toHaveBeenNthCalledWith(1, 1, {
         context: {
@@ -225,7 +219,16 @@ describe('procedureUtils', () => {
             key: generateOperationKey(['planet', 'list'], { prefix: '__prefix__', type: 'mutation' }),
             type: 'mutation',
           },
-          cache: true,
+          cache: 1,
+        },
+      })
+      expect(client).toHaveBeenNthCalledWith(2, 2, {
+        context: {
+          [TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL]: {
+            key: generateOperationKey(['planet', 'list'], { prefix: '__prefix__', type: 'mutation' }),
+            type: 'mutation',
+          },
+          cache: 2,
         },
       })
     })

--- a/packages/tanstack-db/src/procedure-utils.test.ts
+++ b/packages/tanstack-db/src/procedure-utils.test.ts
@@ -140,7 +140,7 @@ describe('procedureUtils', () => {
       collection: {},
     } as any
 
-    it('calls client once per mutation and resolves undefined without output mapper', async () => {
+    it('calls client once per mutation and resolves undefined without refetch option', async () => {
       client.mockResolvedValueOnce('__output1__').mockResolvedValueOnce('__output2__')
 
       const inputMapper = vi.fn((mutation: any) => ({ id: mutation.key, data: mutation.changes }))
@@ -182,18 +182,29 @@ describe('procedureUtils', () => {
       expect(client).toHaveBeenCalledTimes(2)
     })
 
-    it('supports output mapper', async () => {
-      client.mockResolvedValueOnce({ txid: 1 }).mockResolvedValueOnce({ txid: 2 })
+    it('supports static refetch option', async () => {
+      client.mockResolvedValueOnce('__output1__').mockResolvedValueOnce('__output2__')
 
-      const outputMapper = vi.fn((outputs: any[]) => ({ txid: outputs.map(output => output.txid) }))
       const handler = utils.mutationHandler({
         input: (mutation: any) => mutation.modified,
-        output: outputMapper,
+        refetch: false,
       } as any)
 
-      await expect(handler(params)).resolves.toEqual({ txid: [1, 2] })
-      expect(outputMapper).toHaveBeenCalledTimes(1)
-      expect(outputMapper).toHaveBeenCalledWith([{ txid: 1 }, { txid: 2 }], params)
+      await expect(handler(params)).resolves.toEqual({ refetch: false })
+    })
+
+    it('supports dynamic refetch option', async () => {
+      client.mockResolvedValueOnce('__output1__').mockResolvedValueOnce('__output2__')
+
+      const refetchFn = vi.fn(async (outputs: any[]) => outputs.length > 2)
+      const handler = utils.mutationHandler({
+        input: (mutation: any) => mutation.modified,
+        refetch: refetchFn,
+      } as any)
+
+      await expect(handler(params)).resolves.toEqual({ refetch: false })
+      expect(refetchFn).toHaveBeenCalledTimes(1)
+      expect(refetchFn).toHaveBeenCalledWith(['__output1__', '__output2__'], params)
     })
 
     it('resolves context per mutation and includes prefix in mutation key', async () => {

--- a/packages/tanstack-db/src/procedure-utils.test.ts
+++ b/packages/tanstack-db/src/procedure-utils.test.ts
@@ -183,7 +183,7 @@ describe('procedureUtils', () => {
       collection: {},
     } as any
 
-    it('calls client once per mutation and resolves undefined without refetch option', async () => {
+    it('calls client once per mutation and resolves undefined without output mapper', async () => {
       client.mockResolvedValueOnce('__output1__').mockResolvedValueOnce('__output2__')
 
       const inputMapper = vi.fn((mutation: any) => ({ id: mutation.key, data: mutation.changes }))
@@ -223,29 +223,18 @@ describe('procedureUtils', () => {
       await expect(promise).resolves.toBeUndefined()
     })
 
-    it('supports static refetch option', async () => {
-      client.mockResolvedValueOnce('__output1__').mockResolvedValueOnce('__output2__')
+    it('supports output mapper', async () => {
+      client.mockResolvedValueOnce({ txid: 1 }).mockResolvedValueOnce({ txid: 2 })
 
+      const outputFn = vi.fn((outputs: any[]) => ({ txid: outputs.map(output => output.txid) }))
       const handler = utils.mutationHandler({
         input: (mutation: any) => mutation.modified,
-        refetch: false,
+        output: outputFn,
       } as any)
 
-      await expect(handler(params)).resolves.toEqual({ refetch: false })
-    })
-
-    it('supports dynamic refetch option', async () => {
-      client.mockResolvedValueOnce('__output1__').mockResolvedValueOnce('__output2__')
-
-      const refetchFn = vi.fn((outputs: any[]) => outputs.length > 2)
-      const handler = utils.mutationHandler({
-        input: (mutation: any) => mutation.modified,
-        refetch: refetchFn,
-      } as any)
-
-      await expect(handler(params)).resolves.toEqual({ refetch: false })
-      expect(refetchFn).toHaveBeenCalledTimes(1)
-      expect(refetchFn).toHaveBeenCalledWith(['__output1__', '__output2__'], params)
+      await expect(handler(params)).resolves.toEqual({ txid: [1, 2] })
+      expect(outputFn).toHaveBeenCalledTimes(1)
+      expect(outputFn).toHaveBeenCalledWith([{ txid: 1 }, { txid: 2 }], params)
     })
 
     it('resolves context per mutation and includes prefix in mutation key', async () => {

--- a/packages/tanstack-db/src/procedure-utils.test.ts
+++ b/packages/tanstack-db/src/procedure-utils.test.ts
@@ -113,6 +113,23 @@ describe('procedureUtils', () => {
       expect(config.queryKey).toEqual(['__custom__'])
     })
 
+    it('supports custom queryFn', async () => {
+      const customQueryFn = vi.fn(async () => [{ id: 1 }])
+
+      utils.collectionOptions({
+        input: () => ({ search: '__search__' }),
+        queryFn: customQueryFn,
+        queryClient,
+        getKey,
+      } as any)
+
+      const config = queryCollectionOptionsSpy.mock.calls[0]![0] as any
+      expect(config.queryFn).toBe(customQueryFn)
+
+      await expect(config.queryFn({ signal })).resolves.toEqual([{ id: 1 }])
+      expect(client).not.toHaveBeenCalled()
+    })
+
     it('works without input & context', async () => {
       client.mockResolvedValueOnce([{ id: 1 }])
 

--- a/packages/tanstack-db/src/procedure-utils.test.ts
+++ b/packages/tanstack-db/src/procedure-utils.test.ts
@@ -140,13 +140,13 @@ describe('procedureUtils', () => {
       collection: {},
     } as any
 
-    it('calls client once per mutation and returns outputs', async () => {
+    it('calls client once per mutation and resolves undefined without output mapper', async () => {
       client.mockResolvedValueOnce('__output1__').mockResolvedValueOnce('__output2__')
 
       const inputMapper = vi.fn((mutation: any) => ({ id: mutation.key, data: mutation.changes }))
       const handler = utils.mutationHandler({ input: inputMapper } as any)
 
-      await expect(handler(params)).resolves.toEqual(['__output1__', '__output2__'])
+      await expect(handler(params)).resolves.toBeUndefined()
 
       expect(inputMapper).toHaveBeenCalledTimes(2)
       expect(inputMapper).toHaveBeenNthCalledWith(1, params.transaction.mutations[0], params)
@@ -178,7 +178,7 @@ describe('procedureUtils', () => {
       expect(client).toHaveBeenCalledTimes(1)
 
       resolveFirst('__output1__')
-      await expect(promise).resolves.toEqual(['__output1__', '__output2__'])
+      await expect(promise).resolves.toBeUndefined()
       expect(client).toHaveBeenCalledTimes(2)
     })
 
@@ -238,7 +238,7 @@ describe('procedureUtils', () => {
 
       const handler = utils.mutationHandler()
 
-      await expect(handler(params)).resolves.toEqual(['__output1__', '__output2__'])
+      await expect(handler(params)).resolves.toBeUndefined()
       expect(client).toHaveBeenNthCalledWith(1, undefined, expect.any(Object))
     })
   })

--- a/packages/tanstack-db/src/procedure-utils.test.ts
+++ b/packages/tanstack-db/src/procedure-utils.test.ts
@@ -190,7 +190,7 @@ describe('procedureUtils', () => {
       expect(client).toHaveBeenNthCalledWith(2, { id: 2, data: { name: '__modified2__' } }, expect.any(Object))
     })
 
-    it('calls client sequentially', async () => {
+    it('calls client concurrently', async () => {
       let resolveFirst!: (value: string) => void
       client.mockImplementationOnce(() => new Promise((resolve) => {
         resolveFirst = resolve
@@ -200,12 +200,10 @@ describe('procedureUtils', () => {
       const handler = utils.mutationHandler({ input: (mutation: any) => mutation.key } as any)
       const promise = handler(params)
 
-      await new Promise(resolve => setTimeout(resolve, 10))
-      expect(client).toHaveBeenCalledTimes(1)
+      expect(client).toHaveBeenCalledTimes(2)
 
       resolveFirst('__output1__')
       await expect(promise).resolves.toBeUndefined()
-      expect(client).toHaveBeenCalledTimes(2)
     })
 
     it('supports static refetch option', async () => {

--- a/packages/tanstack-db/src/procedure-utils.test.ts
+++ b/packages/tanstack-db/src/procedure-utils.test.ts
@@ -79,6 +79,40 @@ describe('procedureUtils', () => {
       })
     })
 
+    it('supports dynamic input resolved from queryFn context', async () => {
+      client.mockResolvedValueOnce([{ id: 1 }])
+
+      const inputFn = vi.fn((fnContext: any) => ({ search: fnContext.queryKey[1].search }))
+
+      utils.collectionOptions({
+        input: inputFn,
+        queryKey: ['__custom__', { search: '__dynamic__' }],
+        queryClient,
+        getKey,
+      } as any)
+
+      const config = queryCollectionOptionsSpy.mock.calls[0]![0] as any
+
+      expect(config.queryKey).toEqual(['__custom__', { search: '__dynamic__' }])
+
+      await expect(config.queryFn({ signal, queryKey: config.queryKey })).resolves.toEqual([{ id: 1 }])
+
+      expect(inputFn).toHaveBeenCalledTimes(1)
+      expect(inputFn).toHaveBeenCalledWith({ signal, queryKey: config.queryKey })
+      expect(client).toHaveBeenCalledWith({ search: '__dynamic__' }, expect.any(Object))
+    })
+
+    it('excludes dynamic input from generated queryKey', () => {
+      utils.collectionOptions({
+        input: () => ({ search: '__dynamic__' }),
+        queryClient,
+        getKey,
+      } as any)
+
+      const config = queryCollectionOptionsSpy.mock.calls[0]![0] as any
+      expect(config.queryKey).toEqual(generateOperationKey(['planet', 'list'], { type: 'query' }))
+    })
+
     it('supports custom queryKey', () => {
       utils.collectionOptions({
         input: { search: '__search__' },

--- a/packages/tanstack-db/src/procedure-utils.test.ts
+++ b/packages/tanstack-db/src/procedure-utils.test.ts
@@ -31,9 +31,11 @@ describe('procedureUtils', () => {
     const queryClient = new QueryClient()
     const getKey = vi.fn((item: any) => item.id)
 
-    it('forwards options to queryCollectionOptions with a generated queryKey', () => {
+    it('forwards options to queryCollectionOptions with a generated queryKey builder', () => {
+      const inputFn = vi.fn((options: any) => ({ search: '__search__', limit: options.limit }))
+
       const options = utils.collectionOptions({
-        input: () => ({ search: '__search__' }),
+        input: inputFn,
         queryClient,
         getKey,
         startSync: true,
@@ -41,8 +43,17 @@ describe('procedureUtils', () => {
 
       expect(queryCollectionOptionsSpy).toHaveBeenCalledTimes(1)
       const config = queryCollectionOptionsSpy.mock.calls[0]![0] as any
+      inputFn.mockClear()
 
-      expect(config.queryKey).toEqual(generateOperationKey(['planet', 'list'], { type: 'query' }))
+      expect(config.queryKey({})).toEqual(
+        generateOperationKey(['planet', 'list'], { type: 'query', input: { search: '__search__', limit: undefined } }),
+      )
+      expect(config.queryKey({ limit: 5 })).toEqual(
+        generateOperationKey(['planet', 'list'], { type: 'query', input: { search: '__search__', limit: 5 } }),
+      )
+      expect(inputFn).toHaveBeenNthCalledWith(1, {})
+      expect(inputFn).toHaveBeenNthCalledWith(2, { limit: 5 })
+
       expect(config.queryClient).toBe(queryClient)
       expect(config.getKey).toBe(getKey)
       expect(config.startSync).toBe(true)
@@ -52,42 +63,54 @@ describe('procedureUtils', () => {
       expect(options).toBe(queryCollectionOptionsSpy.mock.results[0]!.value)
     })
 
-    it('queryFn resolves input & context from its context and calls client', async () => {
+    it('queryFn resolves input from loadSubsetOptions & context from its context', async () => {
       client.mockResolvedValueOnce([{ id: 1 }])
 
-      const inputFn = vi.fn((fnContext: any) => ({ search: fnContext.queryKey[1].search }))
+      const inputFn = vi.fn((options: any) => ({ limit: options.limit }))
       const contextFn = vi.fn(() => ({ cache: true }))
 
       utils.collectionOptions({
         input: inputFn,
         context: contextFn,
-        queryKey: ['__custom__', { search: '__dynamic__' }],
         queryClient,
         getKey,
       } as any)
 
       const config = queryCollectionOptionsSpy.mock.calls[0]![0] as any
+      const queryKey = config.queryKey({ limit: 5 })
+      inputFn.mockClear()
 
-      expect(config.queryKey).toEqual(['__custom__', { search: '__dynamic__' }])
-
-      await expect(config.queryFn({ signal, queryKey: config.queryKey })).resolves.toEqual([{ id: 1 }])
+      const fnContext = { signal, queryKey, meta: { loadSubsetOptions: { limit: 5 } } }
+      await expect(config.queryFn(fnContext)).resolves.toEqual([{ id: 1 }])
 
       expect(inputFn).toHaveBeenCalledTimes(1)
-      expect(inputFn).toHaveBeenCalledWith({ signal, queryKey: config.queryKey })
+      expect(inputFn).toHaveBeenCalledWith({ limit: 5 })
       expect(contextFn).toHaveBeenCalledTimes(1)
-      expect(contextFn).toHaveBeenCalledWith({ signal, queryKey: config.queryKey })
+      expect(contextFn).toHaveBeenCalledWith(fnContext)
 
       expect(client).toHaveBeenCalledTimes(1)
-      expect(client).toHaveBeenCalledWith({ search: '__dynamic__' }, {
+      expect(client).toHaveBeenCalledWith({ limit: 5 }, {
         signal,
         context: {
           [TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL]: {
-            key: config.queryKey,
+            key: queryKey,
             type: 'query',
           },
           cache: true,
         },
       })
+    })
+
+    it('supports custom queryKey', () => {
+      utils.collectionOptions({
+        input: () => ({ search: '__search__' }),
+        queryKey: ['__custom__'],
+        queryClient,
+        getKey,
+      } as any)
+
+      const config = queryCollectionOptionsSpy.mock.calls[0]![0] as any
+      expect(config.queryKey).toEqual(['__custom__'])
     })
 
     it('works without input & context', async () => {
@@ -100,13 +123,16 @@ describe('procedureUtils', () => {
 
       const config = queryCollectionOptionsSpy.mock.calls[0]![0] as any
 
-      await expect(config.queryFn({ signal, queryKey: config.queryKey })).resolves.toEqual([{ id: 1 }])
+      const queryKey = config.queryKey({})
+      expect(queryKey).toEqual(generateOperationKey(['planet', 'list'], { type: 'query' }))
+
+      await expect(config.queryFn({ signal, queryKey })).resolves.toEqual([{ id: 1 }])
 
       expect(client).toHaveBeenCalledWith(undefined, {
         signal,
         context: {
           [TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL]: {
-            key: config.queryKey,
+            key: queryKey,
             type: 'query',
           },
         },
@@ -123,8 +149,8 @@ describe('procedureUtils', () => {
       } as any)
 
       const config = queryCollectionOptionsSpy.mock.calls[0]![0] as any
-      expect(config.queryKey).toEqual(
-        generateOperationKey(['planet', 'list'], { prefix: '__prefix__', type: 'query' }),
+      expect(config.queryKey({})).toEqual(
+        generateOperationKey(['planet', 'list'], { prefix: '__prefix__', type: 'query', input: { search: '__search__' } }),
       )
     })
   })

--- a/packages/tanstack-db/src/procedure-utils.ts
+++ b/packages/tanstack-db/src/procedure-utils.ts
@@ -87,7 +87,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
    * Create a persistence handler for [TanStack DB](https://tanstack.com/db) collections.
    * Can be used as `onInsert`, `onUpdate`, or `onDelete` in collection options.
    */
-  mutationHandler<UItem extends object = any, UType extends OperationType = OperationType, UReturn = TOutput[]>(
+  mutationHandler<UItem extends object = any, UType extends OperationType = OperationType, UReturn = undefined>(
     ...rest: MaybeOptionalOptions<MutationHandlerOptionsIn<TClientContext, TInput, TOutput, UItem, UType, UReturn>>
   ): MutationHandler<UItem, UType, UReturn> {
     const optionsIn = resolveMaybeOptionalOptions(rest) as any
@@ -109,7 +109,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
         outputs.push(await this.call(optionsIn.input?.(mutation, params), { context: context as any }))
       }
 
-      return optionsIn.output ? optionsIn.output(outputs, params) : outputs as UReturn
+      return optionsIn.output?.(outputs, params)
     }
   }
 }

--- a/packages/tanstack-db/src/procedure-utils.ts
+++ b/packages/tanstack-db/src/procedure-utils.ts
@@ -1,0 +1,115 @@
+import type { Client, ClientContext } from '@orpc/client'
+import type { AnySchema } from '@orpc/contract'
+import type { MaybeOptionalOptions } from '@orpc/shared'
+import type { OperationKeyPrefixOptions, TanstackQueryOperationContext } from '@orpc/tanstack-query'
+import type { OperationType } from '@tanstack/db'
+import type {
+  CollectionOptionsIn,
+  CollectionOptionsOut,
+  InferCollectionItem,
+  InferCollectionSchemaInput,
+  InferCollectionSchemaOutput,
+  MutationHandler,
+  MutationHandlerOptionsIn,
+} from './types'
+import { resolveMaybeOptionalOptions } from '@orpc/shared'
+import { generateOperationKey, TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL } from '@orpc/tanstack-query'
+import { queryCollectionOptions } from '@tanstack/query-db-collection'
+
+export interface ProcedureUtilsOptions extends OperationKeyPrefixOptions {
+}
+
+export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutput, TError> {
+  /**
+   * Calling corresponding procedure client
+   */
+  call: Client<TClientContext, TInput, TOutput, TError>
+
+  constructor(
+    private readonly path: string[],
+    client: Client<TClientContext, TInput, TOutput, TError>,
+    private readonly options: ProcedureUtilsOptions = {},
+  ) {
+    this.call = client
+  }
+
+  /**
+   * Generate options used with `createCollection` from [TanStack DB](https://tanstack.com/db).
+   * Built on top of `queryCollectionOptions` from `@tanstack/query-db-collection`.
+   */
+  collectionOptions<USchema extends AnySchema, UKey extends string | number = string | number>(
+    options: & CollectionOptionsIn<TClientContext, TInput, TOutput, TError, InferCollectionSchemaOutput<USchema>, UKey, USchema>
+      & { schema: USchema, select: (data: TOutput) => InferCollectionSchemaInput<USchema>[] }
+  ): CollectionOptionsOut<InferCollectionSchemaOutput<USchema>, UKey, USchema, InferCollectionSchemaInput<USchema>, TError> & { schema: USchema }
+
+  collectionOptions<UItem extends object, UKey extends string | number = string | number>(
+    options: & CollectionOptionsIn<TClientContext, TInput, TOutput, TError, UItem, UKey, never>
+      & { schema?: never, select: (data: TOutput) => UItem[] }
+  ): CollectionOptionsOut<UItem, UKey, never, UItem, TError> & { schema?: never }
+
+  collectionOptions<USchema extends AnySchema, UKey extends string | number = string | number>(
+    options: & CollectionOptionsIn<TClientContext, TInput, TOutput, TError, InferCollectionSchemaOutput<USchema>, UKey, USchema>
+      & { schema: USchema, select?: never }
+      & (TOutput extends InferCollectionSchemaOutput<USchema>[] ? unknown : { select: (data: TOutput) => InferCollectionSchemaInput<USchema>[] })
+  ): CollectionOptionsOut<InferCollectionSchemaOutput<USchema>, UKey, USchema, InferCollectionSchemaInput<USchema>, TError> & { schema: USchema }
+
+  collectionOptions<UKey extends string | number = string | number>(
+    options: & CollectionOptionsIn<TClientContext, TInput, TOutput, TError, InferCollectionItem<TOutput>, UKey, never>
+      & { schema?: never, select?: never }
+      & (TOutput extends object[] ? unknown : { select: (data: TOutput) => object[] })
+  ): CollectionOptionsOut<InferCollectionItem<TOutput>, UKey, never, InferCollectionItem<TOutput>, TError> & { schema?: never }
+
+  collectionOptions(optionsIn: any): any {
+    const { input, context, queryKey: customQueryKey, ...rest } = optionsIn
+
+    const queryKey = customQueryKey
+      ?? generateOperationKey(this.path, { prefix: this.options.prefix, type: 'query', input })
+
+    return queryCollectionOptions({
+      ...rest,
+      queryKey,
+      queryFn: (fnContext: any) => {
+        return this.call(input, {
+          signal: fnContext.signal,
+          context: {
+            [TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL]: {
+              key: fnContext.queryKey,
+              type: 'query',
+            },
+            ...context,
+          } satisfies TanstackQueryOperationContext,
+        })
+      },
+    })
+  }
+
+  /**
+   * Create a persistence handler for [TanStack DB](https://tanstack.com/db) collections.
+   * Can be used as `onInsert`, `onUpdate`, or `onDelete` in collection options.
+   */
+  mutationHandler<UItem extends object = any, UType extends OperationType = OperationType, UReturn = TOutput[]>(
+    ...rest: MaybeOptionalOptions<MutationHandlerOptionsIn<TClientContext, TInput, TOutput, UItem, UType, UReturn>>
+  ): MutationHandler<UItem, UType, UReturn> {
+    const optionsIn = resolveMaybeOptionalOptions(rest) as any
+
+    const mutationKey = generateOperationKey(this.path, { prefix: this.options.prefix, type: 'mutation' })
+
+    return async (params) => {
+      const context = {
+        [TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL]: {
+          key: mutationKey,
+          type: 'mutation',
+        },
+        ...optionsIn.context,
+      } satisfies TanstackQueryOperationContext
+
+      const outputs: TOutput[] = []
+
+      for (const mutation of params.transaction.mutations) {
+        outputs.push(await this.call(optionsIn.input?.(mutation, params), { context: context as any }))
+      }
+
+      return optionsIn.output ? optionsIn.output(outputs, params) : outputs as UReturn
+    }
+  }
+}

--- a/packages/tanstack-db/src/procedure-utils.ts
+++ b/packages/tanstack-db/src/procedure-utils.ts
@@ -12,7 +12,7 @@ import type {
   MutationHandler,
   MutationHandlerOptionsIn,
 } from './types'
-import { resolveMaybeOptionalOptions, value } from '@orpc/shared'
+import { resolveMaybeOptionalOptions } from '@orpc/shared'
 import { generateOperationKey, TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL } from '@orpc/tanstack-query'
 import { queryCollectionOptions } from '@tanstack/query-db-collection'
 
@@ -80,9 +80,9 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
    * Create a persistence handler for [TanStack DB](https://tanstack.com/db) collections.
    * Can be used as `onInsert`, `onUpdate`, or `onDelete` in collection options.
    */
-  mutationHandler<UItem extends object = any, UType extends OperationType = OperationType>(
-    ...rest: MaybeOptionalOptions<MutationHandlerOptionsIn<TClientContext, TInput, TOutput, UItem, UType>>
-  ): MutationHandler<UItem, UType> {
+  mutationHandler<UItem extends object = any, UType extends OperationType = OperationType, UReturn = undefined>(
+    ...rest: MaybeOptionalOptions<MutationHandlerOptionsIn<TClientContext, TInput, TOutput, UItem, UType, UReturn>>
+  ): MutationHandler<UItem, UType, UReturn> {
     const optionsIn = resolveMaybeOptionalOptions(rest)
 
     const mutationKey = generateOperationKey(this.path, { prefix: this.options.prefix, type: 'mutation' })
@@ -100,9 +100,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
         return this.call(optionsIn.input?.(mutation, params) as TInput, { context: context as any })
       }))
 
-      const refetch = value(optionsIn.refetch, outputs, params)
-
-      return refetch === undefined ? undefined : { refetch }
+      return (optionsIn as any).output?.(outputs, params)
     }
   }
 }

--- a/packages/tanstack-db/src/procedure-utils.ts
+++ b/packages/tanstack-db/src/procedure-utils.ts
@@ -2,7 +2,7 @@ import type { Client, ClientContext } from '@orpc/client'
 import type { AnySchema } from '@orpc/contract'
 import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { OperationKeyPrefixOptions, TanstackQueryOperationContext } from '@orpc/tanstack-query'
-import type { OperationType } from '@tanstack/db'
+import type { LoadSubsetOptions, OperationType } from '@tanstack/db'
 import type {
   CollectionOptionsIn,
   CollectionOptionsOut,
@@ -63,13 +63,17 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
     const { input, context, queryKey: customQueryKey, ...rest } = optionsIn
 
     const queryKey = customQueryKey
-      ?? generateOperationKey(this.path, { prefix: this.options.prefix, type: 'query' })
+      ?? ((options: LoadSubsetOptions) => generateOperationKey(this.path, {
+        prefix: this.options.prefix,
+        type: 'query',
+        input: input?.(options),
+      }))
 
     return queryCollectionOptions({
       ...rest,
       queryKey,
       queryFn: (fnContext) => {
-        return this.call(input?.(fnContext), {
+        return this.call(input?.(fnContext.meta?.loadSubsetOptions ?? {}), {
           signal: fnContext.signal,
           context: {
             [TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL]: {

--- a/packages/tanstack-db/src/procedure-utils.ts
+++ b/packages/tanstack-db/src/procedure-utils.ts
@@ -87,9 +87,9 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
    * Create a persistence handler for [TanStack DB](https://tanstack.com/db) collections.
    * Can be used as `onInsert`, `onUpdate`, or `onDelete` in collection options.
    */
-  mutationHandler<UItem extends object = any, UType extends OperationType = OperationType, UReturn = undefined>(
-    ...rest: MaybeOptionalOptions<MutationHandlerOptionsIn<TClientContext, TInput, TOutput, UItem, UType, UReturn>>
-  ): MutationHandler<UItem, UType, UReturn> {
+  mutationHandler<UItem extends object = any, UType extends OperationType = OperationType>(
+    ...rest: MaybeOptionalOptions<MutationHandlerOptionsIn<TClientContext, TInput, TOutput, UItem, UType>>
+  ): MutationHandler<UItem, UType> {
     const optionsIn = resolveMaybeOptionalOptions(rest) as any
 
     const mutationKey = generateOperationKey(this.path, { prefix: this.options.prefix, type: 'mutation' })
@@ -109,7 +109,11 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
         outputs.push(await this.call(optionsIn.input?.(mutation, params), { context: context as any }))
       }
 
-      return optionsIn.output?.(outputs, params)
+      const refetch = typeof optionsIn.refetch === 'function'
+        ? await optionsIn.refetch(outputs, params)
+        : optionsIn.refetch
+
+      return refetch === undefined ? undefined : { refetch }
     }
   }
 }

--- a/packages/tanstack-db/src/procedure-utils.ts
+++ b/packages/tanstack-db/src/procedure-utils.ts
@@ -2,7 +2,7 @@ import type { Client, ClientContext } from '@orpc/client'
 import type { AnySchema } from '@orpc/contract'
 import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { OperationKeyPrefixOptions, TanstackQueryOperationContext } from '@orpc/tanstack-query'
-import type { LoadSubsetOptions, OperationType } from '@tanstack/db'
+import type { OperationType } from '@tanstack/db'
 import type {
   CollectionOptionsIn,
   CollectionOptionsOut,
@@ -47,24 +47,21 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
 
   collectionOptions<UItem extends object = InferCollectionItem<TOutput>, UKey extends string | number = string | number>(
     options: & CollectionOptionsIn<TClientContext, TInput, TOutput, TError, UItem, UKey, never>
-      & { schema?: never, select?: (data: TOutput) => UItem[] }
-      & (TOutput extends UItem[] ? unknown : { select: unknown })
+      & { schema?: never }
+      & (TOutput extends UItem[] ? { select?: (data: TOutput) => UItem[] } : { select: (data: TOutput) => UItem[] })
   ): CollectionOptionsOut<UItem, UKey, never, UItem, TError> & { schema?: never }
 
   collectionOptions(optionsIn: any): any {
-    const { input, context, queryKey: customQueryKey, ...rest } = optionsIn
-
-    const queryKey = customQueryKey
-      ?? ((options: LoadSubsetOptions) => generateOperationKey(this.path, {
-        prefix: this.options.prefix,
-        type: 'query',
-        input: input?.(options),
-      }))
+    const { input, context, queryKey, queryFn, ...rest } = optionsIn
 
     return queryCollectionOptions({
       ...rest,
-      queryKey,
-      queryFn: (fnContext) => {
+      queryKey: queryKey ?? (options => generateOperationKey(this.path, {
+        prefix: this.options.prefix,
+        type: 'query',
+        input: input?.(options),
+      })),
+      queryFn: queryFn ?? ((fnContext) => {
         return this.call(input?.(fnContext.meta!.loadSubsetOptions!), {
           signal: fnContext.signal,
           context: {
@@ -75,7 +72,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
             ...context?.(fnContext),
           } satisfies TanstackQueryOperationContext,
         })
-      },
+      }),
     })
   }
 

--- a/packages/tanstack-db/src/procedure-utils.ts
+++ b/packages/tanstack-db/src/procedure-utils.ts
@@ -100,7 +100,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
         return this.call(optionsIn.input?.(mutation, params) as TInput, { context: context as any })
       }))
 
-      return (optionsIn as any).output?.(outputs, params)
+      return optionsIn.output?.(outputs, params) as any
     }
   }
 }

--- a/packages/tanstack-db/src/procedure-utils.ts
+++ b/packages/tanstack-db/src/procedure-utils.ts
@@ -73,7 +73,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
       ...rest,
       queryKey,
       queryFn: (fnContext) => {
-        return this.call(input?.(fnContext.meta?.loadSubsetOptions ?? {}), {
+        return this.call(input?.(fnContext.meta!.loadSubsetOptions!), {
           signal: fnContext.signal,
           context: {
             [TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL]: {

--- a/packages/tanstack-db/src/procedure-utils.ts
+++ b/packages/tanstack-db/src/procedure-utils.ts
@@ -63,13 +63,17 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
     const { input, context, queryKey: customQueryKey, ...rest } = optionsIn
 
     const queryKey = customQueryKey
-      ?? generateOperationKey(this.path, { prefix: this.options.prefix, type: 'query', input })
+      ?? generateOperationKey(this.path, {
+        prefix: this.options.prefix,
+        type: 'query',
+        input: typeof input === 'function' ? undefined : input,
+      })
 
     return queryCollectionOptions({
       ...rest,
       queryKey,
-      queryFn: (fnContext: any) => {
-        return this.call(input, {
+      queryFn: (fnContext) => {
+        return this.call(typeof input === 'function' ? input(fnContext) : input, {
           signal: fnContext.signal,
           context: {
             [TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL]: {

--- a/packages/tanstack-db/src/procedure-utils.ts
+++ b/packages/tanstack-db/src/procedure-utils.ts
@@ -94,7 +94,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   mutationHandler<UItem extends object = any, UType extends OperationType = OperationType>(
     ...rest: MaybeOptionalOptions<MutationHandlerOptionsIn<TClientContext, TInput, TOutput, UItem, UType>>
   ): MutationHandler<UItem, UType> {
-    const optionsIn = resolveMaybeOptionalOptions(rest) as any
+    const optionsIn = resolveMaybeOptionalOptions(rest)
 
     const mutationKey = generateOperationKey(this.path, { prefix: this.options.prefix, type: 'mutation' })
 
@@ -108,7 +108,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
           ...optionsIn.context?.(mutation, params),
         } satisfies TanstackQueryOperationContext
 
-        return this.call(optionsIn.input?.(mutation, params), { context: context as any })
+        return this.call(optionsIn.input?.(mutation, params) as TInput, { context: context as any })
       }))
 
       const refetch = value(optionsIn.refetch, outputs, params)

--- a/packages/tanstack-db/src/procedure-utils.ts
+++ b/packages/tanstack-db/src/procedure-utils.ts
@@ -109,7 +109,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
         outputs.push(await this.call(optionsIn.input?.(mutation, params), { context: context as any }))
       }
 
-      const refetch = await value(optionsIn.refetch, outputs, params)
+      const refetch = value(optionsIn.refetch, outputs, params)
 
       return refetch === undefined ? undefined : { refetch }
     }

--- a/packages/tanstack-db/src/procedure-utils.ts
+++ b/packages/tanstack-db/src/procedure-utils.ts
@@ -99,9 +99,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
     const mutationKey = generateOperationKey(this.path, { prefix: this.options.prefix, type: 'mutation' })
 
     return async (params) => {
-      const outputs: TOutput[] = []
-
-      for (const mutation of params.transaction.mutations) {
+      const outputs = await Promise.all(params.transaction.mutations.map((mutation) => {
         const context = {
           [TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL]: {
             key: mutationKey,
@@ -110,8 +108,8 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
           ...optionsIn.context?.(mutation, params),
         } satisfies TanstackQueryOperationContext
 
-        outputs.push(await this.call(optionsIn.input?.(mutation, params), { context: context as any }))
-      }
+        return this.call(optionsIn.input?.(mutation, params), { context: context as any })
+      }))
 
       const refetch = value(optionsIn.refetch, outputs, params)
 

--- a/packages/tanstack-db/src/procedure-utils.ts
+++ b/packages/tanstack-db/src/procedure-utils.ts
@@ -39,25 +39,17 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
    */
   collectionOptions<USchema extends AnySchema, UKey extends string | number = string | number>(
     options: & CollectionOptionsIn<TClientContext, TInput, TOutput, TError, InferCollectionSchemaOutput<USchema>, UKey, USchema>
-      & { schema: USchema, select: (data: TOutput) => InferCollectionSchemaInput<USchema>[] }
+      & { schema: USchema }
+      & (TOutput extends InferCollectionSchemaOutput<USchema>[]
+        ? { select?: (data: TOutput) => InferCollectionSchemaInput<USchema>[] }
+        : { select: (data: TOutput) => InferCollectionSchemaInput<USchema>[] })
   ): CollectionOptionsOut<InferCollectionSchemaOutput<USchema>, UKey, USchema, InferCollectionSchemaInput<USchema>, TError> & { schema: USchema }
 
-  collectionOptions<UItem extends object, UKey extends string | number = string | number>(
+  collectionOptions<UItem extends object = InferCollectionItem<TOutput>, UKey extends string | number = string | number>(
     options: & CollectionOptionsIn<TClientContext, TInput, TOutput, TError, UItem, UKey, never>
-      & { schema?: never, select: (data: TOutput) => UItem[] }
+      & { schema?: never, select?: (data: TOutput) => UItem[] }
+      & (TOutput extends UItem[] ? unknown : { select: unknown })
   ): CollectionOptionsOut<UItem, UKey, never, UItem, TError> & { schema?: never }
-
-  collectionOptions<USchema extends AnySchema, UKey extends string | number = string | number>(
-    options: & CollectionOptionsIn<TClientContext, TInput, TOutput, TError, InferCollectionSchemaOutput<USchema>, UKey, USchema>
-      & { schema: USchema, select?: never }
-      & (TOutput extends InferCollectionSchemaOutput<USchema>[] ? unknown : { select: (data: TOutput) => InferCollectionSchemaInput<USchema>[] })
-  ): CollectionOptionsOut<InferCollectionSchemaOutput<USchema>, UKey, USchema, InferCollectionSchemaInput<USchema>, TError> & { schema: USchema }
-
-  collectionOptions<UKey extends string | number = string | number>(
-    options: & CollectionOptionsIn<TClientContext, TInput, TOutput, TError, InferCollectionItem<TOutput>, UKey, never>
-      & { schema?: never, select?: never }
-      & (TOutput extends object[] ? unknown : { select: (data: TOutput) => object[] })
-  ): CollectionOptionsOut<InferCollectionItem<TOutput>, UKey, never, InferCollectionItem<TOutput>, TError> & { schema?: never }
 
   collectionOptions(optionsIn: any): any {
     const { input, context, queryKey: customQueryKey, ...rest } = optionsIn

--- a/packages/tanstack-db/src/procedure-utils.ts
+++ b/packages/tanstack-db/src/procedure-utils.ts
@@ -63,24 +63,20 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
     const { input, context, queryKey: customQueryKey, ...rest } = optionsIn
 
     const queryKey = customQueryKey
-      ?? generateOperationKey(this.path, {
-        prefix: this.options.prefix,
-        type: 'query',
-        input: typeof input === 'function' ? undefined : input,
-      })
+      ?? generateOperationKey(this.path, { prefix: this.options.prefix, type: 'query' })
 
     return queryCollectionOptions({
       ...rest,
       queryKey,
       queryFn: (fnContext) => {
-        return this.call(typeof input === 'function' ? input(fnContext) : input, {
+        return this.call(input?.(fnContext), {
           signal: fnContext.signal,
           context: {
             [TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL]: {
               key: fnContext.queryKey,
               type: 'query',
             },
-            ...context,
+            ...context?.(fnContext),
           } satisfies TanstackQueryOperationContext,
         })
       },
@@ -99,17 +95,17 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
     const mutationKey = generateOperationKey(this.path, { prefix: this.options.prefix, type: 'mutation' })
 
     return async (params) => {
-      const context = {
-        [TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL]: {
-          key: mutationKey,
-          type: 'mutation',
-        },
-        ...optionsIn.context,
-      } satisfies TanstackQueryOperationContext
-
       const outputs: TOutput[] = []
 
       for (const mutation of params.transaction.mutations) {
+        const context = {
+          [TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL]: {
+            key: mutationKey,
+            type: 'mutation',
+          },
+          ...optionsIn.context?.(mutation, params),
+        } satisfies TanstackQueryOperationContext
+
         outputs.push(await this.call(optionsIn.input?.(mutation, params), { context: context as any }))
       }
 

--- a/packages/tanstack-db/src/procedure-utils.ts
+++ b/packages/tanstack-db/src/procedure-utils.ts
@@ -12,7 +12,7 @@ import type {
   MutationHandler,
   MutationHandlerOptionsIn,
 } from './types'
-import { resolveMaybeOptionalOptions } from '@orpc/shared'
+import { resolveMaybeOptionalOptions, value } from '@orpc/shared'
 import { generateOperationKey, TANSTACK_QUERY_OPERATION_CONTEXT_SYMBOL } from '@orpc/tanstack-query'
 import { queryCollectionOptions } from '@tanstack/query-db-collection'
 
@@ -109,9 +109,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
         outputs.push(await this.call(optionsIn.input?.(mutation, params), { context: context as any }))
       }
 
-      const refetch = typeof optionsIn.refetch === 'function'
-        ? await optionsIn.refetch(outputs, params)
-        : optionsIn.refetch
+      const refetch = await value(optionsIn.refetch, outputs, params)
 
       return refetch === undefined ? undefined : { refetch }
     }

--- a/packages/tanstack-db/src/router-utils.test.ts
+++ b/packages/tanstack-db/src/router-utils.test.ts
@@ -1,0 +1,78 @@
+import { generateOperationKey } from '@orpc/tanstack-query'
+import { ProcedureUtils } from './procedure-utils'
+import { createRouterUtils } from './router-utils'
+
+vi.mock('./procedure-utils', async () => ({
+  ProcedureUtils: vi.fn(class {
+    call = vi.fn()
+    collectionOptions = vi.fn(() => ({ collectionOptions: true }))
+    mutationHandler = vi.fn(() => ({ mutationHandler: true }))
+  }),
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('createRouterUtils', () => {
+  const client = vi.fn() as any
+  client.key = vi.fn() // "key" mean client can handle when client and method is conflict
+  client.key.pong = vi.fn()
+
+  it('create nested procedure & shared utils', () => {
+    const utils = createRouterUtils(client, { prefix: '__prefix__' }) as any
+
+    expect(ProcedureUtils).toHaveBeenCalledTimes(1)
+    expect(ProcedureUtils).toHaveBeenCalledWith([], client, { prefix: '__prefix__' })
+    expect(utils.key({ type: 'query' })).toEqual(generateOperationKey([], { type: 'query', prefix: '__prefix__' }))
+    expect(utils.collectionOptions()).toBe(vi.mocked(ProcedureUtils).mock.results[0]?.value.collectionOptions.mock.results[0]?.value)
+
+    vi.clearAllMocks()
+    const keyUtils = utils.key
+
+    expect(ProcedureUtils).toHaveBeenCalledTimes(1)
+    expect(ProcedureUtils).toHaveBeenCalledWith(['key'], client.key, { prefix: '__prefix__' })
+    expect(keyUtils.key({ type: 'query' })).toEqual(generateOperationKey(['key'], { type: 'query', prefix: '__prefix__' }))
+    expect(keyUtils.collectionOptions()).toBe(vi.mocked(ProcedureUtils).mock.results[0]?.value.collectionOptions.mock.results[0]?.value)
+
+    vi.clearAllMocks()
+    const pongUtils = keyUtils.pong
+
+    expect(ProcedureUtils).toHaveBeenCalledTimes(1)
+    expect(ProcedureUtils).toHaveBeenCalledWith(['key', 'pong'], client.key.pong, { prefix: '__prefix__' })
+    expect(pongUtils.key({ type: 'mutation' })).toEqual(generateOperationKey(['key', 'pong'], { type: 'mutation', prefix: '__prefix__' }))
+    expect(pongUtils.mutationHandler()).toBe(vi.mocked(ProcedureUtils).mock.results[0]?.value.mutationHandler.mock.results[0]?.value)
+  })
+
+  it('roots utils at the given base path', () => {
+    const utils = createRouterUtils(client, { path: ['__base__'] }) as any
+
+    expect(ProcedureUtils).toHaveBeenCalledTimes(1)
+    expect(ProcedureUtils).toHaveBeenCalledWith(['__base__'], client, { prefix: undefined })
+    expect(utils.key({ type: 'query' })).toEqual(generateOperationKey(['__base__'], { type: 'query' }))
+
+    vi.clearAllMocks()
+    const keyUtils = utils.key
+
+    expect(ProcedureUtils).toHaveBeenCalledTimes(1)
+    expect(ProcedureUtils).toHaveBeenCalledWith(['__base__', 'key'], client.key, { prefix: undefined })
+    expect(keyUtils.key({ type: 'query' })).toEqual(generateOperationKey(['__base__', 'key'], { type: 'query' }))
+  })
+
+  it('stops recursive on symbol', async () => {
+    const utils = createRouterUtils(client) as any
+    expect(utils[Symbol.for('a')]).toBe(undefined)
+  })
+
+  it('does not create utils for undefined or unwrap client path', () => {
+    const client = {
+      route: vi.fn(),
+    } as any
+
+    const utils = createRouterUtils(client) as any
+    expect(utils.undefined).toBe(undefined)
+    const call = utils.route.call
+    expect(call.bind).toBe(call.bind)
+    expect(call[Symbol('undefined')]).toBeUndefined()
+  })
+})

--- a/packages/tanstack-db/src/router-utils.ts
+++ b/packages/tanstack-db/src/router-utils.ts
@@ -1,0 +1,72 @@
+import type { AnyNestedClient, Client } from '@orpc/client'
+import type { Public } from '@orpc/shared'
+import type { OperationKeyPrefixOptions, SharedRouterUtils } from '@orpc/tanstack-query'
+import { RECURSIVE_CLIENT_UNWRAP_KEYS } from '@orpc/client'
+import { bindMethods, get, getOrBind, isTypescriptObject, toArray } from '@orpc/shared'
+import { SharedRouterUtils as SharedRouterUtilsImpl } from '@orpc/tanstack-query'
+import { ProcedureUtils } from './procedure-utils'
+
+export type RouterUtils<T extends AnyNestedClient>
+  = T extends Client<infer UClientContext, infer UInput, infer UOutput, infer UError>
+    ? Public<ProcedureUtils<UClientContext, UInput, UOutput, UError>> & Public<SharedRouterUtils<UInput>>
+    : {
+      [K in keyof T]: T[K] extends AnyNestedClient ? RouterUtils<T[K]> : never
+    } & Public<SharedRouterUtils<unknown>>
+
+export interface RouterUtilsOptions extends OperationKeyPrefixOptions {
+  /**
+   * Base path for all keys.
+   *
+   * @internal
+   */
+  path?: string[] | undefined
+}
+
+/**
+ * Create a router utils from a client.
+ *
+ * @info Both client-side and server-side clients are supported.
+ */
+export function createRouterUtils<T extends AnyNestedClient>(
+  client: T,
+  options: RouterUtilsOptions = {},
+): RouterUtils<T> {
+  const path = toArray(options.path)
+  const sharedUtils = bindMethods(new SharedRouterUtilsImpl(path, options))
+
+  const procedureUtils = typeof client === 'function'
+    ? bindMethods(new ProcedureUtils(path, client, { prefix: options.prefix }))
+    : undefined
+
+  const recursive = new Proxy({
+    ...sharedUtils,
+    ...procedureUtils,
+  }, {
+    get(target, prop) {
+      const value = getOrBind(target, prop)
+      const nextClient = get(client, [prop])
+
+      if (typeof prop !== 'string' || RECURSIVE_CLIENT_UNWRAP_KEYS.has(prop) || !isTypescriptObject(nextClient)) {
+        return value
+      }
+
+      const nextUtils = createRouterUtils(nextClient as any, { ...options, path: [...path, prop] })
+
+      if (typeof value !== 'function') {
+        return nextUtils
+      }
+
+      return new Proxy(value, {
+        get(target, prop) {
+          if (typeof prop !== 'string' || RECURSIVE_CLIENT_UNWRAP_KEYS.has(prop)) {
+            return getOrBind(target, prop)
+          }
+
+          return getOrBind(nextUtils, prop)
+        },
+      })
+    },
+  })
+
+  return recursive as any
+}

--- a/packages/tanstack-db/src/types.ts
+++ b/packages/tanstack-db/src/types.ts
@@ -18,17 +18,15 @@ export type InferCollectionItem<TOutput> = TOutput extends Array<infer U extends
 
 export type CollectionQueryFn<TOutput> = (context: QueryFunctionContext) => Promise<TOutput>
 
-/**
- * Can be a static input, or a function that resolves the input
- * from the query function context on each fetch.
- */
-export type CollectionInput<TInput> = TInput | ((context: QueryFunctionContext) => TInput)
-
 export type CollectionOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TItem extends object, TKey extends string | number, TSchema extends AnySchema>
-  = & (undefined extends TInput ? { input?: CollectionInput<TInput> } : { input: CollectionInput<TInput> })
-    & (object extends TClientContext ? { context?: TClientContext } : { context: TClientContext })
-    & { queryKey?: QueryKey | ((options: LoadSubsetOptions) => QueryKey) }
-    & Omit<QueryCollectionConfig<TItem, CollectionQueryFn<TOutput>, TError, QueryKey, TKey, TSchema, TOutput>, 'queryKey' | 'queryFn' | 'select' | 'schema'>
+  = & (undefined extends TInput
+    ? { input?: (context: QueryFunctionContext) => TInput }
+    : { input: (context: QueryFunctionContext) => TInput })
+  & (object extends TClientContext
+    ? { context?: (context: QueryFunctionContext) => TClientContext }
+    : { context: (context: QueryFunctionContext) => TClientContext })
+  & { queryKey?: QueryKey | ((options: LoadSubsetOptions) => QueryKey) }
+  & Omit<QueryCollectionConfig<TItem, CollectionQueryFn<TOutput>, TError, QueryKey, TKey, TSchema, TOutput>, 'queryKey' | 'queryFn' | 'select' | 'schema'>
 
 export type CollectionOptionsOut<TItem extends object, TKey extends string | number, TSchema extends AnySchema, TInsertInput extends object, TError>
   = & CollectionConfig<TItem, TKey, TSchema, QueryCollectionUtils<TItem, TKey, TInsertInput, TError>>
@@ -40,11 +38,13 @@ export interface MutationHandlerParams<TItem extends object = any, TType extends
 }
 
 export type MutationHandlerOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TItem extends object, TType extends OperationType, TReturn>
-  = & (object extends TClientContext ? { context?: TClientContext } : { context: TClientContext })
-    & (undefined extends TInput
-      ? { input?: (mutation: PendingMutation<TItem, TType>, params: MutationHandlerParams<TItem, TType>) => TInput }
-      : { input: (mutation: PendingMutation<TItem, TType>, params: MutationHandlerParams<TItem, TType>) => TInput })
-    & { output?: (outputs: TOutput[], params: MutationHandlerParams<TItem, TType>) => TReturn }
+  = & (undefined extends TInput
+    ? { input?: (mutation: PendingMutation<TItem, TType>, params: MutationHandlerParams<TItem, TType>) => TInput }
+    : { input: (mutation: PendingMutation<TItem, TType>, params: MutationHandlerParams<TItem, TType>) => TInput })
+  & (object extends TClientContext
+    ? { context?: (mutation: PendingMutation<TItem, TType>, params: MutationHandlerParams<TItem, TType>) => TClientContext }
+    : { context: (mutation: PendingMutation<TItem, TType>, params: MutationHandlerParams<TItem, TType>) => TClientContext })
+  & { output?: (outputs: TOutput[], params: MutationHandlerParams<TItem, TType>) => TReturn }
 
 export type MutationHandler<TItem extends object, TType extends OperationType, TReturn>
   = (params: MutationHandlerParams<TItem, TType>) => Promise<TReturn>

--- a/packages/tanstack-db/src/types.ts
+++ b/packages/tanstack-db/src/types.ts
@@ -1,0 +1,44 @@
+import type { ClientContext } from '@orpc/client'
+import type { AnySchema, InferSchemaInput, InferSchemaOutput } from '@orpc/contract'
+import type { Collection, CollectionConfig, LoadSubsetOptions, OperationType, PendingMutation, TransactionWithMutations } from '@tanstack/db'
+import type { QueryFunctionContext, QueryKey } from '@tanstack/query-core'
+import type { QueryCollectionConfig, QueryCollectionUtils } from '@tanstack/query-db-collection'
+
+export type InferCollectionSchemaOutput<T extends AnySchema>
+  = InferSchemaOutput<T> extends object
+    ? InferSchemaOutput<T>
+    : Record<string, unknown>
+
+export type InferCollectionSchemaInput<T extends AnySchema>
+  = InferSchemaInput<T> extends object
+    ? InferSchemaInput<T>
+    : Record<string, unknown>
+
+export type InferCollectionItem<TOutput> = TOutput extends Array<infer U extends object> ? U : never
+
+export type CollectionQueryFn<TOutput> = (context: QueryFunctionContext) => Promise<TOutput>
+
+export type CollectionOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TItem extends object, TKey extends string | number, TSchema extends AnySchema>
+  = & (undefined extends TInput ? { input?: TInput } : { input: TInput })
+    & (object extends TClientContext ? { context?: TClientContext } : { context: TClientContext })
+    & { queryKey?: QueryKey | ((options: LoadSubsetOptions) => QueryKey) }
+    & Omit<QueryCollectionConfig<TItem, CollectionQueryFn<TOutput>, TError, QueryKey, TKey, TSchema, TOutput>, 'queryKey' | 'queryFn' | 'select' | 'schema'>
+
+export type CollectionOptionsOut<TItem extends object, TKey extends string | number, TSchema extends AnySchema, TInsertInput extends object, TError>
+  = & CollectionConfig<TItem, TKey, TSchema, QueryCollectionUtils<TItem, TKey, TInsertInput, TError>>
+    & { utils: QueryCollectionUtils<TItem, TKey, TInsertInput, TError> }
+
+export interface MutationHandlerParams<TItem extends object = any, TType extends OperationType = OperationType> {
+  transaction: TransactionWithMutations<TItem, TType>
+  collection: Collection<TItem, any, any>
+}
+
+export type MutationHandlerOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TItem extends object, TType extends OperationType, TReturn>
+  = & (object extends TClientContext ? { context?: TClientContext } : { context: TClientContext })
+    & (undefined extends TInput
+      ? { input?: (mutation: PendingMutation<TItem, TType>, params: MutationHandlerParams<TItem, TType>) => TInput }
+      : { input: (mutation: PendingMutation<TItem, TType>, params: MutationHandlerParams<TItem, TType>) => TInput })
+    & { output?: (outputs: TOutput[], params: MutationHandlerParams<TItem, TType>) => TReturn }
+
+export type MutationHandler<TItem extends object, TType extends OperationType, TReturn>
+  = (params: MutationHandlerParams<TItem, TType>) => Promise<TReturn>

--- a/packages/tanstack-db/src/types.ts
+++ b/packages/tanstack-db/src/types.ts
@@ -44,7 +44,9 @@ export type MutationHandlerOptionsIn<TClientContext extends ClientContext, TInpu
   & (object extends TClientContext
     ? { context?: (mutation: PendingMutation<TItem, TType>, params: MutationHandlerParams<TItem, TType>) => TClientContext }
     : { context: (mutation: PendingMutation<TItem, TType>, params: MutationHandlerParams<TItem, TType>) => TClientContext })
-  & { output?: (outputs: TOutput[], params: MutationHandlerParams<TItem, TType>) => TReturn }
+  & (undefined extends TReturn
+    ? { output?: (outputs: TOutput[], params: MutationHandlerParams<TItem, TType>) => TReturn }
+    : { output: (outputs: TOutput[], params: MutationHandlerParams<TItem, TType>) => TReturn })
 
 export type MutationHandler<TItem extends object, TType extends OperationType, TReturn>
   = (params: MutationHandlerParams<TItem, TType>) => Promise<TReturn>

--- a/packages/tanstack-db/src/types.ts
+++ b/packages/tanstack-db/src/types.ts
@@ -1,6 +1,6 @@
 import type { ClientContext } from '@orpc/client'
 import type { AnySchema, InferSchemaInput, InferSchemaOutput } from '@orpc/contract'
-import type { SetOptional, Value } from '@orpc/shared'
+import type { SetOptional } from '@orpc/shared'
 import type { Collection, CollectionConfig, LoadSubsetOptions, OperationType, PendingMutation, TransactionWithMutations } from '@tanstack/db'
 import type { QueryFunctionContext, QueryKey } from '@tanstack/query-core'
 import type { QueryCollectionConfig, QueryCollectionUtils } from '@tanstack/query-db-collection'
@@ -37,21 +37,16 @@ export interface MutationHandlerParams<TItem extends object = any, TType extends
   collection: Collection<TItem, any, any>
 }
 
-export type MutationHandlerOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TItem extends object, TType extends OperationType>
+export type MutationHandlerOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TItem extends object, TType extends OperationType, TReturn>
   = & (undefined extends TInput
     ? { input?: (mutation: PendingMutation<TItem, TType>, params: MutationHandlerParams<TItem, TType>) => TInput }
     : { input: (mutation: PendingMutation<TItem, TType>, params: MutationHandlerParams<TItem, TType>) => TInput })
   & (object extends TClientContext
     ? { context?: (mutation: PendingMutation<TItem, TType>, params: MutationHandlerParams<TItem, TType>) => TClientContext }
     : { context: (mutation: PendingMutation<TItem, TType>, params: MutationHandlerParams<TItem, TType>) => TClientContext })
-  & {
-    /**
-     * Whether the collection should refetch after the handler completes.
-     * Can be a static boolean, or a function that decides from the procedure outputs.
-     * When omitted, the collection default applies (query collections refetch).
-     */
-    refetch?: Value<boolean, [outputs: TOutput[], params: MutationHandlerParams<TItem, TType>]>
-  }
+  & (undefined extends TReturn
+    ? { output?: (outputs: TOutput[], params: MutationHandlerParams<TItem, TType>) => TReturn }
+    : { output: (outputs: TOutput[], params: MutationHandlerParams<TItem, TType>) => TReturn })
 
-export type MutationHandler<TItem extends object, TType extends OperationType>
-  = (params: MutationHandlerParams<TItem, TType>) => Promise<{ refetch: boolean } | undefined>
+export type MutationHandler<TItem extends object, TType extends OperationType, TReturn>
+  = (params: MutationHandlerParams<TItem, TType>) => Promise<TReturn>

--- a/packages/tanstack-db/src/types.ts
+++ b/packages/tanstack-db/src/types.ts
@@ -1,6 +1,6 @@
 import type { ClientContext } from '@orpc/client'
 import type { AnySchema, InferSchemaInput, InferSchemaOutput } from '@orpc/contract'
-import type { Promisable } from '@orpc/shared'
+import type { Promisable, Value } from '@orpc/shared'
 import type { Collection, CollectionConfig, LoadSubsetOptions, OperationType, PendingMutation, TransactionWithMutations } from '@tanstack/db'
 import type { QueryFunctionContext, QueryKey } from '@tanstack/query-core'
 import type { QueryCollectionConfig, QueryCollectionUtils } from '@tanstack/query-db-collection'
@@ -26,7 +26,7 @@ export type CollectionOptionsIn<TClientContext extends ClientContext, TInput, TO
   & (object extends TClientContext
     ? { context?: (context: QueryFunctionContext) => TClientContext }
     : { context: (context: QueryFunctionContext) => TClientContext })
-  & { queryKey?: QueryKey | ((options: LoadSubsetOptions) => QueryKey) }
+  & { queryKey?: Value<QueryKey, [options: LoadSubsetOptions]> }
   & Omit<QueryCollectionConfig<TItem, CollectionQueryFn<TOutput>, TError, QueryKey, TKey, TSchema, TOutput>, 'queryKey' | 'queryFn' | 'select' | 'schema'>
 
 export type CollectionOptionsOut<TItem extends object, TKey extends string | number, TSchema extends AnySchema, TInsertInput extends object, TError>
@@ -51,7 +51,7 @@ export type MutationHandlerOptionsIn<TClientContext extends ClientContext, TInpu
      * Can be a static boolean, or a function that decides from the procedure outputs.
      * When omitted, the collection default applies (query collections refetch).
      */
-    refetch?: boolean | ((outputs: TOutput[], params: MutationHandlerParams<TItem, TType>) => Promisable<boolean>)
+    refetch?: Value<Promisable<boolean>, [outputs: TOutput[], params: MutationHandlerParams<TItem, TType>]>
   }
 
 export type MutationHandler<TItem extends object, TType extends OperationType>

--- a/packages/tanstack-db/src/types.ts
+++ b/packages/tanstack-db/src/types.ts
@@ -1,5 +1,6 @@
 import type { ClientContext } from '@orpc/client'
 import type { AnySchema, InferSchemaInput, InferSchemaOutput } from '@orpc/contract'
+import type { Promisable } from '@orpc/shared'
 import type { Collection, CollectionConfig, LoadSubsetOptions, OperationType, PendingMutation, TransactionWithMutations } from '@tanstack/db'
 import type { QueryFunctionContext, QueryKey } from '@tanstack/query-core'
 import type { QueryCollectionConfig, QueryCollectionUtils } from '@tanstack/query-db-collection'
@@ -37,16 +38,21 @@ export interface MutationHandlerParams<TItem extends object = any, TType extends
   collection: Collection<TItem, any, any>
 }
 
-export type MutationHandlerOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TItem extends object, TType extends OperationType, TReturn>
+export type MutationHandlerOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TItem extends object, TType extends OperationType>
   = & (undefined extends TInput
     ? { input?: (mutation: PendingMutation<TItem, TType>, params: MutationHandlerParams<TItem, TType>) => TInput }
     : { input: (mutation: PendingMutation<TItem, TType>, params: MutationHandlerParams<TItem, TType>) => TInput })
   & (object extends TClientContext
     ? { context?: (mutation: PendingMutation<TItem, TType>, params: MutationHandlerParams<TItem, TType>) => TClientContext }
     : { context: (mutation: PendingMutation<TItem, TType>, params: MutationHandlerParams<TItem, TType>) => TClientContext })
-  & (undefined extends TReturn
-    ? { output?: (outputs: TOutput[], params: MutationHandlerParams<TItem, TType>) => TReturn }
-    : { output: (outputs: TOutput[], params: MutationHandlerParams<TItem, TType>) => TReturn })
+  & {
+    /**
+     * Whether the collection should refetch after the handler completes.
+     * Can be a static boolean, or a function that decides from the procedure outputs.
+     * When omitted, the collection default applies (query collections refetch).
+     */
+    refetch?: boolean | ((outputs: TOutput[], params: MutationHandlerParams<TItem, TType>) => Promisable<boolean>)
+  }
 
-export type MutationHandler<TItem extends object, TType extends OperationType, TReturn>
-  = (params: MutationHandlerParams<TItem, TType>) => Promise<TReturn>
+export type MutationHandler<TItem extends object, TType extends OperationType>
+  = (params: MutationHandlerParams<TItem, TType>) => Promise<{ refetch: boolean } | undefined>

--- a/packages/tanstack-db/src/types.ts
+++ b/packages/tanstack-db/src/types.ts
@@ -21,8 +21,8 @@ export type CollectionQueryFn<TOutput> = (context: QueryFunctionContext) => Prom
 
 export type CollectionOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TItem extends object, TKey extends string | number, TSchema extends AnySchema>
   = & (undefined extends TInput
-    ? { input?: (context: QueryFunctionContext) => TInput }
-    : { input: (context: QueryFunctionContext) => TInput })
+    ? { input?: (options: LoadSubsetOptions) => TInput }
+    : { input: (options: LoadSubsetOptions) => TInput })
   & (object extends TClientContext
     ? { context?: (context: QueryFunctionContext) => TClientContext }
     : { context: (context: QueryFunctionContext) => TClientContext })

--- a/packages/tanstack-db/src/types.ts
+++ b/packages/tanstack-db/src/types.ts
@@ -1,6 +1,6 @@
 import type { ClientContext } from '@orpc/client'
 import type { AnySchema, InferSchemaInput, InferSchemaOutput } from '@orpc/contract'
-import type { Promisable, Value } from '@orpc/shared'
+import type { Value } from '@orpc/shared'
 import type { Collection, CollectionConfig, LoadSubsetOptions, OperationType, PendingMutation, TransactionWithMutations } from '@tanstack/db'
 import type { QueryFunctionContext, QueryKey } from '@tanstack/query-core'
 import type { QueryCollectionConfig, QueryCollectionUtils } from '@tanstack/query-db-collection'
@@ -51,7 +51,7 @@ export type MutationHandlerOptionsIn<TClientContext extends ClientContext, TInpu
      * Can be a static boolean, or a function that decides from the procedure outputs.
      * When omitted, the collection default applies (query collections refetch).
      */
-    refetch?: Value<Promisable<boolean>, [outputs: TOutput[], params: MutationHandlerParams<TItem, TType>]>
+    refetch?: Value<boolean, [outputs: TOutput[], params: MutationHandlerParams<TItem, TType>]>
   }
 
 export type MutationHandler<TItem extends object, TType extends OperationType>

--- a/packages/tanstack-db/src/types.ts
+++ b/packages/tanstack-db/src/types.ts
@@ -1,6 +1,6 @@
 import type { ClientContext } from '@orpc/client'
 import type { AnySchema, InferSchemaInput, InferSchemaOutput } from '@orpc/contract'
-import type { Value } from '@orpc/shared'
+import type { SetOptional, Value } from '@orpc/shared'
 import type { Collection, CollectionConfig, LoadSubsetOptions, OperationType, PendingMutation, TransactionWithMutations } from '@tanstack/db'
 import type { QueryFunctionContext, QueryKey } from '@tanstack/query-core'
 import type { QueryCollectionConfig, QueryCollectionUtils } from '@tanstack/query-db-collection'
@@ -26,8 +26,7 @@ export type CollectionOptionsIn<TClientContext extends ClientContext, TInput, TO
   & (object extends TClientContext
     ? { context?: (context: QueryFunctionContext) => TClientContext }
     : { context: (context: QueryFunctionContext) => TClientContext })
-  & { queryKey?: Value<QueryKey, [options: LoadSubsetOptions]> }
-  & Omit<QueryCollectionConfig<TItem, CollectionQueryFn<TOutput>, TError, QueryKey, TKey, TSchema, TOutput>, 'queryKey' | 'queryFn' | 'select' | 'schema'>
+  & SetOptional<Omit<QueryCollectionConfig<TItem, CollectionQueryFn<TOutput>, TError, QueryKey, TKey, TSchema, TOutput>, 'queryFn' | 'select' | 'schema'>, 'queryKey'>
 
 export type CollectionOptionsOut<TItem extends object, TKey extends string | number, TSchema extends AnySchema, TInsertInput extends object, TError>
   = & CollectionConfig<TItem, TKey, TSchema, QueryCollectionUtils<TItem, TKey, TInsertInput, TError>>

--- a/packages/tanstack-db/src/types.ts
+++ b/packages/tanstack-db/src/types.ts
@@ -18,8 +18,14 @@ export type InferCollectionItem<TOutput> = TOutput extends Array<infer U extends
 
 export type CollectionQueryFn<TOutput> = (context: QueryFunctionContext) => Promise<TOutput>
 
+/**
+ * Can be a static input, or a function that resolves the input
+ * from the query function context on each fetch.
+ */
+export type CollectionInput<TInput> = TInput | ((context: QueryFunctionContext) => TInput)
+
 export type CollectionOptionsIn<TClientContext extends ClientContext, TInput, TOutput, TError, TItem extends object, TKey extends string | number, TSchema extends AnySchema>
-  = & (undefined extends TInput ? { input?: TInput } : { input: TInput })
+  = & (undefined extends TInput ? { input?: CollectionInput<TInput> } : { input: CollectionInput<TInput> })
     & (object extends TClientContext ? { context?: TClientContext } : { context: TClientContext })
     & { queryKey?: QueryKey | ((options: LoadSubsetOptions) => QueryKey) }
     & Omit<QueryCollectionConfig<TItem, CollectionQueryFn<TOutput>, TError, QueryKey, TKey, TSchema, TOutput>, 'queryKey' | 'queryFn' | 'select' | 'schema'>

--- a/packages/tanstack-db/tests/__shared__/orpc.ts
+++ b/packages/tanstack-db/tests/__shared__/orpc.ts
@@ -1,0 +1,75 @@
+import type { RouterClient } from '@orpc/server'
+import { createORPCClient } from '@orpc/client'
+import { RPCLink } from '@orpc/client/fetch'
+import { os } from '@orpc/server'
+import { RPCHandler } from '@orpc/server/fetch'
+import { QueryClient } from '@tanstack/query-core'
+import z from 'zod'
+import { createTanstackDBUtils } from '../../src'
+
+export const todoSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+})
+
+export interface Todo {
+  id: number
+  name: string
+}
+
+export const todos: Todo[] = []
+
+export function resetTodos(): void {
+  todos.splice(0, todos.length, { id: 1, name: 'first' })
+}
+
+export const router = {
+  todo: {
+    list: os
+      .errors({ LIST_ERROR: { data: z.object({ list: z.string() }) } })
+      .input(z.object({ search: z.string() }).optional())
+      .output(z.array(todoSchema))
+      .handler(vi.fn(({ input }) => todos.filter(todo => todo.name.includes(input?.search ?? '')))),
+    create: os
+      .input(todoSchema)
+      .output(todoSchema)
+      .handler(vi.fn(({ input }) => {
+        todos.push(input)
+        return input
+      })),
+    update: os
+      .input(z.object({ id: z.number(), data: todoSchema.partial() }))
+      .output(todoSchema)
+      .handler(vi.fn(({ input }) => {
+        const todo = todos.find(todo => todo.id === input.id)!
+        Object.assign(todo, input.data)
+        return todo
+      })),
+    delete: os
+      .input(z.object({ id: z.number() }))
+      .handler(vi.fn(({ input }) => {
+        todos.splice(todos.findIndex(todo => todo.id === input.id), 1)
+      })),
+  },
+}
+
+const handler = new RPCHandler(router)
+
+// prefer createORPCClient over createRouterClient for more close realistic
+export const client: RouterClient<typeof router, { cache?: boolean }> = createORPCClient(new RPCLink({
+  origin: 'http://localhost',
+  fetch: async (url, init) => {
+    const { response } = await handler.handle(new Request(url, init))
+    return response ?? new Response('Not Found', { status: 404 })
+  },
+}))
+
+export const orpc = createTanstackDBUtils(client)
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+})

--- a/packages/tanstack-db/tests/e2e.test-d.ts
+++ b/packages/tanstack-db/tests/e2e.test-d.ts
@@ -1,0 +1,39 @@
+import { createCollection } from '@tanstack/db'
+import { client, orpc, queryClient } from './__shared__/orpc'
+
+it('.key', () => {
+  orpc.key()
+  orpc.todo.key({ type: 'query' })
+  orpc.todo.list.key({ input: { search: '__search__' } })
+  // @ts-expect-error --- input is invalid
+  orpc.todo.list.key({ input: { search: 123 } })
+})
+
+it('.call', () => {
+  expectTypeOf(orpc.todo.list.call).toEqualTypeOf(client.todo.list)
+})
+
+it('.collectionOptions with createCollection', () => {
+  const collection = createCollection(orpc.todo.list.collectionOptions({
+    input: { search: '__search__' },
+    queryClient,
+    getKey: todo => todo.id,
+    onInsert: orpc.todo.create.mutationHandler({
+      input: mutation => mutation.modified,
+    }),
+    onUpdate: orpc.todo.update.mutationHandler({
+      input: mutation => ({ id: mutation.key, data: mutation.changes }),
+    }),
+    onDelete: orpc.todo.delete.mutationHandler({
+      input: mutation => ({ id: mutation.key }),
+    }),
+  }))
+
+  const todo = collection.get(1)
+  expectTypeOf(todo?.id).toEqualTypeOf<number | undefined>()
+  expectTypeOf(todo?.name).toEqualTypeOf<string | undefined>()
+
+  collection.insert({ id: 1, name: '__name__' })
+  // @ts-expect-error --- invalid item
+  collection.insert({ id: '__invalid__' })
+})

--- a/packages/tanstack-db/tests/e2e.test-d.ts
+++ b/packages/tanstack-db/tests/e2e.test-d.ts
@@ -15,7 +15,7 @@ it('.call', () => {
 
 it('.collectionOptions with createCollection', () => {
   const collection = createCollection(orpc.todo.list.collectionOptions({
-    input: { search: '__search__' },
+    input: () => ({ search: '__search__' }),
     queryClient,
     getKey: todo => todo.id,
     onInsert: orpc.todo.create.mutationHandler({

--- a/packages/tanstack-db/tests/e2e.test.ts
+++ b/packages/tanstack-db/tests/e2e.test.ts
@@ -1,0 +1,79 @@
+import { createTanstackQueryUtils } from '@orpc/tanstack-query'
+import { createCollection } from '@tanstack/db'
+import { client, orpc, queryClient, resetTodos, router, todos } from './__shared__/orpc'
+
+beforeEach(() => {
+  resetTodos()
+  queryClient.clear()
+  vi.clearAllMocks()
+})
+
+it('syncs a collection through oRPC procedures', async () => {
+  const collection = createCollection(orpc.todo.list.collectionOptions({
+    input: { search: '' },
+    queryClient,
+    getKey: todo => todo.id,
+    startSync: true,
+    onInsert: orpc.todo.create.mutationHandler({
+      input: mutation => mutation.modified,
+    }),
+    onUpdate: orpc.todo.update.mutationHandler({
+      input: mutation => ({ id: mutation.key, data: mutation.changes }),
+    }),
+    onDelete: orpc.todo.delete.mutationHandler({
+      input: mutation => ({ id: mutation.key }),
+    }),
+  }))
+
+  await collection.preload()
+  expect(collection.toArray).toMatchObject([{ id: 1, name: 'first' }])
+
+  const insertTx = collection.insert({ id: 2, name: 'second' })
+  await insertTx.isPersisted.promise
+  expect(router.todo.create['~orpc'].handler).toHaveBeenCalledTimes(1)
+  expect(todos).toEqual([{ id: 1, name: 'first' }, { id: 2, name: 'second' }])
+  expect(collection.toArray).toMatchObject([{ id: 1, name: 'first' }, { id: 2, name: 'second' }])
+
+  const updateTx = collection.update(2, (draft) => {
+    draft.name = 'updated'
+  })
+  await updateTx.isPersisted.promise
+  expect(router.todo.update['~orpc'].handler).toHaveBeenCalledTimes(1)
+  expect(collection.toArray).toMatchObject([{ id: 1, name: 'first' }, { id: 2, name: 'updated' }])
+
+  const deleteTx = collection.delete(1)
+  await deleteTx.isPersisted.promise
+  expect(router.todo.delete['~orpc'].handler).toHaveBeenCalledTimes(1)
+  expect(collection.toArray).toMatchObject([{ id: 2, name: 'updated' }])
+})
+
+it('shares query keys with @orpc/tanstack-query utils', async () => {
+  const tanstackQueryUtils = createTanstackQueryUtils(client)
+
+  const collection = createCollection(orpc.todo.list.collectionOptions({
+    input: { search: '' },
+    queryClient,
+    getKey: todo => todo.id,
+    startSync: true,
+  }))
+
+  await collection.preload()
+
+  expect(queryClient.getQueryData(tanstackQueryUtils.todo.list.queryKey({ input: { search: '' } }))).toEqual([{ id: 1, name: 'first' }])
+  expect(orpc.todo.list.key({ type: 'query' })).toEqual(tanstackQueryUtils.todo.list.key({ type: 'query' }))
+})
+
+it('supports schema option', async () => {
+  const { todoSchema } = await import('./__shared__/orpc')
+
+  const collection = createCollection(orpc.todo.list.collectionOptions({
+    input: { search: 'first' },
+    queryClient,
+    schema: todoSchema,
+    getKey: todo => todo.id,
+    startSync: true,
+  }))
+
+  await collection.preload()
+  expect(collection.toArray).toMatchObject([{ id: 1, name: 'first' }])
+})

--- a/packages/tanstack-db/tests/e2e.test.ts
+++ b/packages/tanstack-db/tests/e2e.test.ts
@@ -10,7 +10,7 @@ beforeEach(() => {
 
 it('syncs a collection through oRPC procedures', async () => {
   const collection = createCollection(orpc.todo.list.collectionOptions({
-    input: { search: '' },
+    input: () => ({ search: '' }),
     queryClient,
     getKey: todo => todo.id,
     startSync: true,
@@ -51,7 +51,7 @@ it('shares query keys with @orpc/tanstack-query utils', async () => {
   const tanstackQueryUtils = createTanstackQueryUtils(client)
 
   const collection = createCollection(orpc.todo.list.collectionOptions({
-    input: { search: '' },
+    input: () => ({ search: '' }),
     queryClient,
     getKey: todo => todo.id,
     startSync: true,
@@ -59,7 +59,7 @@ it('shares query keys with @orpc/tanstack-query utils', async () => {
 
   await collection.preload()
 
-  expect(queryClient.getQueryData(tanstackQueryUtils.todo.list.queryKey({ input: { search: '' } }))).toEqual([{ id: 1, name: 'first' }])
+  expect(queryClient.getQueryData(tanstackQueryUtils.todo.list.queryKey())).toEqual([{ id: 1, name: 'first' }])
   expect(orpc.todo.list.key({ type: 'query' })).toEqual(tanstackQueryUtils.todo.list.key({ type: 'query' }))
 })
 
@@ -67,7 +67,7 @@ it('supports schema option', async () => {
   const { todoSchema } = await import('./__shared__/orpc')
 
   const collection = createCollection(orpc.todo.list.collectionOptions({
-    input: { search: 'first' },
+    input: () => ({ search: 'first' }),
     queryClient,
     schema: todoSchema,
     getKey: todo => todo.id,

--- a/packages/tanstack-db/tests/e2e.test.ts
+++ b/packages/tanstack-db/tests/e2e.test.ts
@@ -63,7 +63,7 @@ it('shares query keys with @orpc/tanstack-query utils', async () => {
   expect(orpc.todo.list.key({ type: 'query' })).toEqual(tanstackQueryUtils.todo.list.key({ type: 'query' }))
 })
 
-it('supports refetch option', async () => {
+it('supports output mapper', async () => {
   const collection = createCollection(orpc.todo.list.collectionOptions({
     input: () => ({ search: '' }),
     queryClient,
@@ -71,7 +71,7 @@ it('supports refetch option', async () => {
     startSync: true,
     onInsert: orpc.todo.create.mutationHandler({
       input: mutation => mutation.modified,
-      refetch: false,
+      output: () => ({ refetch: false }),
     }),
   }))
 

--- a/packages/tanstack-db/tests/e2e.test.ts
+++ b/packages/tanstack-db/tests/e2e.test.ts
@@ -63,6 +63,28 @@ it('shares query keys with @orpc/tanstack-query utils', async () => {
   expect(orpc.todo.list.key({ type: 'query' })).toEqual(tanstackQueryUtils.todo.list.key({ type: 'query' }))
 })
 
+it('supports refetch option', async () => {
+  const collection = createCollection(orpc.todo.list.collectionOptions({
+    input: () => ({ search: '' }),
+    queryClient,
+    getKey: todo => todo.id,
+    startSync: true,
+    onInsert: orpc.todo.create.mutationHandler({
+      input: mutation => mutation.modified,
+      refetch: false,
+    }),
+  }))
+
+  await collection.preload()
+  const listCalls = vi.mocked(router.todo.list['~orpc'].handler).mock.calls.length
+
+  const insertTx = collection.insert({ id: 2, name: 'second' })
+  await insertTx.isPersisted.promise
+
+  expect(router.todo.create['~orpc'].handler).toHaveBeenCalledTimes(1)
+  expect(router.todo.list['~orpc'].handler).toHaveBeenCalledTimes(listCalls)
+})
+
 it('supports schema option', async () => {
   const { todoSchema } = await import('./__shared__/orpc')
 

--- a/packages/tanstack-db/tests/e2e.test.ts
+++ b/packages/tanstack-db/tests/e2e.test.ts
@@ -59,7 +59,7 @@ it('shares query keys with @orpc/tanstack-query utils', async () => {
 
   await collection.preload()
 
-  expect(queryClient.getQueryData(tanstackQueryUtils.todo.list.queryKey())).toEqual([{ id: 1, name: 'first' }])
+  expect(queryClient.getQueryData(tanstackQueryUtils.todo.list.queryKey({ input: { search: '' } }))).toEqual([{ id: 1, name: 'first' }])
   expect(orpc.todo.list.key({ type: 'query' })).toEqual(tanstackQueryUtils.todo.list.key({ type: 'query' }))
 })
 

--- a/packages/tanstack-db/tsconfig.json
+++ b/packages/tanstack-db/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.lib.json",
+  "references": [
+    { "path": "../client" },
+    { "path": "../contract" },
+    { "path": "../shared" },
+    { "path": "../tanstack-query" }
+  ],
+  "include": ["package.json", "src"],
+  "exclude": [
+    "**/*.test.*",
+    "**/*.test-d.ts",
+    "**/*.bench.*",
+    "**/__tests__/**",
+    "**/__mocks__/**",
+    "**/__snapshots__/**"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -765,6 +765,34 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
 
+  packages/tanstack-db:
+    dependencies:
+      '@orpc/client':
+        specifier: workspace:*
+        version: link:../client
+      '@orpc/contract':
+        specifier: workspace:*
+        version: link:../contract
+      '@orpc/shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@orpc/tanstack-query':
+        specifier: workspace:*
+        version: link:../tanstack-query
+    devDependencies:
+      '@tanstack/db':
+        specifier: ^0.6.16
+        version: 0.6.16(typescript@6.0.3)
+      '@tanstack/query-core':
+        specifier: ^5.101.0
+        version: 5.101.2
+      '@tanstack/query-db-collection':
+        specifier: ^1.1.0
+        version: 1.1.0(@tanstack/query-core@5.101.2)(typescript@6.0.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+
   packages/tanstack-query:
     dependencies:
       '@orpc/client':
@@ -4353,12 +4381,32 @@ packages:
       '@angular/common': '>=16.0.0'
       '@angular/core': '>=16.0.0'
 
+  '@tanstack/db-ivm@0.1.18':
+    resolution: {integrity: sha512-+pZJiRKdoKRM5Epq9T7otD9ZJl82pRFauo7LKuJGrarjVKQ7r+QQlPe3kGdN9LEKSnuNGIWjX9OOY4M8kH4eLw==}
+    peerDependencies:
+      typescript: '>=4.7'
+
+  '@tanstack/db@0.6.16':
+    resolution: {integrity: sha512-6tZ4sAyh7g4G5awO4Q4D/UQVPoPEBsqqDBImjCZNTRJznrpwGqFJZxozov197k8ty8QxZC++eGcbo+BBKF3nzw==}
+    peerDependencies:
+      typescript: '>=4.7'
+
   '@tanstack/match-sorter-utils@8.19.4':
     resolution: {integrity: sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==}
     engines: {node: '>=12'}
 
+  '@tanstack/pacer-lite@0.2.2':
+    resolution: {integrity: sha512-eQ1MyLKCHyXiH7NbdmB80W77OhiMgGBUb+qDx/8WMGbwg5Lf/NlfD0TfNYAqY77i8V3AxoDoYdICrQE5ADw4Yw==}
+    engines: {node: '>=18'}
+
   '@tanstack/query-core@5.101.2':
     resolution: {integrity: sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==}
+
+  '@tanstack/query-db-collection@1.1.0':
+    resolution: {integrity: sha512-duggStGqINUX9dqq7+1JDsq4utNn/XExgtna1ACTO+WueqOmDyh83Lu2XUf+9457m9ozlbZvIFq2bcxdTXhx4Q==}
+    peerDependencies:
+      '@tanstack/query-core': ^5.0.0
+      typescript: '>=4.7'
 
   '@tanstack/query-devtools@5.101.2':
     resolution: {integrity: sha512-o+wHcqgN7Pp0s8v1i0UGq/ZrrEKrxdIiMQmKRdYb2w7NPtylYSJ4+wg/tIn71m9DLstwUwdEGAvROdly6HXP6w==}
@@ -6773,6 +6821,10 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
+  fractional-indexing@3.4.0:
+    resolution: {integrity: sha512-8J3glhz2rrpKG6KmI7wmJo3zH1VjeOpN+vTJSw1fOyO+Viqq3zX6/5NGh6oaZB2qIAYdOYuu5Dz9xp4faOO0Pg==}
+    engines: {node: ^14.13.1 || >=16.0.0}
+
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -9147,6 +9199,9 @@ packages:
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
+  sorted-btree@1.8.1:
+    resolution: {integrity: sha512-395+XIP+wqNn3USkFSrNz7G3Ss/MXlZEqesxvzCRFwL14h6e8LukDHdLBePn5pwbm5OQ9vGu8mDyz2lLDIqamQ==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -13905,11 +13960,33 @@ snapshots:
     optionalDependencies:
       '@tanstack/query-devtools': 5.101.2
 
+  '@tanstack/db-ivm@0.1.18(typescript@6.0.3)':
+    dependencies:
+      fractional-indexing: 3.4.0
+      sorted-btree: 1.8.1
+      typescript: 6.0.3
+
+  '@tanstack/db@0.6.16(typescript@6.0.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@tanstack/db-ivm': 0.1.18(typescript@6.0.3)
+      '@tanstack/pacer-lite': 0.2.2
+      typescript: 6.0.3
+
   '@tanstack/match-sorter-utils@8.19.4':
     dependencies:
       remove-accents: 0.5.0
 
+  '@tanstack/pacer-lite@0.2.2': {}
+
   '@tanstack/query-core@5.101.2': {}
+
+  '@tanstack/query-db-collection@1.1.0(@tanstack/query-core@5.101.2)(typescript@6.0.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@tanstack/db': 0.6.16(typescript@6.0.3)
+      '@tanstack/query-core': 5.101.2
+      typescript: 6.0.3
 
   '@tanstack/query-devtools@5.101.2':
     optional: true
@@ -16612,6 +16689,8 @@ snapshots:
   forwarded@0.2.0: {}
 
   fraction.js@5.3.4: {}
+
+  fractional-indexing@3.4.0: {}
 
   fresh@2.0.0: {}
 
@@ -19335,6 +19414,8 @@ snapshots:
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
+
+  sorted-btree@1.8.1: {}
 
   source-map-js@1.2.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -783,12 +783,18 @@ importers:
       '@tanstack/db':
         specifier: ^0.6.16
         version: 0.6.16(typescript@6.0.3)
+      '@tanstack/electric-db-collection':
+        specifier: ^0.3.14
+        version: 0.3.14(typescript@6.0.3)
       '@tanstack/query-core':
         specifier: ^5.101.0
         version: 5.101.2
       '@tanstack/query-db-collection':
         specifier: ^1.1.0
         version: 1.1.0(@tanstack/query-core@5.101.2)(typescript@6.0.3)
+      '@tanstack/react-db':
+        specifier: ^0.1.94
+        version: 0.1.94(react@19.2.7)(typescript@6.0.3)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -1772,6 +1778,10 @@ packages:
         optional: true
       oxlint:
         optional: true
+
+  '@electric-sql/client@1.5.24':
+    resolution: {integrity: sha512-ItOjBFTfiZvYosglF9Dn4TSqE59yL/psoemHJ7vX8gvEUmElHB2QdP5eQC6q9/lswyv7oqhkZT0Kk8kuq2P5vA==}
+    hasBin: true
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -2803,6 +2813,9 @@ packages:
     resolution: {integrity: sha512-7jf4sBNoaZCz2RSayefcvc/CZX0PDVA9aVk44bHpUebLrap+xjzDDw4T03klcYrBl/FdC7NamwvqjUMCtYdBvQ==}
     peerDependencies:
       '@opentelemetry/api': ~1.9.0
+
+  '@microsoft/fetch-event-source@2.0.1':
+    resolution: {integrity: sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
@@ -4391,6 +4404,9 @@ packages:
     peerDependencies:
       typescript: '>=4.7'
 
+  '@tanstack/electric-db-collection@0.3.14':
+    resolution: {integrity: sha512-r0tknthqxwetQ/ofGTFnNfyO7JgCkLEA4TtTpmi9XsXd6z0YHS2FB1YC5zBt27QcqCkaSfCZeSPsYFRicCdilA==}
+
   '@tanstack/match-sorter-utils@8.19.4':
     resolution: {integrity: sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==}
     engines: {node: '>=12'}
@@ -4411,6 +4427,11 @@ packages:
   '@tanstack/query-devtools@5.101.2':
     resolution: {integrity: sha512-o+wHcqgN7Pp0s8v1i0UGq/ZrrEKrxdIiMQmKRdYb2w7NPtylYSJ4+wg/tIn71m9DLstwUwdEGAvROdly6HXP6w==}
 
+  '@tanstack/react-db@0.1.94':
+    resolution: {integrity: sha512-ZtSMBOCdR/ElcBxg84uboXrqQ+kqiOwlq6kTy+o54UDywYr/by02jmWKHqayrnoiPVlrx83WNHDaomfe141f4A==}
+    peerDependencies:
+      react: '>=16.8.0'
+
   '@tanstack/react-query@5.101.2':
     resolution: {integrity: sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==}
     peerDependencies:
@@ -4420,6 +4441,9 @@ packages:
     resolution: {integrity: sha512-IbCeM23gEbU0lW4wWFQhS4ELjgdmVXjhyCUh8pFemdMIuA5UswlkqEMryEE+lCMtxLS7m0oN1yWMocKi7vwXdw==}
     peerDependencies:
       solid-js: ^1.6.0
+
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
 
   '@tanstack/svelte-query@6.1.36':
     resolution: {integrity: sha512-AVyvXPzBh5OQnWFB7rk9gskciPouayAhU9Vm24uMai+Imf+ZfBEbjOAEtdM41oexFK/cdXmpAIySDSVaAzy9zw==}
@@ -10942,6 +10966,12 @@ snapshots:
     optionalDependencies:
       eslint: 10.7.0(jiti@2.7.0)
 
+  '@electric-sql/client@1.5.24':
+    dependencies:
+      '@microsoft/fetch-event-source': 2.0.1
+    optionalDependencies:
+      '@rollup/rollup-darwin-arm64': 4.62.2
+
   '@emnapi/core@1.11.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
@@ -11767,6 +11797,8 @@ snapshots:
       '@opentelemetry/resources': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.43.0
+
+  '@microsoft/fetch-event-source@2.0.1': {}
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     optional: true
@@ -13973,6 +14005,17 @@ snapshots:
       '@tanstack/pacer-lite': 0.2.2
       typescript: 6.0.3
 
+  '@tanstack/electric-db-collection@0.3.14(typescript@6.0.3)':
+    dependencies:
+      '@electric-sql/client': 1.5.24
+      '@standard-schema/spec': 1.1.0
+      '@tanstack/db': 0.6.16(typescript@6.0.3)
+      '@tanstack/store': 0.9.3
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@tanstack/match-sorter-utils@8.19.4':
     dependencies:
       remove-accents: 0.5.0
@@ -13991,6 +14034,14 @@ snapshots:
   '@tanstack/query-devtools@5.101.2':
     optional: true
 
+  '@tanstack/react-db@0.1.94(react@19.2.7)(typescript@6.0.3)':
+    dependencies:
+      '@tanstack/db': 0.6.16(typescript@6.0.3)
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
+    transitivePeerDependencies:
+      - typescript
+
   '@tanstack/react-query@5.101.2(react@19.2.7)':
     dependencies:
       '@tanstack/query-core': 5.101.2
@@ -14000,6 +14051,8 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.101.2
       solid-js: 1.9.14
+
+  '@tanstack/store@0.9.3': {}
 
   '@tanstack/svelte-query@6.1.36(svelte@5.56.6(@typescript-eslint/types@8.64.0))':
     dependencies:


### PR DESCRIPTION
Resolves #1553

Adds `@orpc/experimental-tanstack-db` for wiring typed oRPC procedures into [TanStack DB](https://tanstack.com/db/latest) collections. It doesn't reinvent any sync logic — `.collectionOptions` builds on `queryCollectionOptions` from `@tanstack/query-db-collection`, and `.mutationHandler` returns a standard TanStack DB persistence handler that also works with other collection types like Electric.

```ts
import { createTanstackDBUtils } from '@orpc/experimental-tanstack-db'
import { createCollection } from '@tanstack/db'

const orpc = createTanstackDBUtils(client)

const todosCollection = createCollection(orpc.todo.list.collectionOptions({
  input: () => ({ search: 'orpc' }),
  queryClient,
  getKey: todo => todo.id,
  onInsert: orpc.todo.create.mutationHandler({
    input: mutation => mutation.modified,
  }),
  onUpdate: orpc.todo.update.mutationHandler({
    input: mutation => ({ id: mutation.key, data: mutation.changes }),
  }),
  onDelete: orpc.todo.delete.mutationHandler({
    input: mutation => ({ id: mutation.key }),
  }),
}))
```

- `.collectionOptions` accepts everything `queryCollectionOptions` accepts (`schema`, `select`, `enabled`, ...) — `queryKey`/`queryFn` are wired to the procedure, with full item type inference from the procedure output, `select`, or `schema`
- `.mutationHandler` maps each mutation to a typed procedure call; the `output` option maps procedure outputs to the handler return value — its return type is inferred from the collection adapter, and it becomes required when the adapter expects a specific shape (e.g. Electric `txid` matching)
- Query keys match `@orpc/tanstack-query`, so both integrations can share a `queryClient` and invalidation works across them
- `prefix`, `.key`, and `.call` work the same as in other integrations
- Live queries and optimistic mutations stay fully native to TanStack DB

Thanks @Yorizel for the API draft.




