### PR TITLE
fix(pino,evlog): only treat thrown ORPCError as business error

### DIFF
--- a/packages/evlog/src/handler-plugin.test.ts
+++ b/packages/evlog/src/handler-plugin.test.ts
@@ -1,3 +1,4 @@
+import { ORPCError } from '@orpc/client'
 import { AbortError, ORPC_NAME, sleep } from '@orpc/shared'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { LOGGER_CONTEXT_SYMBOL } from './context'
@@ -407,11 +408,11 @@ describe('evlogHandlerPlugin', () => {
     })
   })
 
-  it('logs business logic errors and downgrades abort errors to info level', async () => {
+  it('downgrades business errors (ORPCError) to warn level and abort errors to info level, keeps unexpected errors at error level', async () => {
     const logger = createLogger()
     const plugin = new EvlogHandlerPlugin()
     const { interceptor } = getPluginHooks(plugin)
-    const businessError = new Error('boom')
+    const businessError = new ORPCError('UNAUTHORIZED')
 
     await expect(interceptor({
       next: vi.fn().mockRejectedValue(businessError),
@@ -421,6 +422,21 @@ describe('evlogHandlerPlugin', () => {
     })).rejects.toThrow(businessError)
 
     expect(logger.error).toHaveBeenCalledWith(businessError)
+    expect(logger.setLevel).toHaveBeenCalledWith('warn')
+
+    logger.error.mockClear()
+    logger.setLevel.mockClear()
+
+    const unexpectedError = new Error('boom')
+
+    await expect(interceptor({
+      next: vi.fn().mockRejectedValue(unexpectedError),
+      context: { [LOGGER_CONTEXT_SYMBOL]: logger },
+      path: ['ping'],
+      request: createRequest('/ping'),
+    })).rejects.toThrow(unexpectedError)
+
+    expect(logger.error).toHaveBeenCalledWith(unexpectedError)
     expect(logger.setLevel).not.toHaveBeenCalled()
 
     logger.error.mockClear()

--- a/packages/evlog/src/handler-plugin.ts
+++ b/packages/evlog/src/handler-plugin.ts
@@ -3,7 +3,7 @@ import type { StandardHandlerInterceptor, StandardHandlerOptions, StandardHandle
 import type { StandardRequest } from '@standardserver/core'
 import type { RequestLogger } from 'evlog'
 import type { BaseEvlogOptions, FrameworkIntegrationHelpers, FrameworkIntegrationSpec } from 'evlog/toolkit'
-import { wrapAsyncIteratorPreservingEventMeta } from '@orpc/client'
+import { ORPCError, wrapAsyncIteratorPreservingEventMeta } from '@orpc/client'
 import { isAbortError, isAsyncIteratorObject, ORPC_NAME, override, sleep, toArray, wrapReadableStream } from '@orpc/shared'
 import { flattenStandardHeader, parseStandardUrl } from '@standardserver/core'
 import { defineFrameworkIntegration } from 'evlog/toolkit'
@@ -249,8 +249,15 @@ function toErrorOrString(error: unknown) {
 function logBusinessLogicError(logger: RequestLogger | undefined, error: unknown) {
   logger?.error(toErrorOrString(error))
 
-  // DO NOT treat aborted error as error if happen during business logic
+  // An abort means the client withdrew the request, not that something failed,
+  // so record it as normal operation.
   if (isAbortError(error)) {
     logger?.setLevel('info')
+  }
+  // A thrown ORPCError is a deliberate business rejection delivered to the client,
+  // so keep it reviewable without treating it as a failure.
+  // Anything else is unexpected and stays at error level.
+  else if (error instanceof ORPCError) {
+    logger?.setLevel('warn')
   }
 }

--- a/packages/pino/src/handler-plugin.test.ts
+++ b/packages/pino/src/handler-plugin.test.ts
@@ -1,5 +1,5 @@
 import type { StandardLazyRequest } from '@standardserver/core'
-import { os } from '@orpc/server'
+import { ORPCError, os } from '@orpc/server'
 import { StandardHandler } from '@orpc/server/standard'
 import { AbortError } from '@orpc/shared'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -9,6 +9,7 @@ import { PinoHandlerPlugin } from './handler-plugin'
 const globalSpies = {
   child: vi.fn(),
   info: vi.fn(),
+  warn: vi.fn(),
   error: vi.fn(),
   setBindings: vi.fn(),
 }
@@ -28,6 +29,11 @@ class FakeLogger {
   info(...args: any[]) {
     expect(this.childDepth).toBeGreaterThan(0)
     globalSpies.info(...args)
+  }
+
+  warn(...args: any[]) {
+    expect(this.childDepth).toBeGreaterThan(0)
+    globalSpies.warn(...args)
   }
 
   error(...args: any[]) {
@@ -142,9 +148,9 @@ describe('pinoHandlerPlugin', () => {
     expect(globalSpies.info).toHaveBeenCalledWith('request was aborted before handling (manual)')
   })
 
-  it('logs business errors as error and abort errors as info', async () => {
+  it('logs business errors (ORPCError) as warn, unexpected errors as error, and abort errors as info', async () => {
     const baseLogger = new FakeLogger({ rpc: {} })
-    const businessError = new Error('boom')
+    const businessError = new ORPCError('UNAUTHORIZED')
     const handler1 = new StandardHandler(createCodec(os.handler(() => {
       throw businessError
     })) as any, {
@@ -154,14 +160,14 @@ describe('pinoHandlerPlugin', () => {
     const result1 = await handler1.handle(createRequest('GET', '/ping'), { prefix: undefined, context: {} })
 
     expect(result1.matched).toBe(true)
-    expect(result1.response?.status).toBe(500)
-    expect(globalSpies.error).toHaveBeenCalledWith(businessError)
+    expect(globalSpies.warn).toHaveBeenCalledWith(businessError)
+    expect(globalSpies.error).not.toHaveBeenCalled()
 
     vi.clearAllMocks()
 
-    const abortError = new AbortError('reason')
+    const unexpectedError = new Error('boom')
     const handler2 = new StandardHandler(createCodec(os.handler(() => {
-      throw abortError
+      throw unexpectedError
     })) as any, {
       plugins: [new PinoHandlerPlugin({ logger: baseLogger as any })],
     })
@@ -169,7 +175,25 @@ describe('pinoHandlerPlugin', () => {
     const result2 = await handler2.handle(createRequest('GET', '/ping'), { prefix: undefined, context: {} })
 
     expect(result2.matched).toBe(true)
+    expect(result2.response?.status).toBe(500)
+    expect(globalSpies.error).toHaveBeenCalledWith(unexpectedError)
+    expect(globalSpies.warn).not.toHaveBeenCalled()
+
+    vi.clearAllMocks()
+
+    const abortError = new AbortError('reason')
+    const handler3 = new StandardHandler(createCodec(os.handler(() => {
+      throw abortError
+    })) as any, {
+      plugins: [new PinoHandlerPlugin({ logger: baseLogger as any })],
+    })
+
+    const result3 = await handler3.handle(createRequest('GET', '/ping'), { prefix: undefined, context: {} })
+
+    expect(result3.matched).toBe(true)
     expect(globalSpies.info).toHaveBeenCalledWith(abortError)
+    expect(globalSpies.warn).not.toHaveBeenCalled()
+    expect(globalSpies.error).not.toHaveBeenCalled()
   })
 
   it('logs internal errors', async () => {

--- a/packages/pino/src/handler-plugin.ts
+++ b/packages/pino/src/handler-plugin.ts
@@ -2,7 +2,7 @@ import type { Context, ErrorMap, ProcedureClientInterceptor, Schema } from '@orp
 import type { StandardHandlerInterceptor, StandardHandlerOptions, StandardHandlerPlugin, StandardHandlerRoutingInterceptor, StandardHandlerRoutingInterceptorOptions } from '@orpc/server/standard'
 import type { Logger } from 'pino'
 import type { LoggerContext } from './context'
-import { wrapAsyncIteratorPreservingEventMeta } from '@orpc/client'
+import { ORPCError, wrapAsyncIteratorPreservingEventMeta } from '@orpc/client'
 import { isAbortError, isAsyncIteratorObject, ORPC_NAME, override, toArray, wrapReadableStream } from '@orpc/shared'
 import { flattenStandardHeader } from '@standardserver/core'
 import pino from 'pino'
@@ -207,10 +207,17 @@ export class PinoHandlerPlugin<T extends Context> implements StandardHandlerPlug
 }
 
 function logBusinessLogicError(logger: Logger | undefined, error: unknown) {
-  // DO NOT treat aborted error as error if happen during business logic
+  // An abort means the client withdrew the request, not that something failed,
+  // so record it as normal operation.
   if (isAbortError(error)) {
     logger?.info(error)
   }
+  // A thrown ORPCError is a deliberate business rejection delivered to the client,
+  // so keep it reviewable without treating it as a failure.
+  else if (error instanceof ORPCError) {
+    logger?.warn(error)
+  }
+  // Anything else is unexpected and stays at error level.
   else {
     logger?.error(error)
   }


### PR DESCRIPTION
The pino and evlog handler plugins previously logged every error thrown from business logic at error level. Now only a thrown `ORPCError` is classified as a business error and logged at `warn`, so error-level logs are reserved for genuinely unexpected failures.

## Behavior

- Thrown `ORPCError` (deliberate rejections like `UNAUTHORIZED`, `NOT_FOUND`) no longer appears in error-level logs — logged at `warn` (pino) / event level downgraded to `warn` (evlog), keeping them reviewable without triggering error alerting.
- Abort errors remain at `info`: the client withdrew the request, nothing failed.
- Any other thrown error still logs at `error` level, unchanged.
- Applies consistently to regular procedures and streamed outputs (event iterators and readable streams).

## Testing

- Both plugins' test suites now cover the three tiers (ORPCError → warn, unexpected → error, abort → info); all tests, lint, and type checks pass.