### PR TITLE
fix(rpc,openapi): prevent lazy router races under concurrent requests

### DIFF
--- a/packages/openapi/src/adapters/standard/openapi-matcher.test.ts
+++ b/packages/openapi/src/adapters/standard/openapi-matcher.test.ts
@@ -185,6 +185,147 @@ describe('standardOpenAPIMatcher', () => {
     expect(pongLoader).toHaveBeenCalledTimes(4)
   })
 
+  it('lazy router inside lazy router with concurrent requests', async () => {
+    const base = os.$context<any>()
+
+    let resolveNested!: (value: { default: any }) => void
+    const nestedLoader = vi.fn(() => new Promise<{ default: any }>((resolve) => {
+      resolveNested = resolve
+    }))
+    const pongLoader = vi.fn(() => Promise.resolve({ default: pong }))
+
+    const rpcMatcher = new StandardOpenAPIMatcher()
+    rpcMatcher.init(base.router({
+      nested: base.lazy(nestedLoader),
+    }))
+
+    const match1 = rpcMatcher.match('POST', '/nested/pong')
+    const match2 = rpcMatcher.match('POST', '/nested/pong')
+
+    expect(nestedLoader).toHaveBeenCalledTimes(1)
+
+    resolveNested({ default: { pong: base.lazy(pongLoader) } })
+
+    expect(await match1).toEqual({
+      path: ['nested', 'pong'],
+      procedure: pong,
+    })
+
+    expect(await match2).toEqual({
+      path: ['nested', 'pong'],
+      procedure: pong,
+    })
+
+    expect(nestedLoader).toHaveBeenCalledTimes(1)
+    expect(pongLoader).toHaveBeenCalledTimes(1)
+
+    // subsequent requests still work without reloading
+    expect(await rpcMatcher.match('POST', '/nested/pong')).toEqual({
+      path: ['nested', 'pong'],
+      procedure: pong,
+    })
+
+    expect(nestedLoader).toHaveBeenCalledTimes(1)
+    expect(pongLoader).toHaveBeenCalledTimes(1)
+  })
+
+  it('multiple lazy routers with lazy router inside lazy router', async () => {
+    const base = os.$context<any>()
+
+    const userFindLoader = vi.fn(() => Promise.resolve({ default: pong }))
+    const usersLoader = vi.fn(() => Promise.resolve({
+      default: {
+        find: base.lazy(userFindLoader),
+      },
+    }))
+
+    const planetDeepLoader = vi.fn(() => Promise.resolve({ default: pong }))
+    const planetNestedLoader = vi.fn(() => Promise.resolve({
+      default: {
+        deep: base.lazy(planetDeepLoader),
+      },
+    }))
+    const planetsLoader = vi.fn(() => Promise.resolve({
+      default: {
+        nested: base.lazy(planetNestedLoader),
+        pong,
+      },
+    }))
+
+    const unusedLoader = vi.fn(() => Promise.resolve({ default: pong }))
+
+    const rpcMatcher = new StandardOpenAPIMatcher()
+    rpcMatcher.init(base.router({
+      users: base.prefix('/users').lazy(usersLoader),
+      planets: base.prefix('/planets').lazy(planetsLoader),
+      unused: base.prefix('/unused').lazy(unusedLoader),
+    }))
+
+    // concurrent requests across different lazy branches
+    const [match1, match2, match3] = await Promise.all([
+      rpcMatcher.match('POST', '/users/find'),
+      rpcMatcher.match('POST', '/planets/nested/deep'),
+      rpcMatcher.match('POST', '/planets/pong'),
+    ])
+
+    expect(match1).toEqual({
+      path: ['users', 'find'],
+      procedure: pong,
+    })
+
+    expect(match2).toEqual({
+      path: ['planets', 'nested', 'deep'],
+      procedure: pong,
+    })
+
+    expect(match3).toEqual({
+      path: ['planets', 'pong'],
+      procedure: pong,
+    })
+
+    expect(usersLoader).toHaveBeenCalledTimes(1)
+    expect(userFindLoader).toHaveBeenCalledTimes(1)
+    expect(planetsLoader).toHaveBeenCalledTimes(1)
+    expect(planetNestedLoader).toHaveBeenCalledTimes(1)
+    expect(planetDeepLoader).toHaveBeenCalledTimes(1)
+
+    // prefixed router not matched by any request stays lazy
+    expect(unusedLoader).toHaveBeenCalledTimes(0)
+
+    // subsequent requests still work without reloading
+    expect(await rpcMatcher.match('POST', '/planets/nested/deep')).toEqual({
+      path: ['planets', 'nested', 'deep'],
+      procedure: pong,
+    })
+
+    expect(planetsLoader).toHaveBeenCalledTimes(1)
+    expect(planetNestedLoader).toHaveBeenCalledTimes(1)
+    expect(planetDeepLoader).toHaveBeenCalledTimes(1)
+    expect(unusedLoader).toHaveBeenCalledTimes(0)
+  })
+
+  it('lazy router can retry after loader failure', async () => {
+    const base = os.$context<any>()
+
+    const pongLoader = vi.fn()
+      .mockRejectedValueOnce(new Error('loader failed'))
+      .mockResolvedValueOnce({ default: pong })
+
+    const rpcMatcher = new StandardOpenAPIMatcher()
+    rpcMatcher.init(base.router({
+      pong: base.lazy(pongLoader),
+    }))
+
+    await expect(rpcMatcher.match('POST', '/pong')).rejects.toThrow('loader failed')
+
+    expect(await rpcMatcher.match('POST', '/pong')).toEqual({
+      path: ['pong'],
+      procedure: pong,
+    })
+
+    expect(pongLoader).toHaveBeenCalledTimes(2)
+  })
+
   it('/ in path', async () => {
     const ping1 = new Procedure({
       ...ping['~orpc'],

--- a/packages/openapi/src/adapters/standard/openapi-matcher.ts
+++ b/packages/openapi/src/adapters/standard/openapi-matcher.ts
@@ -29,7 +29,11 @@ export class StandardOpenAPIMatcher implements StandardMatcher {
     router: AnyRouter
   }>()
 
-  private pendingRouters: (LazyTraverseContractProceduresOptions & { httpPathPrefix: HTTPPath, laziedPrefix: string | undefined }) [] = []
+  private readonly pendingRouters: (LazyTraverseContractProceduresOptions & {
+    httpPathPrefix: HTTPPath
+    laziedPrefix: string | undefined
+    initPromise?: Promise<void>
+  }) [] = []
 
   constructor(options: StandardOpenAPIMatcherOptions = {}) {
     this.filter = options.filter ?? true
@@ -72,24 +76,35 @@ export class StandardOpenAPIMatcher implements StandardMatcher {
   }
 
   async match(method: string, pathname: HTTPPath): Promise<StandardMatchResult> {
-    if (this.pendingRouters.length) {
-      const newPendingRouters: typeof this.pendingRouters = []
-
-      for (const pendingRouter of this.pendingRouters) {
-        if (
-          !pendingRouter.laziedPrefix
+    /**
+     * Resolve pending routers one at a time and re-scan after each, so lazy routers
+     * nested inside a just-initialized lazy router are also picked up.
+     */
+    while (true) {
+      const pendingRouter = this.pendingRouters.find(
+        pendingRouter => !pendingRouter.laziedPrefix
           || pathname.startsWith(pendingRouter.laziedPrefix)
-          || pathname.startsWith(pendingRouter.httpPathPrefix)
-        ) {
-          const { default: router } = await unlazy(pendingRouter.router)
-          this.init(router, pendingRouter.path)
-        }
-        else {
-          newPendingRouters.push(pendingRouter)
-        }
+          || pathname.startsWith(pendingRouter.httpPathPrefix),
+      )
+
+      if (!pendingRouter) {
+        break
       }
 
-      this.pendingRouters = newPendingRouters
+      /**
+       * Memoize the init work and only remove the pending router after it finishes,
+       * so concurrent requests share a single init instead of re-initializing
+       * the same router or dropping pending routers pushed by each other.
+       */
+      pendingRouter.initPromise ??= unlazy(pendingRouter.router).then(({ default: router }) => {
+        this.init(router, pendingRouter.path)
+        this.pendingRouters.splice(this.pendingRouters.indexOf(pendingRouter), 1)
+      }).catch((error) => {
+        pendingRouter.initPromise = undefined // allow retrying on failure
+        throw error
+      })
+
+      await pendingRouter.initPromise
     }
 
     const match = findRoute(this.tree, method, pathname)

--- a/packages/server/src/adapters/standard/rpc-matcher.test.ts
+++ b/packages/server/src/adapters/standard/rpc-matcher.test.ts
@@ -169,6 +169,157 @@ describe('standardRPCMatcher', () => {
     expect(pongLoader).toHaveBeenCalledTimes(4)
   })
 
+  it('lazy router inside lazy router with concurrent requests', async () => {
+    const base = os.$context<any>()
+
+    let resolveNested!: (value: { default: any }) => void
+    const nestedLoader = vi.fn(() => new Promise<{ default: any }>((resolve) => {
+      resolveNested = resolve
+    }))
+    const pingLoader = vi.fn(() => Promise.resolve({ default: ping }))
+
+    const rpcMatcher = new StandardRPCMatcher()
+    rpcMatcher.init(base.router({
+      pong,
+      nested: base.lazy(nestedLoader),
+    }))
+
+    const match1 = rpcMatcher.match('POST', '/nested/ping')
+    const match2 = rpcMatcher.match('POST', '/nested/ping')
+    // non-matching request should not wait for or drop pending lazy routers
+    const match3 = rpcMatcher.match('POST', '/pong')
+
+    expect(nestedLoader).toHaveBeenCalledTimes(1)
+
+    expect(await match3).toEqual({
+      path: ['pong'],
+      procedure: pong,
+    })
+
+    resolveNested({ default: { ping: base.lazy(pingLoader) } })
+
+    expect(await match1).toEqual({
+      path: ['nested', 'ping'],
+      procedure: ping,
+    })
+
+    expect(await match2).toEqual({
+      path: ['nested', 'ping'],
+      procedure: ping,
+    })
+
+    expect(nestedLoader).toHaveBeenCalledTimes(1)
+    expect(pingLoader).toHaveBeenCalledTimes(1)
+
+    // subsequent requests still work without reloading
+    expect(await rpcMatcher.match('POST', '/nested/ping')).toEqual({
+      path: ['nested', 'ping'],
+      procedure: ping,
+    })
+
+    expect(nestedLoader).toHaveBeenCalledTimes(1)
+    expect(pingLoader).toHaveBeenCalledTimes(1)
+  })
+
+  it('multiple lazy routers with lazy router inside lazy router', async () => {
+    const base = os.$context<any>()
+
+    const userFindLoader = vi.fn(() => Promise.resolve({ default: ping }))
+    const userListLoader = vi.fn(() => Promise.resolve({ default: pong }))
+    const usersLoader = vi.fn(() => Promise.resolve({
+      default: {
+        find: base.lazy(userFindLoader),
+        list: base.lazy(userListLoader),
+      },
+    }))
+
+    const planetDeepLoader = vi.fn(() => Promise.resolve({ default: ping }))
+    const planetNestedLoader = vi.fn(() => Promise.resolve({
+      default: {
+        deep: base.lazy(planetDeepLoader),
+      },
+    }))
+    const planetsLoader = vi.fn(() => Promise.resolve({
+      default: {
+        nested: base.lazy(planetNestedLoader),
+        pong,
+      },
+    }))
+
+    const unusedLoader = vi.fn(() => Promise.resolve({ default: ping }))
+
+    const rpcMatcher = new StandardRPCMatcher()
+    rpcMatcher.init(base.router({
+      users: base.lazy(usersLoader),
+      planets: base.lazy(planetsLoader),
+      unused: base.lazy(unusedLoader),
+    }))
+
+    // concurrent requests across different lazy branches
+    const [match1, match2, match3] = await Promise.all([
+      rpcMatcher.match('POST', '/users/find'),
+      rpcMatcher.match('POST', '/planets/nested/deep'),
+      rpcMatcher.match('POST', '/planets/pong'),
+    ])
+
+    expect(match1).toEqual({
+      path: ['users', 'find'],
+      procedure: ping,
+    })
+
+    expect(match2).toEqual({
+      path: ['planets', 'nested', 'deep'],
+      procedure: ping,
+    })
+
+    expect(match3).toEqual({
+      path: ['planets', 'pong'],
+      procedure: pong,
+    })
+
+    expect(usersLoader).toHaveBeenCalledTimes(1)
+    expect(userFindLoader).toHaveBeenCalledTimes(1)
+    expect(planetsLoader).toHaveBeenCalledTimes(1)
+    expect(planetNestedLoader).toHaveBeenCalledTimes(1)
+    expect(planetDeepLoader).toHaveBeenCalledTimes(1)
+
+    // routers not matched by any request stay lazy
+    expect(userListLoader).toHaveBeenCalledTimes(0)
+    expect(unusedLoader).toHaveBeenCalledTimes(0)
+
+    // remaining pending routers still resolvable afterwards
+    expect(await rpcMatcher.match('POST', '/users/list')).toEqual({
+      path: ['users', 'list'],
+      procedure: pong,
+    })
+
+    expect(usersLoader).toHaveBeenCalledTimes(1)
+    expect(userListLoader).toHaveBeenCalledTimes(1)
+    expect(unusedLoader).toHaveBeenCalledTimes(0)
+  })
+
+  it('lazy router can retry after loader failure', async () => {
+    const base = os.$context<any>()
+
+    const pingLoader = vi.fn()
+      .mockRejectedValueOnce(new Error('loader failed'))
+      .mockResolvedValueOnce({ default: ping })
+
+    const rpcMatcher = new StandardRPCMatcher()
+    rpcMatcher.init(base.router({
+      ping: base.lazy(pingLoader),
+    }))
+
+    await expect(rpcMatcher.match('POST', '/ping')).rejects.toThrow('loader failed')
+
+    expect(await rpcMatcher.match('POST', '/ping')).toEqual({
+      path: ['ping'],
+      procedure: ping,
+    })
+
+    expect(pingLoader).toHaveBeenCalledTimes(2)
+  })
+
   it('filter procedures', async () => {
     const rpcMatcher = new StandardRPCMatcher({
       filter: (options) => {

--- a/packages/server/src/adapters/standard/rpc-matcher.ts
+++ b/packages/server/src/adapters/standard/rpc-matcher.ts
@@ -34,7 +34,10 @@ export class StandardRPCMatcher implements StandardMatcher {
     }
   > = new NullProtoObj()
 
-  private pendingRouters: (LazyTraverseContractProceduresOptions & { httpPathPrefix: HTTPPath }) [] = []
+  private readonly pendingRouters: (LazyTraverseContractProceduresOptions & {
+    httpPathPrefix: HTTPPath
+    initPromise?: Promise<void>
+  }) [] = []
 
   constructor(options: StandardRPCMatcherOptions = {}) {
     this.filter = options.filter ?? true
@@ -75,20 +78,33 @@ export class StandardRPCMatcher implements StandardMatcher {
   }
 
   async match(_method: string, pathname: HTTPPath): Promise<StandardMatchResult> {
-    if (this.pendingRouters.length) {
-      const newPendingRouters: typeof this.pendingRouters = []
+    /**
+     * Resolve pending routers one at a time and re-scan after each, so lazy routers
+     * nested inside a just-initialized lazy router are also picked up.
+     */
+    while (true) {
+      const pendingRouter = this.pendingRouters.find(
+        pendingRouter => pathname.startsWith(pendingRouter.httpPathPrefix),
+      )
 
-      for (const pendingRouter of this.pendingRouters) {
-        if (pathname.startsWith(pendingRouter.httpPathPrefix)) {
-          const { default: router } = await unlazy(pendingRouter.router)
-          this.init(router, pendingRouter.path)
-        }
-        else {
-          newPendingRouters.push(pendingRouter)
-        }
+      if (!pendingRouter) {
+        break
       }
 
-      this.pendingRouters = newPendingRouters
+      /**
+       * Memoize the init work and only remove the pending router after it finishes,
+       * so concurrent requests share a single init instead of re-initializing
+       * the same router or dropping pending routers pushed by each other.
+       */
+      pendingRouter.initPromise ??= unlazy(pendingRouter.router).then(({ default: router }) => {
+        this.init(router, pendingRouter.path)
+        this.pendingRouters.splice(this.pendingRouters.indexOf(pendingRouter), 1)
+      }).catch((error) => {
+        pendingRouter.initPromise = undefined // allow retrying on failure
+        throw error
+      })
+
+      await pendingRouter.initPromise
     }
 
     const match = this.tree[pathname]


### PR DESCRIPTION
## Problem

When multiple requests hit the server at the same time while a lazy router was still loading, the matchers (`StandardRPCMatcher` and `StandardOpenAPIMatcher`) could:

- Invoke the same lazy loader multiple times, once per concurrent request.
- Lose routes entirely when a lazy router contained another lazy router — the nested route could then 404 permanently, even for later requests.

## Fix

Concurrent requests now share a single load per lazy router: each loader runs exactly once, requests arriving mid-load wait for it instead of reloading or missing the route, and nested lazy routers always resolve correctly. If a loader fails, the request rejects and the next request retries as before.

## Tests

New tests in both matchers cover concurrent requests to lazy routers, lazy routers nested inside lazy routers (up to three levels), multiple lazy branches matched in parallel, and retry after loader failure. All of them fail on the previous implementation. Full `server` and `openapi` suites pass (808 tests).