### PR TITLE
fix(server): make callable extension type augmentation work in published builds

### DIFF
--- a/packages/server/src/extensions/callable.ts
+++ b/packages/server/src/extensions/callable.ts
@@ -7,7 +7,7 @@ import type { ProcedureClient, ProcedureClientOptions } from '../procedure-clien
 import { createProcedureClient } from '../procedure-client'
 import { DecoratedProcedure } from '../procedure-decorated'
 
-declare module '../procedure-decorated' {
+declare module '@orpc/server' {
   interface DecoratedProcedure<
     TInitialContext extends Context,
     TInjectedContext extends Context,


### PR DESCRIPTION
## Problem

`import '@orpc/server/extensions/callable'` works at runtime, but in the published package `.callable()` fails type-checking:

```
Property 'callable' does not exist on type 'DecoratedProcedure<...>'
```

## Root cause

The source augments `declare module '../procedure-decorated'`, which declaration bundling rewrites to `declare module "../index"`. That extensionless path resolves to `dist/index.d.ts`, while consumers get their types from `dist/index.d.mts` via the exports map — so the augmentation merges into a module the consumer never uses.

The monorepo never sees this because dev exports point at `src`.

## Fix

Augment `declare module '@orpc/server'` instead, matching every other extension in the repo (next, effect, openapi). The bare specifier survives bundling and resolves to the same entry the consumer imports.

## Verification

- `pnpm test` and `pnpm type:check` pass
- The built `dist` works