### PR TITLE
docs: fix API drift in handler, openapi-reference, and link docs

### DIFF
--- a/apps/content/docs/integrations/effect.md
+++ b/apps/content/docs/integrations/effect.md
@@ -145,7 +145,7 @@ import { Context, Effect } from 'effect'
 interface ServerContext extends WithEffectContext<never> {}
 
 export async function fetch(request: Request) {
-  const { response } = await handler.fetch(request, {
+  const { matched, response } = await handler.handle(request, {
     context: {
       'effect/context': Context.empty(),
       'effect/wrap': (effect, opts) => effect.pipe(
@@ -156,7 +156,11 @@ export async function fetch(request: Request) {
     }
   })
 
-  return response ?? new Response('Not Found', { status: 404 })
+  if (matched) {
+    return response
+  }
+
+  return new Response('Not Found', { status: 404 })
 }
 ```
 
@@ -260,13 +264,17 @@ const TracingLive = Tracer.layerGlobal.pipe(
 )
 
 export async function fetch(request: Request) {
-  const { response } = await handler.fetch(request, {
+  const { matched, response } = await handler.handle(request, {
     context: {
       'effect/context': Context.empty(),
       'effect/wrap': (effect, opts) => effect.pipe(Effect.provide(TracingLive)),
     }
   })
 
-  return response ?? new Response('Not Found', { status: 404 })
+  if (matched) {
+    return response
+  }
+
+  return new Response('Not Found', { status: 404 })
 }
 ```

--- a/apps/content/docs/openapi/handler.md
+++ b/apps/content/docs/openapi/handler.md
@@ -33,12 +33,16 @@ The actual usage of `OpenAPIHandler` depends on the adapter you use. For example
 
 ```ts
 export async function fetch(request: Request) {
-  const { response } = await handler.fetch(request, {
+  const { matched, response } = await handler.handle(request, {
     prefix: '/api',
     context: {} // <- provide initial context if needed
   })
 
-  return response ?? new Response('Not Found', { status: 404 })
+  if (matched) {
+    return response
+  }
+
+  return new Response('Not Found', { status: 404 })
 }
 ```
 

--- a/apps/content/docs/openapi/link.md
+++ b/apps/content/docs/openapi/link.md
@@ -43,7 +43,8 @@ After you create an `OpenAPILink`, pass it to `createORPCClient` to build a type
 
 ```ts
 import { createORPCClient } from '@orpc/client'
-import { JsonifiedClient, RouterContractClient } from '@orpc/contract'
+import { RouterContractClient } from '@orpc/contract'
+import { JsonifiedClient } from '@orpc/openapi'
 import { RouterClient } from '@orpc/server'
 
 // if you are following contract-first approach

--- a/apps/content/docs/plugins/openapi-reference.md
+++ b/apps/content/docs/plugins/openapi-reference.md
@@ -12,7 +12,7 @@ To use this plugin, first create an [OpenAPI Generator](/docs/openapi/specificat
 
 ```ts
 import { OpenAPIGenerator } from '@orpc/openapi'
-import { OpenAPIReferencePlugin } from '@orpc/openapi/plugins'
+import { OpenAPIReferenceHandlerPlugin } from '@orpc/openapi/plugins'
 
 const generator = new OpenAPIGenerator({
   converters: [
@@ -22,15 +22,17 @@ const generator = new OpenAPIGenerator({
 
 const handler = new OpenAPIHandler(router, {
   plugins: [
-    new OpenAPIReferencePlugin({
-      spec: () => generator.generateSpec(router, {
-        info: {
-          title: 'ORPC Playground',
-          version: '1.0.0',
+    new OpenAPIReferenceHandlerPlugin({
+      spec: () => generator.generate(router, {
+        base: {
+          info: {
+            title: 'ORPC Playground',
+            version: '1.0.0',
+          },
+          servers: [
+            { url: 'https://api.example.com/v1', },
+          ],
         },
-        servers: [
-          { url: 'https://api.example.com/v1', },
-        ],
       }),
     }),
   ]
@@ -48,7 +50,7 @@ By default, the API reference UI is served from `/`, and the OpenAPI specificati
 ```ts
 const handler = new OpenAPIHandler(router, {
   plugins: [
-    new OpenAPIReferencePlugin({
+    new OpenAPIReferenceHandlerPlugin({
       provider: 'swagger',
       providerConfig: {
         // Swagger UI specific configuration

--- a/apps/content/docs/rpc/handler.md
+++ b/apps/content/docs/rpc/handler.md
@@ -33,12 +33,16 @@ The actual usage of `RPCHandler` depends on the adapter you use. For example, wh
 
 ```ts
 export async function fetch(request: Request) {
-  const { response } = await handler.fetch(request, {
+  const { matched, response } = await handler.handle(request, {
     prefix: '/rpc',
     context: {} // <- provide initial context if needed
   })
 
-  return response ?? new Response('Not Found', { status: 404 })
+  if (matched) {
+    return response
+  }
+
+  return new Response('Not Found', { status: 404 })
 }
 ```
 


### PR DESCRIPTION
Several v2 docs pages still showed v1 APIs that no longer exist, so copy-pasted snippets failed to compile. All snippets now match the actual v2 exports, verified against package source and playgrounds.

## Fixes

- `handler.fetch(...)` no longer exists on `FetchHandler` — snippets in `rpc/handler.md`, `openapi/handler.md`, and `integrations/effect.md` now use `handler.handle(...)` with the `{ matched, response }` result, matching `adapters/fetch-api.md`.
- `plugins/openapi-reference.md` now uses the v2 names `OpenAPIReferenceHandlerPlugin` and `generator.generate(...)`, with `info`/`servers` under the `base` option as the v2 generator expects.
- `openapi/link.md` now imports `JsonifiedClient` from `@orpc/openapi`, where it is actually exported — it does not exist in `@orpc/contract`.

## Testing

- Grep sweep over `apps/content/docs/` confirms no remaining occurrences of `handler.fetch(`, `OpenAPIReferencePlugin`, or `generateSpec`.