### PR TITLE
docs(openapi): clarify metadata merging behavior

### DIFF
--- a/apps/content/docs/openapi/input-and-output-mapping.md
+++ b/apps/content/docs/openapi/input-and-output-mapping.md
@@ -234,7 +234,7 @@ Learn more about body hints in the [Standard Server documentation](https://githu
 
 ## Metadata Merging
 
-When `openapi` is applied multiple times, `paramsStyles` and `queryStyles` are spreading-merged, while `inputStructure`, `outputStructure`, `responseBodyHint`, and `requestBodyHint` are overridden by the most recent call. For full merge behavior, see the [source code](https://github.com/orpc/orpc/blob/main/packages/openapi/src/meta.ts).
+When `openapi` is applied multiple times, `paramsStyles` and `queryStyles` are merged per parameter, and the most recent style defined for a parameter wins. `inputStructure`, `outputStructure`, `responseBodyHint`, and `requestBodyHint` are overridden by the most recent call. For the full merge behavior of every field, see [Metadata Merging](/docs/openapi/specification#metadata-merging).
 
 ```ts
 const router = os

--- a/apps/content/docs/openapi/routing.md
+++ b/apps/content/docs/openapi/routing.md
@@ -108,7 +108,7 @@ const router = {
 
 ## Metadata Merging
 
-When `openapi` is applied multiple times, `prefix` values are concatenated. `method`, `path`, and `successStatus` are overridden by the most recent call. For full merge behavior, see the [source code](https://github.com/orpc/orpc/blob/main/packages/openapi/src/meta.ts).
+When `openapi` is applied multiple times, `prefix` values are concatenated in definition order, while `method`, `path`, and `successStatus` are overridden by the most recent call. For the full merge behavior of every field, see [Metadata Merging](/docs/openapi/specification#metadata-merging).
 
 ```ts
 const router = os

--- a/apps/content/docs/openapi/specification.md
+++ b/apps/content/docs/openapi/specification.md
@@ -54,7 +54,13 @@ const getPlanet = oc
 
 ### Metadata Merging
 
-When `openapi` is applied multiple times, `tags`, `spec`, `prefix`, `paramsStyle`, and `queryStyles` are deep-merged, while `operationId`, `summary`, `description`, `successDescription`, `method`, `path`, `successStatus`, `inputStructure`, `outputStructure`, `responseBodyHint`, and `requestBodyHint` are overridden by the most recent call. For full merge behavior, see the [source code](https://github.com/orpc/orpc/blob/main/packages/openapi/src/meta.ts).
+When `openapi` is applied multiple times, most fields, such as `method`, `path`, `operationId`, `summary`, and `description`, are overridden by the most recent call. Only the following fields are merged:
+
+- `tags` and `prefix` values are concatenated in definition order.
+- `paramsStyles` and `queryStyles` are merged per parameter. The most recent style defined for a parameter wins.
+- `spec` values are combined: two functions are chained so the most recent one receives the result of the previous one, a function combined with an object is applied to that object, and between two objects the most recent one wins.
+
+For implementation details, see the [source code](https://github.com/orpc/orpc/blob/main/packages/openapi/src/meta.ts).
 
 ```ts
 const router = os

--- a/packages/openapi/src/meta.ts
+++ b/packages/openapi/src/meta.ts
@@ -47,7 +47,8 @@ export interface OpenAPIMeta {
   /**
    * Tags associated with this procedure.
    *
-   * **Note**: Tags are merged when defined multiple times.
+   * **Merging**: When defined multiple times, tags are concatenated in definition order.
+   * Explicitly setting `undefined` resets the tags instead of merging.
    */
   tags?: string[] | undefined
 
@@ -69,7 +70,9 @@ export interface OpenAPIMeta {
   /**
    * Controls how individual path parameters are decoded.
    *
-   * **Note**: Param styles are merged when defined multiple times.
+   * **Merging**: When defined multiple times, styles are merged per parameter.
+   * The most recent style defined for a parameter wins.
+   * Explicitly setting `undefined` resets the styles instead of merging.
    *
    * Each key maps a path parameter name to one of the following strategies:
    *
@@ -118,7 +121,9 @@ export interface OpenAPIMeta {
   /**
    * Controls how individual query parameters are encoding/decoding.
    *
-   * **Note**: Query styles are merged when defined multiple times.
+   * **Merging**: When defined multiple times, styles are merged per parameter.
+   * The most recent style defined for a parameter wins.
+   * Explicitly setting `undefined` resets the styles instead of merging.
    *
    * Each key maps a query parameter name to one of the following strategies:
    *
@@ -284,14 +289,21 @@ export interface OpenAPIMeta {
    * Pass a plain object to replace entire operation object, or a function that receives the current
    * operation object and returns the modified version.
    *
-   * **Note**: Spec is merged when defined multiple times.
+   * **Merging**: When defined multiple times:
+   *
+   * - Two functions are chained: the most recent function receives the result of the previous one.
+   * - A function combined with an object: the function is applied to that object.
+   * - Two objects: the most recent object wins.
+   *
+   * Explicitly setting `undefined` resets the spec instead of merging.
    */
   spec?: Value<OpenAPIOperationObject, [current: OpenAPIOperationObject]>
 
   /**
    * Prefix for the path. Useful when you want to apply a common path prefix across multiple procedures.
    *
-   * **Note**: Prefixes are merged when defined multiple times.
+   * **Merging**: When defined multiple times, prefixes are concatenated in definition order.
+   * Explicitly setting `undefined` resets the prefix instead of merging.
    */
   prefix?: `/${string}` | undefined
 }


### PR DESCRIPTION
## Summary

The docs and jsdoc described `openapi` metadata merging loosely ("deep-merged", "spreading-merged", "merged when defined multiple times"). This PR replaces those with the exact rules.

- Docs: the Metadata Merging section in `specification.md` is now the canonical reference. It lists the exact rule per field and fixes the `paramsStyle` typo. `routing.md` and `input-and-output-mapping.md` keep their short field-specific summaries and link to it.
- Jsdoc: each mergeable field (`tags`, `prefix`, `paramsStyles`, `queryStyles`, `spec`) now states how it merges and that an explicit `undefined` resets the value instead of merging. The `spec` note covers all three cases: function + function chains, function + object applies the function to the object, object + object keeps the most recent.

No runtime changes.