### PR TITLE
fix(json-schema): safer value coercion and smarter union matching

### DIFF
--- a/apps/content/docs/plugins/smart-coercion.md
+++ b/apps/content/docs/plugins/smart-coercion.md
@@ -77,9 +77,9 @@ This plugin relies on [JSON Schema Converters](/docs/openapi/specification#json-
 The plugin coerces values safely by following these rules:
 
 1. **Schema-driven:** Converts only when the schema defines the target type
-2. **Safe only:** Converts only values with an unambiguous representation, such as `'123'` to `123`
+2. **Safe only:** Converts only values with an unambiguous, lossless representation, such as `'123'` to `123`
 3. **Preserve original values:** Leaves the original value unchanged when conversion would be unsafe
-4. **Union-aware:** Picks the best match for union types
+4. **Union-aware:** Tries to determine the best union branch to use for conversion
 5. **Deep conversion:** Applies recursively inside nested objects and arrays
 
 ::: info
@@ -92,7 +92,7 @@ JSON Schema does not natively represent `BigInt`, `Date`, `RegExp`, `URL`, `Set`
 - `x-native-type: 'set'` for Set
 - `x-native-type: 'map'` for Map
 
-The built-in [Standard Json Schema](https://standardschema.dev/json-schema) converter handles these cases. Because this metadata is outside the official JSON Schema specification, custom converters may need to add the appropriate `x-native-type` values explicitly.
+Since this field is not part of the official JSON Schema specification, custom converters must set it themselves. The built-in [ZodToJsonSchemaConverter](/docs/integrations/zod#json-schema-converter), [ValibotToJsonSchemaConverter](/docs/integrations/valibot#json-schema-converter), and [ArkTypeToJsonSchemaConverter](/docs/integrations/arktype#json-schema-converter) already handle it for you.
 :::
 
 ## Conversion Rules
@@ -117,20 +117,21 @@ Supports valid numeric strings:
 
 ### String/Number → BigInt
 
-Supports valid numeric strings or numbers:
+Supports integer strings and whole numbers:
 
 - `'12345678901234567890'` → `12345678901234567890n`
-- `12345678901234567890` → `12345678901234567890n`
+- `123` → `123n`
 
 ### String → Date
 
-Supports ISO date and datetime strings:
+Supports ISO 8601 date and datetime strings:
 
 - `'2023-10-01'` → `new Date('2023-10-01')`
 - `'2020-01-01T06:15'` → `new Date('2020-01-01T06:15')`
 - `'2020-01-01T06:15Z'` → `new Date('2020-01-01T06:15Z')`
 - `'2020-01-01T06:15:00Z'` → `new Date('2020-01-01T06:15:00Z')`
 - `'2020-01-01T06:15:00.123Z'` → `new Date('2020-01-01T06:15:00.123Z')`
+- `'2020-01-01T06:15:00-07:00'` → `new Date('2020-01-01T06:15:00-07:00')`
 
 ### String → RegExp
 
@@ -173,4 +174,4 @@ You can also use this plugin in guides such as [Expanding Type Support for OpenA
 
 ## Learn More
 
-For implementation details, see the [SmartCoercionHandlerPlugin source code](https://github.com/middleapi/orpc/blob/main/packages/json-schema/src/v2/smart-coercion-handler-plugin.ts) or the [SmartCoercionLinkPlugin source code](https://github.com/middleapi/orpc/blob/main/packages/json-schema/src/v2/smart-coercion-link-plugin.ts).
+For implementation details, see the [SmartCoercionHandlerPlugin source code](https://github.com/middleapi/orpc/blob/main/packages/json-schema/src/smart-coercion-handler-plugin.ts), the [SmartCoercionLinkPlugin source code](https://github.com/middleapi/orpc/blob/main/packages/json-schema/src/smart-coercion-link-plugin.ts), or the [coercer source code](https://github.com/middleapi/orpc/blob/main/packages/json-schema/src/coercer.ts).

--- a/apps/content/learn-and-contribute/mini-orpc/server-side-client.md
+++ b/apps/content/learn-and-contribute/mini-orpc/server-side-client.md
@@ -279,7 +279,7 @@ import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { Procedure } from './procedure'
 import type { CreateProcedureClientOptions, ProcedureClient } from './procedure-client'
 import type { AnyRouter, InferRouterInitialContexts } from './router'
-import { get, resolveMaybeOptionalOptions, toArray } from '@orpc/shared'
+import { resolveMaybeOptionalOptions, toArray } from '@orpc/shared'
 import { isProcedure } from './procedure'
 import { createProcedureClient } from './procedure-client'
 
@@ -319,7 +319,7 @@ export function createRouterClient<T extends AnyRouter>(
         return Reflect.get(target, key)
       }
 
-      const next = get(router, [key]) as AnyRouter | undefined
+      const next = router[key] as AnyRouter | undefined
 
       if (!next) {
         return Reflect.get(target, key)

--- a/packages/json-schema/src/coercer.test.ts
+++ b/packages/json-schema/src/coercer.test.ts
@@ -1,401 +1,739 @@
 import type { JsonSchema } from './types'
 import { JsonSchemaCoercer } from './coercer'
 
+const coercer = new JsonSchemaCoercer()
+
+/**
+ * Coerces like the smart coercion plugins do, from the `[jsonSchema, optional]`
+ * pair a `JsonSchemaConverter` returns.
+ */
+function coerce(schema: JsonSchema | Record<string, unknown>, value: unknown, optional: boolean = false): unknown {
+  return coercer.coerce([schema as JsonSchema, optional], value)
+}
+
+/**
+ * Native type schemas as `ZodToJsonSchemaConverter` emits them, so the tests stay tied to
+ * payloads that really reach the plugins. `url` and `regexp` come from custom converters,
+ * because no built-in converter maps a validator to them yet.
+ */
+const DATE_SCHEMA = { 'type': 'string', 'format': 'date-time', 'x-native-type': 'date' }
+const BIGINT_SCHEMA = { 'type': 'string', 'pattern': '^-?[0-9]+$', 'x-native-type': 'bigint' }
+const URL_SCHEMA = { 'type': 'string', 'format': 'uri', 'x-native-type': 'url' }
+const REGEXP_SCHEMA = { 'type': 'string', 'x-native-type': 'regexp' }
+
+function setSchema(items: Record<string, unknown>) {
+  return { 'type': 'array', 'uniqueItems': true, items, 'x-native-type': 'set' }
+}
+
+function mapSchema(key: Record<string, unknown>, value: Record<string, unknown>) {
+  return {
+    'type': 'array',
+    'items': { type: 'array', prefixItems: [key, value], minItems: 2, maxItems: 2 },
+    'x-native-type': 'map',
+  }
+}
+
 describe('jsonSchemaCoercer', () => {
-  const coercer = new JsonSchemaCoercer()
+  describe('booleans', () => {
+    it('accepts the boolean spellings browsers and CLIs send', () => {
+      expect(coerce({ type: 'boolean' }, 'true')).toBe(true)
+      expect(coerce({ type: 'boolean' }, 'TRUE')).toBe(true)
+      expect(coerce({ type: 'boolean' }, 'on')).toBe(true)
+      expect(coerce({ type: 'boolean' }, 'On')).toBe(true)
+      expect(coerce({ type: 'boolean' }, 'false')).toBe(false)
+      expect(coerce({ type: 'boolean' }, 'off')).toBe(false)
+      expect(coerce({ type: 'boolean' }, 'OFF')).toBe(false)
+      expect(coerce({ type: 'boolean' }, true)).toBe(true)
 
-  it('do no thing with boolean/any schema', () => {
-    expect(coercer.coerce([true, false], '123')).toEqual('123')
-    expect(coercer.coerce([false, false], '123')).toEqual('123')
-    expect(coercer.coerce([{}, false], '123')).toEqual('123')
-    expect(coercer.coerce([{ not: {} }, false], '123')).toEqual('123')
-  })
-
-  it('do no thing with optional schema and undefined value', () => {
-    expect(coercer.coerce([{ type: 'number' }, true], undefined)).toEqual(undefined)
-    expect(coercer.coerce([{ type: 'array' }, true], undefined)).toEqual(undefined)
-    expect(coercer.coerce([{ type: 'object' }, true], undefined)).toEqual(undefined)
-  })
-
-  it('can coerce primitive types', () => {
-    expect(coercer.coerce([{ type: 'boolean' }, false], 'true')).toEqual(true)
-    expect(coercer.coerce([{ type: 'boolean' }, false], 'false')).toEqual(false)
-    expect(coercer.coerce([{ type: 'boolean' }, false], 'invalid')).toEqual('invalid')
-
-    expect(coercer.coerce([{ type: 'number' }, false], '123.4')).toEqual(123.4)
-    expect(coercer.coerce([{ type: 'number' }, false], 'invalid')).toEqual('invalid')
-
-    expect(coercer.coerce([{ type: 'integer' }, false], '123')).toEqual(123)
-    expect(coercer.coerce([{ type: 'integer' }, false], '123.4')).toEqual('123.4')
-    expect(coercer.coerce([{ type: 'integer' }, false], 'invalid')).toEqual('invalid')
-    expect(coercer.coerce([{ type: 'integer' }, false], [])).toEqual([])
-
-    // -- no coercion
-    expect(coercer.coerce([{ type: 'null' }, false], null)).toEqual(null)
-    expect(coercer.coerce([{ type: 'null' }, false], undefined)).toEqual(undefined)
-    expect(coercer.coerce([{ type: 'number' }, false], undefined)).toEqual(undefined)
-    expect(coercer.coerce([{ type: 'boolean' }, false], undefined)).toEqual(undefined)
-  })
-
-  it('can coerce multiple types', () => {
-    expect(coercer.coerce([{ type: ['boolean', 'null'] }, false], 'true')).toEqual(true)
-    expect(coercer.coerce([{ type: ['number', 'boolean'] }, false], '123')).toEqual(123)
-  })
-
-  it('can coerce native types', () => {
-    const date = new Date()
-    expect(coercer.coerce([{ 'type': 'string', 'x-native-type': 'date' } as any, false], date.toISOString())).toEqual(date)
-    expect(coercer.coerce([{ 'type': 'string', 'x-native-type': 'date' } as any, false], '1972-01-01')).toEqual(new Date('1972-01-01'))
-    expect(coercer.coerce([{ 'type': 'string', 'x-native-type': 'date' } as any, false], '2018-06-12T19:30')).toEqual(new Date('2018-06-12T19:30'))
-    expect(coercer.coerce([{ 'type': 'string', 'x-native-type': 'date' } as any, false], '2018-06-')).toEqual('2018-06-')
-    expect(coercer.coerce([{ 'type': 'string', 'x-native-type': 'date' } as any, false], 'Invalid Date')).toEqual('Invalid Date')
-    expect(coercer.coerce([{ 'type': 'string', 'x-native-type': 'date' } as any, false], [])).toEqual([])
-
-    expect(coercer.coerce([{ 'type': 'string', 'x-native-type': 'bigint' } as any, false], '123')).toEqual(123n)
-    expect(coercer.coerce([{ 'type': 'string', 'x-native-type': 'bigint' } as any, false], 123)).toEqual(123n)
-    expect(coercer.coerce([{ 'type': 'string', 'x-native-type': 'bigint' } as any, false], Infinity)).toEqual(Infinity)
-    expect(coercer.coerce([{ 'type': 'string', 'x-native-type': 'bigint' } as any, false], 'invalid')).toEqual('invalid')
-    expect(coercer.coerce([{ 'type': 'string', 'x-native-type': 'bigint' } as any, false], [])).toEqual([])
-
-    expect(coercer.coerce([{ 'type': 'string', 'x-native-type': 'url' } as any, false], 'https://example.com')).toEqual(new URL('https://example.com'))
-    expect(coercer.coerce([{ 'type': 'string', 'x-native-type': 'url' } as any, false], 'invalid')).toEqual('invalid')
-    expect(coercer.coerce([{ 'type': 'string', 'x-native-type': 'url' } as any, false], [])).toEqual([])
-
-    expect(coercer.coerce([{ 'type': 'string', 'x-native-type': 'regexp' } as any, false], '/abc/i')).toEqual(/abc/i)
-    expect(coercer.coerce([{ 'type': 'string', 'x-native-type': 'regexp' } as any, false], '/abc/invalid')).toEqual('/abc/invalid')
-    expect(coercer.coerce([{ 'type': 'string', 'x-native-type': 'regexp' } as any, false], 'invalid')).toEqual('invalid')
-    expect(coercer.coerce([{ 'type': 'string', 'x-native-type': 'regexp' } as any, false], [])).toEqual([])
-
-    expect(coercer.coerce(
-      [{ 'type': 'array', 'items': { type: 'number' }, 'x-native-type': 'set' } as any, false],
-      ['1', '2', '3', '4'],
-    )).toEqual(new Set([1, 2, 3, 4]))
-
-    expect(coercer.coerce(
-      [{ 'type': 'array', 'items': { type: 'number' }, 'x-native-type': 'set' } as any, false],
-      ['1', '2', '3', '4', '4'],
-    )).toEqual([1, 2, 3, 4, 4])
-
-    expect(coercer.coerce(
-      [{ 'type': 'array', 'items': { type: 'number' }, 'x-native-type': 'set' } as any, false],
-      {},
-    )).toEqual({})
-
-    expect(coercer.coerce(
-      [{ 'type': 'array', 'items': { type: 'array', prefixItems: [{ type: 'number' }, { type: 'boolean' }] }, 'x-native-type': 'map' } as any, false],
-      [['1', 'true'], ['2', 'false'], ['invalid', 'invalid']],
-    )).toEqual(new Map([[1, true], [2, false], ['invalid', 'invalid']] as any))
-
-    expect(coercer.coerce(
-      [{ 'type': 'array', 'items': { type: 'array', prefixItems: [{ type: 'number' }, { type: 'boolean' }] }, 'x-native-type': 'map' } as any, false],
-      ['1'],
-    )).toEqual(['1'])
-
-    expect(coercer.coerce(
-      [{ 'type': 'array', 'items': { type: 'array', prefixItems: [{ type: 'number' }, { type: 'boolean' }] }, 'x-native-type': 'map' } as any, false],
-      {},
-    )).toEqual({})
-
-    expect(coercer.coerce(
-      [{ 'type': 'array', 'items': { type: 'array', prefixItems: [{ type: 'number' }, { type: 'boolean' }] }, 'x-native-type': 'map' } as any, false],
-      [['1', 'true'], ['2', 'false'], ['1', 'false']],
-    )).toEqual([[1, true], [2, false], [1, false]])
-  })
-
-  it('can coerce enum/const values', () => {
-    expect(coercer.coerce([{ enum: [123, '234', true] }, false], 123)).toEqual(123)
-    expect(coercer.coerce([{ enum: [123, '234', true] }, false], '234')).toEqual('234')
-    expect(coercer.coerce([{ enum: [123, '234', true] }, false], '123')).toEqual(123)
-    expect(coercer.coerce([{ enum: [123, '234', true] }, false], 'off')).toEqual('off')
-    expect(coercer.coerce([{ enum: [123, '234', true] }, false], 'on')).toEqual(true)
-    expect(coercer.coerce([{ enum: [123, '234', true] }, false], ['on'])).toEqual(['on'])
-
-    expect(coercer.coerce([{ const: true }, false], 'off')).toEqual('off')
-    expect(coercer.coerce([{ const: true }, false], 'on')).toEqual(true)
-    expect(coercer.coerce([{ const: true }, false], ['on'])).toEqual(['on'])
-  })
-
-  it('can coerce arrays/tuples', () => {
-    expect(
-      coercer.coerce([{ type: 'array', items: { type: 'number' } }, false], ['1', '2', '3']),
-    ).toEqual([1, 2, 3])
-    expect(
-      coercer.coerce([{ type: 'array', items: { type: 'string' } }, false], ['1', '2', '3']),
-    ).toEqual(['1', '2', '3'])
-
-    // draft-07
-    expect(
-      coercer.coerce(
-        [{ type: 'array', items: [{ type: 'number' }, { type: 'boolean' }], additionalItems: { type: 'number' } } as any, false],
-        ['1', 'true', '2', 'false'],
-      ),
-    ).toEqual([1, true, 2, 'false'])
-
-    // draft-2020
-    expect(
-      coercer.coerce(
-        [{ type: 'array', prefixItems: [{ type: 'number' }, { type: 'boolean' }], items: { type: 'number' } }, false],
-        ['1', 'true', '2', 'false'],
-      ),
-    ).toEqual([1, true, 2, 'false'])
-
-    expect(
-      coercer.coerce(
-        [{ type: 'array', prefixItems: [{ type: 'number' }, { type: 'boolean' }] }, false],
-        ['1', 'true', '2', 'false'],
-      ),
-    ).toEqual([1, true, '2', 'false'])
-  })
-
-  it('can coerce objects', () => {
-    expect(
-      coercer.coerce(
-        [{ type: 'object', properties: { a: { type: 'number' }, b: { type: 'boolean' } } }, false],
-        { a: '123', b: 'true' },
-      ),
-    ).toEqual({ a: 123, b: true })
-
-    expect(
-      coercer.coerce(
-        [{ type: 'object', properties: { a: { type: 'number' }, b: { type: 'boolean' } }, required: ['a'] }, false],
-        { a: undefined, b: 'true' },
-      ),
-    ).toEqual({ a: undefined, b: true })
-
-    expect(
-      coercer.coerce(
-        [{
-          type: 'object',
-          properties: { a: { type: 'number' } },
-          patternProperties: { '^b': { 'type': 'string', 'x-native-type': 'bigint' } as any },
-          additionalProperties: { type: 'boolean' },
-        }, false],
-        { a: '123', b: '123', b1: '123', c: 'false' },
-      ),
-    ).toEqual({ a: 123, b: 123n, b1: 123n, c: false })
-
-    expect(
-      coercer.coerce(
-        [{ type: 'object', properties: { 0: { type: 'number' }, 1: { type: 'boolean' } } }, false],
-        ['123', 'true'],
-      ),
-    ).toEqual({ 0: 123, 1: true })
-  })
-
-  it('can handle union types', () => {
-    const schema = {
-      anyOf: [
-        { type: 'number' },
-        { type: 'boolean' },
-        { type: 'object', properties: { a: { type: 'number' } } },
-        { type: 'object', properties: { a: { type: 'number' }, b: { type: 'number' } } },
-      ],
-    } as any
-
-    expect(coercer.coerce([schema, false], 123)).toEqual(123)
-    expect(coercer.coerce([schema, false], '123')).toEqual(123)
-    expect(coercer.coerce([schema, false], true)).toEqual(true)
-    expect(coercer.coerce([schema, false], 'true')).toEqual(true)
-    expect(coercer.coerce([schema, false], { a: '123' })).toEqual({ a: 123 })
-    expect(coercer.coerce([schema, false], { a: '123', b: undefined })).toEqual({ a: 123, b: undefined })
-    expect(coercer.coerce([schema, false], { a: '123', b: '456' })).toEqual({ a: 123, b: 456 })
-    expect(coercer.coerce([schema, false], 'invalid')).toEqual('invalid')
-
-    const schema2 = {
-      anyOf: [
-        { type: 'object', properties: { a: { type: 'boolean' }, b: { type: 'number' } }, required: ['a', 'b'] },
-        { type: 'object', properties: { a: { type: 'number' }, b: { type: 'number' } } },
-      ],
-    } as any
-
-    expect(coercer.coerce([schema2, false], { a: 'true', b: '123' })).toEqual({ a: true, b: 123 })
-    expect(coercer.coerce([schema2, false], { a: '123' })).toEqual({ a: 123 })
-
-    const schema3 = {
-      anyOf: [
-        { type: 'array', prefixItems: [{ type: 'number' }, { type: 'boolean' }, { type: 'boolean' }], items: { type: 'number' } },
-        { type: 'array', prefixItems: [{ type: 'number' }], items: { type: 'number' } },
-      ],
-    } as any
-
-    expect(coercer.coerce([schema3, false], ['1', 'true', 'true', '2'])).toEqual([1, true, true, 2])
-    expect(coercer.coerce([schema3, false], ['1', '2'])).toEqual([1, 2])
-
-    const schema4 = {
-      oneOf: [
-        { type: 'number', not: { const: 1 } },
-        { 'type': 'number', 'x-native-type': 'bigint', 'not': { const: 2n } },
-      ],
-    }
-
-    expect(coercer.coerce([schema4, false], '1')).toEqual(1n)
-    expect(coercer.coerce([schema4, false], '2')).toEqual(2)
-    expect(coercer.coerce([schema4, false], '3')).toEqual(3)
-  })
-
-  it('can handle discriminated union types', () => {
-    const schema = {
-      anyOf: [
-        { type: 'object', properties: { t: { const: 1 }, v: { type: 'number' } } },
-        { type: 'object', properties: { t: { const: 2 }, v: { 'type': 'string', 'x-native-type': 'bigint' } } },
-      ],
-    } as any
-
-    expect(coercer.coerce([schema, false], { t: '1', v: '123' })).toEqual({ t: 1, v: 123 })
-    expect(coercer.coerce([schema, false], { t: '2', v: '123' })).toEqual({ t: 2, v: 123n })
-  })
-
-  it('can coerce intersection types', () => {
-    const schema = {
-      allOf: [
-        { type: 'object', properties: { a: { type: 'number' } } },
-        { type: 'object', properties: { b: { type: 'number' } } },
-      ],
-    } as any
-
-    expect(coercer.coerce([schema, false], { a: '123', b: '456', c: '789' })).toEqual({ a: 123, b: 456, c: '789' })
-    expect(coercer.coerce([schema, false], { a: '123' })).toEqual({ a: 123 })
-    expect(coercer.coerce([schema, false], { b: '456' })).toEqual({ b: 456 })
-    expect(coercer.coerce([schema, false], 'invalid')).toEqual('invalid')
-  })
-
-  it('can coerce complex structures', () => {
-    const schema = {
-      $defs: {
-        ArrayOfDate: {
-          type: 'array',
-          items: { 'type': 'string', 'x-native-type': 'date' },
-        },
-      },
-      type: 'object',
-      properties: {
-        a: { type: 'boolean' },
-        b: { type: 'number' },
-        c: {
-          $ref: '#/$defs/ArrayOfDate',
-        },
-        d: {
-          type: 'object',
-          properties: {
-            e: {
-              'type': 'array',
-              'items': { 'type': 'string', 'x-native-type': 'url' },
-              'x-native-type': 'set',
-            },
-          },
-        },
-      },
-      required: ['a'],
-    }
-
-    expect(coercer.coerce([schema, false], {
-      a: 'true',
-      b: '123',
-      c: ['2020-01-01', '2020-01-02'],
-      d: {
-        e: ['https://example.com', 'https://example.org'],
-      },
-    })).toEqual({
-      a: true,
-      b: 123,
-      c: [new Date('2020-01-01'), new Date('2020-01-02')],
-      d: {
-        e: new Set([new URL('https://example.com'), new URL('https://example.org')]),
-      },
+      // anything else keeps its original value so validation can report it
+      expect(coerce({ type: 'boolean' }, 'yes')).toBe('yes')
+      expect(coerce({ type: 'boolean' }, '1')).toBe('1')
+      expect(coerce({ type: 'boolean' }, '')).toBe('')
+      expect(coerce({ type: 'boolean' }, 1)).toBe(1)
     })
   })
 
-  it('can coerce recursive types', () => {
-    const schema: JsonSchema = {
-      $defs: {
-        get Test() {
-          return schema
-        },
-      },
-      type: 'object',
-      properties: {
-        a: { type: 'boolean' },
-        b: { $ref: '#/$defs/Test' },
-      },
-      required: ['a'],
-    }
+  describe('numbers', () => {
+    it('coerces numeric strings only when the number is exact', () => {
+      expect(coerce({ type: 'number' }, '123')).toBe(123)
+      expect(coerce({ type: 'number' }, '3.14')).toBe(3.14)
+      expect(coerce({ type: 'number' }, '-0.5')).toBe(-0.5)
+      expect(coerce({ type: 'number' }, 123)).toBe(123)
 
-    expect(coercer.coerce([schema, false], {
-      a: 'true',
-      b: {
-        a: 'off',
-        b: {
-          a: 'invalid',
-          b: {
-            a: 'true',
-            b: 'invalid',
-          },
-        },
-      },
-    })).toEqual({
-      a: true,
-      b: {
-        a: false,
-        b: {
-          a: 'invalid',
-          b: {
-            a: true,
-            b: 'invalid',
-          },
-        },
-      },
+      expect(coerce({ type: 'number' }, '')).toBe('')
+      expect(coerce({ type: 'number' }, 'abc')).toBe('abc')
+      expect(coerce({ type: 'number' }, '12px')).toBe('12px')
+      expect(coerce({ type: 'number' }, '0x10')).toBe('0x10')
+      expect(coerce({ type: 'number' }, '007')).toBe('007')
+      expect(coerce({ type: 'number' }, ' 123 ')).toBe(' 123 ')
+      expect(coerce({ type: 'number' }, 'NaN')).toBe('NaN')
+      expect(coerce({ type: 'number' }, 'Infinity')).toBe('Infinity')
+      expect(coerce({ type: 'number' }, [])).toEqual([])
+
+      // scientific notation is not a plain numeric string
+      expect(coerce({ type: 'number' }, '1e3')).toBe('1e3')
+
+      // beyond the safe integer range digits would get lost
+      expect(coerce({ type: 'number' }, '12345678901234567890')).toBe('12345678901234567890')
+      expect(coerce({ type: 'number' }, '-12345678901234567890')).toBe('-12345678901234567890')
+      expect(coerce({ type: 'number' }, '9'.repeat(400))).toBe('9'.repeat(400))
     })
 
-    const schema2: JsonSchema = {
-      type: 'object',
-      properties: {
-        a: { type: 'boolean' },
-        b: { $ref: '#' },
-      },
-      required: ['a'],
-    }
+    it('coerces integer strings and refuses fractional or lossy ones', () => {
+      // z.int() emits { type: 'integer', minimum, maximum }
+      expect(coerce({ type: 'integer' }, '42')).toBe(42)
+      expect(coerce({ type: 'integer' }, '-7')).toBe(-7)
 
-    expect(coercer.coerce([schema2, false], {
-      a: 'true',
-      b: {
-        a: 'off',
-        b: {
-          a: 'invalid',
-          b: {
-            a: 'true',
-            b: 'invalid',
-          },
-        },
-      },
-    })).toEqual({
-      a: true,
-      b: {
-        a: false,
-        b: {
-          a: 'invalid',
-          b: {
-            a: true,
-            b: 'invalid',
-          },
-        },
-      },
+      expect(coerce({ type: 'integer' }, '1e3')).toBe('1e3')
+      expect(coerce({ type: 'integer' }, '')).toBe('')
+      expect(coerce({ type: 'integer' }, '4.5')).toBe('4.5')
+      expect(coerce({ type: 'integer' }, '0x10')).toBe('0x10')
+      expect(coerce({ type: 'integer' }, 'abc')).toBe('abc')
+      expect(coerce({ type: 'integer' }, [])).toEqual([])
+
+      // beyond the safe integer range digits would get lost
+      expect(coerce({ type: 'integer' }, '12345678901234567890')).toBe('12345678901234567890')
+
+      // an already numeric value is never rewritten
+      expect(coerce({ type: 'integer' }, 4.5)).toBe(4.5)
     })
   })
 
-  it('ignore unresolvable $ref', () => {
-    const schema: JsonSchema = {
-      $ref: '#/$defs/unExisted',
-    }
+  describe('strings and null', () => {
+    it('never rewrites a value into a string or into null', () => {
+      expect(coerce({ type: 'string' }, 'abc')).toBe('abc')
+      expect(coerce({ type: 'string' }, 123)).toBe(123)
+      expect(coerce({ type: 'null' }, null)).toBeNull()
+      expect(coerce({ type: 'null' }, 'null')).toBe('null')
+    })
+  })
 
-    expect(coercer.coerce([schema, false], { a: true })).toEqual({
-      a: true,
+  describe('dates', () => {
+    it('coerces ISO date and datetime strings', () => {
+      expect(coerce(DATE_SCHEMA, '2023-10-01')).toEqual(new Date('2023-10-01'))
+      expect(coerce(DATE_SCHEMA, '2020-01-01T06:15')).toEqual(new Date('2020-01-01T06:15'))
+      expect(coerce(DATE_SCHEMA, '2020-01-01T06:15Z')).toEqual(new Date('2020-01-01T06:15Z'))
+      expect(coerce(DATE_SCHEMA, '2020-01-01T06:15:00Z')).toEqual(new Date('2020-01-01T06:15:00Z'))
+      expect(coerce(DATE_SCHEMA, '2020-01-01T06:15:00.123Z')).toEqual(new Date('2020-01-01T06:15:00.123Z'))
+      expect(coerce(DATE_SCHEMA, '2020-01-01 06:15')).toEqual(new Date('2020-01-01 06:15'))
+
+      // the expanded year form `toISOString` emits outside 0000-9999
+      expect(coerce(DATE_SCHEMA, '+010000-01-01T00:00:00.000Z')).toEqual(new Date('+010000-01-01T00:00:00.000Z'))
     })
 
-    const schema2: JsonSchema = {
-      $ref: 'canNotResolve',
-    }
-    expect(coercer.coerce([schema2, false], { a: true })).toEqual({
-      a: true,
+    it('coerces datetimes carrying a UTC offset in either direction', () => {
+      expect(coerce(DATE_SCHEMA, '2020-01-01T06:15:00+07:00')).toEqual(new Date('2020-01-01T06:15:00+07:00'))
+      expect(coerce(DATE_SCHEMA, '2020-01-01T06:15:00-07:00')).toEqual(new Date('2020-01-01T06:15:00-07:00'))
+      expect(coerce(DATE_SCHEMA, '2020-01-01T06:15:00-0700')).toEqual(new Date('2020-01-01T06:15:00-0700'))
+    })
+
+    it('leaves ambiguous or impossible dates untouched', () => {
+      // month/day order depends on the runtime, so it is never guessed
+      expect(coerce(DATE_SCHEMA, '12-25-2020')).toBe('12-25-2020')
+      expect(coerce(DATE_SCHEMA, '01/02/2020')).toBe('01/02/2020')
+      expect(coerce(DATE_SCHEMA, 'yesterday')).toBe('yesterday')
+      expect(coerce(DATE_SCHEMA, '2018-06-')).toBe('2018-06-')
+
+      // right shape, not a real instant
+      expect(coerce(DATE_SCHEMA, '2020-13-45')).toBe('2020-13-45')
+      expect(coerce(DATE_SCHEMA, '2020-01-01T99:99Z')).toBe('2020-01-01T99:99Z')
+
+      // epoch numbers are ambiguous (seconds or milliseconds)
+      expect(coerce(DATE_SCHEMA, 1700000000000)).toBe(1700000000000)
+      expect(coerce(DATE_SCHEMA, [])).toEqual([])
+    })
+
+    it('keeps a value that is already a Date', () => {
+      const date = new Date('2020-01-01T00:00:00.000Z')
+      expect(coerce(DATE_SCHEMA, date)).toBe(date)
+    })
+  })
+
+  describe('bigints', () => {
+    it('coerces bigints from integer strings and whole numbers', () => {
+      expect(coerce(BIGINT_SCHEMA, '9007199254740993')).toBe(9007199254740993n)
+      expect(coerce(BIGINT_SCHEMA, '-42')).toBe(-42n)
+      expect(coerce(BIGINT_SCHEMA, 42)).toBe(42n)
+      expect(coerce(BIGINT_SCHEMA, 42n)).toBe(42n)
+    })
+
+    it('leaves values a bigint cannot represent unambiguously untouched', () => {
+      expect(coerce(BIGINT_SCHEMA, 'invalid')).toBe('invalid')
+      expect(coerce(BIGINT_SCHEMA, '4.5')).toBe('4.5')
+      expect(coerce(BIGINT_SCHEMA, 4.5)).toBe(4.5)
+      expect(coerce(BIGINT_SCHEMA, Number.POSITIVE_INFINITY)).toBe(Number.POSITIVE_INFINITY)
+      expect(coerce(BIGINT_SCHEMA, true)).toBe(true)
+      expect(coerce(BIGINT_SCHEMA, [])).toEqual([])
+
+      // `BigInt()` accepts these, but they are not plain integer strings
+      expect(coerce(BIGINT_SCHEMA, '')).toBe('')
+      expect(coerce(BIGINT_SCHEMA, '  ')).toBe('  ')
+      expect(coerce(BIGINT_SCHEMA, '0x10')).toBe('0x10')
+    })
+  })
+
+  describe('urls and regexps', () => {
+    it('coerces url strings', () => {
+      expect(coerce(URL_SCHEMA, 'https://example.com')).toEqual(new URL('https://example.com'))
+      expect(coerce(URL_SCHEMA, 'invalid')).toBe('invalid')
+      expect(coerce(URL_SCHEMA, [])).toEqual([])
+
+      const url = new URL('https://example.com')
+      expect(coerce(URL_SCHEMA, url)).toBe(url)
+    })
+
+    it('coerces regexp literals', () => {
+      expect(coerce(REGEXP_SCHEMA, '/^[a-z0-9-]+$/i')).toEqual(/^[a-z0-9-]+$/i)
+      expect(coerce(REGEXP_SCHEMA, '/^\\d+$/')).toEqual(/^\d+$/)
+      expect(coerce(REGEXP_SCHEMA, '/abc/')).toEqual(/abc/)
+      const newline = '\n'
+      expect(coerce(REGEXP_SCHEMA, `/a${newline}b/`)).toEqual(new RegExp(`a${newline}b`))
+      expect(coerce(REGEXP_SCHEMA, '/nested\\/slash/')).toEqual(/nested\/slash/)
+
+      expect(coerce(REGEXP_SCHEMA, '/abc/invalid')).toBe('/abc/invalid')
+      expect(coerce(REGEXP_SCHEMA, '/(unclosed/')).toBe('/(unclosed/')
+      expect(coerce(REGEXP_SCHEMA, 'abc')).toBe('abc')
+      expect(coerce(REGEXP_SCHEMA, [])).toEqual([])
+
+      const regexp = /abc/i
+      expect(coerce(REGEXP_SCHEMA, regexp)).toBe(regexp)
+    })
+  })
+
+  describe('sets and maps', () => {
+    it('coerces a unique array into a Set, after coercing its items', () => {
+      // z.set(z.number())
+      expect(coerce(setSchema({ type: 'number' }), ['1', '2', '3'])).toEqual(new Set([1, 2, 3]))
+      expect(coerce(setSchema({ type: 'string' }), [])).toEqual(new Set())
+    })
+
+    it('leaves an array with duplicates untouched, because a Set would drop data', () => {
+      expect(coerce(setSchema({ type: 'number' }), ['1', '2', '2'])).toEqual([1, 2, 2])
+    })
+
+    it('leaves non arrays untouched for a Set', () => {
+      expect(coerce(setSchema({ type: 'string' }), 'a')).toBe('a')
+      expect(coerce(setSchema({ type: 'string' }), {})).toEqual({})
+
+      const set = new Set(['a'])
+      expect(coerce(setSchema({ type: 'string' }), set)).toBe(set)
+    })
+
+    it('coerces an array of key/value pairs into a Map', () => {
+      // z.map(z.number(), z.boolean())
+      const schema = mapSchema({ type: 'number' }, { type: 'boolean' })
+
+      expect(coerce(schema, [['1', 'true'], ['2', 'off']])).toEqual(new Map<unknown, unknown>([[1, true], [2, false]]))
+      expect(coerce(schema, [])).toEqual(new Map())
+    })
+
+    it('leaves entries that are not unique pairs untouched for a Map', () => {
+      const schema = mapSchema({ type: 'number' }, { type: 'boolean' })
+
+      // duplicated key
+      expect(coerce(schema, [['1', 'true'], ['1', 'off']])).toEqual([[1, true], [1, false]])
+      // not a pair
+      expect(coerce(schema, [['1', 'true'], ['2']])).toEqual([[1, true], [2]])
+      expect(coerce(schema, ['1'])).toEqual(['1'])
+      expect(coerce(schema, {})).toEqual({})
+
+      const map = new Map([[1, true]])
+      expect(coerce(schema, map)).toBe(map)
+    })
+  })
+
+  describe('enums and literals', () => {
+    it('coerces enum members', () => {
+      // z.enum(['pending', 'done'])
+      expect(coerce({ type: 'string', enum: ['pending', 'done'] }, 'done')).toBe('done')
+      // z.enum({ Low: 1, High: 2 })
+      expect(coerce({ type: 'number', enum: [1, 2] }, '2')).toBe(2)
+
+      expect(coerce({ enum: [123, '234', true] }, 123)).toBe(123)
+      expect(coerce({ enum: [123, '234', true] }, '234')).toBe('234')
+      expect(coerce({ enum: [123, '234', true] }, '123')).toBe(123)
+      expect(coerce({ enum: [123, '234', true] }, 'on')).toBe(true)
+      expect(coerce({ enum: [123, '234', true] }, 'off')).toBe('off')
+      expect(coerce({ enum: [123, '234', true] }, ['on'])).toEqual(['on'])
+    })
+
+    it('coerces literals', () => {
+      // z.literal(true)
+      expect(coerce({ type: 'boolean', const: true }, 'on')).toBe(true)
+      expect(coerce({ const: true }, 'off')).toBe('off')
+      expect(coerce({ const: true }, ['on'])).toEqual(['on'])
+    })
+  })
+
+  describe('tuples', () => {
+    it('coerces tuples, with or without a rest schema', () => {
+      // z.tuple([z.number(), z.boolean()])
+      expect(coerce({ type: 'array', prefixItems: [{ type: 'number' }, { type: 'boolean' }] }, ['1', 'on'])).toEqual([1, true])
+      // z.tuple([z.number()], z.boolean())
+      expect(coerce({ type: 'array', prefixItems: [{ type: 'number' }], items: { type: 'boolean' } }, ['1', 'on', 'off'])).toEqual([1, true, false])
+      // draft-07 tuple form
+      expect(coerce({ type: 'array', items: [{ type: 'number' }, { type: 'boolean' }], additionalItems: { type: 'number' } }, ['1', 'on', '2'])).toEqual([1, true, 2])
+    })
+
+    it('leaves items no schema describes untouched', () => {
+      expect(coerce({ type: 'array', prefixItems: [{ type: 'number' }] }, ['1', '2'])).toEqual([1, '2'])
+      expect(coerce({ type: 'array', items: [{ type: 'number' }] }, ['1', '2'])).toEqual([1, '2'])
+      expect(coerce({ type: 'array' }, ['1'])).toEqual(['1'])
+    })
+
+    it('coerces what it can when a tuple is too short', () => {
+      expect(coerce({ type: 'array', prefixItems: [{ type: 'number' }, { type: 'boolean' }] }, ['1'])).toEqual([1])
+    })
+
+    it('leaves non arrays untouched', () => {
+      expect(coerce({ type: 'array', items: { type: 'number' } }, '1')).toBe('1')
+      expect(coerce({ type: 'array', items: { type: 'number' } }, { 0: '1' })).toEqual({ 0: '1' })
+    })
+  })
+
+  describe('objects and records', () => {
+    it('coerces a search query where every value arrives as a string', () => {
+      // z.object({ page: z.int(), perPage: z.int().optional(), q: z.string(), archived: z.boolean() })
+      const schema = {
+        type: 'object',
+        properties: {
+          page: { type: 'integer' },
+          perPage: { type: 'integer' },
+          q: { type: 'string' },
+          archived: { type: 'boolean' },
+        },
+        required: ['page', 'q', 'archived'],
+      }
+
+      expect(coerce(schema, { page: '2', perPage: '25', q: '123', archived: 'on' })).toEqual({
+        page: 2,
+        perPage: 25,
+        q: '123',
+        archived: true,
+      })
+    })
+
+    it('keeps a property that is explicitly undefined', () => {
+      const schema = {
+        type: 'object',
+        properties: { page: { type: 'integer' }, q: { type: 'string' } },
+        required: ['q'],
+      }
+
+      expect(coerce(schema, { page: undefined, q: '1' })).toEqual({ page: undefined, q: '1' })
+      expect(coerce(schema, { page: '2', q: undefined })).toEqual({ page: 2, q: undefined })
+    })
+
+    it('coerces nested objects and arrays of objects', () => {
+      // z.object({ filters: z.object({ since: z.date() }), items: z.array(z.object({ qty: z.int() })) })
+      const schema = {
+        type: 'object',
+        properties: {
+          filters: { type: 'object', properties: { since: DATE_SCHEMA }, required: ['since'] },
+          items: { type: 'array', items: { type: 'object', properties: { qty: { type: 'integer' } }, required: ['qty'] } },
+        },
+        required: ['filters', 'items'],
+      }
+
+      expect(coerce(schema, { filters: { since: '2020-01-01' }, items: [{ qty: '1' }, { qty: '2' }] })).toEqual({
+        filters: { since: new Date('2020-01-01') },
+        items: [{ qty: 1 }, { qty: 2 }],
+      })
+    })
+
+    it('coerces record values through additionalProperties and patternProperties', () => {
+      // z.record(z.string(), z.number())
+      expect(coerce({ type: 'object', additionalProperties: { type: 'number' } }, { a: '1', b: '2' }))
+        .toEqual({ a: 1, b: 2 })
+
+      const schema = {
+        type: 'object',
+        properties: { total: { type: 'integer' } },
+        patternProperties: { '^at': DATE_SCHEMA },
+        additionalProperties: { type: 'number' },
+      }
+
+      expect(coerce(schema, { total: '3', atCreated: '2020-01-01', atUpdated: '2020-01-02', ratio: '0.5' })).toEqual({
+        total: 3,
+        atCreated: new Date('2020-01-01'),
+        atUpdated: new Date('2020-01-02'),
+        ratio: 0.5,
+      })
+    })
+
+    it('leaves keys no schema describes untouched', () => {
+      // z.strictObject({ page: z.int() }) emits additionalProperties: false
+      expect(coerce({ type: 'object', properties: { page: { type: 'integer' } }, additionalProperties: false }, { page: '2', extra: '3' }))
+        .toEqual({ page: 2, extra: '3' })
+
+      expect(coerce({ type: 'object', properties: { page: { type: 'integer' } } }, { page: '2', extra: '3' }))
+        .toEqual({ page: 2, extra: '3' })
+    })
+
+    it('turns an array into an object with numeric keys, for bracket notation', () => {
+      expect(coerce({ type: 'object', properties: { 0: { type: 'number' }, 1: { type: 'boolean' } } }, ['123', 'true']))
+        .toEqual({ 0: 123, 1: true })
+    })
+
+    it('keeps special keys such as __proto__ as own properties', () => {
+      const value = JSON.parse('{"__proto__": {"nested": "1"}, "count": "2"}')
+
+      const coerced = coerce({
+        type: 'object',
+        properties: { count: { type: 'integer' } },
+        additionalProperties: { type: 'object', properties: { nested: { type: 'integer' } } },
+      }, value) as Record<string, unknown>
+
+      expect(Object.keys(coerced)).toEqual(['__proto__', 'count'])
+      expect(coerced.count).toBe(2)
+      expect(Object.getOwnPropertyDescriptor(coerced, '__proto__')?.value).toEqual({ nested: 1 })
+      expect((coerced as any).nested).toBeUndefined()
+      expect(({} as any).nested).toBeUndefined()
+    })
+
+    it('leaves non objects untouched', () => {
+      expect(coerce({ type: 'object', properties: { page: { type: 'integer' } } }, 'nope')).toBe('nope')
+    })
+  })
+
+  describe('unions', () => {
+    it('prefers the branch that needs no conversion', () => {
+      // z.union([z.number(), z.string()]): a string already satisfies the union
+      expect(coerce({ anyOf: [{ type: 'number' }, { type: 'string' }] }, '123')).toBe('123')
+      expect(coerce({ anyOf: [{ type: 'string' }, { type: 'number' }] }, '123')).toBe('123')
+      // z.union([z.number(), z.boolean()]): only one branch can accept 'true'
+      expect(coerce({ anyOf: [{ type: 'number' }, { type: 'boolean' }] }, 'true')).toBe(true)
+      expect(coerce({ anyOf: [{ type: 'number' }, { type: 'boolean' }] }, '123')).toBe(123)
+    })
+
+    it('handles nullable and nullish schemas', () => {
+      // z.date().nullable()
+      const schema = { anyOf: [DATE_SCHEMA, { type: 'null' }] }
+
+      expect(coerce(schema, '2020-01-01')).toEqual(new Date('2020-01-01'))
+      expect(coerce(schema, null)).toBeNull()
+      expect(coerce(schema, 'nope')).toBe('nope')
+
+      // z.number().nullish()
+      expect(coerce({ anyOf: [{ type: 'number' }, { type: 'null' }] }, undefined, true)).toBeUndefined()
+    })
+
+    it('handles the nullable form', () => {
+      expect(coerce({ type: ['integer', 'null'] }, '5')).toBe(5)
+      expect(coerce({ type: ['integer', 'null'] }, null)).toBeNull()
+      expect(coerce({ type: ['boolean', 'null'] }, 'on')).toBe(true)
+      expect(coerce({ type: ['integer', 'null'] }, 'nope')).toBe('nope')
+    })
+
+    it('picks the object branch whose required keys are present', () => {
+      // z.union([z.object({ mode: z.string(), count: z.int() }), z.object({ count: z.number() })])
+      const schema = {
+        anyOf: [
+          { type: 'object', properties: { mode: { type: 'string' }, count: { type: 'integer' } }, required: ['mode', 'count'] },
+          { type: 'object', properties: { count: { type: 'number' } }, required: ['count'] },
+        ],
+      }
+
+      expect(coerce(schema, { mode: 'fast', count: '2' })).toEqual({ mode: 'fast', count: 2 })
+      expect(coerce(schema, { count: '1.5' })).toEqual({ count: 1.5 })
+    })
+
+    it('picks the tuple branch that describes every item', () => {
+      const schema = {
+        anyOf: [
+          { type: 'array', prefixItems: [{ type: 'number' }, { type: 'boolean' }, { type: 'boolean' }], items: { type: 'number' } },
+          { type: 'array', prefixItems: [{ type: 'number' }], items: { type: 'number' } },
+        ],
+      }
+
+      expect(coerce(schema, ['1', 'true', 'true', '2'])).toEqual([1, true, true, 2])
+      expect(coerce(schema, ['1', '2'])).toEqual([1, 2])
+    })
+
+    it('picks the branch matching the discriminator of a discriminated union', () => {
+      // z.discriminatedUnion('type', [...]) emits oneOf with a const discriminator
+      const schema = {
+        oneOf: [
+          {
+            type: 'object',
+            properties: { type: { type: 'string', const: 'text' }, length: { type: 'integer' } },
+            required: ['type', 'length'],
+          },
+          {
+            type: 'object',
+            properties: { type: { type: 'string', const: 'image' }, width: { type: 'integer' }, lossless: { type: 'boolean' } },
+            required: ['type', 'width'],
+          },
+        ],
+      }
+
+      expect(coerce(schema, { type: 'text', length: '12' })).toEqual({ type: 'text', length: 12 })
+      expect(coerce(schema, { type: 'image', width: '800', lossless: 'off' })).toEqual({ type: 'image', width: 800, lossless: false })
+      expect(coerce(schema, { type: 'video', width: '800' })).toEqual({ type: 'video', width: '800' })
+
+      // extra keys do not disqualify the discriminator branch, validators usually strip them
+      expect(coerce(schema, { type: 'text', length: '12', tracking: 'xyz' })).toEqual({ type: 'text', length: 12, tracking: 'xyz' })
+    })
+
+    it('prefers the branch that describes every key', () => {
+      const partial = { type: 'object', properties: { a: { type: 'number' } } }
+      const full = { type: 'object', properties: { a: { type: 'number' }, b: { type: 'boolean' } } }
+
+      expect(coerce({ anyOf: [partial, full] }, { a: '1', b: 'on' })).toEqual({ a: 1, b: true })
+      expect(coerce({ anyOf: [full, partial] }, { a: '1', b: 'on' })).toEqual({ a: 1, b: true })
+    })
+
+    it('prefers an untouched match over a fuller match that converts', () => {
+      const schema = {
+        anyOf: [
+          { type: 'object', properties: { a: { type: 'string' } } },
+          { type: 'object', properties: { a: { type: 'number' }, b: { type: 'string' } } },
+        ],
+      }
+
+      const value = { a: '1', b: 'x' }
+      expect(coerce(schema, value)).toBe(value)
+    })
+
+    it('honours a branch that excludes values with not', () => {
+      const schema = {
+        oneOf: [
+          { type: 'number', not: { const: 1 } },
+          { 'type': 'number', 'x-native-type': 'bigint', 'not': { const: 2n } },
+        ],
+      }
+
+      expect(coerce(schema, '1')).toBe(1n)
+      expect(coerce(schema, '2')).toBe(2)
+      expect(coerce(schema, '3')).toBe(3)
+    })
+
+    it('leaves the value untouched when no branch matches', () => {
+      expect(coerce({ anyOf: [{ type: 'number' }, { type: 'boolean' }] }, 'invalid')).toBe('invalid')
+    })
+
+    it('does not let a matching branch mask a keyword that already failed', () => {
+      // `type` and `anyOf` both apply to the same value, and a string can never satisfy `type: 'null'`,
+      // so the first branch must lose to the one that can really accept the value
+      const schema = {
+        anyOf: [
+          { type: 'null', anyOf: [{ type: 'string' }] },
+          { type: 'boolean' },
+        ],
+      }
+
+      expect(coerce(schema, 'true')).toBe(true)
+    })
+  })
+
+  describe('intersections', () => {
+    it('applies every member of an intersection', () => {
+      // z.intersection(z.object({ a: z.number() }), z.object({ b: z.boolean() }))
+      const schema = {
+        allOf: [
+          { type: 'object', properties: { a: { type: 'number' } } },
+          { type: 'object', properties: { b: { type: 'boolean' } } },
+        ],
+      }
+
+      expect(coerce(schema, { a: '123', b: 'on', c: '789' })).toEqual({ a: 123, b: true, c: '789' })
+      expect(coerce(schema, { a: '123' })).toEqual({ a: 123 })
+      expect(coerce(schema, { b: 'off' })).toEqual({ b: false })
+      expect(coerce(schema, 'invalid')).toBe('invalid')
+    })
+  })
+
+  describe('$ref', () => {
+    it('follows a $ref into $defs', () => {
+      const schema = {
+        $defs: { Timestamps: { type: 'array', items: DATE_SCHEMA } },
+        type: 'object',
+        properties: { seenAt: { $ref: '#/$defs/Timestamps' } },
+        required: ['seenAt'],
+      }
+
+      expect(coerce(schema, { seenAt: ['2020-01-01', '2020-01-02'] })).toEqual({
+        seenAt: [new Date('2020-01-01'), new Date('2020-01-02')],
+      })
+    })
+
+    it('follows a chain of $refs', () => {
+      const schema = {
+        $defs: {
+          Page: { $ref: '#/$defs/PageBase' },
+          PageBase: { type: 'object', properties: { limit: { type: 'integer' } }, required: ['limit'] },
+        },
+        $ref: '#/$defs/Page',
+      }
+
+      expect(coerce(schema, { limit: '10' })).toEqual({ limit: 10 })
+    })
+
+    it('follows a $ref with escaped characters in its pointer', () => {
+      const schema = {
+        $defs: { 'user/id': { type: 'integer' } },
+        $ref: '#/$defs/user~1id',
+      }
+
+      expect(coerce(schema, '7')).toBe(7)
+    })
+
+    it('coerces a recursive schema at every depth', () => {
+      // z.object({ name: z.string(), get children() { return z.array(Category) } })
+      const schema: JsonSchema = {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          visits: { type: 'integer' },
+          children: { type: 'array', items: { $ref: '#' } },
+        },
+        required: ['name', 'children'],
+      }
+
+      expect(coerce(schema, {
+        name: 'root',
+        visits: '1',
+        children: [
+          { name: 'a', visits: '2', children: [] },
+          { name: 'b', visits: '3', children: [{ name: 'c', visits: '4', children: [] }] },
+        ],
+      })).toEqual({
+        name: 'root',
+        visits: 1,
+        children: [
+          { name: 'a', visits: 2, children: [] },
+          { name: 'b', visits: 3, children: [{ name: 'c', visits: 4, children: [] }] },
+        ],
+      })
+    })
+
+    it('coerces a recursive schema declared through $defs', () => {
+      const schema: JsonSchema = {
+        $defs: {
+          get Node() {
+            return schema
+          },
+        },
+        type: 'object',
+        properties: {
+          visits: { type: 'integer' },
+          next: { $ref: '#/$defs/Node' },
+        },
+      }
+
+      expect(coerce(schema, { visits: '1', next: { visits: '2', next: { visits: '3' } } }))
+        .toEqual({ visits: 1, next: { visits: 2, next: { visits: 3 } } })
+    })
+  })
+
+  describe('invalid and unusual schemas', () => {
+    it('ignores an unresolvable $ref', () => {
+      expect(coerce({ $ref: '#/$defs/Missing' }, { a: true })).toEqual({ a: true })
+      expect(coerce({ $ref: 'https://example.com/schema.json' }, { a: true })).toEqual({ a: true })
+      expect(coerce({ $ref: '#/$defs/Missing', type: 'integer' }, '1')).toBe(1)
+    })
+
+    it('does not resolve a $ref into prototype members', () => {
+      expect(coerce({ $ref: '#/constructor' }, '1')).toBe('1')
+      expect(coerce({ $ref: '#/__proto__', type: 'integer' }, '1')).toBe(1)
+    })
+
+    it('stops instead of looping on a $ref cycle', () => {
+      expect(coerce({ $ref: '#' }, { a: '1' })).toEqual({ a: '1' })
+
+      expect(coerce({
+        $defs: { Loop: { allOf: [{ $ref: '#/$defs/Loop' }, { type: 'object', properties: { a: { type: 'integer' } } }] } },
+        $ref: '#/$defs/Loop',
+      }, { a: '1' })).toEqual({ a: 1 })
+
+      expect(coerce({
+        $defs: { A: { $ref: '#/$defs/B' }, B: { $ref: '#/$defs/A' } },
+        $ref: '#/$defs/A',
+      }, { a: '1' })).toEqual({ a: '1' })
+    })
+
+    it('ignores a type it does not know', () => {
+      expect(coerce({ type: 'float' }, '1.5')).toBe('1.5')
+      expect(coerce({ type: 'String' }, 123)).toBe(123)
+      expect(coerce({ type: 'datetime' }, '2020-01-01')).toBe('2020-01-01')
+    })
+
+    it('ignores x-native-type values it does not know', () => {
+      expect(coerce({ 'type': 'string', 'x-native-type': 'temporal' }, '2020-01-01')).toBe('2020-01-01')
+      expect(coerce({ 'type': 'number', 'x-native-type': 42 }, '1')).toBe(1)
+    })
+
+    it('leaves values untouched for schemas without a coercible type', () => {
+      expect(coerce(true, '123')).toBe('123')
+      expect(coerce(false, '123')).toBe('123')
+      expect(coerce({}, '123')).toBe('123')
+      expect(coerce({ description: 'anything goes' }, '123')).toBe('123')
+      expect(coerce({ not: {} }, '123')).toBe('123')
+      expect(coerce({ type: 'number', not: { type: 'string' } }, '123')).toBe(123)
+    })
+
+    it('handles empty enums and unions', () => {
+      expect(coerce({ enum: [] }, 'anything')).toBe('anything')
+      expect(coerce({ anyOf: [] }, '123')).toBe('123')
+      expect(coerce({ oneOf: [] }, '123')).toBe('123')
+    })
+
+    it('skips an invalid patternProperties pattern without breaking the other keys', () => {
+      const schema = {
+        type: 'object',
+        properties: { total: { type: 'integer' } },
+        patternProperties: { '(unclosed': { type: 'number' }, '^n': { type: 'number' } },
+      }
+
+      expect(coerce(schema, { total: '3', n1: '1', other: 'x' })).toEqual({ total: 3, n1: 1, other: 'x' })
+    })
+
+    it('accepts boolean schemas for properties and items', () => {
+      const value = { free: ['anything', 1], never: 'kept' }
+
+      expect(coerce({
+        type: 'object',
+        properties: { free: { type: 'array', items: true }, never: false },
+      }, value)).toBe(value)
+
+      const record = { a: 'kept' }
+      expect(coerce({ type: 'object', additionalProperties: true }, record)).toBe(record)
+    })
+
+    it('tolerates a tuple whose prefixItems is a single schema', () => {
+      expect(coerce({ type: 'array', prefixItems: { type: 'number' } }, ['1', '2'])).toEqual([1, '2'])
+    })
+
+    it('tolerates an empty draft-07 tuple form', () => {
+      expect(coerce({ type: 'array', items: [] }, ['1'])).toEqual(['1'])
+    })
+  })
+
+  describe('untouched values', () => {
+    it('skips a missing optional input entirely', () => {
+      expect(coerce({ type: 'object', properties: { page: { type: 'integer' } } }, undefined, true)).toBeUndefined()
+      expect(coerce({ type: 'integer' }, undefined, true)).toBeUndefined()
+
+      // a required input still reaches validation untouched
+      expect(coerce({ type: 'integer' }, undefined)).toBeUndefined()
+      expect(coerce({ type: 'null' }, undefined)).toBeUndefined()
+    })
+
+    it('returns the very same value when nothing needs coercion', () => {
+      const schema = {
+        type: 'object',
+        properties: {
+          page: { type: 'integer' },
+          tags: { type: 'array', items: { type: 'string' } },
+          nested: { type: 'object', properties: { flag: { type: 'boolean' } } },
+        },
+      }
+
+      const value = { page: 2, tags: ['a', 'b'], nested: { flag: true } }
+
+      const coerced = coerce(schema, value)
+
+      expect(coerced).toBe(value)
     })
   })
 })

--- a/packages/json-schema/src/coercer.ts
+++ b/packages/json-schema/src/coercer.ts
@@ -3,7 +3,24 @@ import { get, isPlainObject, toArray, tryOrUndefined } from '@orpc/shared'
 import { decodeJsonPointerSegment } from './ref-utils'
 import { JsonSchemaXNativeType } from './types'
 
-const FLEXIBLE_DATE_FORMAT_REGEX = /^[^-]+-[^-]+-[^-]+$/
+/**
+ * How well a value matches a schema, used to pick the best union branch.
+ */
+const UNSATISFIED = 0
+/**
+ * Every keyword matches except some object keys or array items no schema describes.
+ * JSON Schema allows those, and validators usually strip or ignore them, but a branch
+ * that describes every key is still a better match.
+ */
+const LOOSELY_SATISFIED = 1
+/** Every keyword matches. */
+const SATISFIED = 2
+
+type Satisfaction = typeof UNSATISFIED | typeof LOOSELY_SATISFIED | typeof SATISFIED
+
+function minSatisfaction(a: Satisfaction, b: Satisfaction): Satisfaction {
+  return a < b ? a : b
+}
 
 export class JsonSchemaCoercer {
   coerce([schema, optional]: [schema: JsonSchema, optional: boolean], value: unknown): unknown {
@@ -15,9 +32,18 @@ export class JsonSchemaCoercer {
     return coerced
   }
 
-  private coerceInternal(rootSchema: JsonSchema, schema: JsonSchema, value: unknown): [satisfied: boolean, coerced: unknown] {
+  private coerceInternal(
+    rootSchema: JsonSchema,
+    schema: JsonSchema,
+    value: unknown,
+    /**
+     * Schemas already applied to this exact value, used to stop `$ref` cycles.
+     * Only shared between keywords that re-apply a schema to the same value, never with nested values.
+     */
+    appliedRefs?: Set<JsonSchema>,
+  ): [satisfied: Satisfaction, coerced: unknown] {
     if (typeof schema === 'boolean') {
-      return [schema, value]
+      return [schema ? SATISFIED : UNSATISFIED, value]
     }
 
     if (Array.isArray(schema.type)) {
@@ -25,11 +51,12 @@ export class JsonSchemaCoercer {
         rootSchema,
         { anyOf: schema.type.map(type => ({ ...schema, type })) },
         value,
+        appliedRefs,
       )
     }
 
     let coerced = value
-    let satisfied = true
+    let satisfied: Satisfaction = SATISFIED
 
     if (typeof schema.$ref === 'string') {
       const resolved
@@ -39,11 +66,16 @@ export class JsonSchemaCoercer {
             ? rootSchema
             : undefined
 
-      if (resolved !== undefined) {
-        const [subSatisfied, subCoerced] = this.coerceInternal(rootSchema, resolved, coerced)
+      if (resolved !== undefined && !appliedRefs?.has(resolved)) {
+        appliedRefs ??= new Set()
+        appliedRefs.add(resolved)
+
+        const [subSatisfied, subCoerced] = this.coerceInternal(rootSchema, resolved, coerced, appliedRefs)
+
+        appliedRefs.delete(resolved)
 
         coerced = subCoerced
-        satisfied = subSatisfied
+        satisfied = minSatisfaction(satisfied, subSatisfied)
       }
     }
 
@@ -62,12 +94,12 @@ export class JsonSchemaCoercer {
             coerced = booleanValue
           }
           else {
-            satisfied = false
+            satisfied = UNSATISFIED
           }
         }
       }
       else {
-        satisfied = false
+        satisfied = UNSATISFIED
       }
     }
 
@@ -75,14 +107,14 @@ export class JsonSchemaCoercer {
       switch (schema.type) {
         case 'null': {
           if (coerced !== null) {
-            satisfied = false
+            satisfied = UNSATISFIED
           }
 
           break
         }
         case 'string': {
           if (typeof coerced !== 'string') {
-            satisfied = false
+            satisfied = UNSATISFIED
           }
 
           break
@@ -93,7 +125,7 @@ export class JsonSchemaCoercer {
           }
 
           if (typeof coerced !== 'number') {
-            satisfied = false
+            satisfied = UNSATISFIED
           }
 
           break
@@ -104,7 +136,7 @@ export class JsonSchemaCoercer {
           }
 
           if (typeof coerced !== 'number' || !Number.isInteger(coerced)) {
-            satisfied = false
+            satisfied = UNSATISFIED
           }
 
           break
@@ -115,7 +147,7 @@ export class JsonSchemaCoercer {
           }
 
           if (typeof coerced !== 'boolean') {
-            satisfied = false
+            satisfied = UNSATISFIED
           }
 
           break
@@ -137,15 +169,13 @@ export class JsonSchemaCoercer {
             const coercedItems = coerced.map((item, i) => {
               const subSchema = prefixItemSchemas[i] ?? itemSchema
               if (subSchema === undefined) {
-                satisfied = false
+                satisfied = minSatisfaction(satisfied, LOOSELY_SATISFIED)
                 return item
               }
 
               const [subSatisfied, subCoerced] = this.coerceInternal(rootSchema, subSchema, item)
 
-              if (!subSatisfied) {
-                satisfied = false
-              }
+              satisfied = minSatisfaction(satisfied, subSatisfied)
 
               if (subCoerced !== item) {
                 shouldUseCoercedItems = true
@@ -155,7 +185,7 @@ export class JsonSchemaCoercer {
             })
 
             if (coercedItems.length < prefixItemSchemas.length) {
-              satisfied = false
+              satisfied = UNSATISFIED
             }
 
             if (shouldUseCoercedItems) {
@@ -163,7 +193,7 @@ export class JsonSchemaCoercer {
             }
           }
           else {
-            satisfied = false
+            satisfied = UNSATISFIED
           }
           break
         }
@@ -174,40 +204,45 @@ export class JsonSchemaCoercer {
 
           if (isPlainObject(coerced)) {
             let shouldUseCoercedItems = false
-            const coercedItems: Record<string, unknown> = {}
+            // copy here so special keys like `__proto__` are kept as own properties
+            const coercedItems = { ...coerced }
 
             const patternProperties = Object.entries(schema.patternProperties ?? {})
-              .map(([key, value]) => [new RegExp(key), value] as const)
+              .flatMap(([key, value]) => {
+                // an invalid pattern is a schema mistake, it should not break coercion of the other keys
+                const pattern = tryOrUndefined(() => new RegExp(key))
+                return pattern ? [[pattern, value] as const] : []
+              })
+
+            const propertySchemas = schema.properties
 
             for (const key in coerced) {
               const value = coerced[key]
-              const subSchema = schema.properties?.[key]
+
+              // `properties[key]` alone would resolve keys like `__proto__` to `Object.prototype`
+              const subSchema = (propertySchemas !== undefined && Object.hasOwn(propertySchemas, key) ? propertySchemas[key] : undefined)
                 ?? patternProperties.find(([pattern]) => pattern.test(key))?.[1]
                 ?? schema.additionalProperties
 
-              if (value === undefined && !schema.required?.includes(key)) {
-                coercedItems[key] = value
-              }
-              else if (subSchema === undefined) {
-                coercedItems[key] = value
-                satisfied = false
-              }
-              else {
-                const [subSatisfied, subCoerced] = this.coerceInternal(rootSchema, subSchema, value)
-                coercedItems[key] = subCoerced
-
-                if (!subSatisfied) {
-                  satisfied = false
+              if (value !== undefined || schema.required?.includes(key)) {
+                if (subSchema === undefined) {
+                  satisfied = minSatisfaction(satisfied, LOOSELY_SATISFIED)
                 }
+                else {
+                  const [subSatisfied, subCoerced] = this.coerceInternal(rootSchema, subSchema, value)
+                  coercedItems[key] = subCoerced
 
-                if (subCoerced !== value) {
-                  shouldUseCoercedItems = true
+                  satisfied = minSatisfaction(satisfied, subSatisfied)
+
+                  if (subCoerced !== value) {
+                    shouldUseCoercedItems = true
+                  }
                 }
               }
             }
 
             if (schema.required?.some(key => !Object.hasOwn(coercedItems, key))) {
-              satisfied = false
+              satisfied = UNSATISFIED
             }
 
             if (shouldUseCoercedItems) {
@@ -215,7 +250,7 @@ export class JsonSchemaCoercer {
             }
           }
           else {
-            satisfied = false
+            satisfied = UNSATISFIED
           }
 
           break
@@ -231,7 +266,7 @@ export class JsonSchemaCoercer {
           }
 
           if (!(coerced instanceof Date)) {
-            satisfied = false
+            satisfied = UNSATISFIED
           }
 
           break
@@ -247,7 +282,7 @@ export class JsonSchemaCoercer {
           }
 
           if (typeof coerced !== 'bigint') {
-            satisfied = false
+            satisfied = UNSATISFIED
           }
 
           break
@@ -258,7 +293,7 @@ export class JsonSchemaCoercer {
           }
 
           if (!(coerced instanceof RegExp)) {
-            satisfied = false
+            satisfied = UNSATISFIED
           }
 
           break
@@ -269,7 +304,7 @@ export class JsonSchemaCoercer {
           }
 
           if (!(coerced instanceof URL)) {
-            satisfied = false
+            satisfied = UNSATISFIED
           }
 
           break
@@ -280,7 +315,7 @@ export class JsonSchemaCoercer {
           }
 
           if (!(coerced instanceof Set)) {
-            satisfied = false
+            satisfied = UNSATISFIED
           }
 
           break
@@ -291,7 +326,7 @@ export class JsonSchemaCoercer {
           }
 
           if (!(coerced instanceof Map)) {
-            satisfied = false
+            satisfied = UNSATISFIED
           }
 
           break
@@ -301,44 +336,54 @@ export class JsonSchemaCoercer {
 
     if (schema.allOf) {
       for (const subSchema of schema.allOf) {
-        const [subSatisfied, subCoerced] = this.coerceInternal(rootSchema, subSchema, coerced)
+        const [subSatisfied, subCoerced] = this.coerceInternal(rootSchema, subSchema, coerced, appliedRefs)
 
         coerced = subCoerced
-
-        if (!subSatisfied) {
-          satisfied = false
-        }
+        satisfied = minSatisfaction(satisfied, subSatisfied)
       }
     }
 
     for (const key of ['anyOf', 'oneOf'] as const) {
       if (schema[key]) {
-        let bestOptions: { coerced: unknown, satisfied: boolean } | undefined
+        /**
+         * The best branch is the first one that accepts the value untouched,
+         * then the most satisfied branch that accepts it after a conversion.
+         */
+        let best: { satisfied: Satisfaction, value: unknown } | undefined
 
         for (const subSchema of schema[key]) {
-          const [subSatisfied, subCoerced] = this.coerceInternal(rootSchema, subSchema, coerced)
+          const [subSatisfied, subCoerced] = this.coerceInternal(rootSchema, subSchema, coerced, appliedRefs)
 
-          if (subSatisfied) {
-            if (!bestOptions || subCoerced === coerced) {
-              bestOptions = { coerced: subCoerced, satisfied: subSatisfied }
-            }
+          if (subSatisfied === UNSATISFIED) {
+            continue
+          }
 
-            if (subCoerced === coerced) {
-              break
-            }
+          if (subCoerced === coerced) {
+            best = { satisfied: subSatisfied, value: subCoerced }
+            break
+          }
+
+          if (!best || subSatisfied > best.satisfied) {
+            best = { satisfied: subSatisfied, value: subCoerced }
           }
         }
 
-        coerced = bestOptions ? bestOptions.coerced : coerced
-        satisfied = bestOptions ? bestOptions.satisfied : false
+        // a matching branch never repairs a sibling keyword that already failed, so satisfaction only decreases
+        if (best) {
+          coerced = best.value
+          satisfied = minSatisfaction(satisfied, best.satisfied)
+        }
+        else {
+          satisfied = UNSATISFIED
+        }
       }
     }
 
     if (typeof schema.not !== 'undefined') {
-      const [notSatisfied] = this.coerceInternal(rootSchema, schema.not, coerced)
+      const [notSatisfied] = this.coerceInternal(rootSchema, schema.not, coerced, appliedRefs)
 
-      if (notSatisfied) {
-        satisfied = false
+      if (notSatisfied !== UNSATISFIED) {
+        satisfied = UNSATISFIED
       }
     }
 
@@ -346,24 +391,51 @@ export class JsonSchemaCoercer {
   }
 }
 
+const NUMBER_PATTERN = /^-?(?:0|[1-9]\d*)(?:\.\d+)?$/
 function stringToNumber(value: string): number | string {
-  const num = Number.parseFloat(value)
+  if (!NUMBER_PATTERN.test(value)) {
+    return value
+  }
 
-  if (Number.isNaN(num) || num !== Number(value)) {
+  const num = Number(value)
+
+  // beyond the safe range digits get lost, `'12345678901234567890'` would become `12345678901234567168`
+  if (num < Number.MIN_SAFE_INTEGER || num > Number.MAX_SAFE_INTEGER) {
     return value
   }
 
   return num
 }
 
+const INTEGER_PATTERN = /^-?(?:0|[1-9]\d*)$/
 function stringToInteger(value: string): number | string {
-  const num = Number.parseInt(value)
+  if (!INTEGER_PATTERN.test(value)) {
+    return value
+  }
 
-  if (Number.isNaN(num) || num !== Number(value)) {
+  const num = Number(value)
+
+  if (!Number.isSafeInteger(num)) {
     return value
   }
 
   return num
+}
+
+function stringToBigInt(value: string): bigint | string {
+  if (!INTEGER_PATTERN.test(value)) {
+    return value
+  }
+
+  return BigInt(value)
+}
+
+function numberToBigInt(value: number): bigint | number {
+  if (!Number.isInteger(value)) {
+    return value
+  }
+
+  return BigInt(value)
 }
 
 function stringToBoolean(value: string): boolean | string {
@@ -380,26 +452,24 @@ function stringToBoolean(value: string): boolean | string {
   return value
 }
 
-function stringToBigInt(value: string): bigint | string {
-  return tryOrUndefined(() => BigInt(value)) ?? value
-}
-
-function numberToBigInt(value: number): bigint | number {
-  return tryOrUndefined(() => BigInt(value)) ?? value
-}
-
+const DATE_TIME_PATTERN = /^[+-]?\d{4,6}-\d{1,2}-\d{1,2}(?:[T ].*)?$/
 function stringToDate(value: string): Date | string {
+  if (!DATE_TIME_PATTERN.test(value)) {
+    return value
+  }
+
   const date = new Date(value)
 
-  if (Number.isNaN(date.getTime()) || !FLEXIBLE_DATE_FORMAT_REGEX.test(value)) {
+  if (Number.isNaN(date.getTime())) {
     return value
   }
 
   return date
 }
 
+const REGEXP_PATTERN = /^\/([\s\S]*)\/([a-z]*)$/
 function stringToRegExp(value: string): RegExp | string {
-  const match = value.match(/^\/(.*)\/([a-z]*)$/)
+  const match = value.match(REGEXP_PATTERN)
 
   if (match) {
     const [, pattern, flags] = match

--- a/packages/nest/src/implement.ts
+++ b/packages/nest/src/implement.ts
@@ -15,7 +15,7 @@ import { DEFAULT_OPENAPI_METHOD, getDynamicPathParams, getOpenAPIMeta } from '@o
 import { OpenAPIHandlerCodecCore } from '@orpc/openapi/standard'
 import { DEFAULT_SUCCESS_STATUS, getRouter, Procedure, unlazy } from '@orpc/server'
 import { StandardHandler } from '@orpc/server/standard'
-import { get, isAsyncIteratorObject, mergeHttpPath, stringifyJSON, value } from '@orpc/shared'
+import { isAsyncIteratorObject, mergeHttpPath, stringifyJSON, value } from '@orpc/shared'
 import { flattenStandardHeader, generateContentDisposition } from '@standardserver/core'
 import { toEventStream, toStandardLazyRequest } from '@standardserver/node'
 import { mergeMap } from 'rxjs'
@@ -85,7 +85,7 @@ export function Implement<T extends RouterContract>(
         Reflect.defineMetadata(p, Reflect.getOwnMetadata(p, target.constructor, propertyKey), target.constructor, methodName)
       }
 
-      Implement(get(contract, [key]) as any)(target, methodName, Object.getOwnPropertyDescriptor(target, methodName)!)
+      Implement(contract[key] as any)(target, methodName, Object.getOwnPropertyDescriptor(target, methodName)!)
     }
   }
 }

--- a/packages/pinia-colada/src/router-utils.ts
+++ b/packages/pinia-colada/src/router-utils.ts
@@ -113,7 +113,7 @@ function createRouterUtilsInternal<T extends AnyNestedClient>(
   const recursive = new Proxy(utils, {
     get(target, prop) {
       const value = getOrBind(target, prop)
-      const nextClient = get(client, [prop])
+      const nextClient = (client as Record<PropertyKey, AnyNestedClient>)[prop]
 
       if (typeof prop !== 'string' || RECURSIVE_CLIENT_UNWRAP_KEYS.has(prop) || !isTypescriptObject(nextClient)) {
         return value

--- a/packages/shared/src/object.test.ts
+++ b/packages/shared/src/object.test.ts
@@ -67,6 +67,10 @@ it('get', () => {
   expect(get({ a: { b: () => { } } }, ['a', 'b', 'name'])).toEqual('b')
   expect(get({ a: { b: () => { } } }, ['a', 'b', 'uuuu'])).toEqual(undefined)
   expect(get({ a: { b: () => { } } }, ['a', 'b', 'uuuu', 'zzzz'])).toEqual(undefined)
+  expect(get({}, ['__proto__'])).toEqual(undefined)
+  expect(get({}, ['constructor'])).toEqual(undefined)
+  expect(get({}, ['toString'])).toEqual(undefined)
+  expect(get({}, ['constructor', 'prototype'])).toEqual(undefined)
 })
 
 describe('set', () => {

--- a/packages/shared/src/object.ts
+++ b/packages/shared/src/object.ts
@@ -59,7 +59,7 @@ export function get(object: unknown, path: readonly PropertyKey[]): unknown {
   let current: unknown = object
 
   for (const key of path) {
-    if (!isTypescriptObject(current)) {
+    if (!isTypescriptObject(current) || !Object.hasOwn(current, key)) {
       return undefined
     }
 

--- a/packages/swr/src/router-utils.ts
+++ b/packages/swr/src/router-utils.ts
@@ -2,7 +2,7 @@ import type { AnyNestedClient, Client } from '@orpc/client'
 import type { Public } from '@orpc/shared'
 import type { OperationKeyPrefixOptions } from './key'
 import { RECURSIVE_CLIENT_UNWRAP_KEYS } from '@orpc/client'
-import { bindMethods, get, getOrBind, isTypescriptObject, toArray } from '@orpc/shared'
+import { bindMethods, getOrBind, isTypescriptObject, toArray } from '@orpc/shared'
 import { ProcedureUtils } from './procedure-utils'
 import { SharedUtils } from './shared-utils'
 
@@ -41,7 +41,7 @@ export function createRouterUtils<T extends AnyNestedClient>(
   const recursive = new Proxy(utils, {
     get(target, prop) {
       const value = getOrBind(target, prop)
-      const nextClient = get(client, [prop])
+      const nextClient = (client as Record<PropertyKey, AnyNestedClient>)[prop]
 
       if (typeof prop !== 'string' || RECURSIVE_CLIENT_UNWRAP_KEYS.has(prop) || !isTypescriptObject(nextClient)) {
         return value

--- a/packages/tanstack-query/src/router-utils.ts
+++ b/packages/tanstack-query/src/router-utils.ts
@@ -112,7 +112,7 @@ function createRouterUtilsInternal<T extends AnyNestedClient>(
   const recursive = new Proxy(utils, {
     get(target, prop) {
       const value = getOrBind(target, prop)
-      const nextClient = get(client, [prop])
+      const nextClient = (client as Record<PropertyKey, AnyNestedClient>)[prop]
 
       if (typeof prop !== 'string' || RECURSIVE_CLIENT_UNWRAP_KEYS.has(prop) || !isTypescriptObject(nextClient)) {
         return value


### PR DESCRIPTION
## Summary

Makes the smart coercion plugins safer and more predictable. Values only convert when the result is unambiguous and lossless, unions pick the branch that actually fits the payload, and malformed schemas or hostile payloads can no longer break a request.

```ts
const handler = new OpenAPIHandler(router, {
  plugins: [
    new SmartCoercionHandlerPlugin({
      converters: [new ZodToJsonSchemaConverter()],
    }),
  ],
})

// GET /messages?type=text&length=12&tracking=xyz
// the extra `tracking` key no longer stops `length` from becoming a number
```

## What changed

- Numbers: only plain numeric strings within the safe integer range convert. No scientific notation, no hex, and a 64 bit id such as `'12345678901234567890'` keeps its digits.
- Dates: strict ISO 8601 only, now including UTC offsets (`-07:00`) and expanded years. Runtime dependent formats such as `'12-25-2020'` stay untouched.
- BigInts: `''` no longer becomes `0n`, and hex or padded strings stay untouched.
- Unions: branches are ranked. A branch that already accepts the value wins, unknown keys no longer disqualify a discriminated union branch, and a branch that describes every key beats one that leaves keys unrecognized.
- Robustness: `$ref` cycles no longer overflow the stack, `$ref` cannot resolve into prototype members, `__proto__` payload keys stay own properties, and an invalid `patternProperties` regex is skipped instead of throwing.
- `get` in `@orpc/shared` treats prototype members as missing. Call sites that only index routers or contracts now do so directly.
- Coercer tests rewritten around real-world payloads (schemas as `ZodToJsonSchemaConverter` emits them) with 100% coverage, including invalid schema edge cases.
- Docs updated to match the new conversion rules.
