### PR TITLE
fix: treat headers like query and params

### DIFF
--- a/packages/openapi/src/adapters/standard/openapi-handler-codec.test.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler-codec.test.ts
@@ -692,8 +692,14 @@ describe('openAPIHandlerCodec', () => {
       })
 
       it('uses explicit status and headers from output', () => {
+        const body = { ok: true }
         const serializer = {
-          serialize: vi.fn().mockReturnValueOnce('__serialized_body__'),
+          serialize: vi.fn().mockImplementation((data) => {
+            if (data === body) {
+              return '__serialized_body__'
+            }
+            return data
+          }),
           deserialize: vi.fn(),
         } as any
 
@@ -703,7 +709,7 @@ describe('openAPIHandlerCodec', () => {
         const response = codec.encodeOutput({
           status: 202,
           headers: { 'x-custom': 'value' },
-          body: { ok: true },
+          body,
         }, procedure, [])
 
         expect(response).toEqual({
@@ -717,7 +723,7 @@ describe('openAPIHandlerCodec', () => {
         ['non-object output', '__invalid__'],
         ['status outside the allowed range', { status: 500 }],
         ['extra keys', { body: 'ok', extra: true }],
-        ['invalid headers', { headers: { 'x-invalid': 123 } }],
+        ['invalid headers', { headers: 'x-invalid' }],
       ])('throws for invalid output: %s', (_, output) => {
         const procedure = os.meta(openapi({ outputStructure: 'detailed' })).handler(vi.fn())
         const codec = new OpenAPIHandlerCodec(procedure)

--- a/packages/openapi/src/adapters/standard/openapi-handler-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler-codec.ts
@@ -8,11 +8,12 @@ import type { OpenAPIMatcherOptions } from './openapi-matcher'
 import { COMMON_ERROR_STATUS_MAP } from '@orpc/client'
 import { DEFAULT_ERROR_STATUS, DEFAULT_SUCCESS_STATUS } from '@orpc/server'
 import { isPlainObject, isTypescriptObject, NullProtoObj, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
-import { isStandardHeaders, parseStandardUrl } from '@standardserver/core'
+import { parseStandardUrl } from '@standardserver/core'
 import {
   DEFAULT_OPENAPI_INPUT_STRUCTURE,
   DEFAULT_OPENAPI_OUTPUT_STRUCTURE,
 } from '../../constants'
+import { serializeHeaders } from '../../helpers/serialize-headers'
 import { getOpenAPIMeta } from '../../meta'
 import { OpenAPISerializer } from '../../openapi-serializer'
 import { isBodylessMethod } from '../../utils'
@@ -119,7 +120,7 @@ export class OpenAPIHandlerCodecCore<T extends Context> {
         Invalid "detailed" output structure returned by procedure (${path.join('.')}):
         • Expected an object with optional properties:
           - status (number 200-399)
-          - headers (Record<string, string | string[] | undefined>)
+          - headers (object)
           - body (any)
         • No extra keys allowed.
 
@@ -130,7 +131,7 @@ export class OpenAPIHandlerCodecCore<T extends Context> {
 
     return {
       status: output.status ?? successStatus,
-      headers: output.headers ?? {},
+      headers: output.headers ? serializeHeaders(output.headers, this.serializer) : {},
       body: this.serializer.serialize(output.body),
     }
   }
@@ -292,7 +293,7 @@ function isValidDetailedOutput(output: unknown): output is { status?: number, bo
     return false
   }
 
-  if (output.headers !== undefined && !isStandardHeaders(output.headers)) {
+  if (output.headers !== undefined && !isTypescriptObject(output.headers)) {
     return false
   }
 

--- a/packages/openapi/src/adapters/standard/openapi-link-codec.test.ts
+++ b/packages/openapi/src/adapters/standard/openapi-link-codec.test.ts
@@ -540,6 +540,57 @@ describe('openAPILinkCodec', () => {
       })
     })
 
+    describe('headers serialization', () => {
+      it('serializes raw headers into correct standard headers', async () => {
+        const codec = new OpenAPILinkCodec({
+          headers: oc.meta(openapi({
+            method: 'GET',
+            inputStructure: 'detailed',
+          })),
+        }, { url: '/api', serializer })
+
+        const request = await codec.encodeInput({
+          headers: {
+            'x-version': 2,
+            'x-array': [1, '2', false],
+            'x-obj': { a: 1, b: 'test', field: true },
+            'x-null': null,
+            'x-undefined': undefined,
+          },
+        }, ['headers'], { context: {} })
+
+        expect(request.headers['x-version']).toEqual('2')
+        expect(request.headers['x-array']).toEqual(['1', '2', 'false'])
+        expect(request.headers['x-obj']).toEqual([
+          'a',
+          '1',
+          'b',
+          'test',
+          'field',
+          'true',
+        ])
+        expect('x-null' in request.headers).toBe(false)
+        expect('x-undefined' in request.headers).toBe(false)
+      })
+
+      it('handles present headers correctly', async () => {
+        const codec = new OpenAPILinkCodec({
+          headers: oc.meta(openapi({
+            method: 'GET',
+            inputStructure: 'detailed',
+          })),
+        }, { url: '/api', headers: { 'x-version': '1' }, serializer })
+
+        const request = await codec.encodeInput({
+          headers: {
+            'x-version': 2,
+          },
+        }, ['headers'], { context: {} })
+
+        expect(request.headers['x-version']).toEqual(['1', '2'])
+      })
+    })
+
     describe('option handling', () => {
       it('accepts Headers instances for base headers', async () => {
         const codec = new OpenAPILinkCodec({

--- a/packages/openapi/src/adapters/standard/openapi-link-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-link-codec.ts
@@ -8,13 +8,14 @@ import { createORPCErrorFromJson, isORPCErrorJson, ORPCError } from '@orpc/clien
 import { getRouterContract, ProcedureContract } from '@orpc/contract'
 import { unlazy } from '@orpc/server'
 import { isTypescriptObject, mergeHttpPath, pathToHttpPath, stringifyJSON, value } from '@orpc/shared'
-import { isStandardHeaders, mergeStandardHeaders, parseStandardUrl } from '@standardserver/core'
+import { mergeStandardHeaders, parseStandardUrl } from '@standardserver/core'
 import { toStandardHeaders } from '@standardserver/fetch'
 import {
   DEFAULT_OPENAPI_INPUT_STRUCTURE,
   DEFAULT_OPENAPI_METHOD,
   DEFAULT_OPENAPI_OUTPUT_STRUCTURE,
 } from '../../constants'
+import { serializeHeaders } from '../../helpers/serialize-headers'
 import { getOpenAPIMeta } from '../../meta'
 import { OpenAPISerializer } from '../../openapi-serializer'
 import { getDynamicPathParams, isBodylessMethod } from '../../utils'
@@ -143,7 +144,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
         • Expected an object or undefined with optional properties:
           - params (object, required when the path has dynamic params)
           - query (object)
-          - headers (Record<string, string | string[] | undefined>)
+          - headers (object)
           - body (any)
 
         Actual value:
@@ -167,7 +168,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
     }
 
     if (input?.headers) {
-      headers = mergeStandardHeaders(headers, input.headers)
+      headers = mergeStandardHeaders(headers, serializeHeaders(input.headers, this.serializer))
     }
 
     pathname = `${basePathname.replace(END_SLASH_REGEX, '')}${pathname}` as `/${string}`
@@ -484,7 +485,7 @@ function isValidDetailedInput(
     return false
   }
 
-  if (input.headers !== undefined && !isStandardHeaders(input.headers)) {
+  if (input.headers !== undefined && !isTypescriptObject(input.headers)) {
     return false
   }
 

--- a/packages/openapi/src/helpers/serialize-headers.test.ts
+++ b/packages/openapi/src/helpers/serialize-headers.test.ts
@@ -1,0 +1,19 @@
+import { OpenAPISerializer } from '../openapi-serializer'
+import { serializeHeaders } from './serialize-headers'
+
+it('serializes headers correctly', () => {
+  const serializer = new OpenAPISerializer()
+  expect(serializeHeaders({}, serializer)).toEqual({})
+
+  expect(serializeHeaders({
+    'x-version': 2,
+    'x-array': [1, '2', false],
+    'x-obj': { a: 1, b: 'test', field: true },
+    'x-null': null,
+    'x-undefined': undefined,
+  }, serializer)).toEqual({
+    'x-version': '2',
+    'x-array': ['1', '2', 'false'],
+    'x-obj': ['a', '1', 'b', 'test', 'field', 'true'],
+  })
+})

--- a/packages/openapi/src/helpers/serialize-headers.ts
+++ b/packages/openapi/src/helpers/serialize-headers.ts
@@ -1,0 +1,47 @@
+import type { StandardHeaders } from '@standardserver/core'
+import type { OpenAPISerializer } from '../openapi-serializer'
+import { isTypescriptObject } from '@standardserver/shared'
+
+export function serializeHeaders(data: unknown, serializer: Pick<OpenAPISerializer, keyof OpenAPISerializer>): StandardHeaders {
+  const headers: StandardHeaders = {}
+
+  if (!isTypescriptObject(data)) {
+    return headers
+  }
+
+  const appendHeadersValue = (key: string, value: string | string[] | undefined) => {
+    if (headers[key]) {
+      headers[key] = [headers[key], value].flat()
+    }
+    else {
+      headers[key] = value
+    }
+  }
+
+  Object.entries(data).forEach(([key, value]) => {
+    if (Array.isArray(value)) {
+      const serializedArray = value
+        .map(val => serializer.serialize(val))
+        .filter(val => val !== undefined && val !== null)
+        .map(val => String(val))
+
+      appendHeadersValue(key, serializedArray)
+    }
+    else if (isTypescriptObject(value)) {
+      const serializedObject = Object.entries(value)
+        .map(([key, val]) => [key, serializer.serialize(val)])
+        .filter(([, val]) => val !== undefined && val !== null)
+        .map(([key, val]) => [String(key), String(val)])
+
+      serializedObject.forEach(val => appendHeadersValue(key, val))
+    }
+    else {
+      const serialized = serializer.serialize(value)
+      if (serialized !== undefined && serialized !== null) {
+        appendHeadersValue(key, String(serialized))
+      }
+    }
+  })
+
+  return headers
+}

--- a/packages/openapi/src/helpers/serialize-headers.ts
+++ b/packages/openapi/src/helpers/serialize-headers.ts
@@ -1,6 +1,6 @@
 import type { StandardHeaders } from '@standardserver/core'
 import type { OpenAPISerializer } from '../openapi-serializer'
-import { isTypescriptObject } from '@standardserver/shared'
+import { isTypescriptObject } from '@orpc/shared'
 
 function appendHeadersValue(headers: StandardHeaders, key: string, value: string | string[] | undefined) {
   if (headers[key]) {
@@ -18,27 +18,27 @@ export function serializeHeaders(data: unknown, serializer: Pick<OpenAPISerializ
     return headers
   }
 
-  Object.entries(data).forEach(([key, value]) => {
-    if (Array.isArray(value)) {
-      const serializedArray = value
+  Object.entries(data).forEach(([dataKey, dataValue]) => {
+    if (Array.isArray(dataValue)) {
+      const serializedArray = dataValue
         .map(val => serializer.serialize(val))
         .filter(val => val !== undefined && val !== null)
         .map(val => String(val))
 
-      appendHeadersValue(headers, key, serializedArray)
+      appendHeadersValue(headers, dataKey, serializedArray)
     }
-    else if (isTypescriptObject(value)) {
-      const serializedObject = Object.entries(value)
+    else if (isTypescriptObject(dataValue)) {
+      const serializedObject = Object.entries(dataValue)
         .map(([key, val]) => [key, serializer.serialize(val)])
         .filter(([, val]) => val !== undefined && val !== null)
         .map(([key, val]) => [String(key), String(val)])
 
-      serializedObject.forEach(val => appendHeadersValue(headers, key, val))
+      serializedObject.forEach(val => appendHeadersValue(headers, dataKey, val))
     }
     else {
-      const serialized = serializer.serialize(value)
+      const serialized = serializer.serialize(dataValue)
       if (serialized !== undefined && serialized !== null) {
-        appendHeadersValue(headers, key, String(serialized))
+        appendHeadersValue(headers, dataKey, String(serialized))
       }
     }
   })

--- a/packages/openapi/src/helpers/serialize-headers.ts
+++ b/packages/openapi/src/helpers/serialize-headers.ts
@@ -2,20 +2,20 @@ import type { StandardHeaders } from '@standardserver/core'
 import type { OpenAPISerializer } from '../openapi-serializer'
 import { isTypescriptObject } from '@standardserver/shared'
 
+function appendHeadersValue(headers: StandardHeaders, key: string, value: string | string[] | undefined) {
+  if (headers[key]) {
+    headers[key] = [headers[key], value].flat()
+  }
+  else {
+    headers[key] = value
+  }
+}
+
 export function serializeHeaders(data: unknown, serializer: Pick<OpenAPISerializer, keyof OpenAPISerializer>): StandardHeaders {
   const headers: StandardHeaders = {}
 
   if (!isTypescriptObject(data)) {
     return headers
-  }
-
-  const appendHeadersValue = (key: string, value: string | string[] | undefined) => {
-    if (headers[key]) {
-      headers[key] = [headers[key], value].flat()
-    }
-    else {
-      headers[key] = value
-    }
   }
 
   Object.entries(data).forEach(([key, value]) => {
@@ -25,7 +25,7 @@ export function serializeHeaders(data: unknown, serializer: Pick<OpenAPISerializ
         .filter(val => val !== undefined && val !== null)
         .map(val => String(val))
 
-      appendHeadersValue(key, serializedArray)
+      appendHeadersValue(headers, key, serializedArray)
     }
     else if (isTypescriptObject(value)) {
       const serializedObject = Object.entries(value)
@@ -33,12 +33,12 @@ export function serializeHeaders(data: unknown, serializer: Pick<OpenAPISerializ
         .filter(([, val]) => val !== undefined && val !== null)
         .map(([key, val]) => [String(key), String(val)])
 
-      serializedObject.forEach(val => appendHeadersValue(key, val))
+      serializedObject.forEach(val => appendHeadersValue(headers, key, val))
     }
     else {
       const serialized = serializer.serialize(value)
       if (serialized !== undefined && serialized !== null) {
-        appendHeadersValue(key, String(serialized))
+        appendHeadersValue(headers, key, String(serialized))
       }
     }
   })


### PR DESCRIPTION
Fixes: https://github.com/middleapi/orpc/issues/1739

Headers can now contain primitive values similar to `query` and `param`, which are then "serialized" to a `StandardHeaders` object.