### PR TITLE
fix(json-schema): prevent prototype injection when coercing objects

### DIFF
--- a/packages/json-schema/src/coercer.test.ts
+++ b/packages/json-schema/src/coercer.test.ts
@@ -162,6 +162,35 @@ describe('jsonSchemaCoercer', () => {
     ).toEqual({ 0: 123, 1: true })
   })
 
+  it('prevents prototype injection when coercing objects', () => {
+    const schema = {
+      type: 'object',
+      properties: { a: { type: 'number' } },
+      additionalProperties: { type: 'boolean' },
+    } as any
+
+    const coerced: any = coercer.coerce(schema, JSON.parse('{"a":"123","__proto__":{"polluted":"true"}}'))
+
+    // `__proto__` must stay a normal own property instead of replacing the prototype
+    expect(coerced.a).toBe(123)
+    expect(Object.hasOwn(coerced, '__proto__')).toBe(true)
+    expect(Object.getOwnPropertyDescriptor(coerced, '__proto__')!.value).toEqual({ polluted: 'true' })
+    expect(coerced.polluted).toBeUndefined()
+    expect(({} as any).polluted).toBeUndefined()
+
+    // `Object.prototype` members must not be used as sub-schemas
+    const unionSchema = {
+      anyOf: [
+        { type: 'object', properties: { a: { type: 'number' } } },
+        { type: 'object', additionalProperties: { type: 'boolean' } },
+      ],
+    } as any
+
+    expect(coercer.coerce(unionSchema, { constructor: 'true' })).toEqual({ constructor: true })
+    expect(coercer.coerce(unionSchema, { toString: 'true' })).toEqual({ toString: true })
+    expect(coercer.coerce(unionSchema, JSON.parse('{"__proto__":"true"}'))).toEqual({ ['__proto__']: true })
+  })
+
   it('can handle union types', () => {
     const schema = {
       anyOf: [

--- a/packages/json-schema/src/coercer.ts
+++ b/packages/json-schema/src/coercer.ts
@@ -1,5 +1,5 @@
 import type { JsonSchema } from './types'
-import { guard, isObject, toArray } from '@orpc/shared'
+import { guard, isObject, NullProtoObj, toArray } from '@orpc/shared'
 import { JsonSchemaXNativeType } from './types'
 
 const FLEXIBLE_DATE_FORMAT_REGEX = /^[^-]+-[^-]+-[^-]+$/
@@ -166,14 +166,18 @@ export class JsonSchemaCoercer {
 
           if (isObject(coerced)) {
             let shouldUseCoercedItems = false
-            const coercedItems: Record<string, unknown> = {}
+            /**
+             * Use a null-prototype object, keys come from untrusted input
+             * so `coercedItems[key] = value` must never touch `Object.prototype` members like `__proto__`.
+             */
+            const coercedItems: Record<string, unknown> = new NullProtoObj()
 
             const patternProperties = Object.entries(schema.patternProperties ?? {})
               .map(([key, value]) => [new RegExp(key), value] as const)
 
             for (const key in coerced) {
               const value = coerced[key]
-              const subSchema = schema.properties?.[key]
+              const subSchema = (schema.properties !== undefined && Object.hasOwn(schema.properties, key) ? schema.properties[key] : undefined)
                 ?? patternProperties.find(([pattern]) => pattern.test(key))?.[1]
                 ?? schema.additionalProperties
 


### PR DESCRIPTION
Fixes two prototype chain bugs in the `object` branch of `JsonSchemaCoercer#coerce`. The coercer runs on untrusted input before validation (`SmartCoercionPlugin`), so the keys below are attacker controlled.

### 1. Coerced properties were collected into a plain `{}`

`coercedItems['__proto__'] = value` triggers the inherited `__proto__` setter instead of creating an own property:

```
schema: { type: 'object', properties: { a: { type: 'number' } } }
input:  {"a":"1","__proto__":{"isAdmin":true}}

out = { a: 1 }        // __proto__ entry dropped from the output
out.isAdmin === true  // attacker object became the prototype
```

`Object.prototype` is not touched, but the returned value inherits attacker controlled properties, and anything reading them through the prototype chain sees them.

Fix: collect into `NullProtoObj`, the helper already used for untrusted keys in `bracket-notation.ts` and `rpc-matcher.ts`.

### 2. `schema.properties?.[key]` returned inherited members

For keys like `constructor`, `toString` and `__proto__` the lookup resolves to `Object.prototype` members, which were then used as sub-schemas. They coerce nothing and report `satisfied: true`, so those keys skipped the unknown property path and selected the wrong union branch:

```
anyOf: [{ type: 'object', properties: { a: { type: 'number' } } },
        { type: 'object', additionalProperties: { type: 'boolean' } }]

{ z: 'true' }           => { z: true }              // correct branch
{ constructor: 'true' } => { constructor: 'true' }  // before: wrong branch, not coerced
```

Fix: guard the lookup with `Object.hasOwn`.

### Verification

`prevents prototype injection when coercing objects` covers both cases and fails without the fix. The json-schema, openapi and openapi-client suites pass (412 tests). `tsc -b` and eslint are clean.
