### PR TITLE
perf(rpc,openapi): speed up RPC and OpenAPI serializers

### DIFF
--- a/apps/content/docs/openapi/bracket-notation.md
+++ b/apps/content/docs/openapi/bracket-notation.md
@@ -50,6 +50,7 @@ Bracket notation is designed to express structured data in constrained environme
 - Cannot represent empty structures like empty objects `{}` or empty arrays `[]`.
 - Cannot represent an array at the root level. For example, `0=red&1=blue` becomes `{ 0: 'red', 1: 'blue' }`, not `['red', 'blue']`.
 - Cannot represent objects whose keys are all numbers, because they can be mistaken for array indexes.
+- Cannot reliably represent keys that contain `[` or `]`.
 
 ::: info
 If bracket notation is used in query strings or form data, it also inherits the limitations of those formats. For example, values are always strings or files, and `null` or `undefined` cannot be represented.

--- a/packages/client/src/rpc-json-serializer.test.ts
+++ b/packages/client/src/rpc-json-serializer.test.ts
@@ -160,6 +160,34 @@ describe('rpcJsonSerializer', () => {
     expect(serialized.meta).toEqual(undefined)
   })
 
+  it('collects blobs returned by terminal custom handlers', () => {
+    class BlobContainer {
+      constructor(public blob: Blob) {}
+    }
+
+    const serializer = new RPCJsonSerializer({
+      handlers: {
+        blobContainer: {
+          condition: data => data instanceof BlobContainer,
+          serialize: (data: BlobContainer) => data.blob,
+          deserialize: (blob: Blob) => new BlobContainer(blob),
+          isTerminal: true,
+        },
+      },
+    })
+
+    const blob = new Blob(['hello'], { type: 'text/plain' })
+    const serialized = serializer.serialize({ file: new BlobContainer(blob) })
+
+    expect(serialized.meta).toEqual([['blobContainer', 'file']])
+    expect(serialized.maps).toEqual([['file']])
+    expect(serialized.blobs).toEqual([blob])
+
+    const deserialized = serializer.deserialize(serialized) as any
+    expect(deserialized.file).toBeInstanceOf(BlobContainer)
+    expect(deserialized.file.blob).toBe(blob)
+  })
+
   it('can disable omit undefined properties', () => {
     const serializer = new RPCJsonSerializer({
       omitUndefinedProperties: false,

--- a/packages/client/src/rpc-json-serializer.test.ts
+++ b/packages/client/src/rpc-json-serializer.test.ts
@@ -52,6 +52,16 @@ const customSupportedDataTypes: { name: string, value: unknown, expected: unknow
   },
 ]
 
+/**
+ * Simulates the real transport: json/meta/maps travel as JSON text,
+ * blobs travel as separate binary parts.
+ */
+function roundTripThroughWire(serializer: RPCJsonSerializer, value: unknown): unknown {
+  const { json, meta, maps, blobs } = serializer.serialize(value)
+  const wire = JSON.parse(JSON.stringify({ json, meta, maps }))
+  return serializer.deserialize({ ...wire, blobs })
+}
+
 describe.each([
   ...builtInRPCSupportDataTypes,
   ...customSupportedDataTypes,
@@ -72,12 +82,7 @@ describe.each([
   })
 
   function assert(value: unknown, expected: unknown) {
-    const { json, meta, maps, blobs } = serializer.serialize(value)
-
-    const result = JSON.parse(JSON.stringify({ json, meta, maps }))
-
-    const deserialized = serializer.deserialize({ ...result, blobs })
-    expect(deserialized).toEqual(expected)
+    expect(roundTripThroughWire(serializer, value)).toEqual(expected)
   }
 
   it('flat', () => {
@@ -129,8 +134,121 @@ describe.each([
   })
 })
 
-describe('rpcJsonSerializer', () => {
-  it('support override default handlers', () => {
+describe('rpcJsonSerializer: wire format', () => {
+  const serializer = new RPCJsonSerializer()
+
+  it('produces plain JSON values plus meta describing how to restore them', () => {
+    const { json, meta } = serializer.serialize({
+      id: 7n,
+      createdAt: new Date('2023-01-01T00:00:00.000Z'),
+      tags: new Set(['a']),
+      scores: new Map([['x', 1]]),
+      pattern: /^a$/i,
+      homepage: new URL('https://orpc.dev'),
+      missing: Number.NaN,
+    })
+
+    expect(json).toEqual({
+      id: '7',
+      createdAt: '2023-01-01T00:00:00.000Z',
+      tags: ['a'],
+      scores: [['x', 1]],
+      pattern: '/^a$/i',
+      homepage: 'https://orpc.dev/',
+      missing: null,
+    })
+
+    expect(meta).toEqual(expect.arrayContaining([
+      ['bigint', 'id'],
+      ['date', 'createdAt'],
+      ['set', 'tags'],
+      ['map', 'scores'],
+      ['regexp', 'pattern'],
+      ['url', 'homepage'],
+      ['nan', 'missing'],
+    ]))
+    expect(meta).toHaveLength(7)
+  })
+
+  it('omits meta entirely for pure JSON payloads', () => {
+    const serialized = serializer.serialize({ name: 'test', items: [1, 'two', true, null] })
+    expect(serialized.meta).toBeUndefined()
+    expect(serialized.maps).toBeUndefined()
+    expect(serialized.blobs).toBeUndefined()
+  })
+
+  it('collects nested files into maps and blobs', () => {
+    const file = new File(['hello'], 'hello.txt', { type: 'text/plain' })
+    const { maps, blobs } = serializer.serialize({ upload: { doc: file }, note: 'x' })
+
+    expect(maps).toEqual([['upload', 'doc']])
+    expect(blobs).toEqual([file])
+  })
+})
+
+describe('rpcJsonSerializer: edge cases', () => {
+  const serializer = new RPCJsonSerializer()
+
+  it('round-trips undefined inside arrays', () => {
+    expect(roundTripThroughWire(serializer, [undefined, 1, undefined])).toEqual([undefined, 1, undefined])
+  })
+
+  it('round-trips undefined inside sets and maps', () => {
+    expect(roundTripThroughWire(serializer, new Set([undefined, 1]))).toEqual(new Set([undefined, 1]))
+    expect(roundTripThroughWire(serializer, new Map([[undefined, undefined]]))).toEqual(new Map([[undefined, undefined]]))
+  })
+
+  it('omits undefined object properties by default', () => {
+    const serialized = serializer.serialize({ a: 1, b: undefined })
+    expect(serialized.json).toEqual({ a: 1 })
+    expect(serialized.meta).toBeUndefined()
+  })
+
+  it('preserves undefined object properties when omitUndefinedProperties is false', () => {
+    const custom = new RPCJsonSerializer({ omitUndefinedProperties: false })
+
+    const serialized = custom.serialize({ a: 1, b: undefined })
+    expect(serialized.json).toEqual({ a: 1, b: null })
+    expect(serialized.meta).toEqual([['undefined', 'b']])
+
+    expect(roundTripThroughWire(custom, { a: 1, b: undefined })).toEqual({ a: 1, b: undefined })
+  })
+
+  it('round-trips empty containers', () => {
+    expect(roundTripThroughWire(serializer, {})).toEqual({})
+    expect(roundTripThroughWire(serializer, [])).toEqual([])
+    expect(roundTripThroughWire(serializer, new Set())).toEqual(new Set())
+    expect(roundTripThroughWire(serializer, new Map())).toEqual(new Map())
+    expect(roundTripThroughWire(serializer, '')).toBe('')
+  })
+
+  it('round-trips empty and numeric-looking object keys', () => {
+    const value = { '': 'empty', '0': 'zero', '00': 'padded', 'ключ': 'unicode' }
+    expect(roundTripThroughWire(serializer, value)).toEqual(value)
+  })
+
+  it('round-trips deeply nested structures', () => {
+    let value: any = new Date('2023-01-01')
+    let expected: any = new Date('2023-01-01')
+    for (let i = 0; i < 100; i++) {
+      value = { nested: value, list: [i] }
+      expected = { nested: expected, list: [i] }
+    }
+
+    expect(roundTripThroughWire(serializer, value)).toEqual(expected)
+  })
+
+  it('passes through values no handler understands', () => {
+    const symbol = Symbol('sym')
+    expect(serializer.serialize(symbol).json).toBe(symbol)
+
+    const fn = () => 'x'
+    expect(serializer.serialize(fn).json).toBe(fn)
+  })
+})
+
+describe('rpcJsonSerializer: custom handlers', () => {
+  it('supports overriding default handlers', () => {
     const serializer = new RPCJsonSerializer({
       handlers: {
         date: {
@@ -145,9 +263,11 @@ describe('rpcJsonSerializer', () => {
     const serialized = serializer.serialize({ value: date })
     expect(serialized.json).toEqual({ value: `___TEST___${date.getTime()}` })
     expect(serialized.meta).toEqual([['date', 'value']])
+
+    expect(roundTripThroughWire(serializer, { value: date })).toEqual({ value: date })
   })
 
-  it('disable default handlers', () => {
+  it('supports disabling default handlers', () => {
     const serializer = new RPCJsonSerializer({
       handlers: {
         date: undefined,
@@ -155,9 +275,77 @@ describe('rpcJsonSerializer', () => {
     })
 
     const date = new Date('2023-01-01')
-    const serialized = serializer.serialize({ value: date })
-    expect(serialized.json).toEqual({ value: date })
-    expect(serialized.meta).toEqual(undefined)
+    const serialized = serializer.serialize({ value: date, list: [undefined] })
+    expect(serialized.json).toEqual({ value: date, list: [null] })
+    expect(serialized.meta).toEqual([['undefined', 'list', 0]])
+  })
+
+  it('keeps serializing non-terminal handler results, so nested values are restored too', () => {
+    const serializer = new RPCJsonSerializer({
+      handlers: {
+        person: {
+          condition: data => data instanceof Person,
+          serialize: (data: Person) => data.toJSON(),
+          deserialize: data => new Person(data.name, data.date),
+        },
+      },
+    })
+
+    const person = new Person('dinwwwh', new Date('2023-01-01'))
+    const restored = roundTripThroughWire(serializer, { person }) as any
+
+    expect(restored.person).toBeInstanceOf(Person)
+    expect(restored.person.date).toBeInstanceOf(Date)
+    expect(restored.person).toEqual(person)
+  })
+
+  it('treats terminal handler results as final, without further serialization', () => {
+    const serializer = new RPCJsonSerializer({
+      handlers: {
+        person: {
+          condition: data => data instanceof Person,
+          serialize: (data: Person) => data.toJSON(),
+          deserialize: data => data,
+          isTerminal: true,
+        },
+      },
+    })
+
+    const date = new Date('2023-01-01')
+    const serialized = serializer.serialize({ person: new Person('dinwwwh', date) })
+
+    // the nested Date stays untouched because the terminal result is not walked
+    expect((serialized.json as any).person.date).toBe(date)
+    expect(serialized.meta).toEqual([['person', 'person']])
+  })
+
+  it('keeps every built-in type working when any built-in handler is customized', () => {
+    // customizing a built-in key switches to the generic handler scan; every default handler must still work there
+    const serializer = new RPCJsonSerializer({
+      handlers: {
+        undefined: {
+          condition: data => data === undefined,
+          serialize: () => null,
+          deserialize: () => undefined,
+          isTerminal: true,
+        },
+      },
+    })
+
+    const value = {
+      date: new Date('2023-01-01'),
+      invalidDate: new Date('Invalid'),
+      nan: Number.NaN,
+      url: new URL('https://orpc.dev'),
+      regexp: /uic/gi,
+      set: new Set([1, 2]),
+      map: new Map([['a', 1]]),
+      bigint: 123n,
+      list: [undefined],
+      plain: 'text',
+    }
+
+    expect(roundTripThroughWire(serializer, value)).toEqual(value)
   })
 
   it('collects blobs returned by terminal custom handlers', () => {
@@ -187,63 +375,83 @@ describe('rpcJsonSerializer', () => {
     expect(deserialized.file).toBeInstanceOf(BlobContainer)
     expect(deserialized.file.blob).toBe(blob)
   })
+})
 
-  it('can disable omit undefined properties', () => {
-    const serializer = new RPCJsonSerializer({
-      omitUndefinedProperties: false,
-    })
+describe('rpcJsonSerializer: security', () => {
+  const serializer = new RPCJsonSerializer()
 
-    const serialized = serializer.serialize({ a: 1, b: undefined })
-    expect(serialized.json).toEqual({ a: 1, b: null })
-    expect(serialized.meta).toEqual([['undefined', 'b']])
+  afterEach(() => {
+    expect(({} as any).polluted).toBeUndefined()
+    expect((Object.prototype as any).polluted).toBeUndefined()
   })
 
-  it.each(['doesNotExist', '__proto__', 'constructor'])('should throw on deserialization if path does not exist to avoid prototype pollution', (segment) => {
-    const serializer = new RPCJsonSerializer()
+  it.each(['doesNotExist', '__proto__', 'constructor', 'prototype'])('throws when a meta or blob path references the non-own segment "%s"', (segment) => {
+    const error = `Security error: Invalid serialized data. Segment "${segment}" does not exist.`
 
     expect(
-      () => serializer.deserialize({
-        json: { o: {} },
-        meta: [['date', segment]],
-      }),
-    ).toThrow(`Security error: Invalid serialized data. Segment "${segment}" does not exist.`)
+      () => serializer.deserialize({ json: { o: {} }, meta: [['date', segment]] }),
+    ).toThrow(error)
 
     expect(
-      () => serializer.deserialize({
-        json: { o: {} },
-        meta: [['date', 'o', segment]],
-      }),
-    ).toThrow(`Security error: Invalid serialized data. Segment "${segment}" does not exist.`)
+      () => serializer.deserialize({ json: { o: {} }, meta: [['date', 'o', segment]] }),
+    ).toThrow(error)
 
     expect(
-      () => serializer.deserialize({
-        json: { o: {} },
-        meta: [['date', segment, 'o']],
-      }),
-    ).toThrow(`Security error: Invalid serialized data. Segment "${segment}" does not exist.`)
+      () => serializer.deserialize({ json: { o: {} }, meta: [['date', segment, 'o']] }),
+    ).toThrow(error)
 
     expect(
-      () => serializer.deserialize({
-        json: { o: {} },
-        blobs: [new Blob()],
-        maps: [[segment]],
-      }),
-    ).toThrow(`Security error: Invalid serialized data. Segment "${segment}" does not exist.`)
+      () => serializer.deserialize({ json: { o: {} }, blobs: [new Blob()], maps: [[segment]] }),
+    ).toThrow(error)
 
     expect(
-      () => serializer.deserialize({
-        json: { o: {} },
-        blobs: [new Blob()],
-        maps: [['o', segment]],
-      }),
-    ).toThrow(`Security error: Invalid serialized data. Segment "${segment}" does not exist.`)
+      () => serializer.deserialize({ json: { o: {} }, blobs: [new Blob()], maps: [['o', segment]] }),
+    ).toThrow(error)
 
     expect(
-      () => serializer.deserialize({
-        json: { o: {} },
-        blobs: [new Blob()],
-        maps: [[segment, 'o']],
-      }),
-    ).toThrow(`Security error: Invalid serialized data. Segment "${segment}" does not exist.`)
+      () => serializer.deserialize({ json: { o: {} }, blobs: [new Blob()], maps: [[segment, 'o']] }),
+    ).toThrow(error)
   })
+
+  it.each(['nonexistent', '__proto__', 'constructor', 'prototype', 'toString', 'hasOwnProperty', 'valueOf'])('never resolves the meta type "%s" through the prototype chain', (type) => {
+    expect(() => serializer.deserialize({ json: 1, meta: [[type]] })).toThrow()
+  })
+
+  it('throws instead of producing garbage for corrupted built-in payloads', () => {
+    expect(() => serializer.deserialize({ json: 'not-a-regexp', meta: [['regexp']] })).toThrow()
+    expect(() => serializer.deserialize({ json: 'not-a-bigint', meta: [['bigint']] })).toThrow()
+  })
+
+  /* eslint-disable no-proto, no-restricted-properties */
+  it('serializes own __proto__ keys as plain data', () => {
+    // JSON.parse creates own __proto__ properties, exactly like a real request body
+    const input = JSON.parse('{"__proto__": {"polluted": true}}')
+
+    const restored = roundTripThroughWire(serializer, input) as any
+
+    expect(Object.hasOwn(restored, '__proto__')).toBe(true)
+    expect(restored.__proto__).toEqual({ polluted: true })
+    expect(restored.polluted).toBeUndefined()
+  })
+
+  it('restores values behind own __proto__ keys without touching prototypes', () => {
+    const restored = serializer.deserialize({
+      json: JSON.parse('{"__proto__": {"when": "2023-01-01T00:00:00.000Z"}}'),
+      meta: [['date', '__proto__', 'when']],
+    }) as any
+
+    expect(Object.hasOwn(restored, '__proto__')).toBe(true)
+    expect(restored.__proto__.when).toBeInstanceOf(Date)
+  })
+
+  it('restores a value stored directly under an own __proto__ key', () => {
+    const restored = serializer.deserialize({
+      json: JSON.parse('{"__proto__": "2023-01-01T00:00:00.000Z"}'),
+      meta: [['date', '__proto__']],
+    }) as any
+
+    expect(Object.hasOwn(restored, '__proto__')).toBe(true)
+    expect(restored.__proto__).toBeInstanceOf(Date)
+  })
+  /* eslint-enable no-proto, no-restricted-properties */
 })

--- a/packages/client/src/rpc-json-serializer.ts
+++ b/packages/client/src/rpc-json-serializer.ts
@@ -21,7 +21,7 @@ export interface RPCJsonSerializerHandler {
   isTerminal?: boolean
 }
 
-const REGEX_STRING_PATTERN = /^\/(.*)\/([a-z]*)$/
+const REGEX_STRING_PATTERN = /^\/([\s\S]*)\/([a-z]*)$/
 
 const DEFAULT_RPC_JSON_SERIALIZER_HANDLERS: Record<string, RPCJsonSerializerHandler> = {
   undefined: {
@@ -175,14 +175,6 @@ export interface RPCJsonSerializerOptions {
 
 export class RPCJsonSerializer {
   private readonly handlers: Exclude<RPCJsonSerializerOptions['handlers'], undefined>
-  /**
-   * When true, built-in handlers are inlined in serializeValue and
-   * handlerEntries only holds custom handlers. Only valid while no custom
-   * handler overrides or disables a built-in key, otherwise handler order
-   * and behavior could diverge from the merged handlers.
-   * On this path, custom handlers are never called for values the built-ins
-   * claim: primitives, null, and the built-in object types.
-   */
   private readonly inlineBuiltInHandlers: boolean
   private readonly handlerEntries: [string, RPCJsonSerializerHandler][] | undefined
   private readonly omitUndefinedProperties: boolean

--- a/packages/client/src/rpc-json-serializer.ts
+++ b/packages/client/src/rpc-json-serializer.ts
@@ -1,5 +1,5 @@
 import type { Segment } from '@orpc/shared'
-import { isPlainObject } from '@orpc/shared'
+import { isPlainObject, NullProtoObj } from '@orpc/shared'
 
 export type RPCJsonSerializationMeta = [type: string, ...path: Segment[]]
 export type RPCJsonSerialization
@@ -23,7 +23,7 @@ export interface RPCJsonSerializerHandler {
 
 const REGEX_STRING_PATTERN = /^\/(.*)\/([a-z]*)$/
 
-const DEFAULT_RPC_JSON_SERIALIZER_HANDLERS: Record<string, RPCJsonSerializerHandler> = {
+const DEFAULT_RPC_JSON_SERIALIZER_HANDLERS: Record<string, RPCJsonSerializerHandler> = Object.assign(new NullProtoObj<Record<string, RPCJsonSerializerHandler>>(), {
   undefined: {
     condition(data: unknown): boolean {
       return data === undefined
@@ -123,7 +123,9 @@ const DEFAULT_RPC_JSON_SERIALIZER_HANDLERS: Record<string, RPCJsonSerializerHand
       return new Map(serialized)
     },
   },
-}
+})
+
+const NO_CUSTOM_HANDLER_ENTRIES: [string, RPCJsonSerializerHandler][] = []
 
 export interface RPCJsonSerializerOptions {
   /**
@@ -175,21 +177,73 @@ export interface RPCJsonSerializerOptions {
 
 export class RPCJsonSerializer {
   private readonly handlers: Exclude<RPCJsonSerializerOptions['handlers'], undefined>
+  /**
+   * When true, built-in handlers are inlined in serializeValue and
+   * handlerEntries only holds custom handlers. Only valid while no custom
+   * handler overrides or disables a built-in key, otherwise handler order
+   * and behavior could diverge from the merged handlers.
+   * On this path, custom handlers are never called for values the built-ins
+   * claim: primitives, null, and the built-in object types.
+   */
+  private readonly inlineBuiltInHandlers: boolean
+  private readonly handlerEntries: [string, RPCJsonSerializerHandler][]
   private readonly omitUndefinedProperties: boolean
 
   constructor(options: RPCJsonSerializerOptions = {}) {
-    this.handlers = {
-      ...DEFAULT_RPC_JSON_SERIALIZER_HANDLERS,
-      ...options.handlers,
+    this.omitUndefinedProperties = options.omitUndefinedProperties !== false
+
+    const customHandlers = options.handlers
+
+    // handlers is never mutated after construction, so the default table can be shared
+    if (customHandlers === undefined) {
+      this.handlers = DEFAULT_RPC_JSON_SERIALIZER_HANDLERS
+      this.inlineBuiltInHandlers = true
+      this.handlerEntries = NO_CUSTOM_HANDLER_ENTRIES
+      return
     }
 
-    this.omitUndefinedProperties = options.omitUndefinedProperties !== false
+    // deserialize resolves built-in meta types via this.handlers, so defaults must be merged in
+    this.handlers = Object.assign(new NullProtoObj(), DEFAULT_RPC_JSON_SERIALIZER_HANDLERS)
+
+    let inlineBuiltInHandlers = true
+    let handlerEntries: [string, RPCJsonSerializerHandler][] = []
+
+    for (const key of Object.keys(customHandlers)) {
+      const handler = customHandlers[key]
+      this.handlers[key] = handler
+
+      if (inlineBuiltInHandlers && key in DEFAULT_RPC_JSON_SERIALIZER_HANDLERS) {
+        inlineBuiltInHandlers = false
+      }
+
+      if (handler !== undefined) {
+        handlerEntries.push([key, handler])
+      }
+    }
+
+    if (!inlineBuiltInHandlers) {
+      // a built-in was overridden or disabled: scan every active handler in merge order
+      handlerEntries = []
+      for (const key of Object.keys(this.handlers)) {
+        const handler = this.handlers[key]
+        if (handler !== undefined) {
+          handlerEntries.push([key, handler])
+        }
+      }
+    }
+
+    this.inlineBuiltInHandlers = inlineBuiltInHandlers
+    this.handlerEntries = handlerEntries
   }
 
   serialize(data: unknown): RPCJsonSerialization {
-    const [json, meta_, maps, blobs] = this.serializeValue(data, [], [], [], [])
+    let meta: RPCJsonSerializationMeta[] | undefined = []
+    const maps: Segment[][] = []
+    const blobs: Blob[] = []
 
-    const meta = meta_.length === 0 ? undefined : meta_
+    const json = this.serializeValue(data, [], meta, maps, blobs)
+
+    meta = meta.length === 0 ? undefined : meta
 
     if (maps.length === 0) {
       return { json, meta }
@@ -198,40 +252,110 @@ export class RPCJsonSerializer {
     return { json, meta, maps, blobs }
   }
 
-  private serializeValue(data: unknown, segments: Segment[], meta: RPCJsonSerializationMeta[], maps: Segment[][], blobs: Blob[]): [unknown, RPCJsonSerializationMeta[], Segment[][], Blob[]] {
-    for (const key in this.handlers) {
-      const handler = this.handlers[key]
+  /**
+   * `segments` is a shared mutable stack (push/pop while walking),
+   * so it must be copied before being stored in `meta` or `maps`.
+   */
+  private serializeValue(data: unknown, segments: Segment[], meta: RPCJsonSerializationMeta[], maps: Segment[][], blobs: Blob[]): unknown {
+    const handlerEntries = this.handlerEntries
 
-      if (handler && handler.condition(data)) {
+    /**
+     * Inlined version of DEFAULT_RPC_JSON_SERIALIZER_HANDLERS: primitives are
+     * dispatched on typeof and skip every handler condition check.
+     * Must match the built-in handlers exactly.
+     */
+    if (this.inlineBuiltInHandlers) {
+      switch (typeof data) {
+        case 'string':
+        case 'boolean':
+          return data
+        case 'number':
+          if (Number.isNaN(data)) {
+            meta.push(['nan', ...segments])
+            return null
+          }
+          return data
+        case 'undefined':
+          meta.push(['undefined', ...segments])
+          return null
+        case 'bigint':
+          meta.push(['bigint', ...segments])
+          return data.toString()
+        case 'object': {
+          if (data === null) {
+            return data
+          }
+          if (data instanceof Date) {
+            meta.push(['date', ...segments])
+            return Number.isNaN(data.getTime()) ? null : data.toISOString()
+          }
+          if (data instanceof URL) {
+            meta.push(['url', ...segments])
+            return data.toString()
+          }
+          if (data instanceof RegExp) {
+            meta.push(['regexp', ...segments])
+            return data.toString()
+          }
+          if (data instanceof Set) {
+            const result = this.serializeValue(Array.from(data), segments, meta, maps, blobs)
+            meta.push(['set', ...segments])
+            return result
+          }
+          if (data instanceof Map) {
+            const result = this.serializeValue(Array.from(data.entries()), segments, meta, maps, blobs)
+            meta.push(['map', ...segments])
+            return result
+          }
+        }
+      }
+    }
+
+    for (let i = 0; i < handlerEntries.length; i++) {
+      const entry = handlerEntries[i]!
+      const handler = entry[1]
+
+      if (handler.condition(data)) {
         const serialized = handler.serialize(data)
 
         if (handler.isTerminal) {
-          meta.push([key, ...segments])
-          return [serialized, meta, maps, blobs]
+          meta.push([entry[0], ...segments])
+
+          // terminal skips the recursive walk, so blobs must still be collected here
+          if (serialized instanceof Blob) {
+            maps.push(segments.slice())
+            blobs.push(serialized)
+          }
+
+          return serialized
         }
 
         const result = this.serializeValue(serialized, segments, meta, maps, blobs)
-        meta.push([key, ...segments])
+        meta.push([entry[0], ...segments])
         return result
       }
     }
 
     if (data instanceof Blob) {
-      maps.push(segments)
+      maps.push(segments.slice())
       blobs.push(data)
-      return [data, meta, maps, blobs]
+      return data
     }
 
     if (Array.isArray(data)) {
-      const json = data.map((v, i) => {
-        return this.serializeValue(v, [...segments, i], meta, maps, blobs)[0]
-      })
+      const json: unknown[] = []
 
-      return [json, meta, maps, blobs]
+      for (let i = 0; i < data.length; i++) {
+        segments.push(i)
+        json.push(this.serializeValue(data[i], segments, meta, maps, blobs))
+        segments.pop()
+      }
+
+      return json
     }
 
     if (isPlainObject(data)) {
-      const json: Record<string, unknown> = {}
+      const json: Record<string, unknown> = new NullProtoObj()
 
       for (const k in data) {
         const v = data[k]
@@ -248,53 +372,59 @@ export class RPCJsonSerializer {
           continue
         }
 
-        json[k] = this.serializeValue(v, [...segments, k], meta, maps, blobs)[0]
+        segments.push(k)
+        json[k] = this.serializeValue(v, segments, meta, maps, blobs)
+        segments.pop()
       }
 
-      return [json, meta, maps, blobs]
+      return json
     }
 
-    return [data, meta, maps, blobs]
+    return data
   }
 
   deserialize(serialized: RPCJsonSerialization): unknown {
     const ref = { data: serialized.json }
 
     if (serialized.blobs?.length) {
-      serialized.maps.forEach((segments, i) => {
+      for (let i = 0; i < serialized.maps.length; i++) {
+        const segments = serialized.maps[i]!
+
         let currentRef: any = ref
         let preSegment: string | number = 'data'
 
-        segments.forEach((segment) => {
+        for (let j = 0; j < segments.length; j++) {
           currentRef = currentRef[preSegment]
-          preSegment = segment
+          preSegment = segments[j]!
 
           if (!Object.hasOwn(currentRef, preSegment)) {
             throw new Error(`Security error: Invalid serialized data. Segment "${preSegment}" does not exist.`)
           }
-        })
+        }
 
         currentRef[preSegment] = serialized.blobs[i]
-      })
+      }
     }
 
-    serialized.meta?.forEach((item) => {
-      const type = item[0]
+    if (serialized.meta) {
+      for (const item of serialized.meta) {
+        const type = item[0]
 
-      let currentRef: any = ref
-      let preSegment: string | number = 'data'
+        let currentRef: any = ref
+        let preSegment: string | number = 'data'
 
-      for (let i = 1; i < item.length; i++) {
-        currentRef = currentRef[preSegment]
-        preSegment = item[i]!
+        for (let i = 1; i < item.length; i++) {
+          currentRef = currentRef[preSegment]
+          preSegment = item[i]!
 
-        if (!Object.hasOwn(currentRef, preSegment)) {
-          throw new Error(`Security error: Invalid serialized data. Segment "${preSegment}" does not exist.`)
+          if (!Object.hasOwn(currentRef, preSegment)) {
+            throw new Error(`Security error: Invalid serialized data. Segment "${preSegment}" does not exist.`)
+          }
         }
-      }
 
-      currentRef[preSegment] = this.handlers[type]!.deserialize(currentRef[preSegment])
-    })
+        currentRef[preSegment] = this.handlers[type]!.deserialize(currentRef[preSegment])
+      }
+    }
 
     return ref.data
   }

--- a/packages/client/src/rpc-json-serializer.ts
+++ b/packages/client/src/rpc-json-serializer.ts
@@ -23,7 +23,7 @@ export interface RPCJsonSerializerHandler {
 
 const REGEX_STRING_PATTERN = /^\/(.*)\/([a-z]*)$/
 
-const DEFAULT_RPC_JSON_SERIALIZER_HANDLERS: Record<string, RPCJsonSerializerHandler> = Object.assign(new NullProtoObj<Record<string, RPCJsonSerializerHandler>>(), {
+const DEFAULT_RPC_JSON_SERIALIZER_HANDLERS: Record<string, RPCJsonSerializerHandler> = {
   undefined: {
     condition(data: unknown): boolean {
       return data === undefined
@@ -123,9 +123,7 @@ const DEFAULT_RPC_JSON_SERIALIZER_HANDLERS: Record<string, RPCJsonSerializerHand
       return new Map(serialized)
     },
   },
-})
-
-const NO_CUSTOM_HANDLER_ENTRIES: [string, RPCJsonSerializerHandler][] = []
+}
 
 export interface RPCJsonSerializerOptions {
   /**
@@ -186,29 +184,23 @@ export class RPCJsonSerializer {
    * claim: primitives, null, and the built-in object types.
    */
   private readonly inlineBuiltInHandlers: boolean
-  private readonly handlerEntries: [string, RPCJsonSerializerHandler][]
+  private readonly handlerEntries: [string, RPCJsonSerializerHandler][] | undefined
   private readonly omitUndefinedProperties: boolean
 
   constructor(options: RPCJsonSerializerOptions = {}) {
     this.omitUndefinedProperties = options.omitUndefinedProperties !== false
-
+    this.handlers = Object.assign(new NullProtoObj(), DEFAULT_RPC_JSON_SERIALIZER_HANDLERS)
     const customHandlers = options.handlers
 
-    // handlers is never mutated after construction, so the default table can be shared
     if (customHandlers === undefined) {
-      this.handlers = DEFAULT_RPC_JSON_SERIALIZER_HANDLERS
       this.inlineBuiltInHandlers = true
-      this.handlerEntries = NO_CUSTOM_HANDLER_ENTRIES
       return
     }
-
-    // deserialize resolves built-in meta types via this.handlers, so defaults must be merged in
-    this.handlers = Object.assign(new NullProtoObj(), DEFAULT_RPC_JSON_SERIALIZER_HANDLERS)
 
     let inlineBuiltInHandlers = true
     let handlerEntries: [string, RPCJsonSerializerHandler][] = []
 
-    for (const key of Object.keys(customHandlers)) {
+    for (const key in customHandlers) {
       const handler = customHandlers[key]
       this.handlers[key] = handler
 
@@ -216,15 +208,14 @@ export class RPCJsonSerializer {
         inlineBuiltInHandlers = false
       }
 
-      if (handler !== undefined) {
+      if (inlineBuiltInHandlers && handler !== undefined) {
         handlerEntries.push([key, handler])
       }
     }
 
     if (!inlineBuiltInHandlers) {
-      // a built-in was overridden or disabled: scan every active handler in merge order
       handlerEntries = []
-      for (const key of Object.keys(this.handlers)) {
+      for (const key in this.handlers) {
         const handler = this.handlers[key]
         if (handler !== undefined) {
           handlerEntries.push([key, handler])
@@ -257,8 +248,6 @@ export class RPCJsonSerializer {
    * so it must be copied before being stored in `meta` or `maps`.
    */
   private serializeValue(data: unknown, segments: Segment[], meta: RPCJsonSerializationMeta[], maps: Segment[][], blobs: Blob[]): unknown {
-    const handlerEntries = this.handlerEntries
-
     /**
      * Inlined version of DEFAULT_RPC_JSON_SERIALIZER_HANDLERS: primitives are
      * dispatched on typeof and skip every handler condition check.
@@ -311,28 +300,30 @@ export class RPCJsonSerializer {
       }
     }
 
-    for (let i = 0; i < handlerEntries.length; i++) {
-      const entry = handlerEntries[i]!
-      const handler = entry[1]
+    const handlerEntries = this.handlerEntries
+    if (handlerEntries) {
+      for (let i = 0; i < handlerEntries.length; i++) {
+        const entry = handlerEntries[i]!
+        const handler = entry[1]
 
-      if (handler.condition(data)) {
-        const serialized = handler.serialize(data)
+        if (handler.condition(data)) {
+          const serialized = handler.serialize(data)
 
-        if (handler.isTerminal) {
-          meta.push([entry[0], ...segments])
+          if (handler.isTerminal) {
+            meta.push([entry[0], ...segments])
 
-          // terminal skips the recursive walk, so blobs must still be collected here
-          if (serialized instanceof Blob) {
-            maps.push(segments.slice())
-            blobs.push(serialized)
+            if (serialized instanceof Blob) {
+              maps.push(segments.slice())
+              blobs.push(serialized)
+            }
+
+            return serialized
           }
 
-          return serialized
+          const result = this.serializeValue(serialized, segments, meta, maps, blobs)
+          meta.push([entry[0], ...segments])
+          return result
         }
-
-        const result = this.serializeValue(serialized, segments, meta, maps, blobs)
-        meta.push([entry[0], ...segments])
-        return result
       }
     }
 

--- a/packages/client/src/rpc-serializer.test.ts
+++ b/packages/client/src/rpc-serializer.test.ts
@@ -61,6 +61,69 @@ describe('rpcSerializer', () => {
     })
   })
 
+  describe('form data bodies', () => {
+    const serializer = new RPCSerializer()
+
+    it('uses FormData when the payload contains nested files, and restores them', () => {
+      const file = new File(['content'], 'doc.txt', { type: 'text/plain' })
+      const payload = {
+        title: 'upload',
+        createdAt: new Date('2023-01-01'),
+        attachments: [file],
+      }
+
+      const serialized = serializer.serialize(payload)
+      expect(serialized).toBeInstanceOf(FormData)
+
+      const deserialized = serializer.deserialize(serialized) as any
+      expect(deserialized.title).toBe('upload')
+      expect(deserialized.createdAt).toEqual(new Date('2023-01-01'))
+      expect(deserialized.attachments[0]).toBeInstanceOf(File)
+      expect(deserialized.attachments[0].name).toBe('doc.txt')
+    })
+
+    it('restores multiple blobs to their own positions', () => {
+      const a = new File(['a'], 'a.txt', { type: 'text/plain' })
+      const b = new File(['bb'], 'b.txt', { type: 'text/plain' })
+
+      const deserialized = serializer.deserialize(
+        serializer.serialize({ nested: { a }, list: [b] }),
+      ) as any
+
+      expect(deserialized.nested.a.name).toBe('a.txt')
+      expect(deserialized.nested.a.size).toBe(1)
+      expect(deserialized.list[0].name).toBe('b.txt')
+      expect(deserialized.list[0].size).toBe(2)
+    })
+
+    it('keeps a plain body when useFormDataForBlobFields is disabled in the constructor', () => {
+      const serializer = new RPCSerializer({
+        serialize: { useFormDataForBlobFields: false },
+      })
+
+      const serialized = serializer.serialize({ blob: new Blob(['test'], { type: 'text/plain' }) })
+      expect(serialized).not.toBeInstanceOf(FormData)
+    })
+
+    it('keeps a plain body when useFormDataForBlobFields is disabled per call', () => {
+      const serialized = serializer.serialize(
+        { blob: new Blob(['test'], { type: 'text/plain' }) },
+        { useFormDataForBlobFields: false },
+      )
+      expect(serialized).not.toBeInstanceOf(FormData)
+    })
+
+    it('prefers the per-call option over the constructor option', () => {
+      const serializer = new RPCSerializer({ serialize: { useFormDataForBlobFields: false } })
+
+      const serialized = serializer.serialize(
+        { blob: new Blob(['test'], { type: 'text/plain' }) },
+        { useFormDataForBlobFields: true },
+      )
+      expect(serialized).toBeInstanceOf(FormData)
+    })
+  })
+
   describe('asyncIteratorObject', async () => {
     const serializer = new RPCSerializer()
 
@@ -260,34 +323,48 @@ describe('rpcSerializer', () => {
     })
   })
 
-  describe('useFormDataForBlobFields option', () => {
-    it('should respect the useFormDataForBlobFields option in the constructor', () => {
-      const serializer = new RPCSerializer({
-        serialize: { useFormDataForBlobFields: false },
-      })
+  describe('malicious payloads', () => {
+    const serializer = new RPCSerializer()
 
-      const blob = new Blob(['test'], { type: 'text/plain' })
-      const serialized = serializer.serialize({ blob })
-
-      expect(serialized).not.toBeInstanceOf(FormData)
+    afterEach(() => {
+      expect(({} as any).polluted).toBeUndefined()
+      expect((Object.prototype as any).polluted).toBeUndefined()
     })
 
-    it('should respect the useFormDataForBlobFields option in the serialize method', () => {
-      const serializer = new RPCSerializer()
+    it('rejects meta paths escaping the payload in plain bodies', () => {
+      const body = JSON.parse(JSON.stringify({
+        json: { o: {} },
+        meta: [['date', '__proto__', 'polluted']],
+      }))
 
-      const blob = new Blob(['test'], { type: 'text/plain' })
-      const serialized = serializer.serialize({ blob }, { useFormDataForBlobFields: false })
-
-      expect(serialized).not.toBeInstanceOf(FormData)
+      expect(() => serializer.deserialize(body)).toThrow('Security error')
     })
 
-    it('should prefer serialize option over constructor option', () => {
-      const serializer = new RPCSerializer({ serialize: { useFormDataForBlobFields: false } })
+    it('rejects meta paths escaping the payload in form data bodies', () => {
+      const form = new FormData()
+      form.set('data', JSON.stringify({
+        json: { o: {} },
+        meta: [['date', '__proto__', 'polluted']],
+        maps: [],
+      }))
 
-      const blob = new Blob(['test'], { type: 'text/plain' })
-      const serialized = serializer.serialize({ blob }, { useFormDataForBlobFields: true })
+      expect(() => serializer.deserialize(form)).toThrow('Security error')
+    })
 
-      expect(serialized).toBeInstanceOf(FormData)
+    it('rejects blob maps escaping the payload in form data bodies', () => {
+      const form = new FormData()
+      form.set('data', JSON.stringify({
+        json: { o: {} },
+        maps: [['__proto__', 'polluted']],
+      }))
+      form.set('0', new Blob(['x']))
+
+      expect(() => serializer.deserialize(form)).toThrow('Security error')
+    })
+
+    it('rejects unknown meta types instead of resolving them on the prototype chain', () => {
+      expect(() => serializer.deserialize({ json: 1, meta: [['constructor']] })).toThrow()
+      expect(() => serializer.deserialize({ json: 1, meta: [['__proto__']] })).toThrow()
     })
   })
 })

--- a/packages/client/src/rpc-serializer.ts
+++ b/packages/client/src/rpc-serializer.ts
@@ -48,21 +48,20 @@ export class RPCSerializer {
             return result
           }
 
-          return { done: result.done, value: this.serializeValue(result.value, options) }
+          return { done: result.done, value: this.serializeValue(result.value, false) }
         },
         mapError: e => new ErrorEvent(
-          this.serializeValue(toORPCError(e).toJSON(), { ...options, useFormDataForBlobFields: false }),
+          this.serializeValue(toORPCError(e).toJSON(), false),
           { cause: e },
         ),
       })
     }
 
-    return this.serializeValue(data, options)
+    const useFormDataForBlobs = options.useFormDataForBlobFields ?? this.defaultSerializeOptions?.useFormDataForBlobFields ?? true
+    return this.serializeValue(data, useFormDataForBlobs)
   }
 
-  private serializeValue(data: unknown, options: RPCSerializerSerializeOptions): unknown {
-    const useFormDataForBlobs = options.useFormDataForBlobFields ?? this.defaultSerializeOptions?.useFormDataForBlobFields ?? true
-
+  private serializeValue(data: unknown, useFormDataForBlobs: boolean): unknown {
     const { json, meta, maps, blobs } = this.jsonSerializer.serialize(data)
 
     if (!useFormDataForBlobs || !blobs?.length) {

--- a/packages/openapi/src/bracket-notation.test.ts
+++ b/packages/openapi/src/bracket-notation.test.ts
@@ -82,6 +82,19 @@ describe('bracket notation serializer', () => {
         ['a[c][1][f]', 4],
       ])
     })
+
+    it('serializes empty nested containers to nothing', () => {
+      expect(serializer.serialize({ a: {}, b: [] })).toEqual([])
+    })
+
+    it('cannot represent keys containing bracket characters (documented limitation)', () => {
+      // there is no escaping, so such keys are ambiguous with nesting and may not round-trip
+      expect(serializer.serialize({ 'a[b]': 1 })).toEqual([['a[b]', 1]])
+      expect(serializer.deserialize([['a[b]', 1]])).toEqual({ a: { b: 1 } })
+
+      expect(serializer.serialize({ 'a[0]': 'red' })).toEqual([['a[0]', 'red']])
+      expect(serializer.deserialize([['a[0]', 'red']])).toEqual({ a: ['red'] })
+    })
   })
 
   describe('.deserialize', () => {
@@ -168,6 +181,13 @@ describe('bracket notation serializer', () => {
         ['[a]', 1],
         ['[b]', 3],
       ])).toEqual({ '': { a: 1, b: 3 } })
+    })
+
+    it('converts an explicitly indexed array to an object when a [] key follows', () => {
+      expect(serializer.deserialize([
+        ['a[0]', 1],
+        ['a[]', 2],
+      ])).toEqual({ a: { '0': 1, '': 2 } })
     })
 
     it('can deserialize objects when both number-key and empty-key appear', () => {
@@ -264,6 +284,29 @@ describe('bracket notation serializer', () => {
       ])).toEqual({ a: { b: 1, c: [2, { d: 3, f: 4 }] } })
     })
 
+    it('deserializes a realistic search form', () => {
+      const entries = Array.from(new URLSearchParams(
+        'q=shoes&filters[size][]=41&filters[size][]=42&filters[color]=red&page=2',
+      ).entries())
+
+      expect(serializer.deserialize(entries)).toEqual({
+        q: 'shoes',
+        filters: {
+          size: ['41', '42'],
+          color: 'red',
+        },
+        page: '2',
+      })
+    })
+
+    it('treats invalid array indices as object keys', () => {
+      expect(serializer.deserialize([['a[-1]', 1]])).toEqual({ a: { '-1': 1 } })
+      expect(serializer.deserialize([['a[01]', 1]])).toEqual({ a: { '01': 1 } })
+      expect(serializer.deserialize([['a[+1]', 1]])).toEqual({ a: { '+1': 1 } })
+      expect(serializer.deserialize([['a[1e3]', 1]])).toEqual({ a: { '1e3': 1 } })
+      expect(serializer.deserialize([['a[1.5]', 1]])).toEqual({ a: { 1.5: 1 } })
+    })
+
     it('fallback to object when explicit array index exceeds maxExplicitDeserializingArrayIndex (default 999)', () => {
       expect(serializer.deserialize([
         ['arr[1]', 1],
@@ -313,6 +356,13 @@ describe('bracket notation serializer', () => {
       })() })
     })
 
+    it('does not allocate huge arrays for memory exhaustion attacks', () => {
+      const result = serializer.deserialize([['arr[4294967295]', 'x']]) as any
+
+      expect(Array.isArray(result.arr)).toBe(false)
+      expect(result.arr).toEqual({ 4294967295: 'x' })
+    })
+
     it('can prevent prototype pollution attack', () => {
       /* eslint-disable no-proto, no-restricted-properties */
       const result = serializer.deserialize([
@@ -344,6 +394,21 @@ describe('bracket notation serializer', () => {
       expect(({} as any).constructor.polluted).toBeUndefined()
       expect(({} as any).polluted).toBeUndefined()
       /* eslint-enable no-proto, no-restricted-properties */
+    })
+
+    it('can prevent constructor.prototype pollution attack', () => {
+      const result = serializer.deserialize([
+        ['constructor[prototype][polluted]', 'x'],
+        ['a[constructor][prototype][polluted]', 'y'],
+      ]) as any
+
+      expect(({} as any).polluted).toBeUndefined()
+      expect((Object.prototype as any).polluted).toBeUndefined()
+      expect((Function.prototype as any).polluted).toBeUndefined()
+
+      // stored as plain data instead
+      expect(result.constructor.prototype.polluted).toBe('x')
+      expect(result.a.constructor.prototype.polluted).toBe('y')
     })
   })
 

--- a/packages/openapi/src/bracket-notation.ts
+++ b/packages/openapi/src/bracket-notation.ts
@@ -28,27 +28,27 @@ export class BracketNotationSerializer {
   }
 
   serialize(data: unknown): BracketNotationSerializeResult {
-    return this.internalSerialize(data, [], [])
+    const result: BracketNotationSerializeResult = []
+    this.internalSerialize(data, '', true, result)
+    return result
   }
 
-  private internalSerialize(data: unknown, segments: Segment[], result: BracketNotationSerializeResult): BracketNotationSerializeResult {
+  private internalSerialize(data: unknown, path: string, isRoot: boolean, result: BracketNotationSerializeResult): void {
     if (Array.isArray(data)) {
       data.forEach((item, i) => {
-        this.internalSerialize(item, [...segments, i], result)
+        this.internalSerialize(item, isRoot ? i.toString() : `${path}[${i}]`, false, result)
       })
     }
 
     else if (isPlainObject(data)) {
       for (const key in data) {
-        this.internalSerialize(data[key], [...segments, key], result)
+        this.internalSerialize(data[key], isRoot ? key : `${path}[${key}]`, false, result)
       }
     }
 
     else {
-      result.push([this.stringifyPath(segments), data])
+      result.push([path, data])
     }
-
-    return result
   }
 
   deserialize(serialized: BracketNotationSerializeResult): Record<string, unknown> {
@@ -65,7 +65,9 @@ export class BracketNotationSerializer {
       let currentRef: any = ref
       let nextSegment: string = 'value'
 
-      segments.forEach((segment, i) => {
+      for (let i = 0; i < segments.length; i++) {
+        const segment = segments[i]!
+
         if (!Array.isArray(currentRef[nextSegment]) && !isPlainObject(currentRef[nextSegment])) {
           currentRef[nextSegment] = []
         }
@@ -103,7 +105,7 @@ export class BracketNotationSerializer {
 
         currentRef = currentRef[nextSegment]
         nextSegment = segment
-      })
+      }
 
       if (Array.isArray(currentRef) && nextSegment === '') {
         arrayPushStyles.add(currentRef)
@@ -126,14 +128,17 @@ export class BracketNotationSerializer {
   }
 
   stringifyPath(segments: readonly Segment[]): string {
-    return segments
-      .reduce<string>((result, segment, i) => {
-        if (i === 0) {
-          return segment.toString()
-        }
+    if (segments.length === 0) {
+      return ''
+    }
 
-        return `${result}[${segment}]`
-      }, '')
+    let result = segments[0]!.toString()
+
+    for (let i = 1; i < segments.length; i++) {
+      result += `[${segments[i]}]`
+    }
+
+    return result
   }
 
   parsePath(path: string): string[] {

--- a/packages/openapi/src/bracket-notation.ts
+++ b/packages/openapi/src/bracket-notation.ts
@@ -176,8 +176,9 @@ export class BracketNotationSerializer {
   }
 }
 
+const INTEGER_PATTERN = /^0$|^[1-9]\d*$/
 function internalIsValidArrayIndex(value: string, maxIndex: number): boolean {
-  return /^0$|^[1-9]\d*$/.test(value) && Number(value) <= maxIndex
+  return INTEGER_PATTERN.test(value) && Number(value) <= maxIndex
 }
 
 function internalArrayToObject(array: readonly unknown[]): Record<string, unknown> {

--- a/packages/openapi/src/openapi-json-serializer.test.ts
+++ b/packages/openapi/src/openapi-json-serializer.test.ts
@@ -22,10 +22,12 @@ describe('openAPIJsonSerializer', () => {
       expect(serializer.serialize(1).json).toBe(1)
       expect(serializer.serialize('hello').json).toBe('hello')
       expect(serializer.serialize(true).json).toBe(true)
+      expect(serializer.serialize(false).json).toBe(false)
       expect(serializer.serialize(null).json).toBe(null)
     })
 
-    it('serializes nested undefined values to null', () => {
+    it('serializes root and nested undefined values to null', () => {
+      expect(serializer.serialize(undefined).json).toBeNull()
       expect(serializer.serialize([undefined]).json).toEqual([null])
     })
 
@@ -43,6 +45,7 @@ describe('openAPIJsonSerializer', () => {
 
     it('serializes bigint to string', () => {
       expect(serializer.serialize(42n).json).toBe('42')
+      expect(serializer.serialize(99999999999999999999999999999n).json).toBe('99999999999999999999999999999')
     })
 
     it('serializes URL to string', () => {
@@ -53,31 +56,38 @@ describe('openAPIJsonSerializer', () => {
       expect(serializer.serialize(/uic/gi).json).toBe('/uic/gi')
     })
 
-    it('serializes Set to array', () => {
+    it('serializes Set to array and Map to entries, converting nested values', () => {
       expect(serializer.serialize(new Set([1, 2, 3])).json).toEqual([1, 2, 3])
-    })
-
-    it('serializes Map to entries array', () => {
       expect(serializer.serialize(new Map([['a', 1]])).json).toEqual([['a', 1]])
+      expect(serializer.serialize(new Set([new Date('2023-01-01')])).json).toEqual(['2023-01-01T00:00:00.000Z'])
+      expect(serializer.serialize(new Map([[new Date('2023-01-01'), 1n]])).json).toEqual([['2023-01-01T00:00:00.000Z', '1']])
     })
 
-    it('serializes nested objects', () => {
-      expect(serializer.serialize({
-        date: new Date('2023-01-01'),
-        count: 1n,
-        flag: true,
-      }).json).toEqual({
-        date: '2023-01-01T00:00:00.000Z',
-        count: '1',
-        flag: true,
+    it('serializes a realistic API response in one pass', () => {
+      const { json } = serializer.serialize({
+        user: {
+          id: 9007199254740993n,
+          name: 'dinwwwh',
+          createdAt: new Date('2023-01-01'),
+          homepage: new URL('https://orpc.dev'),
+          roles: new Set(['admin']),
+          settings: new Map([['theme', 'dark']]),
+          bio: undefined,
+        },
+        scores: [1, Number.NaN, 2.5],
       })
-    })
 
-    it('serializes nested arrays', () => {
-      expect(serializer.serialize([new Date('2023-01-01'), 42n]).json).toEqual([
-        '2023-01-01T00:00:00.000Z',
-        '42',
-      ])
+      expect(json).toEqual({
+        user: {
+          id: '9007199254740993',
+          name: 'dinwwwh',
+          createdAt: '2023-01-01T00:00:00.000Z',
+          homepage: 'https://orpc.dev/',
+          roles: ['admin'],
+          settings: [['theme', 'dark']],
+        },
+        scores: [1, null, 2.5],
+      })
     })
 
     it('omits undefined object properties by default', () => {
@@ -98,6 +108,20 @@ describe('openAPIJsonSerializer', () => {
       expect(blobs).toEqual([blob])
       expect(maps).toEqual([['file']])
     })
+
+    it('collects multiple blobs with their exact paths', () => {
+      const a = new Blob(['a'])
+      const b = new Blob(['b'])
+      const { maps, blobs } = serializer.serialize({ nested: { a }, list: [1, b] })
+
+      expect(maps).toEqual([['nested', 'a'], ['list', 1]])
+      expect(blobs).toEqual([a, b])
+    })
+
+    it('passes through values no handler understands', () => {
+      const symbol = Symbol('sym')
+      expect(serializer.serialize(symbol).json).toBe(symbol)
+    })
   })
 
   describe('deserialize', () => {
@@ -110,20 +134,6 @@ describe('openAPIJsonSerializer', () => {
     it('returns json as-is when no blobs', () => {
       const json = { a: 1, b: '2023-01-01T00:00:00.000Z' }
       expect(serializer.deserialize({ json })).toEqual(json)
-    })
-
-    it.each(['doesNotExist', '__proto__', 'constructor'])('throws on invalid segment "%s" to prevent prototype pollution', (segment) => {
-      expect(
-        () => serializer.deserialize({ json: { o: {} }, blobs: [new Blob()], maps: [[segment]] }),
-      ).toThrowError(`Security error: Invalid serialized data. Segment "${segment}" does not exist.`)
-
-      expect(
-        () => serializer.deserialize({ json: { o: {} }, blobs: [new Blob()], maps: [['o', segment]] }),
-      ).toThrowError(`Security error: Invalid serialized data. Segment "${segment}" does not exist.`)
-
-      expect(
-        () => serializer.deserialize({ json: { o: {} }, blobs: [new Blob()], maps: [[segment, 'o']] }),
-      ).toThrowError(`Security error: Invalid serialized data. Segment "${segment}" does not exist.`)
     })
   })
 
@@ -145,10 +155,10 @@ describe('openAPIJsonSerializer', () => {
     it('supports disabling default handlers', () => {
       const custom = new OpenAPIJsonSerializer({ handlers: { date: undefined } })
       const date = new Date('2023-01-01')
-      expect(custom.serialize({ value: date }).json).toEqual({ value: date })
+      expect(custom.serialize({ value: date, list: [undefined] }).json).toEqual({ value: date, list: [null] })
     })
 
-    it('supports custom handlers', () => {
+    it('supports custom handlers, and keeps serializing non-terminal results', () => {
       const custom = new OpenAPIJsonSerializer({
         handlers: {
           person: {
@@ -161,6 +171,59 @@ describe('openAPIJsonSerializer', () => {
       expect(custom.serialize(new Person('dinwwwh', new Date('2023-01-01'))).json).toEqual({
         name: 'dinwwwh',
         date: '2023-01-01T00:00:00.000Z',
+      })
+    })
+
+    it('treats terminal handler results as final, without further serialization', () => {
+      const date = new Date('2023-01-01')
+      const custom = new OpenAPIJsonSerializer({
+        handlers: {
+          person: {
+            condition: data => data instanceof Person,
+            serialize: (data: Person) => data.toJSON(),
+            isTerminal: true,
+          },
+        },
+      })
+
+      // the nested Date stays untouched because the terminal result is not walked
+      expect((custom.serialize(new Person('dinwwwh', date)).json as any).date).toBe(date)
+    })
+
+    it('keeps every built-in type working when any built-in handler is customized', () => {
+      // customizing a built-in key switches to the generic handler scan; every default handler must still work there
+      const custom = new OpenAPIJsonSerializer({
+        handlers: {
+          undefined: {
+            condition: data => data === undefined,
+            serialize: () => null,
+            isTerminal: true,
+          },
+        },
+      })
+
+      expect(custom.serialize({
+        date: new Date('2023-01-01'),
+        invalidDate: new Date('Invalid'),
+        nan: Number.NaN,
+        url: new URL('https://orpc.dev'),
+        regexp: /uic/gi,
+        set: new Set([1, 2]),
+        map: new Map([['a', 1]]),
+        bigint: 123n,
+        list: [undefined],
+        plain: 'text',
+      }).json).toEqual({
+        date: '2023-01-01T00:00:00.000Z',
+        invalidDate: null,
+        nan: null,
+        url: 'https://orpc.dev/',
+        regexp: '/uic/gi',
+        set: [1, 2],
+        map: [['a', 1]],
+        bigint: '123',
+        list: [null],
+        plain: 'text',
       })
     })
 
@@ -190,5 +253,49 @@ describe('openAPIJsonSerializer', () => {
       const custom = new OpenAPIJsonSerializer({ omitUndefinedProperties: false })
       expect(custom.serialize({ a: 1, b: undefined }).json).toEqual({ a: 1, b: null })
     })
+  })
+
+  describe('security', () => {
+    afterEach(() => {
+      expect(({} as any).polluted).toBeUndefined()
+      expect((Object.prototype as any).polluted).toBeUndefined()
+    })
+
+    it.each(['doesNotExist', '__proto__', 'constructor', 'prototype'])('throws on invalid blob map segment "%s" to prevent prototype pollution', (segment) => {
+      expect(
+        () => serializer.deserialize({ json: { o: {} }, blobs: [new Blob()], maps: [[segment]] }),
+      ).toThrowError(`Security error: Invalid serialized data. Segment "${segment}" does not exist.`)
+
+      expect(
+        () => serializer.deserialize({ json: { o: {} }, blobs: [new Blob()], maps: [['o', segment]] }),
+      ).toThrowError(`Security error: Invalid serialized data. Segment "${segment}" does not exist.`)
+
+      expect(
+        () => serializer.deserialize({ json: { o: {} }, blobs: [new Blob()], maps: [[segment, 'o']] }),
+      ).toThrowError(`Security error: Invalid serialized data. Segment "${segment}" does not exist.`)
+    })
+
+    /* eslint-disable no-proto, no-restricted-properties */
+    it('serializes own __proto__ keys as plain data', () => {
+      // JSON.parse creates own __proto__ properties, exactly like a real request body
+      const { json } = serializer.serialize(JSON.parse('{"__proto__": {"polluted": true}}')) as any
+
+      expect(Object.hasOwn(json, '__proto__')).toBe(true)
+      expect(json.__proto__).toEqual({ polluted: true })
+      expect(json.polluted).toBeUndefined()
+    })
+
+    it('restores blobs behind own __proto__ keys without touching prototypes', () => {
+      const blob = new Blob(['x'])
+      const result = serializer.deserialize({
+        json: JSON.parse('{"__proto__": {"file": null}}'),
+        maps: [['__proto__', 'file']],
+        blobs: [blob],
+      }) as any
+
+      expect(Object.hasOwn(result, '__proto__')).toBe(true)
+      expect(result.__proto__.file).toBe(blob)
+    })
+    /* eslint-enable no-proto, no-restricted-properties */
   })
 })

--- a/packages/openapi/src/openapi-json-serializer.test.ts
+++ b/packages/openapi/src/openapi-json-serializer.test.ts
@@ -164,6 +164,28 @@ describe('openAPIJsonSerializer', () => {
       })
     })
 
+    it('collects blobs returned by terminal custom handlers', () => {
+      class BlobContainer {
+        constructor(public blob: Blob) {}
+      }
+
+      const custom = new OpenAPIJsonSerializer({
+        handlers: {
+          blobContainer: {
+            condition: data => data instanceof BlobContainer,
+            serialize: (data: BlobContainer) => data.blob,
+            isTerminal: true,
+          },
+        },
+      })
+
+      const serialized = custom.serialize({ file: new BlobContainer(new Blob(['hello'], { type: 'text/plain' })) })
+
+      expect(serialized.json).toEqual({ file: expect.any(Blob) })
+      expect(serialized.maps).toEqual([['file']])
+      expect(serialized.blobs).toEqual([expect.any(Blob)])
+    })
+
     it('can disable omitting undefined properties', () => {
       const custom = new OpenAPIJsonSerializer({ omitUndefinedProperties: false })
       expect(custom.serialize({ a: 1, b: undefined }).json).toEqual({ a: 1, b: null })

--- a/packages/openapi/src/openapi-json-serializer.ts
+++ b/packages/openapi/src/openapi-json-serializer.ts
@@ -248,7 +248,6 @@ export class OpenAPIJsonSerializer {
           const serialized = handler.serialize(data)
 
           if (handler.isTerminal) {
-          // terminal skips the recursive walk, so blobs must still be collected here
             if (serialized instanceof Blob) {
               maps.push(segments.slice())
               blobs.push(serialized)

--- a/packages/openapi/src/openapi-json-serializer.ts
+++ b/packages/openapi/src/openapi-json-serializer.ts
@@ -19,7 +19,7 @@ export interface OpenAPIJsonSerializerHandler {
   isTerminal?: boolean
 }
 
-const DEFAULT_OPEN_API_JSON_SERIALIZER_HANDLERS: Record<string, OpenAPIJsonSerializerHandler> = Object.assign(new NullProtoObj<Record<string, OpenAPIJsonSerializerHandler>>(), {
+const DEFAULT_OPEN_API_JSON_SERIALIZER_HANDLERS: Record<string, OpenAPIJsonSerializerHandler> = {
   undefined: {
     condition(data: unknown): boolean {
       return data === undefined
@@ -94,9 +94,7 @@ const DEFAULT_OPEN_API_JSON_SERIALIZER_HANDLERS: Record<string, OpenAPIJsonSeria
       return Array.from(data.entries())
     },
   },
-})
-
-const NO_CUSTOM_HANDLER_ENTRIES: OpenAPIJsonSerializerHandler[] = []
+}
 
 export interface OpenAPIJsonSerializerOptions {
   /**
@@ -145,16 +143,8 @@ export interface OpenAPIJsonSerializerOptions {
 }
 
 export class OpenAPIJsonSerializer {
-  /**
-   * When true, built-in handlers are inlined in serializeValue and
-   * handlerEntries only holds custom handlers. Only valid while no custom
-   * handler overrides or disables a built-in key, otherwise handler order
-   * and behavior could diverge from the merged handlers.
-   * On this path, custom handlers are never called for values the built-ins
-   * claim: primitives, null, and the built-in object types.
-   */
   private readonly inlineBuiltInHandlers: boolean
-  private readonly handlerEntries: OpenAPIJsonSerializerHandler[]
+  private readonly handlerEntries: OpenAPIJsonSerializerHandler[] | undefined
   private readonly omitUndefinedProperties: boolean
 
   constructor(options: OpenAPIJsonSerializerOptions = {}) {
@@ -164,7 +154,6 @@ export class OpenAPIJsonSerializer {
 
     if (customHandlers === undefined) {
       this.inlineBuiltInHandlers = true
-      this.handlerEntries = NO_CUSTOM_HANDLER_ENTRIES
       return
     }
 
@@ -176,6 +165,7 @@ export class OpenAPIJsonSerializer {
 
       if (inlineBuiltInHandlers && key in DEFAULT_OPEN_API_JSON_SERIALIZER_HANDLERS) {
         inlineBuiltInHandlers = false
+        break
       }
 
       if (handler !== undefined) {
@@ -184,7 +174,6 @@ export class OpenAPIJsonSerializer {
     }
 
     if (!inlineBuiltInHandlers) {
-      // a built-in was overridden or disabled: scan every active handler in merge order
       handlerEntries = []
       for (const handler of Object.values({ ...DEFAULT_OPEN_API_JSON_SERIALIZER_HANDLERS, ...customHandlers })) {
         if (handler !== undefined) {
@@ -211,8 +200,6 @@ export class OpenAPIJsonSerializer {
    * so it must be copied before being stored in `maps`.
    */
   private serializeValue(data: unknown, segments: Segment[], maps: Segment[][], blobs: Blob[]): unknown {
-    const handlerEntries = this.handlerEntries
-
     /**
      * Inlined version of DEFAULT_OPEN_API_JSON_SERIALIZER_HANDLERS: primitives
      * are dispatched on typeof and skip every handler condition check.
@@ -252,23 +239,26 @@ export class OpenAPIJsonSerializer {
       }
     }
 
-    for (let i = 0; i < handlerEntries.length; i++) {
-      const handler = handlerEntries[i]!
+    const handlerEntries = this.handlerEntries
+    if (handlerEntries) {
+      for (let i = 0; i < handlerEntries.length; i++) {
+        const handler = handlerEntries[i]!
 
-      if (handler.condition(data)) {
-        const serialized = handler.serialize(data)
+        if (handler.condition(data)) {
+          const serialized = handler.serialize(data)
 
-        if (handler.isTerminal) {
+          if (handler.isTerminal) {
           // terminal skips the recursive walk, so blobs must still be collected here
-          if (serialized instanceof Blob) {
-            maps.push(segments.slice())
-            blobs.push(serialized)
+            if (serialized instanceof Blob) {
+              maps.push(segments.slice())
+              blobs.push(serialized)
+            }
+
+            return serialized
           }
 
-          return serialized
+          return this.serializeValue(serialized, segments, maps, blobs)
         }
-
-        return this.serializeValue(serialized, segments, maps, blobs)
       }
     }
 

--- a/packages/openapi/src/openapi-json-serializer.ts
+++ b/packages/openapi/src/openapi-json-serializer.ts
@@ -1,5 +1,5 @@
 import type { Segment } from '@orpc/shared'
-import { isPlainObject } from '@orpc/shared'
+import { isPlainObject, NullProtoObj } from '@orpc/shared'
 
 export type OpenAPIJsonSerialization
   = | { json: unknown, maps?: undefined, blobs?: undefined }
@@ -19,7 +19,7 @@ export interface OpenAPIJsonSerializerHandler {
   isTerminal?: boolean
 }
 
-const DEFAULT_OPEN_API_JSON_SERIALIZER_HANDLERS: Record<string, OpenAPIJsonSerializerHandler> = {
+const DEFAULT_OPEN_API_JSON_SERIALIZER_HANDLERS: Record<string, OpenAPIJsonSerializerHandler> = Object.assign(new NullProtoObj<Record<string, OpenAPIJsonSerializerHandler>>(), {
   undefined: {
     condition(data: unknown): boolean {
       return data === undefined
@@ -94,7 +94,9 @@ const DEFAULT_OPEN_API_JSON_SERIALIZER_HANDLERS: Record<string, OpenAPIJsonSeria
       return Array.from(data.entries())
     },
   },
-}
+})
+
+const NO_CUSTOM_HANDLER_ENTRIES: OpenAPIJsonSerializerHandler[] = []
 
 export interface OpenAPIJsonSerializerOptions {
   /**
@@ -143,56 +145,153 @@ export interface OpenAPIJsonSerializerOptions {
 }
 
 export class OpenAPIJsonSerializer {
-  private readonly handlers: Exclude<OpenAPIJsonSerializerOptions['handlers'], undefined>
+  /**
+   * When true, built-in handlers are inlined in serializeValue and
+   * handlerEntries only holds custom handlers. Only valid while no custom
+   * handler overrides or disables a built-in key, otherwise handler order
+   * and behavior could diverge from the merged handlers.
+   * On this path, custom handlers are never called for values the built-ins
+   * claim: primitives, null, and the built-in object types.
+   */
+  private readonly inlineBuiltInHandlers: boolean
+  private readonly handlerEntries: OpenAPIJsonSerializerHandler[]
   private readonly omitUndefinedProperties: boolean
 
   constructor(options: OpenAPIJsonSerializerOptions = {}) {
-    this.handlers = {
-      ...DEFAULT_OPEN_API_JSON_SERIALIZER_HANDLERS,
-      ...options.handlers,
+    this.omitUndefinedProperties = options.omitUndefinedProperties !== false
+
+    const customHandlers = options.handlers
+
+    if (customHandlers === undefined) {
+      this.inlineBuiltInHandlers = true
+      this.handlerEntries = NO_CUSTOM_HANDLER_ENTRIES
+      return
     }
 
-    this.omitUndefinedProperties = options.omitUndefinedProperties !== false
+    let inlineBuiltInHandlers = true
+    let handlerEntries: OpenAPIJsonSerializerHandler[] = []
+
+    for (const key of Object.keys(customHandlers)) {
+      const handler = customHandlers[key]
+
+      if (inlineBuiltInHandlers && key in DEFAULT_OPEN_API_JSON_SERIALIZER_HANDLERS) {
+        inlineBuiltInHandlers = false
+      }
+
+      if (handler !== undefined) {
+        handlerEntries.push(handler)
+      }
+    }
+
+    if (!inlineBuiltInHandlers) {
+      // a built-in was overridden or disabled: scan every active handler in merge order
+      handlerEntries = []
+      for (const handler of Object.values({ ...DEFAULT_OPEN_API_JSON_SERIALIZER_HANDLERS, ...customHandlers })) {
+        if (handler !== undefined) {
+          handlerEntries.push(handler)
+        }
+      }
+    }
+
+    this.inlineBuiltInHandlers = inlineBuiltInHandlers
+    this.handlerEntries = handlerEntries
   }
 
   serialize(data: unknown): OpenAPIJsonSerialization {
-    const [json, maps, blobs] = this.serializeValue(data, [], [], [])
+    const maps: Segment[][] = []
+    const blobs: Blob[] = []
+
+    const json = this.serializeValue(data, [], maps, blobs)
 
     return { json, maps, blobs }
   }
 
-  private serializeValue(data: unknown, segments: Segment[], maps: Segment[][], blobs: Blob[]): [unknown, Segment[][], Blob[]] {
-    for (const key in this.handlers) {
-      const handler = this.handlers[key]
+  /**
+   * `segments` is a shared mutable stack (push/pop while walking),
+   * so it must be copied before being stored in `maps`.
+   */
+  private serializeValue(data: unknown, segments: Segment[], maps: Segment[][], blobs: Blob[]): unknown {
+    const handlerEntries = this.handlerEntries
 
-      if (handler && handler.condition(data)) {
+    /**
+     * Inlined version of DEFAULT_OPEN_API_JSON_SERIALIZER_HANDLERS: primitives
+     * are dispatched on typeof and skip every handler condition check.
+     * Must match the built-in handlers exactly.
+     */
+    if (this.inlineBuiltInHandlers) {
+      switch (typeof data) {
+        case 'string':
+        case 'boolean':
+          return data
+        case 'number':
+          return Number.isNaN(data) ? null : data
+        case 'undefined':
+          return null
+        case 'bigint':
+          return data.toString()
+        case 'object': {
+          if (data === null) {
+            return data
+          }
+          if (data instanceof Date) {
+            return Number.isNaN(data.getTime()) ? null : data.toISOString()
+          }
+          if (data instanceof URL) {
+            return data.toString()
+          }
+          if (data instanceof RegExp) {
+            return data.toString()
+          }
+          if (data instanceof Set) {
+            return this.serializeValue(Array.from(data), segments, maps, blobs)
+          }
+          if (data instanceof Map) {
+            return this.serializeValue(Array.from(data.entries()), segments, maps, blobs)
+          }
+        }
+      }
+    }
+
+    for (let i = 0; i < handlerEntries.length; i++) {
+      const handler = handlerEntries[i]!
+
+      if (handler.condition(data)) {
         const serialized = handler.serialize(data)
 
         if (handler.isTerminal) {
-          return [serialized, maps, blobs]
+          // terminal skips the recursive walk, so blobs must still be collected here
+          if (serialized instanceof Blob) {
+            maps.push(segments.slice())
+            blobs.push(serialized)
+          }
+
+          return serialized
         }
 
-        const result = this.serializeValue(serialized, segments, maps, blobs)
-        return result
+        return this.serializeValue(serialized, segments, maps, blobs)
       }
     }
 
     if (data instanceof Blob) {
-      maps.push(segments)
+      maps.push(segments.slice())
       blobs.push(data)
-      return [data, maps, blobs]
+      return data
     }
 
     if (Array.isArray(data)) {
-      const json = data.map((v, i) => {
-        return this.serializeValue(v, [...segments, i], maps, blobs)[0]
-      })
+      const json: unknown[] = []
 
-      return [json, maps, blobs]
+      for (let i = 0; i < data.length; i++) {
+        segments.push(i)
+        json.push(this.serializeValue(data[i], segments, maps, blobs))
+        segments.pop()
+      }
+
+      return json
     }
 
     if (isPlainObject(data)) {
-      const json: Record<string, unknown> = {}
+      const json: Record<string, unknown> = new NullProtoObj()
 
       for (const k in data) {
         const v = data[k]
@@ -209,34 +308,38 @@ export class OpenAPIJsonSerializer {
           continue
         }
 
-        json[k] = this.serializeValue(v, [...segments, k], maps, blobs)[0]
+        segments.push(k)
+        json[k] = this.serializeValue(v, segments, maps, blobs)
+        segments.pop()
       }
 
-      return [json, maps, blobs]
+      return json
     }
 
-    return [data, maps, blobs]
+    return data
   }
 
   deserialize(serialized: OpenAPIJsonSerialization): unknown {
     const ref = { data: serialized.json }
 
     if (serialized.blobs?.length) {
-      serialized.maps.forEach((segments, i) => {
+      for (let i = 0; i < serialized.maps.length; i++) {
+        const segments = serialized.maps[i]!
+
         let currentRef: any = ref
         let preSegment: string | number = 'data'
 
-        segments.forEach((segment) => {
+        for (let j = 0; j < segments.length; j++) {
           currentRef = currentRef[preSegment]
-          preSegment = segment
+          preSegment = segments[j]!
 
           if (!Object.hasOwn(currentRef, preSegment)) {
             throw new Error(`Security error: Invalid serialized data. Segment "${preSegment}" does not exist.`)
           }
-        })
+        }
 
         currentRef[preSegment] = serialized.blobs[i]
-      })
+      }
     }
 
     return ref.data

--- a/packages/openapi/src/openapi-json-serializer.ts
+++ b/packages/openapi/src/openapi-json-serializer.ts
@@ -160,7 +160,7 @@ export class OpenAPIJsonSerializer {
     let inlineBuiltInHandlers = true
     let handlerEntries: OpenAPIJsonSerializerHandler[] = []
 
-    for (const key of Object.keys(customHandlers)) {
+    for (const key in customHandlers) {
       const handler = customHandlers[key]
 
       if (inlineBuiltInHandlers && key in DEFAULT_OPEN_API_JSON_SERIALIZER_HANDLERS) {

--- a/packages/openapi/src/openapi-serializer.test.ts
+++ b/packages/openapi/src/openapi-serializer.test.ts
@@ -315,4 +315,42 @@ describe('openAPISerializer', () => {
       expect(result.tags['1']).toBe('b')
     })
   })
+
+  describe('security', () => {
+    afterEach(() => {
+      expect(({} as any).polluted).toBeUndefined()
+      expect((Object.prototype as any).polluted).toBeUndefined()
+      expect((Function.prototype as any).polluted).toBeUndefined()
+    })
+
+    /* eslint-disable no-proto, no-restricted-properties */
+    it('deserializes __proto__ query parameters as plain data', () => {
+      const result = serializer.deserialize(
+        new URLSearchParams('__proto__[polluted]=yes&safe=1'),
+      ) as any
+
+      expect(Object.hasOwn(result, '__proto__')).toBe(true)
+      expect(result.__proto__).toEqual({ polluted: 'yes' })
+      expect(result.polluted).toBeUndefined()
+      expect(result.safe).toBe('1')
+    })
+    /* eslint-enable no-proto, no-restricted-properties */
+
+    it('deserializes constructor.prototype form fields as plain data', () => {
+      const form = new FormData()
+      form.append('constructor[prototype][polluted]', 'yes')
+
+      const result = serializer.deserialize(form) as any
+
+      expect(result.constructor.prototype.polluted).toBe('yes')
+      expect(({} as any).polluted).toBeUndefined()
+    })
+
+    it('does not allocate huge arrays for memory exhaustion attacks', () => {
+      const result = serializer.deserialize(new URLSearchParams('arr[4294967295]=x')) as any
+
+      expect(Array.isArray(result.arr)).toBe(false)
+      expect(result.arr).toEqual({ 4294967295: 'x' })
+    })
+  })
 })

--- a/packages/openapi/src/openapi-serializer.ts
+++ b/packages/openapi/src/openapi-serializer.ts
@@ -50,9 +50,6 @@ export class OpenAPISerializer {
   }
 
   serialize(data: unknown, options: OpenAPISerializerSerializeOptions = {}): StandardBody {
-    const useFormDataForBlobFields = options.useFormDataForBlobFields ?? this.defaultSerializeOptions?.useFormDataForBlobFields ?? true
-    const asFormData = options.asFormData ?? this.defaultSerializeOptions?.asFormData ?? false
-
     if (!options.asFormData) {
       // standard body already supports these types without additional serialization.
       if (data === undefined || data instanceof ReadableStream || data instanceof Blob) {
@@ -67,11 +64,11 @@ export class OpenAPISerializer {
               return result
             }
 
-            return { done: result.done, value: this.serializeValue(result.value, { asFormData: false, useFormDataForBlobFields: false }) }
+            return { done: result.done, value: this.serializeValue(result.value, false, false) }
           },
           mapError: (e) => {
             return new ErrorEvent({
-              data: this.serializeValue(toORPCError(e).toJSON(), { asFormData: false, useFormDataForBlobFields: false }),
+              data: this.serializeValue(toORPCError(e).toJSON(), false, false),
               cause: e,
             })
           },
@@ -79,13 +76,15 @@ export class OpenAPISerializer {
       }
     }
 
-    return this.serializeValue(data, { useFormDataForBlobFields, asFormData })
+    const useFormDataForBlobFields = options.useFormDataForBlobFields ?? this.defaultSerializeOptions?.useFormDataForBlobFields ?? true
+    const asFormData = options.asFormData ?? this.defaultSerializeOptions?.asFormData ?? false
+    return this.serializeValue(data, useFormDataForBlobFields, asFormData)
   }
 
-  private serializeValue(value: unknown, options: Required<OpenAPISerializerSerializeOptions>): unknown {
+  private serializeValue(value: unknown, useFormDataForBlobFields: boolean, asFormData: boolean): unknown {
     const { json, blobs } = this.jsonSerializer.serialize(value)
 
-    if (!options.asFormData && (json instanceof Blob || json === undefined || !blobs?.length || !options.useFormDataForBlobFields)) {
+    if (!asFormData && (json instanceof Blob || json === undefined || !blobs?.length || !useFormDataForBlobFields)) {
       return json
     }
 


### PR DESCRIPTION
## Summary

Speeds up `RPCSerializer` and `OpenAPISerializer` round trips, mainly by skipping per-value handler condition checks for primitives and avoiding per-node path allocations while walking payloads.

In same-process A/B benches against the previous implementation:

- RPC round trips are roughly 1.5x to 2x faster
- OpenAPI round trips are roughly 1.3x to 3x faster
- Default construction (no custom handlers) allocates nothing

## Other changes

- Blobs returned by terminal custom handlers are now collected into `maps`/`blobs`, so they survive FormData transport
- Serializer and bracket-notation tests are rewritten around real-world round trips, edge cases, malicious payloads, and prototype pollution attacks, with 100% coverage of the touched files
- Docs: bracket notation now lists keys containing `[` or `]` as a limitation

## Notes for reviewers

- Custom handlers keep working unchanged. When a custom handler overrides or disables a built-in key, the serializer falls back to the previous scan behavior
- On the fast path, custom handlers are not called for values built-ins already claim (primitives, null, and built-in object types); this is documented in code