### PR TITLE
fix(standard-server): avoid quadratic EventDecoder.feed on large events

### DIFF
--- a/packages/standard-server/src/event-iterator/decoder.test.ts
+++ b/packages/standard-server/src/event-iterator/decoder.test.ts
@@ -158,6 +158,44 @@ describe('eventDecoder', () => {
       comments: [],
     })
   })
+
+  it('decodes identically no matter how a message is split across feed calls', () => {
+    const full = 'id: 1\nevent: a\ndata: {"x":1}\n\nid: 2\nevent: b\ndata: {"x":2}\n\nid: 3\nevent: c\ndata: {"x":3}\n\n'
+
+    for (const chunkSize of [1, 2, 3, 7, 1000]) {
+      const onEvent = vi.fn()
+      const decoder = new EventDecoder({ onEvent })
+
+      for (let i = 0; i < full.length; i += chunkSize) {
+        decoder.feed(full.slice(i, i + chunkSize))
+      }
+      decoder.end()
+
+      expect(onEvent.mock.calls.map(([event]) => event.id)).toEqual(['1', '2', '3'])
+    }
+  })
+
+  it('decodes a large single event fed in many small chunks, and stays fast doing it', () => {
+    const onEvent = vi.fn()
+    const decoder = new EventDecoder({ onEvent })
+
+    // Regression test for a quadratic-time bug: the previous implementation
+    // buffered chunks into one growing string and re-scanned the whole thing
+    // on every feed(), which made decoding a single large event O(n^2) in its
+    // size. A 6MB event fed in 64-byte chunks took minutes under that
+    // implementation; this must complete well within the test timeout.
+    const chunk = 'x'.repeat(64)
+    const chunkCount = Math.floor((6 * 1024 * 1024) / chunk.length)
+
+    for (let i = 0; i < chunkCount; i++) {
+      decoder.feed(chunk)
+    }
+    decoder.feed('\n\n')
+    decoder.end()
+
+    expect(onEvent).toHaveBeenCalledTimes(1)
+    expect(onEvent.mock.calls[0][0].comments).toEqual([])
+  }, 2000)
 })
 
 describe('eventDecoderStream', () => {

--- a/packages/standard-server/src/event-iterator/decoder.ts
+++ b/packages/standard-server/src/event-iterator/decoder.ts
@@ -53,23 +53,67 @@ export interface EventDecoderOptions {
   onEvent?: (event: EventMessage) => void
 }
 
+/**
+ * Buffers incoming SSE chunks and emits a decoded {@link EventMessage} for
+ * each complete `\n\n`-terminated event.
+ *
+ * Chunks are kept in an array rather than concatenated into one string.
+ * `'\n\n'` is 2 characters, so it can only appear (a) inside one incoming
+ * chunk, or (b) split exactly across the boundary between the previous
+ * chunk's last character and this chunk's first — never spanning 3+ chunks.
+ * So each `feed` only needs to check the new chunk (bounded by that chunk's
+ * own size) plus one carried-over character, not the buffered backlog.
+ * `chunks.join('')` — the only operation whose cost depends on the backlog
+ * size — runs once per completed event rather than once per chunk.
+ *
+ * The previous implementation kept a single growing string (`incomplete +=
+ * chunk`) and called `incomplete.lastIndexOf('\n\n')` on every `feed`. That
+ * search is O(n) in the buffered length so far, and for one large event
+ * delivered across many small chunks — no `'\n\n'` appears until the event
+ * completes — every intermediate call pays that O(n) cost just to confirm
+ * absence, making the whole decode O(n^2) in that event's size. A `fromIndex`
+ * does not fix it either: a string built by repeated `+=` is represented as a
+ * rope (V8's ConsString), and any read forces reflattening the whole rope
+ * regardless of where the search starts.
+ */
 export class EventDecoder {
-  private incomplete: string = ''
+  private chunks: string[] = []
+  private chunksLength = 0
+  private lastChar = ''
 
   constructor(private options: EventDecoderOptions = {}) {
   }
 
   feed(chunk: string): void {
-    this.incomplete += chunk
-
-    const lastCompleteIndex = this.incomplete.lastIndexOf('\n\n')
-
-    if (lastCompleteIndex === -1) {
+    if (chunk.length === 0) {
       return
     }
 
-    const completes = this.incomplete.slice(0, lastCompleteIndex).split(/\n\n/)
-    this.incomplete = this.incomplete.slice(lastCompleteIndex + 2)
+    const boundaryDelimiter = this.lastChar === '\n' && chunk.charCodeAt(0) === 10
+    const hasDelimiterInChunk = chunk.includes('\n\n')
+
+    this.chunks.push(chunk)
+    this.chunksLength += chunk.length
+    this.lastChar = chunk.slice(-1)
+
+    if (!boundaryDelimiter && !hasDelimiterInChunk) {
+      return
+    }
+
+    const incomplete = this.chunks.join('')
+    const lastCompleteIndex = incomplete.lastIndexOf('\n\n')
+
+    if (lastCompleteIndex === -1) {
+      this.chunks = [incomplete]
+      return
+    }
+
+    const completes = incomplete.slice(0, lastCompleteIndex).split(/\n\n/)
+    const remainder = incomplete.slice(lastCompleteIndex + 2)
+
+    this.chunks = remainder.length > 0 ? [remainder] : []
+    this.chunksLength = remainder.length
+    this.lastChar = remainder.slice(-1)
 
     for (const encoded of completes) {
       const message = decodeEventMessage(`${encoded}\n\n`)
@@ -81,7 +125,7 @@ export class EventDecoder {
   }
 
   end(): void {
-    if (this.incomplete) {
+    if (this.chunksLength > 0) {
       throw new EventDecoderError('Event Iterator ended before complete')
     }
   }


### PR DESCRIPTION
## What

`EventDecoder.feed()` is O(n²) in the size of a single event when that event arrives across many small chunks.

## Why

`feed()` buffers incoming chunks into one growing string and checks for a complete event with `this.incomplete.lastIndexOf('\n\n')` on every call:

```ts
feed(chunk: string): void {
  this.incomplete += chunk
  const lastCompleteIndex = this.incomplete.lastIndexOf('\n\n')
  if (lastCompleteIndex === -1) {
    return
  }
  ...
}
```

For one large event delivered across many small chunks — no `\n\n` appears until the event completes — every intermediate call re-scans the *entire* buffered string just to confirm the delimiter is still absent. That's O(n) work per call, repeated once per chunk, so the total cost is O(n²) in the event's size.

Measured on the current release (`@orpc/standard-server@1.14.8`, and reproduced identically against `1.14.10`, the latest 1.x release): a single 6MB event fed in 64-byte chunks (~98k `feed()` calls) took **several minutes** and pinned a Node process's CPU at ~100% the whole time. This is exactly the shape of workload a proxy relaying another server's SSE stream produces — I hit this in production relaying an upstream agent's event stream through oRPC's typed client.

I want to flag one thing explicitly, since it's the natural first fix to reach for and it **doesn't work**: adding a search offset to `lastIndexOf` (searching forward from where the previous scan left off, instead of backward from the end every time) does **not** fix this. I tried it first. A string built by repeated `+=` is represented by V8 as a `ConsString` (a rope), and any read operation — `indexOf`, `lastIndexOf`, even a `fromIndex`-bounded one — forces reflattening the *whole* rope first, regardless of where the search itself starts. The offset narrows the search but not the mandatory reflatten underneath it, so the cost stays quadratic.

## Fix

Buffer chunks in an array instead of concatenating into one string. `'\n\n'` is 2 characters, so it can only ever appear (a) inside a single incoming chunk, or (b) split exactly across the boundary between the previous chunk's last character and the new chunk's first — never spanning 3+ chunks. So each `feed()` call only needs to check the *new* chunk (bounded by that chunk's own size) plus one carried-over character, never the accumulated backlog.

`chunks.join('')` — the only operation whose cost depends on the backlog size — now runs exactly once per *completed* event, rather than once per chunk. Total cost across a stream becomes O(bytes received), not O(bytes²).

Same 6MB/64-byte-chunk case now completes in single-digit milliseconds.

## Testing

- Added a test across 5 different chunk-size splits (1, 2, 3, 7, 1000 bytes) of a 3-event message, including sizes that land a split exactly on the `\n\n` delimiter itself — decoded output is identical regardless of how the bytes are chunked.
- Added the 6MB/64-byte-chunk regression case with a 2000ms test timeout — comfortably passes now (actual runtime is a few ms); would have taken minutes and timed out under the previous implementation.
- The existing `'on success with mixed chunks'` test (explicitly commented `NOTE: a chunk contain 1,5 events is important test, carefully when modify`) still passes unchanged — multiple ready events arriving in a single `feed()` call, including a chunk boundary landing mid-event, still batch and decode correctly.
- `pnpm --filter @orpc/standard-server type:check` (`tsc -b`) — clean.
- `pnpm vitest run packages/standard-server/src/event-iterator/decoder.test.ts` — 11/11 pass.
- `pnpm vitest run packages/standard-server` — no new failures (32/35 files, matching main branch exactly).
- I also ran the broader `packages/standard-server-peer` suite, unrelated to this change, and noticed it's flaky independent of this patch — the specific FormData/file tests that fail vary between identical runs (13, then 9, then 11 failures across 3 back-to-back runs with zero code changes). Flagging in case it's useful, but did not investigate further since it's out of scope here.
- Committed via the repo's own pre-commit hook (lint-staged, `eslint --max-warnings=0`) — passed clean.

Based against `1.x` (not `main`) since the affected code and the version I reproduced this against (1.14.8, confirmed still present in 1.14.10) are both on the 1.x line.
