### PR TITLE
refactor(tanstack-query,pinia-colada): rename SharedRouterUtils to SharedUtils in dedicated module

### DIFF
--- a/packages/pinia-colada/src/contract-utils.test-d.ts
+++ b/packages/pinia-colada/src/contract-utils.test-d.ts
@@ -2,7 +2,7 @@ import type { ORPCError } from '@orpc/client'
 import type { ContractClientFactory } from '@orpc/contract'
 import type { PromiseWithError } from '@orpc/shared'
 import type { ProcedureUtils } from './procedure-utils'
-import type { SharedRouterUtils } from './router-utils'
+import type { SharedUtils } from './shared-utils'
 import type { OperationContext } from './types'
 import { meta, oc, type } from '@orpc/contract'
 import { createContractJsonifiedUtilsFactory, createContractUtilsFactory } from './contract-utils'
@@ -82,7 +82,6 @@ describe('createContractUtilsFactory', () => {
 
     expectTypeOf(utils).toEqualTypeOf<
       & Omit<ProcedureUtils<{ cache?: boolean }, string, Date, Error | ORPCError<'BAD_GATEWAY', RegExp>>, 'path' | 'options'>
-      & Omit<SharedRouterUtils<string>, 'path'>
     >()
   })
 
@@ -92,10 +91,9 @@ describe('createContractUtilsFactory', () => {
 
     expectTypeOf(utils.nested.pong).toEqualTypeOf<
       & Omit<ProcedureUtils<{ cache?: boolean }, string, Date, Error | ORPCError<'BAD_GATEWAY', RegExp>>, 'path' | 'options'>
-      & Omit<SharedRouterUtils<string>, 'path'>
     >()
 
-    expectTypeOf(utils.key).toEqualTypeOf<SharedRouterUtils<unknown>['key']>()
+    expectTypeOf(utils.key).toEqualTypeOf<SharedUtils<unknown>['key']>()
   })
 })
 
@@ -163,7 +161,6 @@ describe('createContractJsonifiedUtilsFactory', () => {
 
     expectTypeOf(utils).toEqualTypeOf<
       & Omit<ProcedureUtils<{ cache?: boolean }, string, string, Error | ORPCError<'BAD_GATEWAY', string>>, 'path' | 'options'>
-      & Omit<SharedRouterUtils<string>, 'path'>
     >()
   })
 
@@ -173,7 +170,6 @@ describe('createContractJsonifiedUtilsFactory', () => {
 
     expectTypeOf(utils.nested.pong).toEqualTypeOf<
       & Omit<ProcedureUtils<{ cache?: boolean }, string, string, Error | ORPCError<'BAD_GATEWAY', string>>, 'path' | 'options'>
-      & Omit<SharedRouterUtils<string>, 'path'>
     >()
   })
 })

--- a/packages/pinia-colada/src/index.ts
+++ b/packages/pinia-colada/src/index.ts
@@ -7,6 +7,7 @@ export * from './router-utils'
 export {
   createRouterUtils as createPiniaColadaUtils,
 } from './router-utils'
+export * from './shared-utils'
 export * from './stream-query'
 export * from './types'
 export {

--- a/packages/pinia-colada/src/procedure-utils.test-d.ts
+++ b/packages/pinia-colada/src/procedure-utils.test-d.ts
@@ -1,8 +1,9 @@
-import type { Client } from '@orpc/client'
+import type { Client, ORPCError } from '@orpc/client'
 import type { ORPCErrorFromErrorMap } from '@orpc/contract'
-import type { Public } from '@orpc/shared'
-import type { UseInfiniteQueryData } from '@pinia/colada'
-import type { ProcedureUtils } from './procedure-utils'
+import type { PromiseWithError, Public } from '@orpc/shared'
+import type { UseInfiniteQueryData, UseInfiniteQueryFnContext } from '@pinia/colada'
+import type { ProcedureUtils, ProcedureUtilsOptions } from './procedure-utils'
+import type { InfiniteOptionsIn, MutationKeyOptions, MutationOptionsIn, QueryKeyOptions, QueryOptionsIn, StreamedKeyOptions, StreamedOptionsIn, UseMutationFnContext, UseQueryFnContext } from './types'
 import { useInfiniteQuery, useMutation, useQuery, useQueryCache } from '@pinia/colada'
 import { computed } from 'vue'
 import z from 'zod'
@@ -323,5 +324,440 @@ describe('ProcedureUtils', () => {
         },
       })
     })
+  })
+})
+
+describe('ProcedureUtilsOptions', () => {
+  type TestClientContext = { batch?: boolean }
+  type TestInput = { search?: string }
+  type TestOutput = { title: string }
+  type TestError = ORPCError<'TEST', unknown>
+
+  type TestOptions = ProcedureUtilsOptions<TestClientContext, TestInput, TestOutput, TestError>
+
+  type TestStreamedOutput = AsyncIterable<TestOutput>
+  type TestStreamedOptions = ProcedureUtilsOptions<TestClientContext, TestInput, TestStreamedOutput, TestError>
+
+  it('should have all keys that ProcedureUtils provides', () => {
+    // Ensures every utility method in ProcedureUtils (except 'call') has a corresponding key in ProcedureUtilsOptions
+    type ProcedureUtilsKeys = Exclude<keyof ProcedureUtils<any, any, any, any>, 'call' | 'key'>
+    type DefaultsKeys = keyof ProcedureUtilsOptions<any, any, any, any>
+
+    expectTypeOf<ProcedureUtilsKeys>().toExtend<DefaultsKeys>()
+  })
+
+  it('all properties should be optional', () => {
+    const emptyDefaults: TestOptions = {}
+    expectTypeOf(emptyDefaults).toExtend<TestOptions>()
+  })
+
+  it('queryKey should accept Partial<QueryKeyOptions> | modifier function', () => {
+    const _defaults: TestOptions = {
+      queryKey: {
+        input: { search: 'test' },
+      },
+    }
+
+    const _defaults2: TestOptions = {
+      queryKey: {
+        key: ['__custom__'],
+      },
+    }
+
+    const _invalid: TestOptions = {
+      queryKey: {
+        // @ts-expect-error - invalid input type
+        input: { invalid: 'test' },
+      },
+    }
+
+    const _defaults3: TestOptions = {
+      queryKey: (options) => {
+        expectTypeOf(options).toEqualTypeOf<QueryKeyOptions<TestInput>>()
+
+        return { input: { search: 'test' } }
+      },
+    }
+
+    const _invalid2: TestOptions = {
+      // @ts-expect-error - invalid input type
+      queryKey: (options) => {
+        return { input: { invalid: 'test' } }
+      },
+    }
+  })
+
+  it('queryInterceptors should infer correct types', () => {
+    const defaults: TestOptions = {
+      queryInterceptors: [
+        (opts) => {
+          expectTypeOf(opts.input).toEqualTypeOf<TestInput>()
+          expectTypeOf(opts.next()).toEqualTypeOf<PromiseWithError<TestOutput, TestError>>()
+          expectTypeOf(opts.fnContext).toEqualTypeOf<UseQueryFnContext>()
+
+          return opts.next()
+        },
+      ],
+    }
+  })
+
+  it('queryOptions should accept Partial<QueryOptionsIn> | modifier function', () => {
+    const _defaults: TestOptions = {
+      queryOptions: {
+        input: { search: 'test' },
+        staleTime: 1000,
+        context: { batch: true },
+      },
+    }
+
+    const _invalid: TestOptions = {
+      queryOptions: {
+        // @ts-expect-error - invalid input type
+        input: { invalid: 'test' },
+      },
+    }
+
+    const _defaults2: TestOptions = {
+      queryOptions: (options) => {
+        expectTypeOf(options).toEqualTypeOf<QueryOptionsIn<TestClientContext, TestInput, TestOutput, TestError, TestOutput | undefined>>()
+
+        return {
+          ...options,
+          input: { search: 'test' },
+          staleTime: 1000,
+          context: { batch: true },
+        }
+      },
+    }
+
+    const _invalid2: TestOptions = {
+      // @ts-expect-error - invalid input type
+      queryOptions: options => ({
+        ...options,
+        input: { invalid: 'test' },
+      }),
+    }
+  })
+
+  it('streamedKey should accept Partial<StreamedKeyOptions> | modifier function', () => {
+    const _defaults: TestOptions = {
+      streamedKey: {
+        input: { search: 'test' },
+        fnOptions: { maxChunks: 10 },
+      },
+    }
+
+    const _invalid: TestOptions = {
+      streamedKey: {
+        // @ts-expect-error - invalid input type
+        input: { invalid: 'test' },
+      },
+    }
+
+    const _defaults2: TestOptions = {
+      streamedKey: (options) => {
+        expectTypeOf(options).toEqualTypeOf<StreamedKeyOptions<TestInput>>()
+
+        return {
+          input: { search: 'test' },
+          fnOptions: { maxChunks: 10 },
+        }
+      },
+    }
+
+    const _invalid2: TestOptions = {
+      // @ts-expect-error - invalid input type
+      streamedKey: () => ({
+        input: { invalid: 'test' },
+      }),
+    }
+  })
+
+  it('streamedInterceptors should infer correct types', () => {
+    const defaults: TestStreamedOptions = {
+      streamedInterceptors: [
+        (opts) => {
+          expectTypeOf(opts.input).toEqualTypeOf<TestInput>()
+          expectTypeOf(opts.next()).toEqualTypeOf<PromiseWithError<TestOutput[], TestError>>()
+          expectTypeOf(opts.fnContext).toEqualTypeOf<UseQueryFnContext>()
+
+          return opts.next()
+        },
+      ],
+    }
+  })
+
+  it('streamedOptions should accept Partial<StreamedOptionsIn> | modifier function', () => {
+    const _defaults: TestOptions = {
+      streamedOptions: {
+        input: { search: 'test' },
+        staleTime: 1000,
+      },
+    }
+
+    const _invalid: TestOptions = {
+      streamedOptions: {
+        // @ts-expect-error - invalid input type
+        input: { invalid: 'test' },
+      },
+    }
+
+    const _defaults2: TestOptions = {
+      streamedOptions: (options) => {
+        expectTypeOf(options).toEqualTypeOf<StreamedOptionsIn<TestClientContext, TestInput, never, TestError, undefined>>()
+
+        return {
+          ...options,
+          input: { search: 'test' },
+          staleTime: 1000,
+        }
+      },
+    }
+
+    const _invalid2: TestOptions = {
+      // @ts-expect-error - invalid input type
+      streamedOptions: options => ({
+        ...options,
+        input: { invalid: 'test' },
+      }),
+    }
+  })
+
+  it('liveKey should accept Partial<QueryKeyOptions> | modifier function', () => {
+    const _defaults: TestOptions = {
+      liveKey: {
+        input: { search: 'test' },
+      },
+    }
+
+    const _invalid: TestOptions = {
+      liveKey: {
+        // @ts-expect-error - invalid input type
+        input: { invalid: 'test' },
+      },
+    }
+
+    const _defaults2: TestOptions = {
+      liveKey: (options) => {
+        expectTypeOf(options).toEqualTypeOf<QueryKeyOptions<TestInput>>()
+
+        return {
+          input: { search: 'test' },
+        }
+      },
+    }
+
+    const _invalid2: TestOptions = {
+      // @ts-expect-error - invalid input type
+      liveKey: options => ({
+        ...options,
+        input: { invalid: 'test' },
+      }),
+    }
+  })
+
+  it('liveInterceptors should infer correct types', () => {
+    const defaults: TestStreamedOptions = {
+      liveInterceptors: [
+        (opts) => {
+          expectTypeOf(opts.input).toEqualTypeOf<TestInput>()
+          expectTypeOf(opts.next()).toEqualTypeOf<PromiseWithError<TestOutput, TestError>>()
+          expectTypeOf(opts.fnContext).toEqualTypeOf<UseQueryFnContext>()
+
+          return opts.next()
+        },
+      ],
+    }
+  })
+
+  it('liveOptions should accept Partial<QueryOptionsIn> | modifier function', () => {
+    const _defaults: TestOptions = {
+      liveOptions: {
+        input: { search: 'test' },
+        staleTime: 1000,
+      },
+    }
+
+    const _invalid: TestOptions = {
+      liveOptions: {
+        // @ts-expect-error - invalid input type
+        input: { invalid: 'test' },
+      },
+    }
+
+    const _defaults2: TestOptions = {
+      liveOptions: (options) => {
+        expectTypeOf(options).toEqualTypeOf<QueryOptionsIn<TestClientContext, TestInput, never, TestError, undefined>>()
+
+        return {
+          ...options,
+          input: { search: 'test' },
+          staleTime: 1000,
+        }
+      },
+    }
+
+    const _invalid2: TestOptions = {
+      // @ts-expect-error - invalid input type
+      liveOptions: options => ({
+        ...options,
+        input: { invalid: 'test' },
+      }),
+    }
+  })
+
+  it('infiniteKey should accept Partial input, initialPageParam, key', () => {
+    const _defaults: TestOptions = {
+      infiniteKey: {
+        initialPageParam: 0,
+      },
+    }
+
+    const _defaults2: TestOptions = {
+      infiniteKey: {
+        key: ['__custom__'],
+      },
+    }
+
+    const _invalid: TestOptions = {
+      infiniteKey: {
+        // @ts-expect-error - invalid input type
+        input: { invalid: 'test' },
+      },
+    }
+  })
+
+  it('infiniteInterceptors should infer correct types', () => {
+    const defaults: TestOptions = {
+      infiniteInterceptors: [
+        (opts) => {
+          expectTypeOf(opts.input).toEqualTypeOf<TestInput>()
+          expectTypeOf(opts.next()).toEqualTypeOf<PromiseWithError<TestOutput, TestError>>()
+          expectTypeOf(opts.fnContext).toEqualTypeOf<UseInfiniteQueryFnContext<any, any, any, any>>()
+
+          return opts.next()
+        },
+      ],
+    }
+  })
+
+  it('infiniteOptions should accept Partial<InfiniteOptionsIn> | modifier function', () => {
+    const _defaults: TestOptions = {
+      infiniteOptions: {
+        staleTime: 1000,
+      },
+    }
+
+    const _invalid: TestOptions = {
+      infiniteOptions: {
+        // @ts-expect-error - invalid input type
+        input: { invalid: 'test' },
+      },
+    }
+
+    const _defaults2: TestOptions = {
+      infiniteOptions: (options) => {
+        expectTypeOf(options).toEqualTypeOf<InfiniteOptionsIn<TestClientContext, TestInput, TestOutput, TestError, unknown, UseInfiniteQueryData<TestOutput, unknown> | undefined>>()
+
+        return {
+          ...options,
+          staleTime: 1000,
+        }
+      },
+    }
+
+    const _invalid2: TestOptions = {
+      // @ts-expect-error - invalid input type
+      infiniteOptions: options => ({
+        ...options,
+        input: { invalid: 'test' },
+      }),
+    }
+  })
+
+  it('mutationKey should accept Partial key | modifier function', () => {
+    const _defaults: TestOptions = {
+      mutationKey: {
+        key: ['__custom__'],
+      },
+    }
+
+    const _invalid: TestOptions = {
+      mutationKey: {
+        // @ts-expect-error - invalid key type
+        key: 1,
+      },
+    }
+
+    const _defaults2: TestOptions = {
+      mutationKey: (options) => {
+        expectTypeOf(options).toEqualTypeOf<MutationKeyOptions<TestInput>>()
+
+        return {
+          key: ['__custom__'],
+        }
+      },
+    }
+
+    const _invalid2: TestOptions = {
+      // @ts-expect-error - invalid key type
+      mutationKey: options => ({
+        key: 1,
+      }),
+    }
+  })
+
+  it('mutationInterceptors should infer correct types', () => {
+    const defaults: TestOptions = {
+      mutationInterceptors: [
+        (opts) => {
+          expectTypeOf(opts.input).toEqualTypeOf<TestInput>()
+          expectTypeOf(opts.next()).toEqualTypeOf<PromiseWithError<TestOutput, TestError>>()
+          expectTypeOf(opts.fnContext).toEqualTypeOf<UseMutationFnContext>()
+
+          return opts.next()
+        },
+      ],
+    }
+  })
+
+  it('mutationOptions should accept Partial<MutationOptionsIn> | modifier function', () => {
+    const _defaults: TestOptions = {
+      mutationOptions: {
+        onSuccess: (output) => {
+          expectTypeOf(output).toEqualTypeOf<TestOutput>()
+        },
+        context: { batch: true },
+      },
+    }
+
+    const _invalid: TestOptions = {
+      mutationOptions: {
+        // @ts-expect-error - invalid context type
+        context: { batch: 'invalid' },
+      },
+    }
+
+    const _defaults2: TestOptions = {
+      mutationOptions: (options) => {
+        expectTypeOf(options).toEqualTypeOf<MutationOptionsIn<TestClientContext, TestInput, TestOutput, TestError, Record<any, any>>>()
+
+        return {
+          ...options,
+          onSuccess: (output) => {
+            expectTypeOf(output).toEqualTypeOf<TestOutput>()
+          },
+          context: { batch: true },
+        }
+      },
+    }
+
+    const _invalid2: TestOptions = {
+      // @ts-expect-error - invalid context type
+      mutationOptions: options => ({
+        ...options,
+        context: { batch: 'invalid' },
+      }),
+    }
   })
 })

--- a/packages/pinia-colada/src/procedure-utils.ts
+++ b/packages/pinia-colada/src/procedure-utils.ts
@@ -6,6 +6,7 @@ import type { InferLiveQueryOutput, InferStreamedQueryOutput, InfiniteKeyOptions
 import { intercept, isAsyncIteratorObject, resolveMaybeOptionalOptions } from '@orpc/shared'
 import { generateOperationKey } from './key'
 import { liveQuery } from './live-query'
+import { SharedUtils } from './shared-utils'
 import { serializableStreamedQuery } from './stream-query'
 import { OPERATION_CONTEXT_SYMBOL } from './types'
 
@@ -159,7 +160,9 @@ export interface ProcedureUtilsOptions<TClientContext extends ClientContext, TIn
   >
 }
 
-export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutput, TError> {
+export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutput, TError> extends SharedUtils<TInput> {
+  declare protected readonly options: ProcedureUtilsOptions<TClientContext, TInput, TOutput, TError>
+
   /**
    * Calling corresponding procedure client
    *
@@ -168,10 +171,11 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   call: Client<TClientContext, TInput, TOutput, TError>
 
   constructor(
-    private readonly path: string[],
+    path: string[],
     client: Client<TClientContext, TInput, TOutput, TError>,
-    private readonly options: ProcedureUtilsOptions<TClientContext, TInput, TOutput, TError> = {},
+    options: ProcedureUtilsOptions<TClientContext, TInput, TOutput, TError> = {},
   ) {
+    super(path, options)
     this.call = client
   }
 

--- a/packages/pinia-colada/src/router-utils.test-d.ts
+++ b/packages/pinia-colada/src/router-utils.test-d.ts
@@ -2,9 +2,9 @@ import type { ORPCErrorFromErrorMap } from '@orpc/contract'
 import type { RouterClient } from '@orpc/server'
 import type { Public } from '@orpc/shared'
 import type { ProcedureUtils } from './procedure-utils'
-import type { RouterUtils, SharedRouterUtils } from './router-utils'
+import type { RouterUtils } from './router-utils'
+import type { SharedUtils } from './shared-utils'
 import { os } from '@orpc/server'
-import { ref } from 'vue'
 import z from 'zod'
 import { createRouterUtils } from './router-utils'
 
@@ -31,46 +31,14 @@ const router = {
   }),
 }
 
-describe('SharedRouterUtils', () => {
-  const utils = {} as Public<SharedRouterUtils<{ a: { b: { c: number } } }>>
-
-  it('.key', () => {
-    utils.key()
-    utils.key({})
-    utils.key({ type: 'mutation' })
-    // unlike tanstack-query, mutation keys can contain input
-    utils.key({ type: 'mutation', input: {} })
-    utils.key({ input: {}, type: 'query' })
-    utils.key({ input: {}, type: 'streamed', fnOptions: { refetchMode: 'append' } })
-    utils.key({ input: {} })
-    utils.key({ input: { a: {} } })
-    utils.key({ input: { a: { b: {} } } })
-    utils.key({ input: { a: { b: { c: 1 } } } })
-
-    // @ts-expect-error invalid input
-    utils.key({ input: 123 })
-    // @ts-expect-error invalid input
-    utils.key({ input: { a: { b: { c: '1' } } } })
-
-    // @ts-expect-error not allow ref
-    utils.key({ input: { a: { b: ref({ c: 1 }) } } })
-
-    // @ts-expect-error invalid type
-    utils.key({ type: 'ddd' })
-
-    // @ts-expect-error fnOptions is only allowed for streamed type
-    utils.key({ type: 'infinite', fnOptions: { refetchMode: 'append' } })
-  })
-})
-
 it('RouterUtils', () => {
   const utils = {} as RouterUtils<RouterClient<typeof router, { batch?: boolean }>>
 
-  expectTypeOf(utils).toExtend<Public<SharedRouterUtils<unknown>>>()
-  expectTypeOf(utils.nested).toExtend<Public<SharedRouterUtils<unknown>>>()
+  expectTypeOf(utils).toExtend<Public<SharedUtils<unknown>>>()
+  expectTypeOf(utils.nested).toExtend<Public<SharedUtils<unknown>>>()
 
-  expectTypeOf(utils.ping).toExtend<Public<SharedRouterUtils<{ input: number }>>>()
-  expectTypeOf(utils.nested.ping).toExtend<Public<SharedRouterUtils<{ input: number }>>>()
+  expectTypeOf(utils.ping).toExtend<Public<SharedUtils<{ input: number }>>>()
+  expectTypeOf(utils.nested.ping).toExtend<Public<SharedUtils<{ input: number }>>>()
 
   expectTypeOf(utils.ping).toExtend<
     Public<ProcedureUtils<{ batch?: boolean }, { input: number }, { output: string }, ORPCErrorFromErrorMap<typeof baseErrorMap> | Error>>

--- a/packages/pinia-colada/src/router-utils.test.ts
+++ b/packages/pinia-colada/src/router-utils.test.ts
@@ -1,15 +1,24 @@
 import type { RouterUtilsPlugin } from './plugin'
 import * as KeyModule from './key'
 import { ProcedureUtils } from './procedure-utils'
-import { createRouterUtils, SharedRouterUtils } from './router-utils'
+import { createRouterUtils } from './router-utils'
 
-vi.mock('./procedure-utils', async () => ({
-  ProcedureUtils: vi.fn(class {
-    call = vi.fn()
-    queryOptions = vi.fn(() => ({ queryOptions: true }))
-    mutationOptions = vi.fn(() => ({ mutationOptions: true }))
-  }),
-}))
+vi.mock('./procedure-utils', async () => {
+  const { SharedUtils } = await import('./shared-utils')
+
+  return {
+    ProcedureUtils: vi.fn(class extends SharedUtils<unknown> {
+      call = vi.fn()
+      override key = SharedUtils.prototype.key
+      queryOptions = vi.fn(() => ({ queryOptions: true }))
+      mutationOptions = vi.fn(() => ({ mutationOptions: true }))
+
+      constructor(path: string[], _client: unknown, options: any = {}) {
+        super(path, options)
+      }
+    }),
+  }
+})
 
 const generateOperationKeySpy = vi.spyOn(KeyModule, 'generateOperationKey')
 
@@ -23,30 +32,6 @@ const emptyInterceptors = {
 
 beforeEach(() => {
   vi.clearAllMocks()
-})
-
-describe('sharedRouterUtils', () => {
-  const utils = new SharedRouterUtils(['path'], {})
-
-  it('.key', () => {
-    expect(
-      utils.key({ input: { search: '__search__' }, type: 'query' }),
-    ).toBe(generateOperationKeySpy.mock.results[0]!.value)
-
-    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
-    expect(generateOperationKeySpy).toHaveBeenCalledWith(['path'], { input: { search: '__search__' }, type: 'query', prefix: undefined })
-  })
-
-  it('.key with prefix', () => {
-    const prefixedUtils = new SharedRouterUtils(['path'], { prefix: '__prefix__' })
-
-    expect(
-      prefixedUtils.key({ type: 'query' }),
-    ).toBe(generateOperationKeySpy.mock.results[0]!.value)
-
-    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
-    expect(generateOperationKeySpy).toHaveBeenCalledWith(['path'], { type: 'query', prefix: '__prefix__' })
-  })
 })
 
 describe('createRouterUtils', () => {

--- a/packages/pinia-colada/src/router-utils.ts
+++ b/packages/pinia-colada/src/router-utils.ts
@@ -1,37 +1,20 @@
 import type { AnyNestedClient, Client, InferClientContext, InferClientError } from '@orpc/client'
 import type { Public } from '@orpc/shared'
-import type { OperationKey, OperationKeyOptions, OperationKeyPrefixOptions } from './key'
+import type { OperationKeyPrefixOptions } from './key'
 import type { RouterUtilsPlugin } from './plugin'
 import type { ProcedureUtilsInfiniteInterceptor, ProcedureUtilsLiveInterceptor, ProcedureUtilsMutationInterceptor, ProcedureUtilsOptions, ProcedureUtilsQueryInterceptor, ProcedureUtilsStreamedInterceptor } from './procedure-utils'
-import type { OperationType } from './types'
 import { RECURSIVE_CLIENT_UNWRAP_KEYS } from '@orpc/client'
 import { bindMethods, get, getOrBind, isTypescriptObject, toArray } from '@orpc/shared'
-import { generateOperationKey } from './key'
 import { CompositeRouterUtilsPlugin } from './plugin'
 import { ProcedureUtils } from './procedure-utils'
-
-export class SharedRouterUtils<TInput> {
-  constructor(
-    private readonly path: string[],
-    private readonly options: OperationKeyPrefixOptions,
-  ) {}
-
-  /**
-   * Generate a **partial matching** key for actions like revalidating queries, checking mutation status, etc.
-   *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key Pinia Colada Query/Mutation Key Docs}
-   */
-  key<TType extends OperationType>(options: Omit<OperationKeyOptions<TType, TInput>, 'prefix'> = {}): OperationKey<TType, TInput> {
-    return generateOperationKey(this.path, { ...options, prefix: this.options.prefix })
-  }
-}
+import { SharedUtils } from './shared-utils'
 
 export type RouterUtils<T extends AnyNestedClient>
   = T extends Client<infer UClientContext, infer UInput, infer UOutput, infer UError>
-    ? Public<ProcedureUtils<UClientContext, UInput, UOutput, UError>> & Public<SharedRouterUtils<UInput>>
+    ? Public<ProcedureUtils<UClientContext, UInput, UOutput, UError>>
     : {
       [K in keyof T]: T[K] extends AnyNestedClient ? RouterUtils<T[K]> : never
-    } & Public<SharedRouterUtils<unknown>>
+    } & Public<SharedUtils<unknown>>
 
 export type RouterUtilsScoped<T extends AnyNestedClient>
   = T extends Client<infer UClientContext, infer UInput, infer UOutput, infer UError>
@@ -108,9 +91,8 @@ function createRouterUtilsInternal<T extends AnyNestedClient>(
   plugin: CompositeRouterUtilsPlugin<any>,
 ): RouterUtils<T> {
   const path = toArray(options.path)
-  const sharedUtils = bindMethods(new SharedRouterUtils(path, options))
 
-  const procedureUtils = typeof client === 'function' && (options.scoped === undefined || isProcedureUtilsOptions(options.scoped))
+  const utils = typeof client === 'function' && (options.scoped === undefined || isProcedureUtilsOptions(options.scoped))
     ? bindMethods(new ProcedureUtils(
         path,
         client,
@@ -124,12 +106,9 @@ function createRouterUtilsInternal<T extends AnyNestedClient>(
           mutationInterceptors: [...toArray(options.mutationInterceptors) as any, ...toArray(options.scoped?.mutationInterceptors)],
         }),
       ))
-    : undefined
+    : bindMethods(new SharedUtils(path, options))
 
-  const recursive = new Proxy({
-    ...sharedUtils,
-    ...procedureUtils,
-  }, {
+  const recursive = new Proxy(utils, {
     get(target, prop) {
       const value = getOrBind(target, prop)
       const nextClient = get(client, [prop])

--- a/packages/pinia-colada/src/shared-utils.test-d.ts
+++ b/packages/pinia-colada/src/shared-utils.test-d.ts
@@ -1,0 +1,35 @@
+import type { Public } from '@orpc/shared'
+import type { SharedUtils } from './shared-utils'
+import { ref } from 'vue'
+
+describe('SharedUtils', () => {
+  const utils = {} as Public<SharedUtils<{ a: { b: { c: number } } }>>
+
+  it('.key', () => {
+    utils.key()
+    utils.key({})
+    utils.key({ type: 'mutation' })
+    // unlike tanstack-query, mutation keys can contain input
+    utils.key({ type: 'mutation', input: {} })
+    utils.key({ input: {}, type: 'query' })
+    utils.key({ input: {}, type: 'streamed', fnOptions: { refetchMode: 'append' } })
+    utils.key({ input: {} })
+    utils.key({ input: { a: {} } })
+    utils.key({ input: { a: { b: {} } } })
+    utils.key({ input: { a: { b: { c: 1 } } } })
+
+    // @ts-expect-error invalid input
+    utils.key({ input: 123 })
+    // @ts-expect-error invalid input
+    utils.key({ input: { a: { b: { c: '1' } } } })
+
+    // @ts-expect-error not allow ref
+    utils.key({ input: { a: { b: ref({ c: 1 }) } } })
+
+    // @ts-expect-error invalid type
+    utils.key({ type: 'ddd' })
+
+    // @ts-expect-error fnOptions is only allowed for streamed type
+    utils.key({ type: 'infinite', fnOptions: { refetchMode: 'append' } })
+  })
+})

--- a/packages/pinia-colada/src/shared-utils.test.ts
+++ b/packages/pinia-colada/src/shared-utils.test.ts
@@ -1,0 +1,32 @@
+import * as KeyModule from './key'
+import { SharedUtils } from './shared-utils'
+
+const generateOperationKeySpy = vi.spyOn(KeyModule, 'generateOperationKey')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('sharedUtils', () => {
+  const utils = new SharedUtils(['path'], {})
+
+  it('.key', () => {
+    expect(
+      utils.key({ input: { search: '__search__' }, type: 'query' }),
+    ).toBe(generateOperationKeySpy.mock.results[0]!.value)
+
+    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+    expect(generateOperationKeySpy).toHaveBeenCalledWith(['path'], { input: { search: '__search__' }, type: 'query', prefix: undefined })
+  })
+
+  it('.key with prefix', () => {
+    const prefixedUtils = new SharedUtils(['path'], { prefix: '__prefix__' })
+
+    expect(
+      prefixedUtils.key({ type: 'query' }),
+    ).toBe(generateOperationKeySpy.mock.results[0]!.value)
+
+    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+    expect(generateOperationKeySpy).toHaveBeenCalledWith(['path'], { type: 'query', prefix: '__prefix__' })
+  })
+})

--- a/packages/pinia-colada/src/shared-utils.ts
+++ b/packages/pinia-colada/src/shared-utils.ts
@@ -1,0 +1,19 @@
+import type { OperationKey, OperationKeyOptions, OperationKeyPrefixOptions } from './key'
+import type { OperationType } from './types'
+import { generateOperationKey } from './key'
+
+export class SharedUtils<TInput> {
+  constructor(
+    protected readonly path: string[],
+    protected readonly options: OperationKeyPrefixOptions,
+  ) {}
+
+  /**
+   * Generate a **partial matching** key for actions like revalidating queries, checking mutation status, etc.
+   *
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key Pinia Colada Query/Mutation Key Docs}
+   */
+  key<TType extends OperationType>(options: Omit<OperationKeyOptions<TType, TInput>, 'prefix'> = {}): OperationKey<TType, TInput> {
+    return generateOperationKey(this.path, { ...options, prefix: this.options.prefix })
+  }
+}

--- a/packages/tanstack-query/src/contract-utils.test-d.ts
+++ b/packages/tanstack-query/src/contract-utils.test-d.ts
@@ -2,7 +2,7 @@ import type { ORPCError } from '@orpc/client'
 import type { ContractClientFactory } from '@orpc/contract'
 import type { PromiseWithError } from '@orpc/shared'
 import type { ProcedureUtils } from './procedure-utils'
-import type { SharedRouterUtils } from './router-utils'
+import type { SharedUtils } from './shared-utils'
 import type { OperationContext } from './types'
 import { meta, oc, type } from '@orpc/contract'
 import { createContractJsonifiedUtilsFactory, createContractUtilsFactory } from './contract-utils'
@@ -82,7 +82,6 @@ describe('createContractUtilsFactory', () => {
 
     expectTypeOf(utils).toEqualTypeOf<
       & Omit<ProcedureUtils<{ cache?: boolean }, string, Date, Error | ORPCError<'BAD_GATEWAY', RegExp>>, 'path' | 'options'>
-      & Omit<SharedRouterUtils<string>, 'path'>
     >()
   })
 
@@ -92,10 +91,9 @@ describe('createContractUtilsFactory', () => {
 
     expectTypeOf(utils.nested.pong).toEqualTypeOf<
       & Omit<ProcedureUtils<{ cache?: boolean }, string, Date, Error | ORPCError<'BAD_GATEWAY', RegExp>>, 'path' | 'options'>
-      & Omit<SharedRouterUtils<string>, 'path'>
     >()
 
-    expectTypeOf(utils.key).toEqualTypeOf<SharedRouterUtils<unknown>['key']>()
+    expectTypeOf(utils.key).toEqualTypeOf<SharedUtils<unknown>['key']>()
   })
 })
 
@@ -163,7 +161,6 @@ describe('createContractJsonifiedUtilsFactory', () => {
 
     expectTypeOf(utils).toEqualTypeOf<
       & Omit<ProcedureUtils<{ cache?: boolean }, string, string, Error | ORPCError<'BAD_GATEWAY', string>>, 'path' | 'options'>
-      & Omit<SharedRouterUtils<string>, 'path'>
     >()
   })
 
@@ -173,7 +170,6 @@ describe('createContractJsonifiedUtilsFactory', () => {
 
     expectTypeOf(utils.nested.pong).toEqualTypeOf<
       & Omit<ProcedureUtils<{ cache?: boolean }, string, string, Error | ORPCError<'BAD_GATEWAY', string>>, 'path' | 'options'>
-      & Omit<SharedRouterUtils<string>, 'path'>
     >()
   })
 })

--- a/packages/tanstack-query/src/index.ts
+++ b/packages/tanstack-query/src/index.ts
@@ -3,6 +3,7 @@ export * from './key'
 export * from './procedure-utils'
 export * from './router-utils'
 export { createRouterUtils as createTanstackQueryUtils } from './router-utils'
+export * from './shared-utils'
 export * from './stream-query'
 export * from './types'
 export {

--- a/packages/tanstack-query/src/procedure-utils.test-d.ts
+++ b/packages/tanstack-query/src/procedure-utils.test-d.ts
@@ -867,7 +867,7 @@ describe('CreateProcedureUtilsOptions', () => {
 
   it('should have all keys that ProcedureUtils provides', () => {
     // Ensures every utility method in ProcedureUtils (except 'call') has a corresponding key in CreateProcedureUtilsOptions
-    type ProcedureUtilsKeys = Exclude<keyof ProcedureUtils<any, any, any, any>, 'call'>
+    type ProcedureUtilsKeys = Exclude<keyof ProcedureUtils<any, any, any, any>, 'call' | 'key'>
     type DefaultsKeys = keyof ProcedureUtilsOptions<any, any, any, any>
 
     expectTypeOf<ProcedureUtilsKeys>().toExtend<DefaultsKeys>()

--- a/packages/tanstack-query/src/procedure-utils.test-d.ts
+++ b/packages/tanstack-query/src/procedure-utils.test-d.ts
@@ -854,7 +854,7 @@ describe('ProcedureUtils', () => {
   })
 })
 
-describe('CreateProcedureUtilsOptions', () => {
+describe('ProcedureUtilsOptions', () => {
   type TestClientContext = { batch?: boolean }
   type TestInput = { search?: string }
   type TestOutput = { title: string }

--- a/packages/tanstack-query/src/procedure-utils.ts
+++ b/packages/tanstack-query/src/procedure-utils.ts
@@ -23,6 +23,7 @@ import { intercept, isAsyncIteratorObject, resolveMaybeOptionalOptions, toArray 
 import { skipToken } from '@tanstack/query-core'
 import { generateOperationKey } from './key'
 import { liveQuery } from './live-query'
+import { SharedUtils } from './shared-utils'
 import { serializableStreamedQuery } from './stream-query'
 import { OPERATION_CONTEXT_SYMBOL } from './types'
 
@@ -171,17 +172,20 @@ export interface ProcedureUtilsOptions<TClientContext extends ClientContext, TIn
   >
 }
 
-export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutput, TError> {
+export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutput, TError> extends SharedUtils<TInput> {
+  declare protected readonly options: ProcedureUtilsOptions<TClientContext, TInput, TOutput, TError>
+
   /**
    * Calling corresponding procedure client
    */
   call: Client<TClientContext, TInput, TOutput, TError>
 
   constructor(
-    private readonly path: string[],
+    path: string[],
     client: Client<TClientContext, TInput, TOutput, TError>,
-    private readonly options: ProcedureUtilsOptions<TClientContext, TInput, TOutput, TError> = {},
+    options: ProcedureUtilsOptions<TClientContext, TInput, TOutput, TError> = {},
   ) {
+    super(path, options)
     this.call = client
   }
 

--- a/packages/tanstack-query/src/router-utils.test-d.ts
+++ b/packages/tanstack-query/src/router-utils.test-d.ts
@@ -1,7 +1,8 @@
 import type { ORPCErrorFromErrorMap } from '@orpc/contract'
 import type { RouterClient } from '@orpc/server'
 import type { ProcedureUtils, ProcedureUtilsOptions } from './procedure-utils'
-import type { RouterUtils, RouterUtilsScoped, SharedRouterUtils } from './router-utils'
+import type { RouterUtils, RouterUtilsScoped } from './router-utils'
+import type { SharedUtils } from './shared-utils'
 import { os } from '@orpc/server'
 import z from 'zod'
 import { createRouterUtils } from './router-utils'
@@ -29,55 +30,26 @@ const scopedRouter = {
   }),
 }
 
-describe('SharedRouterUtils', () => {
-  const utils = {} as SharedRouterUtils<{ a: { b: { c: number } } }>
-
-  it('.key', () => {
-    utils.key()
-    utils.key({})
-    utils.key({ type: 'mutation' })
-    utils.key({ input: {}, type: 'query' })
-    utils.key({ input: {}, type: 'streamed', fnOptions: { refetchMode: 'append' } })
-    utils.key({ input: {} })
-    utils.key({ input: { a: {} } })
-    utils.key({ input: { a: { b: {} } } })
-    utils.key({ input: { a: { b: { c: 1 } } } })
-
-    // @ts-expect-error invalid input
-    utils.key({ input: 123 })
-    // @ts-expect-error invalid input
-    utils.key({ input: { a: { b: { c: '1' } } } })
-
-    // @ts-expect-error invalid input
-    utils.key({ type: 'ddd' })
-
-    // @ts-expect-error input is not allowed when type is mutation
-    utils.key({ type: 'mutation', input: {} })
-    // @ts-expect-error fnOptions is not allowed when type not streamed
-    utils.key({ type: 'infinite', fnOptions: { refetchMode: 'append' } })
-  })
-})
-
 it('RouterUtils', () => {
   type G = RouterClient<typeof scopedRouter, { batch?: boolean }>['nested']['ping']
   const utils = {} as RouterUtils<RouterClient<typeof scopedRouter, { batch?: boolean }>>
 
-  expectTypeOf(utils).toExtend<Omit<SharedRouterUtils<unknown>, 'path'>>()
+  expectTypeOf(utils).toExtend<Omit<SharedUtils<unknown>, 'path'>>()
   expectTypeOf<typeof utils>().not.toExtend<
     ProcedureUtils<any, any, any, any>
   >()
 
-  expectTypeOf(utils.nested).toExtend<Omit<SharedRouterUtils<unknown>, 'path'>>()
+  expectTypeOf(utils.nested).toExtend<Omit<SharedUtils<unknown>, 'path'>>()
   expectTypeOf<typeof utils.nested>().not.toExtend<
     ProcedureUtils<any, any, any, any>
   >()
 
-  expectTypeOf(utils.ping).toExtend<Omit<SharedRouterUtils<{ input: number }>, 'path'>>()
+  expectTypeOf(utils.ping).toExtend<Omit<SharedUtils<{ input: number }>, 'path'>>()
   expectTypeOf(utils.ping).toExtend<
     Omit<ProcedureUtils<{ batch?: boolean }, { input: number }, { output: string }, ORPCErrorFromErrorMap<typeof baseErrorMap> | Error>, 'path' | 'options'>
   >()
 
-  expectTypeOf(utils.nested.ping).toExtend<Omit<SharedRouterUtils<{ input: number }>, 'path'>>()
+  expectTypeOf(utils.nested.ping).toExtend<Omit<SharedUtils<{ input: number }>, 'path'>>()
   expectTypeOf(utils.nested.ping).toExtend<
     Omit<ProcedureUtils<{ batch?: boolean }, { input: number }, { output: string }, ORPCErrorFromErrorMap<typeof baseErrorMap> | Error>, 'path' | 'options'>
   >()

--- a/packages/tanstack-query/src/router-utils.test.ts
+++ b/packages/tanstack-query/src/router-utils.test.ts
@@ -1,15 +1,24 @@
 import type { RouterUtilsPlugin } from './plugin'
 import * as KeyModule from './key'
 import { ProcedureUtils } from './procedure-utils'
-import { createRouterUtils, SharedRouterUtils } from './router-utils'
+import { createRouterUtils } from './router-utils'
 
-vi.mock('./procedure-utils', async () => ({
-  ProcedureUtils: vi.fn(class {
-    call = vi.fn()
-    queryOptions = vi.fn(() => ({ queryOptions: true }))
-    mutationOptions = vi.fn(() => ({ mutationOptions: true }))
-  }),
-}))
+vi.mock('./procedure-utils', async () => {
+  const { SharedUtils } = await import('./shared-utils')
+
+  return {
+    ProcedureUtils: vi.fn(class extends SharedUtils<unknown> {
+      call = vi.fn()
+      override key = SharedUtils.prototype.key
+      queryOptions = vi.fn(() => ({ queryOptions: true }))
+      mutationOptions = vi.fn(() => ({ mutationOptions: true }))
+
+      constructor(path: string[], _client: unknown, options: any = {}) {
+        super(path, options)
+      }
+    }),
+  }
+})
 
 const generateOperationKeySpy = vi.spyOn(KeyModule, 'generateOperationKey')
 
@@ -23,30 +32,6 @@ const emptyInterceptors = {
 
 beforeEach(() => {
   vi.clearAllMocks()
-})
-
-describe('sharedRouterUtils', () => {
-  const utils = new SharedRouterUtils(['path'], {})
-
-  it('.key', () => {
-    expect(
-      utils.key({ input: { search: '__search__' }, type: 'infinite' }),
-    ).toBe(generateOperationKeySpy.mock.results[0]!.value)
-
-    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
-    expect(generateOperationKeySpy).toHaveBeenCalledWith(['path'], { input: { search: '__search__' }, type: 'infinite', prefix: undefined })
-  })
-
-  it('.key with prefix', () => {
-    const prefixedUtils = new SharedRouterUtils(['path'], { prefix: '__prefix__' })
-
-    expect(
-      prefixedUtils.key({ type: 'query' }),
-    ).toBe(generateOperationKeySpy.mock.results[0]!.value)
-
-    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
-    expect(generateOperationKeySpy).toHaveBeenCalledWith(['path'], { type: 'query', prefix: '__prefix__' })
-  })
 })
 
 describe('createRouterUtils', () => {

--- a/packages/tanstack-query/src/router-utils.ts
+++ b/packages/tanstack-query/src/router-utils.ts
@@ -1,35 +1,20 @@
 import type { AnyNestedClient, Client, InferClientContext, InferClientError } from '@orpc/client'
 import type { Public } from '@orpc/shared'
-import type { OperationKey, OperationKeyOptions, OperationKeyPrefixOptions } from './key'
+import type { OperationKeyPrefixOptions } from './key'
 import type { RouterUtilsPlugin } from './plugin'
 import type { ProcedureUtilsInfiniteInterceptor, ProcedureUtilsLiveInterceptor, ProcedureUtilsMutationInterceptor, ProcedureUtilsOptions, ProcedureUtilsQueryInterceptor, ProcedureUtilsStreamedInterceptor } from './procedure-utils'
-import type { OperationType } from './types'
 import { RECURSIVE_CLIENT_UNWRAP_KEYS } from '@orpc/client'
 import { bindMethods, get, getOrBind, isTypescriptObject, toArray } from '@orpc/shared'
-import { generateOperationKey } from './key'
 import { CompositeRouterUtilsPlugin } from './plugin'
 import { ProcedureUtils } from './procedure-utils'
-
-export class SharedRouterUtils<TInput> {
-  constructor(
-    private readonly path: string[],
-    private readonly options: OperationKeyPrefixOptions,
-  ) {}
-
-  /**
-   * Generate a **partial matching** key for actions like revalidating queries, checking mutation status, etc.
-   */
-  key<TType extends OperationType>(options: Omit<OperationKeyOptions<TType, TInput>, 'prefix'> = {}): OperationKey<TType, TInput> {
-    return generateOperationKey(this.path, { ...options, prefix: this.options.prefix })
-  }
-}
+import { SharedUtils } from './shared-utils'
 
 export type RouterUtils<T extends AnyNestedClient>
   = T extends Client<infer UClientContext, infer UInput, infer UOutput, infer UError>
-    ? Public<ProcedureUtils<UClientContext, UInput, UOutput, UError>> & Public<SharedRouterUtils<UInput>>
+    ? Public<ProcedureUtils<UClientContext, UInput, UOutput, UError>>
     : {
       [K in keyof T]: T[K] extends AnyNestedClient ? RouterUtils<T[K]> : never
-    } & Public<SharedRouterUtils<unknown>>
+    } & Public<SharedUtils<unknown>>
 
 export type RouterUtilsScoped<T extends AnyNestedClient>
   = T extends Client<infer UClientContext, infer UInput, infer UOutput, infer UError>
@@ -105,9 +90,8 @@ function createRouterUtilsInternal<T extends AnyNestedClient>(
   plugin: CompositeRouterUtilsPlugin<any>,
 ): RouterUtils<T> {
   const path = toArray(options.path)
-  const sharedUtils = bindMethods(new SharedRouterUtils(path, options))
 
-  const procedureUtils = typeof client === 'function' && (options.scoped === undefined || isProcedureUtilsOptions(options.scoped))
+  const utils = typeof client === 'function' && (options.scoped === undefined || isProcedureUtilsOptions(options.scoped))
     ? bindMethods(new ProcedureUtils(
         path,
         client,
@@ -121,12 +105,9 @@ function createRouterUtilsInternal<T extends AnyNestedClient>(
           mutationInterceptors: [...toArray(options.mutationInterceptors) as any, ...toArray(options.scoped?.mutationInterceptors)],
         }),
       ))
-    : undefined
+    : bindMethods(new SharedUtils(path, options))
 
-  const recursive = new Proxy({
-    ...sharedUtils,
-    ...procedureUtils,
-  }, {
+  const recursive = new Proxy(utils, {
     get(target, prop) {
       const value = getOrBind(target, prop)
       const nextClient = get(client, [prop])

--- a/packages/tanstack-query/src/shared-utils.test-d.ts
+++ b/packages/tanstack-query/src/shared-utils.test-d.ts
@@ -1,0 +1,30 @@
+import type { SharedUtils } from './shared-utils'
+
+describe('SharedUtils', () => {
+  const utils = {} as SharedUtils<{ a: { b: { c: number } } }>
+
+  it('.key', () => {
+    utils.key()
+    utils.key({})
+    utils.key({ type: 'mutation' })
+    utils.key({ input: {}, type: 'query' })
+    utils.key({ input: {}, type: 'streamed', fnOptions: { refetchMode: 'append' } })
+    utils.key({ input: {} })
+    utils.key({ input: { a: {} } })
+    utils.key({ input: { a: { b: {} } } })
+    utils.key({ input: { a: { b: { c: 1 } } } })
+
+    // @ts-expect-error invalid input
+    utils.key({ input: 123 })
+    // @ts-expect-error invalid input
+    utils.key({ input: { a: { b: { c: '1' } } } })
+
+    // @ts-expect-error invalid input
+    utils.key({ type: 'ddd' })
+
+    // @ts-expect-error input is not allowed when type is mutation
+    utils.key({ type: 'mutation', input: {} })
+    // @ts-expect-error fnOptions is not allowed when type not streamed
+    utils.key({ type: 'infinite', fnOptions: { refetchMode: 'append' } })
+  })
+})

--- a/packages/tanstack-query/src/shared-utils.test.ts
+++ b/packages/tanstack-query/src/shared-utils.test.ts
@@ -1,0 +1,32 @@
+import * as KeyModule from './key'
+import { SharedUtils } from './shared-utils'
+
+const generateOperationKeySpy = vi.spyOn(KeyModule, 'generateOperationKey')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('sharedUtils', () => {
+  const utils = new SharedUtils(['path'], {})
+
+  it('.key', () => {
+    expect(
+      utils.key({ input: { search: '__search__' }, type: 'infinite' }),
+    ).toBe(generateOperationKeySpy.mock.results[0]!.value)
+
+    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+    expect(generateOperationKeySpy).toHaveBeenCalledWith(['path'], { input: { search: '__search__' }, type: 'infinite', prefix: undefined })
+  })
+
+  it('.key with prefix', () => {
+    const prefixedUtils = new SharedUtils(['path'], { prefix: '__prefix__' })
+
+    expect(
+      prefixedUtils.key({ type: 'query' }),
+    ).toBe(generateOperationKeySpy.mock.results[0]!.value)
+
+    expect(generateOperationKeySpy).toHaveBeenCalledTimes(1)
+    expect(generateOperationKeySpy).toHaveBeenCalledWith(['path'], { type: 'query', prefix: '__prefix__' })
+  })
+})

--- a/packages/tanstack-query/src/shared-utils.ts
+++ b/packages/tanstack-query/src/shared-utils.ts
@@ -1,0 +1,17 @@
+import type { OperationKey, OperationKeyOptions, OperationKeyPrefixOptions } from './key'
+import type { OperationType } from './types'
+import { generateOperationKey } from './key'
+
+export class SharedUtils<TInput> {
+  constructor(
+    protected readonly path: string[],
+    protected readonly options: OperationKeyPrefixOptions,
+  ) {}
+
+  /**
+   * Generate a **partial matching** key for actions like revalidating queries, checking mutation status, etc.
+   */
+  key<TType extends OperationType>(options: Omit<OperationKeyOptions<TType, TInput>, 'prefix'> = {}): OperationKey<TType, TInput> {
+    return generateOperationKey(this.path, { ...options, prefix: this.options.prefix })
+  }
+}


### PR DESCRIPTION
## Summary

`SharedRouterUtils` is renamed to `SharedUtils` and moved into a dedicated `shared-utils` module (with its own runtime and type tests) in both `@orpc/tanstack-query` and `@orpc/pinia-colada`. `ProcedureUtils` now extends `SharedUtils`, so procedure utils provide the full `.key()` helper (including `prefix`) directly:

```ts
const orpc = createTanstackQueryUtils(client)

orpc.planet.find.key({ type: 'query' }) // available on procedure utils themselves
```

- `SharedUtils` lives in `shared-utils.ts` and is exported from both packages; `SharedRouterUtils` no longer exists (breaking for anyone importing it)
- `createRouterUtils` builds a single utils instance per node: `ProcedureUtils` for procedures, `SharedUtils` otherwise
- Extracted from #1703 (structural part only — no interceptor changes)