### PR TITLE
feat(pinia-colada): define base options and interceptors via contract meta

### DIFF
--- a/apps/content/docs/integrations/pinia-colada.md
+++ b/apps/content/docs/integrations/pinia-colada.md
@@ -323,7 +323,7 @@ Types inferred from the contract are for reference only. The actual types depend
 :::
 
 ::: details Passing runtime values into contract meta?
-Contracts are defined separately from your app, so anything inside `piniaColada` cannot import runtime values such as your router utils. Instead, augment [`UseMutationGlobalContext`](https://pinia-colada.esm.dev/api/@pinia/colada/interfaces/UseMutationGlobalContext.html) and provide the values through a global `onMutate` hook, which merges them into the `fnContext` of every mutation. The example below reads router utils and the query cache from `fnContext` to optimistically update a query:
+Contracts are defined separately from your app, so anything inside `piniaColada` cannot import runtime values such as your router utils. Instead, augment [`UseMutationContextCommon`](https://pinia-colada.esm.dev/api/@pinia/colada/interfaces/UseMutationContextCommon.html) and provide the values through a global `onMutate` hook, which merges them into the `fnContext` of every mutation. The example below reads router utils and the query cache from `fnContext` to optimistically update a query:
 
 ```ts
 import type { RouterContractClient } from '@orpc/contract'
@@ -331,9 +331,9 @@ import type { RouterUtils } from '@orpc/pinia-colada'
 import type { QueryCache } from '@pinia/colada'
 
 declare module '@pinia/colada' {
-  export interface UseMutationGlobalContext {
-    utils?: RouterUtils<RouterContractClient<typeof contract>>
-    queryCache?: QueryCache
+  interface UseMutationContextCommon {
+    utils: RouterUtils<RouterContractClient<typeof contract>>
+    queryCache: QueryCache
   }
 }
 

--- a/apps/content/docs/integrations/pinia-colada.md
+++ b/apps/content/docs/integrations/pinia-colada.md
@@ -322,6 +322,70 @@ const orpc = createPiniaColadaUtils(client, {
 Types inferred from the contract are for reference only. The actual types depend on the client the utils are created from. For example, a `JsonifiedClient` created from [OpenAPI Link](/docs/openapi/link#typesafe-clients) returns jsonified outputs that may not match the contract schemas.
 :::
 
+::: details Passing runtime values into contract meta?
+Contracts are defined separately from your app, so anything inside `piniaColada` cannot import runtime values such as your router utils. Instead, augment [`UseMutationGlobalContext`](https://pinia-colada.esm.dev/api/@pinia/colada/interfaces/UseMutationGlobalContext.html) and provide the values through a global `onMutate` hook, which merges them into the `fnContext` of every mutation. The example below reads router utils and the query cache from `fnContext` to optimistically update a query:
+
+```ts
+import type { RouterContractClient } from '@orpc/contract'
+import type { RouterUtils } from '@orpc/pinia-colada'
+import type { QueryCache } from '@pinia/colada'
+
+declare module '@pinia/colada' {
+  export interface UseMutationGlobalContext {
+    utils?: RouterUtils<RouterContractClient<typeof contract>>
+    queryCache?: QueryCache
+  }
+}
+
+export const contract = {
+  planet: {
+    find: oc.input(z.object({ id: z.number() })),
+    update: oc
+      .input(z.object({ id: z.number(), name: z.string() }))
+      .meta(piniaColada({
+        mutationInterceptors: [
+          async ({ input, next, fnContext }) => {
+            const { utils, queryCache } = fnContext
+
+            if (!utils || !queryCache) {
+              return next()
+            }
+
+            const queryKey = utils.planet.find.queryKey({ input: { id: input.id } })
+            const previous = queryCache.getQueryData(queryKey)
+
+            // optimistically update before the request
+            queryCache.setQueryData(queryKey, input)
+
+            try {
+              return await next()
+            }
+            catch (error) {
+              // roll back on error
+              queryCache.setQueryData(queryKey, previous)
+              throw error
+            }
+            finally {
+              queryCache.invalidateQueries({ key: queryKey })
+            }
+          },
+        ],
+      })),
+  },
+}
+
+app.use(PiniaColada, {
+  mutationOptions: {
+    onMutate: () => ({
+      utils: orpc,
+      queryCache: useQueryCache(pinia),
+    }),
+  },
+})
+```
+
+:::
+
 ## Client Context
 
 When a client is invoked through the Pinia Colada integration, an **operation context** is automatically added to the [client context](/docs/client/client-side#client-context). You can use this context to configure request behavior, such as selecting the HTTP method for [RPC Link](/docs/rpc/link#request-method).

--- a/apps/content/docs/integrations/pinia-colada.md
+++ b/apps/content/docs/integrations/pinia-colada.md
@@ -288,6 +288,40 @@ const orpc = createPiniaColadaUtils(client, {
 })
 ```
 
+### Contract Options Plugin
+
+Use `piniaColada` to define base options and interceptors directly on a [procedure contract](/docs/contract/procedure), then pass the contract to `ContractOptionsUtilsPlugin` to apply them automatically. Meta options act as the base layer: [default options](#default-options) and [interceptors](#interceptors) defined on the utils merge on top of them.
+
+```ts
+import { ContractOptionsUtilsPlugin, piniaColada } from '@orpc/pinia-colada'
+
+export const contract = {
+  planet: {
+    find: oc
+      .input(z.object({ id: z.number() }))
+      .meta(piniaColada({
+        queryOptions: {
+          staleTime: 60 * 1000,
+        },
+        queryInterceptors: [
+          async ({ input, next }) => {
+            // input, output, and errors are typed based on the contract
+            return await next()
+          },
+        ],
+      })),
+  },
+}
+
+const orpc = createPiniaColadaUtils(client, {
+  plugins: [new ContractOptionsUtilsPlugin(contract)],
+})
+```
+
+::: warning
+Types inferred from the contract are for reference only. The actual types depend on the client the utils are created from. For example, a `JsonifiedClient` created from [OpenAPI Link](/docs/openapi/link#typesafe-clients) returns jsonified outputs that may not match the contract schemas.
+:::
+
 ## Client Context
 
 When a client is invoked through the Pinia Colada integration, an **operation context** is automatically added to the [client context](/docs/client/client-side#client-context). You can use this context to configure request behavior, such as selecting the HTTP method for [RPC Link](/docs/rpc/link#request-method).

--- a/apps/content/docs/integrations/pinia-colada.md
+++ b/apps/content/docs/integrations/pinia-colada.md
@@ -290,7 +290,7 @@ const orpc = createPiniaColadaUtils(client, {
 
 ### Contract Options Plugin
 
-Use `piniaColada` to define base options and interceptors directly on a [procedure contract](/docs/contract/procedure), then pass the contract to `ContractOptionsUtilsPlugin` to apply them automatically. Meta options act as the base layer: [default options](#default-options) and [interceptors](#interceptors) defined on the utils merge on top of them.
+Use `piniaColada` to define base options and interceptors directly on a [procedure contract](/docs/contract/procedure), then pass the contract to `ContractOptionsUtilsPlugin` to apply them automatically. Meta options act as the base layer: [default options](#default-options) and [interceptors](#interceptors) defined on the utils merge on top of them. Passing `undefined` explicitly for a key resets the value from lower layers instead of merging.
 
 ```ts
 import { ContractOptionsUtilsPlugin, piniaColada } from '@orpc/pinia-colada'

--- a/packages/pinia-colada/src/index.ts
+++ b/packages/pinia-colada/src/index.ts
@@ -1,6 +1,7 @@
 export * from './contract-utils'
 export * from './key'
 export * from './live-query'
+export * from './meta'
 export * from './plugin'
 export * from './procedure-utils'
 export * from './router-utils'

--- a/packages/pinia-colada/src/meta.test-d.ts
+++ b/packages/pinia-colada/src/meta.test-d.ts
@@ -1,0 +1,46 @@
+import type { ClientContext, ORPCError } from '@orpc/client'
+import type { PromiseWithError } from '@orpc/shared'
+import type { OperationContext } from './types'
+import { oc, type } from '@orpc/contract'
+import { piniaColada } from './meta'
+
+describe('piniaColada', () => {
+  it('infers input, output and error types from the contract', () => {
+    oc
+      .errors({ BAD_GATEWAY: { data: type<string, RegExp>(vi.fn()) } })
+      .input(type<string, boolean>(vi.fn()))
+      .output(type<number, Date>(vi.fn()))
+      .meta(piniaColada({
+        queryOptions: { staleTime: 1000 },
+        queryInterceptors: [
+          async ({ context, input, next }) => {
+            expectTypeOf(input).toEqualTypeOf<string>()
+            expectTypeOf(context).toEqualTypeOf<ClientContext & OperationContext>()
+
+            const result = next()
+
+            expectTypeOf(result).toEqualTypeOf<
+              PromiseWithError<Date, Error | ORPCError<'BAD_GATEWAY', RegExp>>
+            >()
+
+            return result
+          },
+        ],
+        mutationOptions: {
+          onSuccess: (data, input) => {
+            expectTypeOf(data).toEqualTypeOf<Date>()
+            expectTypeOf(input).toEqualTypeOf<string>()
+          },
+        },
+      }))
+  })
+
+  it('rejects invalid base options', () => {
+    oc.output(type<number, Date>(vi.fn())).meta(piniaColada({
+      queryOptions: {
+        // @ts-expect-error - staleTime must be a number
+        staleTime: 'invalid',
+      },
+    }))
+  })
+})

--- a/packages/pinia-colada/src/meta.test.ts
+++ b/packages/pinia-colada/src/meta.test.ts
@@ -1,0 +1,191 @@
+import { oc } from '@orpc/contract'
+import { ContractOptionsUtilsPlugin, getPiniaColadaMeta, piniaColada } from './meta'
+import { createRouterUtils } from './router-utils'
+
+describe('piniaColada', () => {
+  it('stores options readable via getPiniaColadaMeta', () => {
+    const interceptor = vi.fn()
+    const contract = oc.meta(piniaColada({
+      queryOptions: { staleTime: 1000 },
+      queryInterceptors: [interceptor],
+    }))
+
+    expect(getPiniaColadaMeta(contract)).toEqual({
+      queryOptions: { staleTime: 1000 },
+      queryInterceptors: [interceptor],
+    })
+
+    expect(getPiniaColadaMeta(oc)).toBeUndefined()
+  })
+
+  it('merges options when applied multiple times', () => {
+    const interceptor1 = vi.fn()
+    const interceptor2 = vi.fn()
+    const keyModifier = vi.fn()
+
+    const contract = oc
+      .meta(piniaColada({
+        queryKey: keyModifier,
+        queryOptions: { staleTime: 1000, gcTime: 1 },
+        queryInterceptors: [interceptor1],
+      }))
+      .meta(piniaColada({
+        queryOptions: { gcTime: 2 },
+        mutationInterceptors: [interceptor2],
+      }))
+
+    expect(getPiniaColadaMeta(contract)).toEqual({
+      queryKey: keyModifier,
+      queryOptions: { staleTime: 1000, gcTime: 2 },
+      queryInterceptors: [interceptor1],
+      streamedInterceptors: [],
+      liveInterceptors: [],
+      infiniteInterceptors: [],
+      mutationInterceptors: [interceptor2],
+    })
+  })
+
+  it('composes function modifiers, base applied first', () => {
+    const contract = oc
+      .meta(piniaColada({
+        queryOptions: options => ({ ...options, staleTime: 1000, gcTime: 1 }),
+      }))
+      .meta(piniaColada({
+        queryOptions: options => ({ ...options, gcTime: 2 }),
+      }))
+
+    const merged: any = getPiniaColadaMeta(contract)?.queryOptions
+
+    expect(merged({ enabled: true })).toEqual({ enabled: true, staleTime: 1000, gcTime: 2 })
+  })
+
+  it('composes mixed object and function modifiers', () => {
+    const objectFirst = oc
+      .meta(piniaColada({ queryOptions: { staleTime: 1000, gcTime: 1 } }))
+      .meta(piniaColada({ queryOptions: options => ({ ...options, gcTime: 2 }) }))
+
+    const objectFirstMerged: any = getPiniaColadaMeta(objectFirst)?.queryOptions
+
+    expect(objectFirstMerged({ enabled: true })).toEqual({ enabled: true, staleTime: 1000, gcTime: 2 })
+
+    const functionFirst = oc
+      .meta(piniaColada({ queryOptions: options => ({ ...options, staleTime: 1000 }) }))
+      .meta(piniaColada({ queryOptions: { gcTime: 2 } }))
+
+    const functionFirstMerged: any = getPiniaColadaMeta(functionFirst)?.queryOptions
+
+    expect(functionFirstMerged({ enabled: true })).toEqual({ enabled: true, staleTime: 1000, gcTime: 2 })
+  })
+
+  it('propagates base meta to procedures via .router', () => {
+    const router = oc
+      .meta(piniaColada({ queryOptions: { staleTime: 1000 } }))
+      .router({
+        ping: oc.meta(piniaColada({ queryOptions: { gcTime: 2 } })),
+        pong: oc,
+      })
+
+    expect(getPiniaColadaMeta(router.ping)).toEqual({
+      queryOptions: { staleTime: 1000, gcTime: 2 },
+      queryInterceptors: [],
+      streamedInterceptors: [],
+      liveInterceptors: [],
+      infiniteInterceptors: [],
+      mutationInterceptors: [],
+    })
+
+    expect(getPiniaColadaMeta(router.pong)).toEqual({
+      queryOptions: { staleTime: 1000 },
+    })
+  })
+})
+
+describe('contractOptionsUtilsPlugin', () => {
+  it('leaves options unchanged when no procedure or no meta at path', () => {
+    const plugin = new ContractOptionsUtilsPlugin({ planet: { find: oc } })
+    const options = { prefix: '__prefix__' }
+
+    expect(plugin.initProcedureOptions(['unknown'], options)).toBe(options)
+    expect(plugin.initProcedureOptions(['planet'], options)).toBe(options)
+    expect(plugin.initProcedureOptions(['planet', 'find'], options)).toBe(options)
+  })
+
+  it('merges meta options as base under current options', () => {
+    const metaInterceptor = vi.fn()
+    const existingInterceptor = vi.fn()
+
+    const plugin = new ContractOptionsUtilsPlugin({
+      planet: {
+        find: oc.meta(piniaColada({
+          queryOptions: { staleTime: 1000, gcTime: 1 },
+          queryInterceptors: [metaInterceptor],
+        })),
+      },
+    })
+
+    const result = plugin.initProcedureOptions(['planet', 'find'], {
+      prefix: '__prefix__',
+      queryOptions: { gcTime: 2 },
+      queryInterceptors: [existingInterceptor],
+    } as any)
+
+    expect(result).toEqual({
+      prefix: '__prefix__',
+      queryOptions: { staleTime: 1000, gcTime: 2 },
+      queryInterceptors: [metaInterceptor, existingInterceptor],
+      streamedInterceptors: [],
+      liveInterceptors: [],
+      infiniteInterceptors: [],
+      mutationInterceptors: [],
+    })
+  })
+
+  it('applies contract meta through createRouterUtils', async () => {
+    const marks: string[] = []
+    const metaInterceptor = vi.fn(({ next }: any) => {
+      marks.push('meta')
+      return next()
+    })
+    const utilsInterceptor = vi.fn(({ next }: any) => {
+      marks.push('utils')
+      return next()
+    })
+
+    const contract = {
+      planet: {
+        find: oc.meta(piniaColada({
+          queryOptions: { staleTime: 1000, gcTime: 1 },
+          queryInterceptors: [metaInterceptor],
+        })),
+      },
+    }
+
+    const client = {
+      planet: {
+        find: vi.fn(async () => '__found__'),
+      },
+    }
+
+    const utils = createRouterUtils(client as any, {
+      queryInterceptors: [utilsInterceptor],
+      scoped: {
+        planet: {
+          find: {
+            queryOptions: { gcTime: 2 },
+          },
+        },
+      },
+      plugins: [new ContractOptionsUtilsPlugin(contract)],
+    }) as any
+
+    const options = utils.planet.find.queryOptions({ input: { id: 1 } })
+
+    expect(options.staleTime).toBe(1000)
+    expect(options.gcTime).toBe(2)
+
+    await expect(options.query({ signal: undefined })).resolves.toBe('__found__')
+
+    expect(marks).toEqual(['meta', 'utils'])
+    expect(client.planet.find).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/pinia-colada/src/meta.test.ts
+++ b/packages/pinia-colada/src/meta.test.ts
@@ -38,43 +38,8 @@ describe('piniaColada', () => {
       queryKey: keyModifier,
       queryOptions: { staleTime: 1000, gcTime: 2 },
       queryInterceptors: [interceptor1],
-      streamedInterceptors: [],
-      liveInterceptors: [],
-      infiniteInterceptors: [],
       mutationInterceptors: [interceptor2],
     })
-  })
-
-  it('composes function modifiers, base applied first', () => {
-    const contract = oc
-      .meta(piniaColada({
-        queryOptions: options => ({ ...options, staleTime: 1000, gcTime: 1 }),
-      }))
-      .meta(piniaColada({
-        queryOptions: options => ({ ...options, gcTime: 2 }),
-      }))
-
-    const merged: any = getPiniaColadaMeta(contract)?.queryOptions
-
-    expect(merged({ enabled: true })).toEqual({ enabled: true, staleTime: 1000, gcTime: 2 })
-  })
-
-  it('composes mixed object and function modifiers', () => {
-    const objectFirst = oc
-      .meta(piniaColada({ queryOptions: { staleTime: 1000, gcTime: 1 } }))
-      .meta(piniaColada({ queryOptions: options => ({ ...options, gcTime: 2 }) }))
-
-    const objectFirstMerged: any = getPiniaColadaMeta(objectFirst)?.queryOptions
-
-    expect(objectFirstMerged({ enabled: true })).toEqual({ enabled: true, staleTime: 1000, gcTime: 2 })
-
-    const functionFirst = oc
-      .meta(piniaColada({ queryOptions: options => ({ ...options, staleTime: 1000 }) }))
-      .meta(piniaColada({ queryOptions: { gcTime: 2 } }))
-
-    const functionFirstMerged: any = getPiniaColadaMeta(functionFirst)?.queryOptions
-
-    expect(functionFirstMerged({ enabled: true })).toEqual({ enabled: true, staleTime: 1000, gcTime: 2 })
   })
 
   it('propagates base meta to procedures via .router', () => {
@@ -87,11 +52,6 @@ describe('piniaColada', () => {
 
     expect(getPiniaColadaMeta(router.ping)).toEqual({
       queryOptions: { staleTime: 1000, gcTime: 2 },
-      queryInterceptors: [],
-      streamedInterceptors: [],
-      liveInterceptors: [],
-      infiniteInterceptors: [],
-      mutationInterceptors: [],
     })
 
     expect(getPiniaColadaMeta(router.pong)).toEqual({
@@ -133,10 +93,6 @@ describe('contractOptionsUtilsPlugin', () => {
       prefix: '__prefix__',
       queryOptions: { staleTime: 1000, gcTime: 2 },
       queryInterceptors: [metaInterceptor, existingInterceptor],
-      streamedInterceptors: [],
-      liveInterceptors: [],
-      infiniteInterceptors: [],
-      mutationInterceptors: [],
     })
   })
 

--- a/packages/pinia-colada/src/meta.ts
+++ b/packages/pinia-colada/src/meta.ts
@@ -1,0 +1,95 @@
+import type { AnyNestedClient, ClientContext, InferClientContext, InferClientError } from '@orpc/client'
+import type { AnySchema, ErrorMap, InferSchemaInput, InferSchemaOutput, Meta, MetaPlugin, ORPCErrorFromErrorMap, RouterContract } from '@orpc/contract'
+import type { ThrowableError } from '@orpc/shared'
+import type { RouterUtilsPlugin } from './plugin'
+import type { ProcedureUtilsOptions } from './procedure-utils'
+import { getRouterContract, ProcedureContract } from '@orpc/contract'
+import { mergeProcedureUtilsOptions } from './procedure-utils'
+
+export type PiniaColadaMetaOptions<TClientContext extends ClientContext, TInput, TOutput, TError>
+  = Omit<ProcedureUtilsOptions<TClientContext, TInput, TOutput, TError>, 'prefix'>
+
+export interface PiniaColadaMetaPlugin<
+  TInputSchema extends AnySchema,
+  TOutputSchema extends AnySchema,
+  TErrorMap extends ErrorMap,
+> extends MetaPlugin<TInputSchema, TOutputSchema, TErrorMap> {
+  name: '~pinia-colada'
+}
+
+/**
+ * Define base Pinia Colada options and interceptors on a procedure contract.
+ * Applied multiple times, later options are spread-merged with higher priority
+ * while interceptors are concatenated.
+ *
+ * Apply them to router utils with {@link ContractOptionsUtilsPlugin}.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/pinia-colada#contract-options-plugin Pinia Colada Contract Options Plugin Docs}
+ */
+export function piniaColada<
+  TInputSchema extends AnySchema,
+  TOutputSchema extends AnySchema,
+  TErrorMap extends ErrorMap,
+>(
+  options: PiniaColadaMetaOptions<
+    ClientContext,
+    InferSchemaInput<TInputSchema>,
+    InferSchemaOutput<TOutputSchema>,
+    ORPCErrorFromErrorMap<TErrorMap> | ThrowableError
+  >,
+): PiniaColadaMetaPlugin<TInputSchema, TOutputSchema, TErrorMap> {
+  return {
+    name: '~pinia-colada',
+    init(meta) {
+      const current = meta['~pinia-colada'] as ProcedureUtilsOptions<ClientContext, any, any, any> | undefined
+
+      return {
+        ...meta,
+        '~pinia-colada': current ? mergeProcedureUtilsOptions(current, options) : options,
+      }
+    },
+  }
+}
+
+export function getPiniaColadaMeta(
+  procedureOrLazy: { '~orpc': { meta: Meta } },
+): PiniaColadaMetaOptions<ClientContext, unknown, unknown, ThrowableError> | undefined {
+  return procedureOrLazy['~orpc'].meta['~pinia-colada'] as PiniaColadaMetaOptions<ClientContext, unknown, unknown, ThrowableError> | undefined
+}
+
+/**
+ * Router utils plugin that applies base options defined via {@link piniaColada}
+ * on the given router contract. Meta options act as the base layer: options defined
+ * on the utils override them, and utils interceptors run after meta interceptors.
+ *
+ * The contract shape must match the client the utils are created from,
+ * so pass the root router contract when utils paths start from the root.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/pinia-colada#contract-options-plugin Pinia Colada Contract Options Plugin Docs}
+ */
+export class ContractOptionsUtilsPlugin<T extends AnyNestedClient = AnyNestedClient> implements RouterUtilsPlugin<T> {
+  readonly name = '~contract-options'
+
+  constructor(
+    private readonly contract: RouterContract,
+  ) {}
+
+  initProcedureOptions(
+    path: string[],
+    options: ProcedureUtilsOptions<InferClientContext<T>, any, any, InferClientError<T>>,
+  ): ProcedureUtilsOptions<InferClientContext<T>, any, any, InferClientError<T>> {
+    const procedure = getRouterContract(this.contract, path)
+
+    if (!(procedure instanceof ProcedureContract)) {
+      return options
+    }
+
+    const base = getPiniaColadaMeta(procedure)
+
+    if (!base) {
+      return options
+    }
+
+    return mergeProcedureUtilsOptions(base as any, options)
+  }
+}

--- a/packages/pinia-colada/src/meta.ts
+++ b/packages/pinia-colada/src/meta.ts
@@ -20,7 +20,8 @@ export interface PiniaColadaMetaPlugin<
 /**
  * Define base Pinia Colada options and interceptors on a procedure contract.
  * Applied multiple times, later options are spread-merged with higher priority
- * while interceptors are concatenated.
+ * while interceptors are concatenated. A key explicitly set to `undefined`
+ * resets the value from earlier applications instead of merging.
  *
  * Apply them to router utils with {@link ContractOptionsUtilsPlugin}.
  *

--- a/packages/pinia-colada/src/procedure-utils.test.ts
+++ b/packages/pinia-colada/src/procedure-utils.test.ts
@@ -1,6 +1,6 @@
 import * as KeyModule from './key'
 import * as LiveQueryModule from './live-query'
-import { ProcedureUtils } from './procedure-utils'
+import { isProcedureUtilsOptions, ProcedureUtils } from './procedure-utils'
 import * as StreamQueryModule from './stream-query'
 import { OPERATION_CONTEXT_SYMBOL } from './types'
 
@@ -914,5 +914,25 @@ describe('procedureUtils', () => {
       expect(modifier).toHaveBeenCalledWith({ onSuccess })
       expect(options.gcTime).toEqual(3000)
     })
+  })
+})
+
+describe('isProcedureUtilsOptions', () => {
+  it('accepts procedure utils options shapes', () => {
+    expect(isProcedureUtilsOptions({})).toBe(true)
+    expect(isProcedureUtilsOptions({ prefix: 'planet' })).toBe(true)
+    expect(isProcedureUtilsOptions({ queryInterceptors: [], mutationInterceptors: [vi.fn()] })).toBe(true)
+    expect(isProcedureUtilsOptions({ queryOptions: { staleTime: 1000 }, mutationKey: () => ({}) })).toBe(true)
+    expect(isProcedureUtilsOptions({ liveOptions: undefined, streamedKey: undefined })).toBe(true)
+    expect(isProcedureUtilsOptions({ unknown: 'allowed' })).toBe(true)
+  })
+
+  it('rejects non procedure utils options shapes', () => {
+    expect(isProcedureUtilsOptions(undefined)).toBe(false)
+    expect(isProcedureUtilsOptions('invalid')).toBe(false)
+    expect(isProcedureUtilsOptions({ prefix: 123 })).toBe(false)
+    expect(isProcedureUtilsOptions({ queryInterceptors: { invalid: true } })).toBe(false)
+    expect(isProcedureUtilsOptions({ queryInterceptors: [{ invalid: true }] })).toBe(false)
+    expect(isProcedureUtilsOptions({ queryOptions: 'invalid' })).toBe(false)
   })
 })

--- a/packages/pinia-colada/src/procedure-utils.test.ts
+++ b/packages/pinia-colada/src/procedure-utils.test.ts
@@ -1,6 +1,6 @@
 import * as KeyModule from './key'
 import * as LiveQueryModule from './live-query'
-import { isProcedureUtilsOptions, ProcedureUtils } from './procedure-utils'
+import { isProcedureUtilsOptions, mergeProcedureUtilsOptions, ProcedureUtils } from './procedure-utils'
 import * as StreamQueryModule from './stream-query'
 import { OPERATION_CONTEXT_SYMBOL } from './types'
 
@@ -934,5 +934,74 @@ describe('isProcedureUtilsOptions', () => {
     expect(isProcedureUtilsOptions({ queryInterceptors: { invalid: true } })).toBe(false)
     expect(isProcedureUtilsOptions({ queryInterceptors: [{ invalid: true }] })).toBe(false)
     expect(isProcedureUtilsOptions({ queryOptions: 'invalid' })).toBe(false)
+  })
+})
+
+describe('mergeProcedureUtilsOptions', () => {
+  it('overrides by key presence, keeping absent keys from base', () => {
+    const merged = mergeProcedureUtilsOptions<any, any, any, any>(
+      { prefix: 'base', queryOptions: { staleTime: 1000 } },
+      { prefix: 'override' },
+    )
+
+    expect(merged).toEqual({
+      prefix: 'override',
+      queryOptions: { staleTime: 1000 },
+    })
+  })
+
+  it('resets keys explicitly set to undefined in override', () => {
+    const merged = mergeProcedureUtilsOptions<any, any, any, any>(
+      { queryOptions: { staleTime: 1000 }, queryInterceptors: [vi.fn()] },
+      { queryOptions: undefined, queryInterceptors: undefined },
+    )
+
+    expect(merged).toEqual({})
+  })
+
+  it('concatenates interceptors when both defined, base first', () => {
+    const interceptor1 = vi.fn()
+    const interceptor2 = vi.fn()
+
+    const merged = mergeProcedureUtilsOptions<any, any, any, any>(
+      { mutationInterceptors: [interceptor1] },
+      { mutationInterceptors: [interceptor2] },
+    )
+
+    expect(merged).toEqual({ mutationInterceptors: [interceptor1, interceptor2] })
+  })
+
+  it('spread-merges plain object modifiers', () => {
+    const merged = mergeProcedureUtilsOptions<any, any, any, any>(
+      { queryOptions: { staleTime: 1000, gcTime: 1 } },
+      { queryOptions: { gcTime: 2 } },
+    )
+
+    expect(merged).toEqual({ queryOptions: { staleTime: 1000, gcTime: 2 } })
+  })
+
+  it('composes function modifiers, base applied first', () => {
+    const merged = mergeProcedureUtilsOptions<any, any, any, any>(
+      { queryOptions: (options: any) => ({ ...options, staleTime: 1000, gcTime: 1 }) },
+      { queryOptions: (options: any) => ({ ...options, gcTime: 2 }) },
+    )
+
+    expect((merged.queryOptions as any)({ enabled: true })).toEqual({ enabled: true, staleTime: 1000, gcTime: 2 })
+  })
+
+  it('composes mixed object and function modifiers', () => {
+    const objectFirst = mergeProcedureUtilsOptions<any, any, any, any>(
+      { queryOptions: { staleTime: 1000, gcTime: 1 } },
+      { queryOptions: (options: any) => ({ ...options, gcTime: 2 }) },
+    )
+
+    expect((objectFirst.queryOptions as any)({ enabled: true })).toEqual({ enabled: true, staleTime: 1000, gcTime: 2 })
+
+    const functionFirst = mergeProcedureUtilsOptions<any, any, any, any>(
+      { queryOptions: (options: any) => ({ ...options, staleTime: 1000 }) },
+      { queryOptions: { gcTime: 2 } },
+    )
+
+    expect((functionFirst.queryOptions as any)({ enabled: true })).toEqual({ enabled: true, staleTime: 1000, gcTime: 2 })
   })
 })

--- a/packages/pinia-colada/src/procedure-utils.ts
+++ b/packages/pinia-colada/src/procedure-utils.ts
@@ -3,7 +3,7 @@ import type { Interceptor, MaybeOptionalOptions, PromiseWithError } from '@orpc/
 import type { _EmptyObject, EntryKeyTagged, UseInfiniteQueryData, UseInfiniteQueryFnContext } from '@pinia/colada'
 import type { OperationKeyPrefixOptions } from './key'
 import type { InferLiveQueryOutput, InferStreamedQueryOutput, InfiniteKeyOptions, InfiniteOptionsIn, InfiniteOptionsOut, MutationKeyOptions, MutationOptionsIn, MutationOptionsOut, OperationContext, QueryKeyOptions, QueryOptionsIn, QueryOptionsOut, StreamedKeyOptions, StreamedOptionsIn, StreamedOptionsOut, UseMutationFnContext, UseQueryFnContext } from './types'
-import { intercept, isAsyncIteratorObject, resolveMaybeOptionalOptions } from '@orpc/shared'
+import { intercept, isAsyncIteratorObject, isTypescriptObject, resolveMaybeOptionalOptions, toArray } from '@orpc/shared'
 import { generateOperationKey } from './key'
 import { liveQuery } from './live-query'
 import { SharedUtils } from './shared-utils'
@@ -158,6 +158,106 @@ export interface ProcedureUtilsOptions<TClientContext extends ClientContext, TIn
   mutationOptions?: ProcedureUtilsModifier<
     MutationOptionsIn<TClientContext, TInput, TOutput, TError, Record<any, any>>
   >
+}
+
+const PROCEDURE_UTILS_INTERCEPTOR_KEYS: string[] = [
+  'queryInterceptors',
+  'streamedInterceptors',
+  'liveInterceptors',
+  'infiniteInterceptors',
+  'mutationInterceptors',
+]
+
+const PROCEDURE_UTILS_MODIFIER_KEYS: string[] = [
+  'queryKey',
+  'queryOptions',
+  'streamedKey',
+  'streamedOptions',
+  'liveKey',
+  'liveOptions',
+  'infiniteKey',
+  'infiniteOptions',
+  'mutationKey',
+  'mutationOptions',
+]
+
+export function isProcedureUtilsOptions(value: unknown): value is ProcedureUtilsOptions<any, any, any, any> {
+  if (!isTypescriptObject(value)) {
+    return false
+  }
+
+  for (const key in value) {
+    if (value[key] === undefined) {
+      continue
+    }
+
+    if (key === 'prefix') {
+      if (typeof value[key] !== 'string') {
+        return false
+      }
+    }
+    else if (PROCEDURE_UTILS_INTERCEPTOR_KEYS.includes(key)) {
+      if (!Array.isArray(value[key]) || value[key].some(i => typeof i !== 'function')) {
+        return false
+      }
+    }
+    else if (PROCEDURE_UTILS_MODIFIER_KEYS.includes(key)) {
+      if (!isTypescriptObject(value[key])) {
+        return false
+      }
+    }
+  }
+
+  return true
+}
+
+function mergeProcedureUtilsModifier<T extends object>(
+  base: ProcedureUtilsModifier<T> | undefined,
+  override: ProcedureUtilsModifier<T> | undefined,
+): ProcedureUtilsModifier<T> | undefined {
+  if (!base || !override) {
+    return override ?? base
+  }
+
+  if (typeof base !== 'function' && typeof override !== 'function') {
+    return { ...base, ...override } as Partial<T>
+  }
+
+  const applyBase = typeof base === 'function' ? base : (options: T) => ({ ...base, ...options })
+  const applyOverride = typeof override === 'function' ? override : (options: T) => ({ ...override, ...options })
+
+  return options => applyOverride(applyBase(options))
+}
+
+/**
+ * Merge two procedure utils options where `override` takes priority:
+ * interceptors are concatenated (base ones run first), modifiers are
+ * spread-merged when both are plain objects and composed (base applied first)
+ * otherwise, with plain objects applied as regular spread merges.
+ */
+export function mergeProcedureUtilsOptions<TClientContext extends ClientContext, TInput, TOutput, TError>(
+  base: ProcedureUtilsOptions<TClientContext, TInput, TOutput, TError>,
+  override: ProcedureUtilsOptions<TClientContext, TInput, TOutput, TError>,
+): ProcedureUtilsOptions<TClientContext, TInput, TOutput, TError> {
+  return {
+    ...base,
+    ...override,
+    queryKey: mergeProcedureUtilsModifier(base.queryKey, override.queryKey),
+    queryInterceptors: [...toArray(base.queryInterceptors), ...toArray(override.queryInterceptors)],
+    queryOptions: mergeProcedureUtilsModifier(base.queryOptions, override.queryOptions),
+    streamedKey: mergeProcedureUtilsModifier(base.streamedKey, override.streamedKey),
+    streamedInterceptors: [...toArray(base.streamedInterceptors), ...toArray(override.streamedInterceptors)],
+    streamedOptions: mergeProcedureUtilsModifier(base.streamedOptions, override.streamedOptions),
+    liveKey: mergeProcedureUtilsModifier(base.liveKey, override.liveKey),
+    liveInterceptors: [...toArray(base.liveInterceptors), ...toArray(override.liveInterceptors)],
+    liveOptions: mergeProcedureUtilsModifier(base.liveOptions, override.liveOptions),
+    infiniteKey: mergeProcedureUtilsModifier(base.infiniteKey, override.infiniteKey),
+    infiniteInterceptors: [...toArray(base.infiniteInterceptors), ...toArray(override.infiniteInterceptors)],
+    infiniteOptions: mergeProcedureUtilsModifier(base.infiniteOptions, override.infiniteOptions),
+    mutationKey: mergeProcedureUtilsModifier(base.mutationKey, override.mutationKey),
+    mutationInterceptors: [...toArray(base.mutationInterceptors), ...toArray(override.mutationInterceptors)],
+    mutationOptions: mergeProcedureUtilsModifier(base.mutationOptions, override.mutationOptions),
+  }
 }
 
 export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutput, TError> extends SharedUtils<TInput> {

--- a/packages/pinia-colada/src/procedure-utils.ts
+++ b/packages/pinia-colada/src/procedure-utils.ts
@@ -3,7 +3,7 @@ import type { Interceptor, MaybeOptionalOptions, PromiseWithError } from '@orpc/
 import type { _EmptyObject, EntryKeyTagged, UseInfiniteQueryData, UseInfiniteQueryFnContext } from '@pinia/colada'
 import type { OperationKeyPrefixOptions } from './key'
 import type { InferLiveQueryOutput, InferStreamedQueryOutput, InfiniteKeyOptions, InfiniteOptionsIn, InfiniteOptionsOut, MutationKeyOptions, MutationOptionsIn, MutationOptionsOut, OperationContext, QueryKeyOptions, QueryOptionsIn, QueryOptionsOut, StreamedKeyOptions, StreamedOptionsIn, StreamedOptionsOut, UseMutationFnContext, UseQueryFnContext } from './types'
-import { intercept, isAsyncIteratorObject, isTypescriptObject, resolveMaybeOptionalOptions, toArray } from '@orpc/shared'
+import { intercept, isAsyncIteratorObject, isTypescriptObject, resolveMaybeOptionalOptions } from '@orpc/shared'
 import { generateOperationKey } from './key'
 import { liveQuery } from './live-query'
 import { SharedUtils } from './shared-utils'
@@ -212,13 +212,9 @@ export function isProcedureUtilsOptions(value: unknown): value is ProcedureUtils
 }
 
 function mergeProcedureUtilsModifier<T extends object>(
-  base: ProcedureUtilsModifier<T> | undefined,
-  override: ProcedureUtilsModifier<T> | undefined,
-): ProcedureUtilsModifier<T> | undefined {
-  if (!base || !override) {
-    return override ?? base
-  }
-
+  base: ProcedureUtilsModifier<T>,
+  override: ProcedureUtilsModifier<T>,
+): ProcedureUtilsModifier<T> {
   if (typeof base !== 'function' && typeof override !== 'function') {
     return { ...base, ...override } as Partial<T>
   }
@@ -230,34 +226,37 @@ function mergeProcedureUtilsModifier<T extends object>(
 }
 
 /**
- * Merge two procedure utils options where `override` takes priority:
- * interceptors are concatenated (base ones run first), modifiers are
- * spread-merged when both are plain objects and composed (base applied first)
- * otherwise, with plain objects applied as regular spread merges.
+ * Merge two procedure utils options where `override` takes priority.
+ * A key explicitly set to `undefined` in `override` resets the base value.
+ * When both sides define a key: interceptors are concatenated (base ones run first),
+ * modifiers are spread-merged when both are plain objects and composed (base applied
+ * first) otherwise, with plain objects applied as regular spread merges.
  */
 export function mergeProcedureUtilsOptions<TClientContext extends ClientContext, TInput, TOutput, TError>(
   base: ProcedureUtilsOptions<TClientContext, TInput, TOutput, TError>,
   override: ProcedureUtilsOptions<TClientContext, TInput, TOutput, TError>,
 ): ProcedureUtilsOptions<TClientContext, TInput, TOutput, TError> {
-  return {
-    ...base,
-    ...override,
-    queryKey: mergeProcedureUtilsModifier(base.queryKey, override.queryKey),
-    queryInterceptors: [...toArray(base.queryInterceptors), ...toArray(override.queryInterceptors)],
-    queryOptions: mergeProcedureUtilsModifier(base.queryOptions, override.queryOptions),
-    streamedKey: mergeProcedureUtilsModifier(base.streamedKey, override.streamedKey),
-    streamedInterceptors: [...toArray(base.streamedInterceptors), ...toArray(override.streamedInterceptors)],
-    streamedOptions: mergeProcedureUtilsModifier(base.streamedOptions, override.streamedOptions),
-    liveKey: mergeProcedureUtilsModifier(base.liveKey, override.liveKey),
-    liveInterceptors: [...toArray(base.liveInterceptors), ...toArray(override.liveInterceptors)],
-    liveOptions: mergeProcedureUtilsModifier(base.liveOptions, override.liveOptions),
-    infiniteKey: mergeProcedureUtilsModifier(base.infiniteKey, override.infiniteKey),
-    infiniteInterceptors: [...toArray(base.infiniteInterceptors), ...toArray(override.infiniteInterceptors)],
-    infiniteOptions: mergeProcedureUtilsModifier(base.infiniteOptions, override.infiniteOptions),
-    mutationKey: mergeProcedureUtilsModifier(base.mutationKey, override.mutationKey),
-    mutationInterceptors: [...toArray(base.mutationInterceptors), ...toArray(override.mutationInterceptors)],
-    mutationOptions: mergeProcedureUtilsModifier(base.mutationOptions, override.mutationOptions),
+  const merged: Record<string, unknown> = { ...base, ...override }
+
+  for (const key of PROCEDURE_UTILS_INTERCEPTOR_KEYS) {
+    const baseValue = (base as Record<string, unknown>)[key] as ProcedureUtilsQueryInterceptor<any, any, any, any>[] | undefined
+    const overrideValue = (override as Record<string, unknown>)[key] as ProcedureUtilsQueryInterceptor<any, any, any, any>[] | undefined
+
+    if (baseValue && overrideValue) {
+      merged[key] = [...baseValue, ...overrideValue]
+    }
   }
+
+  for (const key of PROCEDURE_UTILS_MODIFIER_KEYS) {
+    const baseValue = (base as Record<string, unknown>)[key] as ProcedureUtilsModifier<any> | undefined
+    const overrideValue = (override as Record<string, unknown>)[key] as ProcedureUtilsModifier<any> | undefined
+
+    if (baseValue && overrideValue) {
+      merged[key] = mergeProcedureUtilsModifier(baseValue, overrideValue)
+    }
+  }
+
+  return merged as ProcedureUtilsOptions<TClientContext, TInput, TOutput, TError>
 }
 
 export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutput, TError> extends SharedUtils<TInput> {

--- a/packages/pinia-colada/src/router-utils.test.ts
+++ b/packages/pinia-colada/src/router-utils.test.ts
@@ -3,10 +3,11 @@ import * as KeyModule from './key'
 import { ProcedureUtils } from './procedure-utils'
 import { createRouterUtils } from './router-utils'
 
-vi.mock('./procedure-utils', async () => {
+vi.mock('./procedure-utils', async (importOriginal) => {
   const { SharedUtils } = await import('./shared-utils')
 
   return {
+    ...await importOriginal<typeof import('./procedure-utils')>(),
     ProcedureUtils: vi.fn(class extends SharedUtils<unknown> {
       call = vi.fn()
       override key = SharedUtils.prototype.key
@@ -274,58 +275,31 @@ describe('createRouterUtils', () => {
     expect(routeUtils.queryOptions()).toBe(vi.mocked(ProcedureUtils).mock.results[0]?.value.queryOptions.mock.results[0]?.value)
   })
 
-  it.each([
-    'queryInterceptors',
-    'streamedInterceptors',
-    'liveInterceptors',
-    'infiniteInterceptors',
-    'mutationInterceptors',
-  ] as const)('does not create procedure utils for invalid %s scoped options', (key) => {
-    const client = {
-      route: vi.fn(),
-    } as any
-    client.route = vi.fn()
-    client.route.child = vi.fn()
+  it('does not create procedure utils when scoped options are not procedure utils options', () => {
+    const client = vi.fn() as any
+    client.child = vi.fn()
 
     const utils = createRouterUtils(client, {
       scoped: {
-        route: {
-          [key]: { invalid: true },
-          child: {
-            queryOptions: {
-              staleTime: 1000,
-            },
+        queryInterceptors: { invalid: true },
+        child: {
+          queryOptions: {
+            staleTime: 1000,
           },
-        } as any,
-      },
+        },
+      } as any,
     } as any) as any
 
-    const routeUtils = utils.route
-
-    expect(typeof routeUtils.key).toBe('function')
-    expect(typeof routeUtils.queryOptions).not.toBe('function')
+    expect(typeof utils.key).toBe('function')
+    expect(typeof utils.queryOptions).not.toBe('function')
     expect(ProcedureUtils).toHaveBeenCalledTimes(0)
 
-    vi.clearAllMocks()
-    const childUtils = routeUtils.child
+    const childUtils = utils.child
 
-    expect(typeof childUtils.key).toBe('function')
     expect(ProcedureUtils).toHaveBeenCalledTimes(1)
-  })
-
-  it('does not create procedure utils for invalid scoped options', () => {
-    const client = {
-      route: vi.fn(),
-    } as any
-
-    const utils = createRouterUtils(client, {
-      scoped: {
-        route: 'invalid' as any,
-      },
-    } as any) as any
-
-    expect(typeof utils.route.key).toBe('function')
-    expect(typeof utils.route.queryOptions).not.toBe('function')
-    expect(ProcedureUtils).toHaveBeenCalledTimes(0)
+    expect(ProcedureUtils).toHaveBeenCalledWith(['child'], client.child, expect.objectContaining({
+      queryOptions: { staleTime: 1000 },
+    }))
+    expect(typeof childUtils.queryOptions).toBe('function')
   })
 })

--- a/packages/pinia-colada/src/router-utils.test.ts
+++ b/packages/pinia-colada/src/router-utils.test.ts
@@ -23,14 +23,6 @@ vi.mock('./procedure-utils', async (importOriginal) => {
 
 const generateOperationKeySpy = vi.spyOn(KeyModule, 'generateOperationKey')
 
-const emptyInterceptors = {
-  queryInterceptors: [],
-  streamedInterceptors: [],
-  liveInterceptors: [],
-  infiniteInterceptors: [],
-  mutationInterceptors: [],
-}
-
 beforeEach(() => {
   vi.clearAllMocks()
 })
@@ -46,7 +38,7 @@ describe('createRouterUtils', () => {
     }) as any
 
     expect(ProcedureUtils).toHaveBeenCalledTimes(1)
-    expect(ProcedureUtils).toHaveBeenCalledWith([], client, { ...emptyInterceptors, prefix: '__prefix__' })
+    expect(ProcedureUtils).toHaveBeenCalledWith([], client, { prefix: '__prefix__' })
     expect(utils.key({ type: 'query' })).toBe(generateOperationKeySpy.mock.results[0]?.value)
     expect(generateOperationKeySpy).toHaveBeenNthCalledWith(1, [], { type: 'query', prefix: '__prefix__' })
     expect(utils.queryOptions()).toBe(vi.mocked(ProcedureUtils).mock.results[0]?.value.queryOptions.mock.results[0]?.value)
@@ -55,7 +47,7 @@ describe('createRouterUtils', () => {
     const keyUtils = utils.key
 
     expect(ProcedureUtils).toHaveBeenCalledTimes(1)
-    expect(ProcedureUtils).toHaveBeenCalledWith(['key'], client.key, { ...emptyInterceptors, prefix: '__prefix__' })
+    expect(ProcedureUtils).toHaveBeenCalledWith(['key'], client.key, { prefix: '__prefix__' })
     expect(keyUtils.key({ type: 'mutation' })).toBe(generateOperationKeySpy.mock.results[0]?.value)
     expect(generateOperationKeySpy).toHaveBeenNthCalledWith(1, ['key'], { type: 'mutation', prefix: '__prefix__' })
     expect(keyUtils.queryOptions()).toBe(vi.mocked(ProcedureUtils).mock.results[0]?.value.queryOptions.mock.results[0]?.value)
@@ -64,7 +56,7 @@ describe('createRouterUtils', () => {
     const pongUtils = keyUtils.pong
 
     expect(ProcedureUtils).toHaveBeenCalledTimes(1)
-    expect(ProcedureUtils).toHaveBeenCalledWith(['key', 'pong'], client.key.pong, { ...emptyInterceptors, prefix: '__prefix__' })
+    expect(ProcedureUtils).toHaveBeenCalledWith(['key', 'pong'], client.key.pong, { prefix: '__prefix__' })
     expect(pongUtils.key({ type: 'query' })).toBe(generateOperationKeySpy.mock.results[0]?.value)
     expect(generateOperationKeySpy).toHaveBeenNthCalledWith(1, ['key', 'pong'], { type: 'query', prefix: '__prefix__' })
     expect(pongUtils.queryOptions()).toBe(vi.mocked(ProcedureUtils).mock.results[0]?.value.queryOptions.mock.results[0]?.value)
@@ -88,7 +80,7 @@ describe('createRouterUtils', () => {
     const pingUtils = nestedUtils.ping
 
     expect(ProcedureUtils).toHaveBeenCalledTimes(1)
-    expect(ProcedureUtils).toHaveBeenCalledWith(['nested', 'ping'], router.nested.ping, emptyInterceptors)
+    expect(ProcedureUtils).toHaveBeenCalledWith(['nested', 'ping'], router.nested.ping, {})
     expect(pingUtils.queryOptions()).toBe(vi.mocked(ProcedureUtils).mock.results[0]?.value.queryOptions.mock.results[0]?.value)
   })
 
@@ -154,12 +146,12 @@ describe('createRouterUtils', () => {
     vi.clearAllMocks()
     const keyUtils = utils.key
     expect(ProcedureUtils).toHaveBeenCalledTimes(1)
-    expect(ProcedureUtils).toHaveBeenCalledWith(['key'], client.key, { ...keyOptions, ...emptyInterceptors })
+    expect(ProcedureUtils).toHaveBeenCalledWith(['key'], client.key, { ...keyOptions })
 
     vi.clearAllMocks()
     const pongUtils = keyUtils.pong
     expect(ProcedureUtils).toHaveBeenCalledTimes(1)
-    expect(ProcedureUtils).toHaveBeenCalledWith(['key', 'pong'], client.key.pong, emptyInterceptors)
+    expect(ProcedureUtils).toHaveBeenCalledWith(['key', 'pong'], client.key.pong, {})
     expect(pongUtils.queryOptions()).toBe(vi.mocked(ProcedureUtils).mock.results[0]?.value.queryOptions.mock.results[0]?.value)
   })
 

--- a/packages/pinia-colada/src/router-utils.ts
+++ b/packages/pinia-colada/src/router-utils.ts
@@ -6,7 +6,7 @@ import type { ProcedureUtilsInfiniteInterceptor, ProcedureUtilsLiveInterceptor, 
 import { RECURSIVE_CLIENT_UNWRAP_KEYS } from '@orpc/client'
 import { bindMethods, get, getOrBind, isTypescriptObject, toArray } from '@orpc/shared'
 import { CompositeRouterUtilsPlugin } from './plugin'
-import { ProcedureUtils } from './procedure-utils'
+import { isProcedureUtilsOptions, mergeProcedureUtilsOptions, ProcedureUtils } from './procedure-utils'
 import { SharedUtils } from './shared-utils'
 
 export type RouterUtils<T extends AnyNestedClient>
@@ -96,15 +96,17 @@ function createRouterUtilsInternal<T extends AnyNestedClient>(
     ? bindMethods(new ProcedureUtils(
         path,
         client,
-        plugin.initProcedureOptions(path, {
-          prefix: options.prefix,
-          ...options.scoped,
-          queryInterceptors: [...toArray(options.queryInterceptors) as any, ...toArray(options.scoped?.queryInterceptors)],
-          streamedInterceptors: [...toArray(options.streamedInterceptors) as any, ...toArray(options.scoped?.streamedInterceptors)],
-          liveInterceptors: [...toArray(options.liveInterceptors) as any, ...toArray(options.scoped?.liveInterceptors)],
-          infiniteInterceptors: [...toArray(options.infiniteInterceptors) as any, ...toArray(options.scoped?.infiniteInterceptors)],
-          mutationInterceptors: [...toArray(options.mutationInterceptors) as any, ...toArray(options.scoped?.mutationInterceptors)],
-        }),
+        plugin.initProcedureOptions(path, mergeProcedureUtilsOptions(
+          {
+            prefix: options.prefix,
+            queryInterceptors: options.queryInterceptors as any,
+            streamedInterceptors: options.streamedInterceptors as any,
+            liveInterceptors: options.liveInterceptors as any,
+            infiniteInterceptors: options.infiniteInterceptors as any,
+            mutationInterceptors: options.mutationInterceptors as any,
+          },
+          options.scoped ?? {},
+        )),
       ))
     : bindMethods(new SharedUtils(path, options))
 
@@ -140,32 +142,4 @@ function createRouterUtilsInternal<T extends AnyNestedClient>(
   })
 
   return recursive as any
-}
-
-function isProcedureUtilsOptions(value: unknown): value is ProcedureUtilsOptions<any, any, any, any> {
-  if (!isTypescriptObject(value)) {
-    return false
-  }
-
-  if (value.queryInterceptors !== undefined && !Array.isArray(value.queryInterceptors)) {
-    return false
-  }
-
-  if (value.streamedInterceptors !== undefined && !Array.isArray(value.streamedInterceptors)) {
-    return false
-  }
-
-  if (value.liveInterceptors !== undefined && !Array.isArray(value.liveInterceptors)) {
-    return false
-  }
-
-  if (value.infiniteInterceptors !== undefined && !Array.isArray(value.infiniteInterceptors)) {
-    return false
-  }
-
-  if (value.mutationInterceptors !== undefined && !Array.isArray(value.mutationInterceptors)) {
-    return false
-  }
-
-  return true
 }

--- a/packages/pinia-colada/src/types.ts
+++ b/packages/pinia-colada/src/types.ts
@@ -1,5 +1,5 @@
 import type { ClientContext } from '@orpc/client'
-import type { DefineInfiniteQueryOptions, DefineInfiniteQueryOptionsTagged, DefineMutationOptionsTagged, DefineQueryOptions, DefineQueryOptionsTagged, EntryKey, UseInfiniteQueryData, UseMutationOptions, UseQueryOptions } from '@pinia/colada'
+import type { DefineInfiniteQueryOptions, DefineInfiniteQueryOptionsTagged, DefineMutationOptionsTagged, DefineQueryOptions, DefineQueryOptionsTagged, EntryKey, UseInfiniteQueryData, UseMutationOptions, UseMutationOptionsGlobal, UseQueryOptions } from '@pinia/colada'
 import type { SerializableStreamedQueryOptions } from './stream-query'
 
 export type InferStreamedQueryOutput<TOutput> = TOutput extends AsyncIterable<infer U> ? U[] : never
@@ -7,7 +7,11 @@ export type InferLiveQueryOutput<TOutput> = TOutput extends AsyncIterable<infer 
 
 export type UseQueryFnContext = Parameters<UseQueryOptions<any>['query']>[0]
 
-export type UseMutationFnContext = Parameters<UseMutationOptions<any, any>['mutation']>[1]
+/**
+ * The context passed to the mutation function, including the merged
+ * `UseMutationGlobalContext` values provided by a global `onMutate` hook.
+ */
+export type UseMutationFnContext = Parameters<NonNullable<UseMutationOptionsGlobal['onSuccess']>>[2]
 
 export const OPERATION_CONTEXT_SYMBOL: unique symbol = Symbol.for('ORPC_PINIA_COLADA_OPERATION_CONTEXT') as any
 


### PR DESCRIPTION
## Summary

Port of #1705 to `@orpc/pinia-colada`. Define base Pinia Colada options and interceptors directly on a procedure contract via `piniaColada`, and apply them automatically with the new `ContractOptionsUtilsPlugin`.

```ts
export const contract = {
  planet: {
    find: oc
      .input(z.object({ id: z.number() }))
      .meta(piniaColada({
        queryOptions: {
          staleTime: 60 * 1000,
        },
      })),
  },
}

const orpc = createPiniaColadaUtils(client, {
  plugins: [new ContractOptionsUtilsPlugin(contract)],
})
```

- `piniaColada` infers input, output, and error types from the contract, supports all procedure utils options (keys, options, interceptors), and merges when applied multiple times
- `ContractOptionsUtilsPlugin` applies meta options as the base layer: utils level options override them and utils interceptors run after meta interceptors
- Merging is consistent across all layers: interceptors concatenate, plain option objects spread-merge, any pair involving a function modifier composes, and a key explicitly set to `undefined` resets the value from lower layers
- `getPiniaColadaMeta` reads the stored options for custom integrations
- `UseMutationFnContext` now matches the runtime merged mutation context, so values provided by a global `onMutate` are typed inside mutation interceptors via `UseMutationContextCommon` augmentation
- Docs cover the plugin, the reference-only nature of contract types, and passing runtime values such as router utils through a global `onMutate` hook for optimistic updates

