### PR TITLE
fix(shared): prevent prototype injection in set util

### DIFF
--- a/packages/shared/src/object.test.ts
+++ b/packages/shared/src/object.test.ts
@@ -144,6 +144,37 @@ describe('set', () => {
     expect(root.a).toBe(date)
     expect((root.a as Record<string, unknown>).b).toBe('value')
   })
+
+  it('does not pollute the prototype via __proto__', () => {
+    const root: Record<string, unknown> = {}
+    set(root, ['__proto__', 'polluted'], 'yes')
+
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+    expect(Object.getPrototypeOf(root)).toBe(Object.prototype)
+    expect(Object.hasOwn(root, '__proto__')).toBe(true)
+    // eslint-disable-next-line no-proto, no-restricted-properties
+    expect((root as any).__proto__).toEqual({ polluted: 'yes' })
+  })
+
+  it('does not pollute the prototype via constructor.prototype', () => {
+    const root: Record<string, unknown> = {}
+    set(root, ['constructor', 'prototype', 'polluted'], 'yes')
+
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+    expect((Object.prototype as any).polluted).toBeUndefined()
+    expect(Object.hasOwn(root, 'constructor')).toBe(true)
+    expect(root.constructor).toEqual({ prototype: { polluted: 'yes' } })
+  })
+
+  it('sets __proto__ as an own property instead of changing the prototype', () => {
+    const root: Record<string, unknown> = {}
+    set(root, ['__proto__'], 'value')
+
+    expect(Object.getPrototypeOf(root)).toBe(Object.prototype)
+    expect(Object.hasOwn(root, '__proto__')).toBe(true)
+    // eslint-disable-next-line no-proto, no-restricted-properties
+    expect((root as any).__proto__).toBe('value')
+  })
 })
 
 describe('omit', () => {

--- a/packages/shared/src/object.ts
+++ b/packages/shared/src/object.ts
@@ -81,16 +81,28 @@ export function set(
 
   for (let i = 0; i < path.length - 1; i++) {
     const key = path[i]!
-    const next = (current as Record<PropertyKey, unknown>)[key]
+    const next = Object.hasOwn(current, key) ? (current as Record<PropertyKey, unknown>)[key] : undefined
 
     if (!isTypescriptObject(next)) {
-      ;(current as Record<PropertyKey, unknown>)[key] = {}
+      const child = {}
+      defineOwnProperty(current, key, child)
+      current = child
     }
-
-    current = (current as Record<PropertyKey, object>)[key]!
+    else {
+      current = next
+    }
   }
 
-  ;(current as Record<PropertyKey, unknown>)[path.at(-1)!] = value
+  defineOwnProperty(current, path.at(-1)!, value)
+}
+
+function defineOwnProperty(object: object, key: PropertyKey, value: unknown): void {
+  Object.defineProperty(object, key, {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  })
 }
 
 export function omit<T extends object, K extends keyof T>(


### PR DESCRIPTION
## What

Hardens the `set` util in `@orpc/shared` against prototype injection.

Previously, a path like `['__proto__', 'polluted']` would read the inherited `__proto__` getter, walk into `Object.prototype`, and write onto it — polluting every object. `['constructor', 'prototype', 'x']` reached the same place through the `Object` constructor.

## How

Mirrors the `Object.hasOwn` guard that `get` already uses:

- Traversal only descends into **own** properties; inherited intermediates (`__proto__`, `constructor`, …) are treated as absent, so a fresh plain object is created instead of walking the prototype chain.
- Writes go through `Object.defineProperty` (writable/enumerable/configurable), which creates an own data property even for keys like `__proto__` instead of triggering the inherited setter that would swap the object's prototype.

Includes tests for the `__proto__` and `constructor.prototype` pollution vectors.