### PR TITLE
fix(openapi): serialize headers in detailed input/output structures

### DIFF
--- a/packages/openapi/src/adapters/standard/index.ts
+++ b/packages/openapi/src/adapters/standard/index.ts
@@ -1,3 +1,4 @@
 export * from './openapi-handler-codec'
 export * from './openapi-link-codec'
 export * from './openapi-matcher'
+export * from './utils'

--- a/packages/openapi/src/adapters/standard/openapi-handler-codec.test.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler-codec.test.ts
@@ -692,13 +692,8 @@ describe('openAPIHandlerCodec', () => {
       })
 
       it('uses explicit status and headers from output', () => {
-        const serializer = {
-          serialize: vi.fn().mockReturnValueOnce('__serialized_body__'),
-          deserialize: vi.fn(),
-        } as any
-
         const procedure = os.meta(openapi({ outputStructure: 'detailed' })).handler(vi.fn())
-        const codec = new OpenAPIHandlerCodec(procedure, { serializer })
+        const codec = new OpenAPIHandlerCodec(procedure)
 
         const response = codec.encodeOutput({
           status: 202,
@@ -709,15 +704,76 @@ describe('openAPIHandlerCodec', () => {
         expect(response).toEqual({
           status: 202,
           headers: { 'x-custom': 'value' },
-          body: '__serialized_body__',
+          body: { ok: true },
         })
+      })
+
+      it('accepts informational and redirect statuses since any status below 400 is success', () => {
+        const procedure = os.meta(openapi({ outputStructure: 'detailed' })).handler(vi.fn())
+        const codec = new OpenAPIHandlerCodec(procedure)
+
+        const response = codec.encodeOutput({
+          status: 302,
+          headers: { location: 'https://example.com' },
+        }, procedure, [])
+
+        expect(response).toEqual({
+          status: 302,
+          headers: { location: 'https://example.com' },
+          body: undefined,
+        })
+      })
+
+      it('serializes non-string header values', () => {
+        const procedure = os.meta(openapi({ outputStructure: 'detailed' })).handler(vi.fn())
+        const codec = new OpenAPIHandlerCodec(procedure)
+
+        const response = codec.encodeOutput({
+          headers: {
+            'x-string': 'value',
+            'x-number': 42,
+            'x-boolean': true,
+            'x-date': new Date('2020-01-02T03:04:05.000Z'),
+            'x-array': ['a', 1, null, undefined],
+            'x-null': null,
+            'x-undefined': undefined,
+          },
+          body: undefined,
+        }, procedure, []) as any
+
+        expect(response.headers).toEqual({
+          'x-string': 'value',
+          'x-number': '42',
+          'x-boolean': 'true',
+          'x-date': '2020-01-02T03:04:05.000Z',
+          'x-array': ['a', '1'],
+        })
+        expect(Object.keys(response.headers)).not.toContain('x-null')
+        expect(Object.keys(response.headers)).not.toContain('x-undefined')
+      })
+
+      it('prevents prototype injection via header keys', () => {
+        const procedure = os.meta(openapi({ outputStructure: 'detailed' })).handler(vi.fn())
+        const codec = new OpenAPIHandlerCodec(procedure)
+
+        const response = codec.encodeOutput({
+          headers: JSON.parse('{"__proto__": "injected", "constructor": "c", "x-safe": "ok"}'),
+        }, procedure, []) as any
+
+        expect(response.headers['x-safe']).toBe('ok')
+
+        // `__proto__` and `constructor` become plain own properties, not prototype-chain mutations
+        expect(Object.getOwnPropertyDescriptor(response.headers, '__proto__')?.value).toBe('injected')
+        expect(Object.getOwnPropertyDescriptor(response.headers, 'constructor')?.value).toBe('c')
       })
 
       it.each([
         ['non-object output', '__invalid__'],
-        ['status outside the allowed range', { status: 500 }],
+        ['status of 400 or above', { status: 400 }],
+        ['non-integer status', { status: 250.5 }],
+        ['non-number status', { status: '200' }],
         ['extra keys', { body: 'ok', extra: true }],
-        ['invalid headers', { headers: { 'x-invalid': 123 } }],
+        ['non-object headers', { headers: 'invalid' }],
       ])('throws for invalid output: %s', (_, output) => {
         const procedure = os.meta(openapi({ outputStructure: 'detailed' })).handler(vi.fn())
         const codec = new OpenAPIHandlerCodec(procedure)

--- a/packages/openapi/src/adapters/standard/openapi-handler-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler-codec.ts
@@ -2,13 +2,13 @@ import type { AnyORPCError } from '@orpc/client'
 import type { AnyProcedure, AnyRouter, Context } from '@orpc/server'
 import type { StandardHandlerCodec, StandardHandlerCodecResolvedProcedure, StandardHandlerHandleOptions } from '@orpc/server/standard'
 import type { Promisable } from '@orpc/shared'
-import type { StandardHeaders, StandardLazyRequest, StandardResponse } from '@standardserver/core'
+import type { StandardLazyRequest, StandardResponse } from '@standardserver/core'
 import type { OpenAPIMeta } from '../../meta'
 import type { OpenAPIMatcherOptions } from './openapi-matcher'
 import { COMMON_ERROR_STATUS_MAP } from '@orpc/client'
 import { DEFAULT_ERROR_STATUS, DEFAULT_SUCCESS_STATUS } from '@orpc/server'
 import { isPlainObject, isTypescriptObject, NullProtoObj, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
-import { isStandardHeaders, parseStandardUrl } from '@standardserver/core'
+import { parseStandardUrl } from '@standardserver/core'
 import {
   DEFAULT_OPENAPI_INPUT_STRUCTURE,
   DEFAULT_OPENAPI_OUTPUT_STRUCTURE,
@@ -17,6 +17,7 @@ import { getOpenAPIMeta } from '../../meta'
 import { OpenAPISerializer } from '../../openapi-serializer'
 import { isBodylessMethod } from '../../utils'
 import { OpenAPIMatcher } from './openapi-matcher'
+import { serializeHeaders } from './utils'
 
 export interface OpenAPIHandlerCodecCoreOptions<_T extends Context> {
   /**
@@ -118,8 +119,8 @@ export class OpenAPIHandlerCodecCore<T extends Context> {
       throw new TypeError(`
         Invalid "detailed" output structure returned by procedure (${path.join('.')}):
         • Expected an object with optional properties:
-          - status (number 200-399)
-          - headers (Record<string, string | string[] | undefined>)
+          - status (number <400)
+          - headers (object)
           - body (any)
         • No extra keys allowed.
 
@@ -130,7 +131,7 @@ export class OpenAPIHandlerCodecCore<T extends Context> {
 
     return {
       status: output.status ?? successStatus,
-      headers: output.headers ?? {},
+      headers: output.headers !== undefined ? serializeHeaders(output.headers, this.serializer) : {},
       body: this.serializer.serialize(output.body),
     }
   }
@@ -274,7 +275,7 @@ export class OpenAPIHandlerCodec<T extends Context> extends OpenAPIHandlerCodecC
   }
 }
 
-function isValidDetailedOutput(output: unknown): output is { status?: number, body?: unknown, headers?: StandardHeaders } {
+function isValidDetailedOutput(output: unknown): output is { status?: number, body?: unknown, headers?: object } {
   if (!isTypescriptObject(output)) {
     return false
   }
@@ -286,13 +287,12 @@ function isValidDetailedOutput(output: unknown): output is { status?: number, bo
   if (output.status !== undefined && (
     typeof output.status !== 'number'
     || !Number.isInteger(output.status)
-    || output.status < 200
     || output.status > 399
   )) {
     return false
   }
 
-  if (output.headers !== undefined && !isStandardHeaders(output.headers)) {
+  if (output.headers !== undefined && !isTypescriptObject(output.headers)) {
     return false
   }
 

--- a/packages/openapi/src/adapters/standard/openapi-link-codec.test.ts
+++ b/packages/openapi/src/adapters/standard/openapi-link-codec.test.ts
@@ -180,6 +180,38 @@ describe('openAPILinkCodec', () => {
         expect(request.headers).toEqual({ 'x-base': 'yes' })
       })
 
+      it('serializes non-string header values before merging', async () => {
+        const codec = new OpenAPILinkCodec({
+          ping: oc.meta(openapi({ inputStructure: 'detailed' })),
+        }, {
+          url: '/api',
+          headers: { 'x-multi': 'base' },
+          serializer,
+        })
+
+        const request = await codec.encodeInput({
+          headers: {
+            'x-number': 42,
+            'x-boolean': false,
+            'x-date': new Date('2020-01-02T03:04:05.000Z'),
+            'x-array': ['a', 1, null, undefined],
+            'x-multi': ['b', 'c'],
+            'x-null': null,
+            'x-undefined': undefined,
+          },
+        }, ['ping'], { context: {} })
+
+        expect(request.headers).toEqual({
+          'x-number': '42',
+          'x-boolean': 'false',
+          'x-date': '2020-01-02T03:04:05.000Z',
+          'x-array': ['a', '1'],
+          'x-multi': ['base', 'b', 'c'],
+        })
+        expect(Object.keys(request.headers)).not.toContain('x-null')
+        expect(Object.keys(request.headers)).not.toContain('x-undefined')
+      })
+
       it('omits the body for GET requests while still serializing the query', async () => {
         const codec = new OpenAPILinkCodec({
           search: oc.meta(openapi({

--- a/packages/openapi/src/adapters/standard/openapi-link-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-link-codec.ts
@@ -8,7 +8,7 @@ import { createORPCErrorFromJson, isORPCErrorJson, ORPCError } from '@orpc/clien
 import { getRouterContract, ProcedureContract } from '@orpc/contract'
 import { unlazy } from '@orpc/server'
 import { isTypescriptObject, mergeHttpPath, pathToHttpPath, stringifyJSON, value } from '@orpc/shared'
-import { isStandardHeaders, mergeStandardHeaders, parseStandardUrl } from '@standardserver/core'
+import { mergeStandardHeaders, parseStandardUrl } from '@standardserver/core'
 import { toStandardHeaders } from '@standardserver/fetch'
 import {
   DEFAULT_OPENAPI_INPUT_STRUCTURE,
@@ -18,6 +18,7 @@ import {
 import { getOpenAPIMeta } from '../../meta'
 import { OpenAPISerializer } from '../../openapi-serializer'
 import { getDynamicPathParams, isBodylessMethod } from '../../utils'
+import { serializeHeaders } from './utils'
 
 export class OpenAPILinkCodecError extends TypeError {}
 
@@ -143,7 +144,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
         • Expected an object or undefined with optional properties:
           - params (object, required when the path has dynamic params)
           - query (object)
-          - headers (Record<string, string | string[] | undefined>)
+          - headers (object)
           - body (any)
 
         Actual value:
@@ -167,7 +168,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
     }
 
     if (input?.headers) {
-      headers = mergeStandardHeaders(headers, input.headers)
+      headers = mergeStandardHeaders(headers, serializeHeaders(input.headers, this.serializer))
     }
 
     pathname = `${basePathname.replace(END_SLASH_REGEX, '')}${pathname}` as `/${string}`
@@ -471,7 +472,7 @@ function toResolvedStandardHeaders(headers: Headers | StandardHeaders): Standard
 
 function isValidDetailedInput(
   input: unknown,
-): input is undefined | { params?: Record<string, unknown>, query?: Record<string, unknown>, headers?: StandardHeaders, body?: unknown } {
+): input is undefined | { params?: Record<string, unknown>, query?: Record<string, unknown>, headers?: object, body?: unknown } {
   if (!isTypescriptObject(input)) {
     return input === undefined
   }
@@ -484,7 +485,7 @@ function isValidDetailedInput(
     return false
   }
 
-  if (input.headers !== undefined && !isStandardHeaders(input.headers)) {
+  if (input.headers !== undefined && !isTypescriptObject(input.headers)) {
     return false
   }
 

--- a/packages/openapi/src/adapters/standard/utils.test.ts
+++ b/packages/openapi/src/adapters/standard/utils.test.ts
@@ -1,0 +1,66 @@
+import { OpenAPISerializer } from '../../openapi-serializer'
+import { serializeHeaders } from './utils'
+
+const serializer = new OpenAPISerializer()
+
+describe('serializeHeaders', () => {
+  it('keeps string and string[] values as-is', () => {
+    expect(serializeHeaders({
+      'x-string': 'value',
+      'x-array': ['a', 'b'],
+    }, serializer)).toEqual({
+      'x-string': 'value',
+      'x-array': ['a', 'b'],
+    })
+  })
+
+  it('serializes non-string values into strings', () => {
+    expect(serializeHeaders({
+      'x-number': 42,
+      'x-boolean': true,
+      'x-date': new Date('2020-01-02T03:04:05.000Z'),
+      'x-array': ['a', 1, false, new Date('2020-01-02T03:04:05.000Z')],
+    }, serializer)).toEqual({
+      'x-number': '42',
+      'x-boolean': 'true',
+      'x-date': '2020-01-02T03:04:05.000Z',
+      'x-array': ['a', '1', 'false', '2020-01-02T03:04:05.000Z'],
+    })
+  })
+
+  it('serializes objects as comma-delimited key,value pairs', () => {
+    expect(serializeHeaders({
+      'x-object': { enabled: true, count: 2 },
+      'x-object-nested-date': { at: new Date('2020-01-02T03:04:05.000Z') },
+      'x-object-skip-nullish': { keep: 'yes', skip: null, omit: undefined },
+    }, serializer)).toEqual({
+      'x-object': 'enabled,true,count,2',
+      'x-object-nested-date': 'at,2020-01-02T03:04:05.000Z',
+      'x-object-skip-nullish': 'keep,yes',
+    })
+  })
+
+  it('drops undefined and null values, including array items', () => {
+    const serialized = serializeHeaders({
+      'x-null': null,
+      'x-undefined': undefined,
+      'x-array': ['keep', null, undefined],
+    }, serializer)
+
+    expect(serialized).toEqual({ 'x-array': ['keep'] })
+    expect(Object.keys(serialized)).toEqual(['x-array'])
+  })
+
+  it('prevents prototype injection via header keys', () => {
+    const serialized = serializeHeaders(JSON.parse(
+      '{"__proto__": { "polluted": "yes" }, "constructor": "c", "toString": "t"}',
+    ), serializer)
+
+    expect(({} as any).polluted).toBeUndefined()
+
+    // dangerous keys become plain own properties, not prototype-chain mutations
+    expect(Object.getOwnPropertyDescriptor(serialized, '__proto__')?.value).toBe('polluted,yes')
+    expect(Object.getOwnPropertyDescriptor(serialized, 'constructor')?.value).toBe('c')
+    expect(Object.getOwnPropertyDescriptor(serialized, 'toString')?.value).toBe('t')
+  })
+})

--- a/packages/openapi/src/adapters/standard/utils.ts
+++ b/packages/openapi/src/adapters/standard/utils.ts
@@ -1,0 +1,33 @@
+import type { StandardHeaders } from '@standardserver/core'
+import type { OpenAPISerializer } from '../../openapi-serializer'
+import { isTypescriptObject, NullProtoObj } from '@orpc/shared'
+
+export function serializeHeaders(
+  headers: object,
+  serializer: Pick<OpenAPISerializer, 'serialize'>,
+): StandardHeaders {
+  const result = new NullProtoObj<Record<string, string | string[]>>()
+
+  for (const [key, value] of Object.entries(headers)) {
+    const serialized = serializer.serialize(value)
+
+    if (Array.isArray(serialized)) {
+      result[key] = serialized
+        .filter(item => item !== undefined && item !== null)
+        .map(String)
+    }
+
+    else if (isTypescriptObject(serialized)) {
+      result[key] = Object.entries(serialized)
+        .filter(([, val]) => val !== undefined && val !== null)
+        .map(([key, val]) => `${String(key)},${String(val)}`)
+        .join(',')
+    }
+
+    else if (serialized !== undefined && serialized !== null) {
+      result[key] = String(serialized)
+    }
+  }
+
+  return result
+}


### PR DESCRIPTION
Resolves #1739

Header values in `detailed` input/output structures are now serialized the same way query params and body values are, instead of being strictly validated as `string | string[]` upfront. This lets schemas accept non-string header values (numbers, dates, arrays, objects, ...) that are coerced during the transform phase, consistent with how `query` is handled.

Co-authored-by: Rene Haas <king-sora@hotmail.de>

