### PR TITLE
fix(standard-server): make event iterator encoder/decoder SSE spec compliant

### DIFF
--- a/packages/standard-server/src/event-iterator/decoder.test.ts
+++ b/packages/standard-server/src/event-iterator/decoder.test.ts
@@ -1,6 +1,19 @@
 import type { EventMessage } from './types'
 import { decodeEventMessage, EventDecoder, EventDecoderStream } from './decoder'
 
+function feedAll(chunks: string[]): EventMessage[] {
+  const events: EventMessage[] = []
+  const decoder = new EventDecoder({ onEvent: event => events.push(event) })
+
+  for (const chunk of chunks) {
+    decoder.feed(chunk)
+  }
+
+  decoder.end()
+
+  return events
+}
+
 describe('decodeEventMessage', () => {
   it('on success', () => {
     expect(decodeEventMessage('\n')).toEqual({
@@ -45,10 +58,37 @@ describe('decodeEventMessage', () => {
       data: ' hello\n world',
       comments: [' hi'],
     })
+
+    // Per spec, only a single U+0020 SPACE is stripped — not tabs.
+    expect(decodeEventMessage('data:\thello\n\n')).toEqual({
+      data: '\thello',
+      comments: [],
+    })
+  })
+
+  it('supports LF, CR, and CRLF line endings', () => {
+    expect(decodeEventMessage('event: message\rdata: hello\r\ndata: world\rid: 123\r\nretry: 10000\r\r\n')).toEqual({
+      event: 'message',
+      data: 'hello\nworld',
+      id: '123',
+      retry: 10000,
+      comments: [],
+    })
+  })
+
+  it('treats lines without a colon as fields with empty values', () => {
+    expect(decodeEventMessage('data\n\n')).toEqual({ data: '', comments: [] })
+    expect(decodeEventMessage('data:\n\n')).toEqual({ data: '', comments: [] })
+    expect(decodeEventMessage('data: a\ndata:\ndata: b\n\n')).toEqual({ data: 'a\n\nb', comments: [] })
+    expect(decodeEventMessage('event\ndata: x\n\n')).toEqual({ event: '', data: 'x', comments: [] })
   })
 
   it('unknown keys', () => {
     expect(decodeEventMessage('foo: bar\n\n')).toEqual({
+      comments: [],
+    })
+
+    expect(decodeEventMessage('Data: x\nEVENT: y\n\n')).toEqual({
       comments: [],
     })
   })
@@ -61,6 +101,11 @@ describe('decodeEventMessage', () => {
   })
 
   it('invalid retry', () => {
+    expect(decodeEventMessage('retry: 0\n\n')).toEqual({
+      retry: 0,
+      comments: [],
+    })
+
     expect(decodeEventMessage('retry: hello\n\n')).toEqual({
       comments: [],
     })
@@ -78,6 +123,19 @@ describe('decodeEventMessage', () => {
     })
 
     expect(decodeEventMessage('retry: Infinity\n\n')).toEqual({
+      comments: [],
+    })
+
+    expect(decodeEventMessage('retry: 010\n\n')).toEqual({
+      comments: [],
+    })
+
+    expect(decodeEventMessage('retry: +10\n\n')).toEqual({
+      comments: [],
+    })
+
+    // extra space survives the single-space strip
+    expect(decodeEventMessage('retry:  10\n\n')).toEqual({
       comments: [],
     })
   })
@@ -137,6 +195,121 @@ describe('eventDecoder', () => {
       retry: 10000,
       comments: [],
     })
+  })
+
+  it('ignores empty chunks', () => {
+    expect(feedAll(['', 'data: hello', '', '\n\n', ''])).toEqual([
+      { data: 'hello', comments: [] },
+    ])
+  })
+
+  it('emits the same events regardless of chunk size', () => {
+    const stream = 'event: a\r\ndata: 1\r\n\r\n: comment\ndata: 2\ndata: 3\n\nid: 9\rretry: 50\rdata: 4\r\revent: done\ndata: bye\n\n'
+
+    const expected = feedAll([stream])
+    expect(expected).toHaveLength(4)
+
+    for (const size of [1, 2, 3, 4, 5, 7, 11]) {
+      const chunks: string[] = []
+      for (let i = 0; i < stream.length; i += size) {
+        chunks.push(stream.slice(i, i + size))
+      }
+
+      expect(feedAll(chunks), `chunk size ${size}`).toEqual(expected)
+    }
+  })
+
+  it('decodes a large message fed in many small chunks', () => {
+    const value = 'x'.repeat(64 * 1024)
+    const stream = `event: big\ndata: ${value}\ndata: ${value}\n\n`
+
+    const chunks: string[] = []
+    for (let i = 0; i < stream.length; i += 251) {
+      chunks.push(stream.slice(i, i + 251))
+    }
+
+    expect(feedAll(chunks)).toEqual([
+      { event: 'big', data: `${value}\n${value}`, comments: [] },
+    ])
+  })
+
+  it('handles every delimiter split at every position', () => {
+    for (const delimiter of ['\n\n', '\r\r', '\n\r', '\n\r\n', '\r\n\n', '\r\n\r\n']) {
+      const stream = `data: first${delimiter}data: second${delimiter}`
+
+      for (let split = 1; split < stream.length; split++) {
+        const events = feedAll([stream.slice(0, split), stream.slice(split)])
+
+        expect(events, `delimiter ${JSON.stringify(delimiter)} split at ${split}`).toEqual([
+          { data: 'first', comments: [] },
+          { data: 'second', comments: [] },
+        ])
+      }
+    }
+  })
+
+  it('handles CR & CRLF delimiters', () => {
+    const events = feedAll([
+      'event: message\rdata: hello\r\ndata: world\r',
+      '\r\nevent: done\r',
+      'data: bye\r\n\r',
+    ])
+
+    expect(events).toEqual([
+      { event: 'message', data: 'hello\nworld', comments: [] },
+      { event: 'done', data: 'bye', comments: [] },
+    ])
+  })
+
+  it('handles CRLF line endings split across chunks', () => {
+    const events = feedAll([
+      'event: message\r',
+      '\ndata: hello\r',
+      '\ndata: world\r',
+      '\n\r',
+      '\n',
+      'event: done\rdata: bye\r\r',
+    ])
+
+    expect(events).toEqual([
+      { event: 'message', data: 'hello\nworld', comments: [] },
+      { event: 'done', data: 'bye', comments: [] },
+    ])
+  })
+
+  it('keeps the CRLF discard window open across empty chunks', () => {
+    const events = feedAll([
+      'data: first\n\r',
+      '',
+      '\n\ndata: second\n\n',
+    ])
+
+    expect(events).toEqual([
+      { data: 'first', comments: [] },
+      { data: 'second', comments: [] },
+    ])
+  })
+
+  // Per spec, the '\n' completes the buffered '\r' into a single CRLF line
+  // ending, so the following '\n' is a blank line terminating the message.
+  it('handles a CRLF+LF delimiter split between the CR and LF', () => {
+    const events = feedAll([
+      'data: first\r',
+      '\n\ndata: second\n\n',
+    ])
+
+    expect(events).toEqual([
+      { data: 'first', comments: [] },
+      { data: 'second', comments: [] },
+    ])
+  })
+
+  it('does not throw when nothing was fed or the stream completed cleanly', () => {
+    const decoder = new EventDecoder()
+    expect(() => decoder.end()).not.toThrow()
+
+    decoder.feed('data: hello\n\n')
+    expect(() => decoder.end()).not.toThrow()
   })
 
   it('on incomplete message', () => {

--- a/packages/standard-server/src/event-iterator/decoder.ts
+++ b/packages/standard-server/src/event-iterator/decoder.ts
@@ -1,9 +1,20 @@
 import type { EventMessage } from './types'
 import { EventDecoderError } from './errors'
 
-export function decodeEventMessage(encoded: string): EventMessage {
-  const lines = encoded.replace(/\n+$/, '').split(/\n/)
+// A line ending is CR, LF or CRLF.
+const LINE_ENDING_REGEX = /\r\n|\r(?!\n)|\n/
+const MESSAGE_DELIMITER_REGEX = /(?:\r\n|\r(?!\n)|\n){2}/
+const MESSAGE_DELIMITER_GLOBAL_REGEX = /(?:\r\n|\r(?!\n)|\n){2}/g
 
+// A delimiter is at most 4 characters ('\r\n\r\n'), so one crossing a chunk
+// boundary must start within the last 3 characters of what came before.
+const MAX_DELIMITER_OVERLAP = 3
+
+const CR = 0x0D
+const LF = 0x0A
+const SPACE = 0x20
+
+export function decodeEventMessage(encoded: string): EventMessage {
   const message: EventMessage = {
     data: undefined,
     event: undefined,
@@ -12,39 +23,52 @@ export function decodeEventMessage(encoded: string): EventMessage {
     comments: [],
   }
 
-  for (const line of lines) {
+  for (const line of encoded.split(LINE_ENDING_REGEX)) {
+    if (line === '') {
+      continue
+    }
+
     const index = line.indexOf(':')
 
-    const key = index === -1 ? line : line.slice(0, index)
-    const value = index === -1 ? '' : line.slice(index + 1).replace(/^\s/, '')
+    // The value may be prefixed by a single space
+    // https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
+    const value = index === -1
+      ? ''
+      : line.slice(line.charCodeAt(index + 1) === SPACE ? index + 2 : index + 1)
 
-    if (index === 0) {
+    if (index === 0) { // comment starting with ':'
       message.comments.push(value)
+      continue
     }
 
-    else if (key === 'data') {
-      message.data ??= ''
-      message.data += `${value}\n`
-    }
+    switch (index === -1 ? line : line.slice(0, index)) {
+      case 'data':
+        // data can be sent in multiple lines if containing newlines
+        // https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation
+        message.data = message.data === undefined
+          ? value
+          : `${message.data}\n${value}`
+        break
 
-    else if (key === 'event') {
-      message.event = value
-    }
+      case 'event':
+        message.event = value
+        break
 
-    else if (key === 'id') {
-      message.id = value
-    }
+      case 'id':
+        message.id = value
+        break
 
-    else if (key === 'retry') {
-      const maybeInteger = Number.parseInt(value)
+      case 'retry': {
+        const maybeInteger = Number.parseInt(value, 10)
 
-      if (Number.isInteger(maybeInteger) && maybeInteger >= 0 && maybeInteger.toString() === value) {
-        message.retry = maybeInteger
+        // The round-trip check already rejects NaN, signs, padding and floats.
+        if (maybeInteger >= 0 && maybeInteger.toString() === value) {
+          message.retry = maybeInteger
+        }
+        break
       }
     }
   }
-
-  message.data = message.data?.replace(/\n$/, '')
 
   return message
 }
@@ -54,25 +78,69 @@ export interface EventDecoderOptions {
 }
 
 export class EventDecoder {
-  private incomplete: string = ''
+  private pending: string[] = []
+  // Last up-to-3 characters of the pending buffer, prefixed to the next chunk
+  // so a delimiter straddling the boundary is still found.
+  private tail: string = ''
+  // Set when a chunk-ending '\r' was already consumed as a line ending, so a
+  // leading '\n' in the next chunk is the second half of that CRLF pair.
+  private discardLeadingLF: boolean = false
 
   constructor(private options: EventDecoderOptions = {}) {
   }
 
   feed(chunk: string): void {
-    this.incomplete += chunk
-
-    const lastCompleteIndex = this.incomplete.lastIndexOf('\n\n')
-
-    if (lastCompleteIndex === -1) {
+    // empty chunk has no meaningful content to process
+    if (chunk === '') {
       return
     }
 
-    const completes = this.incomplete.slice(0, lastCompleteIndex).split(/\n\n/)
-    this.incomplete = this.incomplete.slice(lastCompleteIndex + 2)
+    if (this.discardLeadingLF) {
+      this.discardLeadingLF = false
 
-    for (const encoded of completes) {
-      const message = decodeEventMessage(`${encoded}\n\n`)
+      if (chunk.charCodeAt(0) === LF) {
+        chunk = chunk.slice(1)
+
+        // empty chunk has no meaningful content to process
+        if (chunk === '') {
+          return
+        }
+      }
+    }
+
+    const scan = this.tail + chunk
+
+    if (!MESSAGE_DELIMITER_REGEX.test(scan)) {
+      this.pending.push(chunk)
+      this.tail = scan.slice(-MAX_DELIMITER_OVERLAP)
+      return
+    }
+
+    this.pending.push(chunk)
+    const buffered = this.pending.length === 1 ? chunk : this.pending.join('')
+    const offset = buffered.length - scan.length
+
+    const parts: string[] = []
+    let start = 0
+
+    for (const match of scan.matchAll(MESSAGE_DELIMITER_GLOBAL_REGEX)) {
+      parts.push(buffered.slice(start, offset + match.index))
+      start = offset + match.index + match[0].length
+    }
+
+    const incomplete = buffered.slice(start)
+    this.pending.length = 0
+    this.tail = incomplete.slice(-MAX_DELIMITER_OVERLAP)
+
+    if (incomplete === '') {
+      this.discardLeadingLF = chunk.charCodeAt(chunk.length - 1) === CR
+    }
+    else {
+      this.pending.push(incomplete)
+    }
+
+    for (const encoded of parts) {
+      const message = decodeEventMessage(encoded)
 
       if (this.options.onEvent) {
         this.options.onEvent(message)
@@ -81,7 +149,7 @@ export class EventDecoder {
   }
 
   end(): void {
-    if (this.incomplete) {
+    if (this.pending.length !== 0) {
       throw new EventDecoderError('Event Iterator ended before complete')
     }
   }

--- a/packages/standard-server/src/event-iterator/encoder.test.ts
+++ b/packages/standard-server/src/event-iterator/encoder.test.ts
@@ -1,9 +1,45 @@
-import { encodeEventData, encodeEventMessage } from './encoder'
+import type { EventMessage } from './types'
+import { decodeEventMessage } from './decoder'
+import { encodeEventComments, encodeEventData, encodeEventMessage } from './encoder'
 
-it('encodeEventData', () => {
-  expect(encodeEventData(undefined)).toBe('')
-  expect(encodeEventData('hello\nworld')).toBe('data: hello\ndata: world\n')
-  expect(encodeEventData('hello\nworld\n')).toBe('data: hello\ndata: world\ndata: \n')
+describe('encodeEventData', () => {
+  it('encodes undefined as no output', () => {
+    expect(encodeEventData(undefined)).toBe('')
+  })
+
+  it('encodes single-line data', () => {
+    expect(encodeEventData('hello')).toBe('data: hello\n')
+    expect(encodeEventData('')).toBe('data: \n')
+  })
+
+  it('splits multi-line data into one data field per line', () => {
+    expect(encodeEventData('hello\nworld')).toBe('data: hello\ndata: world\n')
+    expect(encodeEventData('hello\rworld')).toBe('data: hello\ndata: world\n')
+    expect(encodeEventData('hello\r\nworld')).toBe('data: hello\ndata: world\n')
+  })
+
+  it('preserves trailing line endings as an empty data field', () => {
+    expect(encodeEventData('hello\nworld\n')).toBe('data: hello\ndata: world\ndata: \n')
+    expect(encodeEventData('hello\rworld\r')).toBe('data: hello\ndata: world\ndata: \n')
+    expect(encodeEventData('hello\r\nworld\r\n')).toBe('data: hello\ndata: world\ndata: \n')
+  })
+})
+
+describe('encodeEventComments', () => {
+  it('encodes undefined or empty comments as no output', () => {
+    expect(encodeEventComments(undefined)).toBe('')
+    expect(encodeEventComments([])).toBe('')
+  })
+
+  it('encodes each comment on its own line', () => {
+    expect(encodeEventComments(['hello'])).toBe(': hello\n')
+    expect(encodeEventComments(['hello', 'world'])).toBe(': hello\n: world\n')
+  })
+
+  it('rejects comments containing line breaks', () => {
+    expect(() => encodeEventComments(['hi\n']))
+      .toThrowError('Event\'s comment must not contain a carriage return or newline character')
+  })
 })
 
 describe('encodeEventMessage', () => {
@@ -16,14 +52,31 @@ describe('encodeEventMessage', () => {
       .toEqual(': hello\n: world\nevent: message\nretry: 10000\nid: 123\n\n')
   })
 
+  it('round-trips through decodeEventMessage', () => {
+    const messages: Partial<EventMessage>[] = [
+      {},
+      { data: 'hello' },
+      { data: 'hello\nworld\n' },
+      { event: 'message', data: 'hello', id: '123', retry: 10000, comments: ['hi'] },
+    ]
+
+    for (const message of messages) {
+      expect(decodeEventMessage(encodeEventMessage(message))).toEqual({ comments: [], ...message })
+    }
+  })
+
   it('invalid event', () => {
-    expect(() => encodeEventMessage({ event: 'hi\n' }))
-      .toThrowError('Event\'s event must not contain a newline character')
+    for (const lineBreak of ['\n', '\r', '\r\n']) {
+      expect(() => encodeEventMessage({ event: `hi${lineBreak}` }))
+        .toThrowError('Event\'s event must not contain a carriage return or newline character')
+    }
   })
 
   it('invalid id', () => {
-    expect(() => encodeEventMessage({ event: 'message', id: 'hi\n' }))
-      .toThrowError('Event\'s id must not contain a newline character')
+    for (const lineBreak of ['\n', '\r', '\r\n']) {
+      expect(() => encodeEventMessage({ event: 'message', id: `hi${lineBreak}` }))
+        .toThrowError('Event\'s id must not contain a carriage return or newline character')
+    }
   })
 
   it('invalid retry', () => {
@@ -38,7 +91,9 @@ describe('encodeEventMessage', () => {
   })
 
   it('invalid comment', () => {
-    expect(() => encodeEventMessage({ event: 'message', comments: ['hi\n'] }))
-      .toThrowError('Event\'s comment must not contain a newline character')
+    for (const lineBreak of ['\n', '\r', '\r\n']) {
+      expect(() => encodeEventMessage({ event: 'message', comments: [`hi${lineBreak}`] }))
+        .toThrowError('Event\'s comment must not contain a carriage return or newline character')
+    }
   })
 })

--- a/packages/standard-server/src/event-iterator/encoder.ts
+++ b/packages/standard-server/src/event-iterator/encoder.ts
@@ -1,15 +1,22 @@
 import type { EventMessage } from './types'
 import { EventEncoderError } from './errors'
 
+const LINE_ENDING_REGEX = /\r\n|[\n\r]/
+const LINE_ENDING_GLOBAL_REGEX = /\r\n|[\n\r]/g
+
+function containsLineBreak(value: string): boolean {
+  return LINE_ENDING_REGEX.test(value)
+}
+
 export function assertEventId(id: string): void {
-  if (id.includes('\n')) {
-    throw new EventEncoderError('Event\'s id must not contain a newline character')
+  if (containsLineBreak(id)) {
+    throw new EventEncoderError('Event\'s id must not contain a carriage return or newline character')
   }
 }
 
 export function assertEventName(event: string): void {
-  if (event.includes('\n')) {
-    throw new EventEncoderError('Event\'s event must not contain a newline character')
+  if (containsLineBreak(event)) {
+    throw new EventEncoderError('Event\'s event must not contain a carriage return or newline character')
   }
 }
 
@@ -20,21 +27,17 @@ export function assertEventRetry(retry: number): void {
 }
 
 export function assertEventComment(comment: string): void {
-  if (comment.includes('\n')) {
-    throw new EventEncoderError('Event\'s comment must not contain a newline character')
+  if (containsLineBreak(comment)) {
+    throw new EventEncoderError('Event\'s comment must not contain a carriage return or newline character')
   }
 }
 
 export function encodeEventData(data: string | undefined): string {
-  const lines = data?.split(/\n/) ?? []
-
-  let output = ''
-
-  for (const line of lines) {
-    output += `data: ${line}\n`
+  if (data === undefined) {
+    return ''
   }
 
-  return output
+  return `data: ${data.replace(LINE_ENDING_GLOBAL_REGEX, '\ndata: ')}\n`
 }
 
 export function encodeEventComments(comments: string[] | undefined): string {

--- a/packages/standard-server/src/event-iterator/meta.test.ts
+++ b/packages/standard-server/src/event-iterator/meta.test.ts
@@ -9,11 +9,11 @@ it('get/withEventMeta', () => {
   expect(getEventMeta(data)).toEqual(undefined)
   expect(getEventMeta(1)).toEqual(undefined)
 
-  expect(() => withEventMeta(data, { id: '123\n' })).toThrow('Event\'s id must not contain a newline character')
+  expect(() => withEventMeta(data, { id: '123\n' })).toThrow('Event\'s id must not contain a carriage return or newline character')
   expect(() => withEventMeta(data, { retry: Number.NaN })).toThrow('Event\'s retry must be a integer and >= 0')
   expect(() => withEventMeta(data, { retry: 1.1 })).toThrow('Event\'s retry must be a integer and >= 0')
   expect(() => withEventMeta(data, { retry: -1 })).toThrow('Event\'s retry must be a integer and >= 0')
-  expect(() => withEventMeta(data, { comments: ['hi\n'] })).toThrow('Event\'s comment must not contain a newline character')
+  expect(() => withEventMeta(data, { comments: ['hi\n'] })).toThrow('Event\'s comment must not contain a carriage return or newline character')
 })
 
 it('withEventMeta only proxy when make sense', () => {


### PR DESCRIPTION
## Summary

Applies the event stream encoder/decoder from the [standardserver repo](https://github.com/middleapi/standardserver/tree/main/packages/core/src/event-stream) to `@orpc/standard-server`'s `event-iterator`.

## What this fixes

- Streams using CR or CRLF line endings now decode correctly per the [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation), including messages and delimiters split at any chunk boundary.
- Data containing `\r` or `\r\n` now encodes to valid SSE output.
- Decoding large or finely-chunked streams is faster.

## Compatibility

No breaking changes: all exported names, signatures, and shapes are unchanged. The only observable differences are the spec fixes above and the assertion error messages now mentioning carriage returns.