### PR TITLE
fix(zod): prevent prototype injection in smart coercion

### DIFF
--- a/packages/zod/src/coercer.test.ts
+++ b/packages/zod/src/coercer.test.ts
@@ -394,3 +394,42 @@ it('zodSmartCoercionPlugin ignore non-zod schemas', async () => {
   const v = await import('valibot')
   expect(coerce(v.object({}), val)).toBe(val)
 })
+
+it('zodSmartCoercionPlugin prevents prototype injection', () => {
+  const plugin = new ZodSmartCoercionPlugin()
+  const options = {} as any
+  plugin.init(options)
+
+  const coerce = (schema: any, input: unknown) => {
+    let coerced: unknown
+
+    options.clientInterceptors[0]({
+      procedure: {
+        '~orpc': {
+          inputSchema: schema,
+        },
+      },
+      input,
+      next: (options: any) => {
+        coerced = typeof options === 'object' ? options.input : input
+      },
+    })
+
+    return coerced
+  }
+
+  // `__proto__` must stay a normal own property instead of replacing the prototype
+  for (const schema of [z.object({ a: z.number() }), z.record(z.string())]) {
+    const coerced: any = coerce(schema, JSON.parse('{"a":"123","__proto__":{"polluted":"true"}}'))
+
+    expect(Object.hasOwn(coerced, '__proto__')).toBe(true)
+    expect(Object.getOwnPropertyDescriptor(coerced, '__proto__')!.value).toEqual({ polluted: 'true' })
+    expect(coerced.polluted).toBeUndefined()
+    expect(({} as any).polluted).toBeUndefined()
+  }
+
+  // `Object.prototype` members must not be used as sub-schemas
+  expect(coerce(z.object({ a: z.number() }), { a: '123', constructor: '456' })).toEqual({ a: 123, constructor: '456' })
+  expect(coerce(z.object({ a: z.number() }), { a: '123', toString: '456' })).toEqual({ a: 123, toString: '456' })
+  expect(coerce(z.object({ a: z.number() }).catchall(z.number()), { a: '123', constructor: '456' })).toEqual({ a: 123, constructor: 456 })
+})

--- a/packages/zod/src/coercer.ts
+++ b/packages/zod/src/coercer.ts
@@ -24,7 +24,7 @@ import type {
   ZodTypeAny,
   ZodUnion,
 } from 'zod/v3'
-import { guard, isObject } from '@orpc/shared'
+import { guard, isObject, NullProtoObj } from '@orpc/shared'
 import { ZodFirstPartyTypeKind } from 'zod/v3'
 import { getCustomZodDef } from './schemas/base'
 
@@ -146,16 +146,22 @@ function zodCoerceInternal(
       const schema_ = schema as ZodObject<{ [k: string]: ZodTypeAny }>
 
       if (isObject(value)) {
-        const newObj: Record<string, unknown> = {}
+        /**
+         * Keys come from untrusted input, a null-prototype object keeps
+         * `newObj[key] = value` from reaching `Object.prototype` members like `__proto__`.
+         */
+        const newObj: Record<string, unknown> = new NullProtoObj()
+
+        const shape = schema_.shape
 
         const keys = new Set([
           ...Object.keys(value),
-          ...Object.keys(schema_.shape),
+          ...Object.keys(shape),
         ])
 
         for (const k of keys) {
           newObj[k] = zodCoerceInternal(
-            schema_.shape[k] ?? schema_._def.catchall,
+            (Object.hasOwn(shape, k) ? shape[k] : undefined) ?? schema_._def.catchall,
             value[k],
           )
         }
@@ -170,7 +176,7 @@ function zodCoerceInternal(
       const schema_ = schema as ZodRecord
 
       if (isObject(value)) {
-        const newObj: any = {}
+        const newObj: any = new NullProtoObj()
 
         for (const [k, v] of Object.entries(value)) {
           const key = zodCoerceInternal(schema_._def.keyType, k)

--- a/packages/zod/src/zod4/coercer.test.ts
+++ b/packages/zod/src/zod4/coercer.test.ts
@@ -37,3 +37,42 @@ it('zodSmartCoercionPlugin ignore non-zod schemas', async () => {
   const v = await import('valibot')
   expect(coerce(v.object({}), val)).toBe(val)
 })
+
+it('zodSmartCoercionPlugin prevents prototype injection', () => {
+  const plugin = new ZodSmartCoercionPlugin()
+  const options = {} as any
+  plugin.init(options)
+
+  const coerce = (schema: any, input: unknown) => {
+    let coerced: unknown
+
+    options.clientInterceptors[0]({
+      procedure: {
+        '~orpc': {
+          inputSchema: schema,
+        },
+      },
+      input,
+      next: (options: any) => {
+        coerced = typeof options === 'object' ? options.input : input
+      },
+    })
+
+    return coerced
+  }
+
+  // `__proto__` must stay a normal own property instead of replacing the prototype
+  for (const schema of [z.object({ a: z.number() }), z.record(z.string(), z.string())]) {
+    const coerced: any = coerce(schema, JSON.parse('{"a":"123","__proto__":{"polluted":"true"}}'))
+
+    expect(Object.hasOwn(coerced, '__proto__')).toBe(true)
+    expect(Object.getOwnPropertyDescriptor(coerced, '__proto__')!.value).toEqual({ polluted: 'true' })
+    expect(coerced.polluted).toBeUndefined()
+    expect(({} as any).polluted).toBeUndefined()
+  }
+
+  // `Object.prototype` members must not be used as sub-schemas
+  expect(coerce(z.object({ a: z.number() }), { a: '123', constructor: '456' })).toEqual({ a: 123, constructor: '456' })
+  expect(coerce(z.object({ a: z.number() }), { a: '123', toString: '456' })).toEqual({ a: 123, toString: '456' })
+  expect(coerce(z.object({ a: z.number() }).catchall(z.number()), { a: '123', constructor: '456' })).toEqual({ a: 123, constructor: 456 })
+})

--- a/packages/zod/src/zod4/coercer.ts
+++ b/packages/zod/src/zod4/coercer.ts
@@ -22,7 +22,7 @@ import type {
   $ZodType,
   $ZodUnion,
 } from 'zod/v4/core'
-import { guard, isObject } from '@orpc/shared'
+import { guard, isObject, NullProtoObj } from '@orpc/shared'
 
 /**
  * @deprecated Use [Smart Coercion Plugin](https://orpc.dev/docs/openapi/plugins/smart-coercion) instead.
@@ -164,15 +164,21 @@ export class experimental_ZodSmartCoercionPlugin<TContext extends Context> imple
         }
 
         if (isObject(value)) {
-          const newObj: Record<string, unknown> = {}
+          /**
+           * Keys come from untrusted input, a null-prototype object keeps
+           * `newObj[key] = value` from reaching `Object.prototype` members like `__proto__`.
+           */
+          const newObj: Record<string, unknown> = new NullProtoObj()
+
+          const shape = object._zod.def.shape
 
           const keys = new Set([
             ...Object.keys(value),
-            ...Object.keys(object._zod.def.shape),
+            ...Object.keys(shape),
           ])
 
           for (const k of keys) {
-            const s = object._zod.def.shape[k] ?? object._zod.def.catchall
+            const s = (Object.hasOwn(shape, k) ? shape[k] : undefined) ?? object._zod.def.catchall
             newObj[k] = s ? this.#coerce(s, value[k]) : value[k]
           }
 
@@ -190,7 +196,7 @@ export class experimental_ZodSmartCoercionPlugin<TContext extends Context> imple
         }
 
         if (isObject(value)) {
-          const newObj: Record<string, unknown> = {}
+          const newObj: Record<string, unknown> = new NullProtoObj()
 
           for (const [k, v] of Object.entries(value)) {
             const key = this.#coerce(record._zod.def.keyType, k)


### PR DESCRIPTION
Same two prototype chain bugs as #1726, in `ZodSmartCoercionPlugin` (zod 3) and `experimental_ZodSmartCoercionPlugin` (zod 4). Both plugins coerce untrusted input before validation, so the keys below are attacker controlled.

### 1. Coerced properties were collected into a plain `{}`

`newObj['__proto__'] = value` triggers the inherited `__proto__` setter instead of creating an own property. This affects the `object` and `record` branches in both plugins.

Fix: collect into `NullProtoObj`, the helper already used for untrusted keys in `bracket-notation.ts` and `rpc-matcher.ts`.

### 2. `shape[key]` returned inherited members

For keys like `constructor`, `toString` and `__proto__` the lookup resolves to `Object.prototype` members, which were then dereferenced as Zod schemas:

```
schema: z.object({ a: z.number() })
input:  { a: '123', constructor: '456' }

zod 3 => TypeError: Cannot read properties of undefined (reading 'Symbol(ORPC_CUSTOM_ZOD_DEF)')
zod 4 => TypeError: Cannot read properties of undefined (reading 'def')
```

The throw happens before the assignment, so in practice these keys made coercion fail rather than injecting a prototype. Any client could break a request this way.

Fix: guard the lookup with `Object.hasOwn`, so unknown keys fall through to `catchall` as they already do for every other name.

### Verification

`zodSmartCoercionPlugin prevents prototype injection` added to both test files, covering `object`, `record` and `catchall`. Both fail without the fix. The zod coercer suites pass (583 tests). `tsc -b` and eslint are clean.
