### PR TITLE
fix: keep nested clients and utils referentially stable

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,10 +29,6 @@ export default antfu({
         message: 'decodeURIComponent can throw an error, use tryDecodeURIComponent instead',
       },
       {
-        name: ['Reflect', 'get'],
-        message: 'Use getOrBind instead',
-      },
-      {
         name: ['AbortSignal', 'any'],
         message: 'Use anyAbortSignal instead',
       },

--- a/packages/client/src/client-safe.test.ts
+++ b/packages/client/src/client-safe.test.ts
@@ -49,6 +49,15 @@ describe('createSafeClient', () => {
     expect(client.ping).toHaveBeenCalledWith('input')
   })
 
+  it('returns strictly equal client on repeated access', () => {
+    expect(safeClient.ping).toBe(safeClient.ping)
+    expect(safeClient.nested).toBe(safeClient.nested)
+    expect(safeClient.nested.pong).toBe(safeClient.nested.pong)
+    expect(safeClient.nested.pong).not.toBe(safeClient.ping)
+
+    expect(createSafeClient(client)).not.toBe(safeClient)
+  })
+
   it('not proxy on non-object or symbol properties', () => {
     expect(safeClient.invalid).toBe('invalid')
     expect(safeClient[Symbol('test')]).toEqual(undefined)

--- a/packages/client/src/client-safe.ts
+++ b/packages/client/src/client-safe.ts
@@ -1,6 +1,7 @@
 import type { AnyNestedClient, Client, ClientRest } from './types'
 import type { SafeResult } from './utils'
-import { getOrBind, isTypescriptObject } from '@orpc/shared'
+import { isTypescriptObject } from '@orpc/shared'
+import { RECURSIVE_CLIENT_UNWRAP_KEYS } from './consts'
 import { safe } from './utils'
 
 export type SafeClient<T extends AnyNestedClient>
@@ -23,15 +24,28 @@ export type SafeClient<T extends AnyNestedClient>
  * @see {@link https://orpc.dev/docs/client/error-handling#using-createsafeclient Safe Client Docs}
  */
 export function createSafeClient<T extends AnyNestedClient>(client: T): SafeClient<T> {
-  const proxy = new Proxy((...args: any[]) => safe((client as any)(...args)), {
-    get(_, prop) {
-      const value = getOrBind(client, prop)
+  const cache = new Map<string, SafeClient<AnyNestedClient>>()
 
-      if (!isTypescriptObject(value)) {
-        return value
+  const proxy = new Proxy((...args: any[]) => safe((client as any)(...args)), {
+    get(target, prop) {
+      if (typeof prop !== 'string' || RECURSIVE_CLIENT_UNWRAP_KEYS.has(prop)) {
+        return Reflect.get(target, prop)
       }
 
-      return createSafeClient(value as AnyNestedClient)
+      let safeClient = cache.get(prop)
+
+      if (safeClient === undefined) {
+        const value = (client as Record<string, unknown>)[prop]
+
+        if (!isTypescriptObject(value)) {
+          return value
+        }
+
+        safeClient = createSafeClient(value as AnyNestedClient)
+        cache.set(prop, safeClient)
+      }
+
+      return safeClient
     },
   })
 

--- a/packages/client/src/client.test.ts
+++ b/packages/client/src/client.test.ts
@@ -179,6 +179,17 @@ describe('createORPCClient', () => {
     )
   })
 
+  it('returns strictly equal client on repeated access', async () => {
+    const client = createORPCClient(mockedLink) as any
+
+    expect(client.ping).toBe(client.ping)
+    expect(client.nested).toBe(client.nested)
+    expect(client.nested.pong).toBe(client.nested.pong)
+    expect(client.nested.pong).not.toBe(client.ping)
+
+    expect(createORPCClient(mockedLink)).not.toBe(client)
+  })
+
   it('not recursive on symbol and unwrap keys', async () => {
     const client = createORPCClient(mockedLink) as any
     expect(client[Symbol('test')]).toBeUndefined()

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,6 +1,6 @@
 import type { Interceptor, PromiseWithError } from '@orpc/shared'
 import type { AnyNestedClient, Client, ClientContext, ClientLink, ClientOptions, InferClientContext, InferClientError } from './types'
-import { getOrBind, intercept, toArray } from '@orpc/shared'
+import { intercept, toArray } from '@orpc/shared'
 import { RECURSIVE_CLIENT_UNWRAP_KEYS } from './consts'
 import { resolveClientRest } from './utils'
 
@@ -64,21 +64,27 @@ export function createORPCClient<T extends AnyNestedClient>(
     )
   }
 
+  const cache = new Map<string, AnyNestedClient>()
+
   const recursive = new Proxy(procedureClient, {
     get(target, key) {
       if (typeof key !== 'string' || RECURSIVE_CLIENT_UNWRAP_KEYS.has(key)) {
-        return getOrBind(target, key)
+        return Reflect.get(target, key)
       }
 
-      const scoped = options.scoped === undefined
-        ? undefined
-        : (options.scoped as Record<string, unknown>)[key] as ORPCClientOptions<T>['scoped']
+      let client = cache.get(key)
 
-      return createORPCClient(link, {
-        ...options,
-        path: [...path, key],
-        scoped,
-      })
+      if (client === undefined) {
+        client = createORPCClient(link, {
+          ...options,
+          path: [...path, key],
+          scoped: (options.scoped as undefined | Record<string, ORPCClientOptions<T>['scoped']>)?.[key],
+        })
+
+        cache.set(key, client)
+      }
+
+      return client
     },
   })
 

--- a/packages/pinia-colada/src/router-utils.test.ts
+++ b/packages/pinia-colada/src/router-utils.test.ts
@@ -43,23 +43,31 @@ describe('createRouterUtils', () => {
     expect(generateOperationKeySpy).toHaveBeenNthCalledWith(1, [], { type: 'query', prefix: '__prefix__' })
     expect(utils.queryOptions()).toBe(vi.mocked(ProcedureUtils).mock.results[0]?.value.queryOptions.mock.results[0]?.value)
 
-    vi.clearAllMocks()
     const keyUtils = utils.key
 
-    expect(ProcedureUtils).toHaveBeenCalledTimes(1)
-    expect(ProcedureUtils).toHaveBeenCalledWith(['key'], client.key, { prefix: '__prefix__' })
-    expect(keyUtils.key({ type: 'mutation' })).toBe(generateOperationKeySpy.mock.results[0]?.value)
-    expect(generateOperationKeySpy).toHaveBeenNthCalledWith(1, ['key'], { type: 'mutation', prefix: '__prefix__' })
-    expect(keyUtils.queryOptions()).toBe(vi.mocked(ProcedureUtils).mock.results[0]?.value.queryOptions.mock.results[0]?.value)
+    expect(ProcedureUtils).toHaveBeenCalledTimes(2)
+    expect(ProcedureUtils).toHaveBeenNthCalledWith(2, ['key'], client.key, { prefix: '__prefix__' })
+    expect(keyUtils.key({ type: 'mutation' })).toBe(generateOperationKeySpy.mock.results[1]?.value)
+    expect(generateOperationKeySpy).toHaveBeenNthCalledWith(2, ['key'], { type: 'mutation', prefix: '__prefix__' })
+    expect(keyUtils.queryOptions()).toBe(vi.mocked(ProcedureUtils).mock.results[1]?.value.queryOptions.mock.results[0]?.value)
 
-    vi.clearAllMocks()
     const pongUtils = keyUtils.pong
 
-    expect(ProcedureUtils).toHaveBeenCalledTimes(1)
-    expect(ProcedureUtils).toHaveBeenCalledWith(['key', 'pong'], client.key.pong, { prefix: '__prefix__' })
-    expect(pongUtils.key({ type: 'query' })).toBe(generateOperationKeySpy.mock.results[0]?.value)
-    expect(generateOperationKeySpy).toHaveBeenNthCalledWith(1, ['key', 'pong'], { type: 'query', prefix: '__prefix__' })
-    expect(pongUtils.queryOptions()).toBe(vi.mocked(ProcedureUtils).mock.results[0]?.value.queryOptions.mock.results[0]?.value)
+    expect(ProcedureUtils).toHaveBeenCalledTimes(3)
+    expect(ProcedureUtils).toHaveBeenNthCalledWith(3, ['key', 'pong'], client.key.pong, { prefix: '__prefix__' })
+    expect(pongUtils.key({ type: 'query' })).toBe(generateOperationKeySpy.mock.results[2]?.value)
+    expect(generateOperationKeySpy).toHaveBeenNthCalledWith(3, ['key', 'pong'], { type: 'query', prefix: '__prefix__' })
+    expect(pongUtils.queryOptions()).toBe(vi.mocked(ProcedureUtils).mock.results[2]?.value.queryOptions.mock.results[0]?.value)
+  })
+
+  it('returns strictly equal utils on repeated access', () => {
+    const utils = createRouterUtils(client) as any
+
+    expect(utils.key).toBe(utils.key)
+    expect(utils.key.pong).toBe(utils.key.pong)
+    expect(utils.key.pong).not.toBe(utils.key)
+
+    expect(createRouterUtils(client)).not.toBe(utils)
   })
 
   it('works with plain object routers', () => {

--- a/packages/pinia-colada/src/router-utils.ts
+++ b/packages/pinia-colada/src/router-utils.ts
@@ -4,7 +4,7 @@ import type { OperationKeyPrefixOptions } from './key'
 import type { RouterUtilsPlugin } from './plugin'
 import type { ProcedureUtilsInfiniteInterceptor, ProcedureUtilsLiveInterceptor, ProcedureUtilsMutationInterceptor, ProcedureUtilsOptions, ProcedureUtilsQueryInterceptor, ProcedureUtilsStreamedInterceptor } from './procedure-utils'
 import { RECURSIVE_CLIENT_UNWRAP_KEYS } from '@orpc/client'
-import { bindMethods, get, getOrBind, isTypescriptObject, toArray } from '@orpc/shared'
+import { bindMethods, isTypescriptObject, toArray } from '@orpc/shared'
 import { CompositeRouterUtilsPlugin } from './plugin'
 import { isProcedureUtilsOptions, mergeProcedureUtilsOptions, ProcedureUtils } from './procedure-utils'
 import { SharedUtils } from './shared-utils'
@@ -110,34 +110,42 @@ function createRouterUtilsInternal<T extends AnyNestedClient>(
       ))
     : bindMethods(new SharedUtils(path, options))
 
+  const cache = new Map<string, unknown>()
+
   const recursive = new Proxy(utils, {
     get(target, prop) {
-      const value = getOrBind(target, prop)
-      const nextClient = (client as Record<PropertyKey, AnyNestedClient>)[prop]
+      const value = Reflect.get(target, prop)
+      const nextClient = Reflect.get(client, prop)
 
       if (typeof prop !== 'string' || RECURSIVE_CLIENT_UNWRAP_KEYS.has(prop) || !isTypescriptObject(nextClient)) {
         return value
       }
 
-      const nextUtils = createRouterUtilsInternal(nextClient as any, {
-        ...options,
-        path: [...path, prop],
-        scoped: get(options.scoped, [prop]) as any,
-      }, plugin)
+      let result = cache.get(prop)
 
-      if (typeof value !== 'function') {
-        return nextUtils
+      if (result === undefined) {
+        const nextUtils = createRouterUtilsInternal(nextClient as any, {
+          ...options,
+          path: [...path, prop],
+          scoped: (options.scoped as undefined | Record<string, RouterUtilsOptions<T>['scoped']>)?.[prop],
+        }, plugin)
+
+        result = typeof value !== 'function'
+          ? nextUtils
+          : new Proxy(value, {
+              get(target, prop) {
+                if (typeof prop !== 'string' || RECURSIVE_CLIENT_UNWRAP_KEYS.has(prop)) {
+                  return Reflect.get(target, prop)
+                }
+
+                return Reflect.get(nextUtils, prop)
+              },
+            })
+
+        cache.set(prop, result)
       }
 
-      return new Proxy(value, {
-        get(target, prop) {
-          if (typeof prop !== 'string' || RECURSIVE_CLIENT_UNWRAP_KEYS.has(prop)) {
-            return getOrBind(target, prop)
-          }
-
-          return getOrBind(nextUtils, prop)
-        },
-      })
+      return result
     },
   })
 

--- a/packages/pinia-colada/src/router-utils.ts
+++ b/packages/pinia-colada/src/router-utils.ts
@@ -107,7 +107,7 @@ function createRouterUtilsInternal<T extends AnyNestedClient>(
           },
           options.scoped ?? {},
         )),
-      ))
+      ), { unbound: ['call'] })
     : bindMethods(new SharedUtils(path, options))
 
   const cache = new Map<string, unknown>()

--- a/packages/server/src/error.ts
+++ b/packages/server/src/error.ts
@@ -2,7 +2,7 @@ import type { ORPCErrorCode, ORPCErrorOptions } from '@orpc/client'
 import type { ErrorMap, ErrorMapItem, InferSchemaInput } from '@orpc/contract'
 import type { MaybeOptionalOptions, Writable } from '@orpc/shared'
 import { ORPCError } from '@orpc/client'
-import { getOrBind, resolveMaybeOptionalOptions } from '@orpc/shared'
+import { resolveMaybeOptionalOptions } from '@orpc/shared'
 
 export type ORPCErrorConstructorMapItemOptions<TData> = Omit<ORPCErrorOptions<TData>, 'status'>
 
@@ -47,7 +47,7 @@ export function createORPCErrorConstructorMap<T extends ErrorMap>(errorMap: T): 
   const proxy = new Proxy(errorMap, {
     get(target, code) {
       if (typeof code !== 'string') {
-        return getOrBind(target, code)
+        return Reflect.get(target, code)
       }
 
       const item: ORPCErrorConstructorMapItem<string, unknown> = (...rest) => {

--- a/packages/server/src/implementer-router.ts
+++ b/packages/server/src/implementer-router.ts
@@ -7,7 +7,7 @@ import type { ProcedureConfig } from './procedure'
 import type { ContractedRouter } from './router'
 import type { AugmentedRouterWithMiddlewares } from './router-utils'
 import { ProcedureContract } from '@orpc/contract'
-import { bindMethods, getOrBind } from '@orpc/shared'
+import { bindMethods } from '@orpc/shared'
 import { ProcedureImplementer } from './implementer-procedure'
 import { Lazy } from './lazy'
 import { decorateMiddleware } from './middleware-decorated'
@@ -254,7 +254,7 @@ function createRouterImplementerInternal<
 
       implementer[key] = new Proxy(method, {
         get(_, p) {
-          return getOrBind(child, p)
+          return Reflect.get(child, p)
         },
       })
     }

--- a/packages/server/src/implementer.ts
+++ b/packages/server/src/implementer.ts
@@ -4,7 +4,7 @@ import type { DefaultInitialContext } from './builder'
 import type { Context } from './context'
 import type { RouterImplementer } from './implementer-router'
 import type { ProcedureConfig } from './procedure'
-import { getOrBind, isTypescriptObject } from '@orpc/shared'
+import { isTypescriptObject } from '@orpc/shared'
 import { createRouterImplementer } from './implementer-router'
 
 export type Implementer<
@@ -36,7 +36,7 @@ export function implement<TContract extends RouterContract, TInitialContext exte
         method = (incoming: ProcedureConfig) => implement(contract, { ...config, ...incoming })
       }
 
-      const value = getOrBind(routerImplementer, p)
+      const value = Reflect.get(routerImplementer, p)
 
       if (method) {
         if (!isTypescriptObject(value)) {
@@ -45,7 +45,7 @@ export function implement<TContract extends RouterContract, TInitialContext exte
 
         return new Proxy(method, {
           get(_, p) {
-            return getOrBind(value, p)
+            return Reflect.get(value, p)
           },
         })
       }

--- a/packages/server/src/router-client.test.ts
+++ b/packages/server/src/router-client.test.ts
@@ -86,6 +86,21 @@ describe('createRouterClient', () => {
     expect((pengClient as any)()).toBe('__MOCK2__')
   })
 
+  it('returns strictly equal client on repeated access', () => {
+    const isolatedClient = createRouterClient(router, options)
+
+    expect(isolatedClient.ping).toBe(isolatedClient.ping)
+    expect(isolatedClient.nested).toBe(isolatedClient.nested)
+    expect(isolatedClient.nested.pong).toBe(isolatedClient.nested.pong)
+    expect(isolatedClient.lazy.peng).toBe(isolatedClient.lazy.peng)
+    expect(isolatedClient.nested.pong).not.toBe(isolatedClient.ping)
+
+    // ping, nested.pong, lazy, and lazy.peng — each created exactly once
+    expect(createProcedureClientSpy).toHaveBeenCalledTimes(4)
+
+    expect(createRouterClient(router, options).ping).not.toBe(isolatedClient.ping)
+  })
+
   it('not define on Symbol, undefined procedure, or unwrap lazy properties', () => {
     expect((client as any).invalid).toBeUndefined()
     expect((client as any)[Symbol.for('something')]).toBeUndefined()

--- a/packages/server/src/router-client.ts
+++ b/packages/server/src/router-client.ts
@@ -1,11 +1,11 @@
-import type { ClientContext } from '@orpc/client'
+import type { AnyNestedClient, ClientContext } from '@orpc/client'
 import type { ErrorMap, Schema } from '@orpc/contract'
 import type { MaybeOptionalOptions } from '@orpc/shared'
 import type { Lazyable } from './lazy'
 import type { ProcedureClient, ProcedureClientOptions } from './procedure-client'
 import type { AnyRouter, InferRouterInitialContext } from './router'
 import { RECURSIVE_CLIENT_UNWRAP_KEYS } from '@orpc/client'
-import { getOrBind, resolveMaybeOptionalOptions, toArray } from '@orpc/shared'
+import { resolveMaybeOptionalOptions, toArray } from '@orpc/shared'
 import { Lazy } from './lazy'
 import { Procedure } from './procedure'
 import { createProcedureClient } from './procedure-client'
@@ -41,22 +41,30 @@ export function createRouterClient<T extends AnyRouter, TClientContext extends C
     ? createProcedureClient(createGuardedProcedureLazy(router), options)
     : {}
 
+  const cache = new Map<string, AnyNestedClient>()
+
   const recursive = new Proxy(procedureCaller, {
     get(target, key) {
       if (typeof key !== 'string' || (router instanceof Lazy && RECURSIVE_CLIENT_UNWRAP_KEYS.has(key))) {
-        return getOrBind(target, key)
+        return Reflect.get(target, key)
       }
 
-      const next = getRouter(router, [key])
+      let nextClient = cache.get(key)
 
-      if (!next) {
-        return getOrBind(target, key)
+      if (nextClient === undefined) {
+        const next = getRouter(router, [key])
+
+        if (!next) {
+          return Reflect.get(target, key)
+        }
+
+        nextClient = createRouterClient(next as any, {
+          ...options,
+          path: [...toArray(options.path), key],
+        })
+
+        cache.set(key, nextClient)
       }
-
-      const nextClient = createRouterClient(next as any, {
-        ...options,
-        path: [...toArray(options.path), key],
-      })
 
       return nextClient
     },

--- a/packages/server/src/router-hidden.ts
+++ b/packages/server/src/router-hidden.ts
@@ -1,7 +1,6 @@
 import type { RouterContract } from '@orpc/contract'
 import type { Lazyable } from './lazy'
 import type { AnyRouter } from './router'
-import { getOrBind } from '@orpc/shared'
 
 const HIDDEN_ROUTER_CONTRACT_SYMBOL = Symbol.for('ORPC_HIDDEN_ROUTER_CONTRACT')
 
@@ -12,7 +11,7 @@ export function withHiddenRouterContract<T extends Lazyable<AnyRouter>>(router: 
         return contract
       }
 
-      return getOrBind(target, key)
+      return Reflect.get(target, key)
     },
   })
 }

--- a/packages/shared/src/object.test.ts
+++ b/packages/shared/src/object.test.ts
@@ -411,4 +411,55 @@ describe('bindMethods', () => {
 
     expect(Reflect.ownKeys(methods)).toEqual([])
   })
+
+  it('leaves methods listed in `unbound` unbound', () => {
+    const obj = {
+      value: 123,
+      getValue() {
+        return this.value
+      },
+      getDouble() {
+        return this.value * 2
+      },
+      [syb1]() {
+        return this.value + 1
+      },
+      [syb2]() {
+        return this.value + 2
+      },
+    }
+
+    const methods = bindMethods(obj, { unbound: ['getValue', syb1] })
+
+    // listed methods are the raw functions
+    expect(methods.getValue).toBe(obj.getValue)
+    expect(methods[syb1]).toBe(obj[syb1])
+    expect(methods.getValue.call({ value: 999 })).toBe(999)
+    expect(methods[syb1].call({ value: 999 })).toBe(1000)
+
+    // the rest stay bound to the original object
+    expect(methods.getDouble).not.toBe(obj.getDouble)
+    expect(methods.getDouble.call({ value: 999 })).toBe(246)
+    expect(methods[syb2].call({ value: 999 })).toBe(125)
+  })
+
+  it('supports `unbound` for methods from the prototype chain', () => {
+    class Base {
+      value = 123
+      getValue() {
+        return this.value
+      }
+    }
+    class Child extends Base {
+      double() {
+        return this.value * 2
+      }
+    }
+
+    const methods = bindMethods(new Child(), { unbound: ['getValue'] })
+
+    expect(methods.getValue).toBe(Base.prototype.getValue)
+    expect(methods.getValue.call({ value: 5 })).toBe(5)
+    expect(methods.double()).toBe(246)
+  })
 })

--- a/packages/shared/src/object.ts
+++ b/packages/shared/src/object.ts
@@ -1,5 +1,5 @@
 import type { AnyFunction } from './function'
-import { isTypescriptObject } from '@standardserver/shared'
+import { getOrBind, isTypescriptObject } from '@standardserver/shared'
 
 export type Segment = string | number
 
@@ -159,7 +159,12 @@ export const NullProtoObj = /* @__PURE__ */ (() => {
  * Methods are collected from both the object itself and its prototype chain
  * (excluding `Object.prototype` and the `constructor` property).
  */
-export function bindMethods<T extends object>(obj: T): Pick<T, { [K in keyof T]: T[K] extends AnyFunction ? K : never; }[keyof T]> {
+export function bindMethods<T extends object>(
+  obj: T,
+  options: { unbound?: (keyof T)[] } = {},
+): Pick<T, { [K in keyof T]: T[K] extends AnyFunction ? K : never; }[keyof T]> {
+  const unbound = new Set<PropertyKey>(options.unbound)
+
   // Use NullProtoObj so special methods like toString and __proto__ are supported.
   const methods = new NullProtoObj()
 
@@ -170,9 +175,9 @@ export function bindMethods<T extends object>(obj: T): Pick<T, { [K in keyof T]:
         continue
       }
 
-      const val = (obj as Record<PropertyKey, unknown>)[key]
+      const val = getOrBind(obj, key, { bind: !unbound.has(key) })
       if (typeof val === 'function') {
-        methods[key] = val.bind(obj)
+        methods[key] = val
       }
     }
 
@@ -181,9 +186,9 @@ export function bindMethods<T extends object>(obj: T): Pick<T, { [K in keyof T]:
         continue
       }
 
-      const val = (obj as Record<PropertyKey, unknown>)[sym]
+      const val = getOrBind(obj, sym, { bind: !unbound.has(sym) })
       if (typeof val === 'function') {
-        methods[sym] = val.bind(obj)
+        methods[sym] = val
       }
     }
 

--- a/packages/swr/src/router-utils.test.ts
+++ b/packages/swr/src/router-utils.test.ts
@@ -56,6 +56,16 @@ describe('createRouterUtils', () => {
     expect(pongUtils.fetcher()).toBe(vi.mocked(ProcedureUtils).mock.results[0]?.value.fetcher.mock.results[0]?.value)
   })
 
+  it('returns strictly equal utils on repeated access', () => {
+    const utils = createRouterUtils(client) as any
+
+    expect(utils.key).toBe(utils.key)
+    expect(utils.key.pong).toBe(utils.key.pong)
+    expect(utils.key.pong).not.toBe(utils.key)
+
+    expect(createRouterUtils(client)).not.toBe(utils)
+  })
+
   it('works with plain object routers', () => {
     const router = { nested: { ping: vi.fn() } } as any
     const utils = createRouterUtils(router) as any

--- a/packages/swr/src/router-utils.ts
+++ b/packages/swr/src/router-utils.ts
@@ -2,7 +2,7 @@ import type { AnyNestedClient, Client } from '@orpc/client'
 import type { Public } from '@orpc/shared'
 import type { OperationKeyPrefixOptions } from './key'
 import { RECURSIVE_CLIENT_UNWRAP_KEYS } from '@orpc/client'
-import { bindMethods, getOrBind, isTypescriptObject, toArray } from '@orpc/shared'
+import { bindMethods, isTypescriptObject, toArray } from '@orpc/shared'
 import { ProcedureUtils } from './procedure-utils'
 import { SharedUtils } from './shared-utils'
 
@@ -38,30 +38,38 @@ export function createRouterUtils<T extends AnyNestedClient>(
     ? bindMethods(new ProcedureUtils(path, client, { prefix: options.prefix }))
     : bindMethods(new SharedUtils(path, { prefix: options.prefix }))
 
+  const cache = new Map<string, unknown>()
+
   const recursive = new Proxy(utils, {
     get(target, prop) {
-      const value = getOrBind(target, prop)
-      const nextClient = (client as Record<PropertyKey, AnyNestedClient>)[prop]
+      const value = Reflect.get(target, prop)
+      const nextClient = Reflect.get(client, prop)
 
       if (typeof prop !== 'string' || RECURSIVE_CLIENT_UNWRAP_KEYS.has(prop) || !isTypescriptObject(nextClient)) {
         return value
       }
 
-      const nextUtils = createRouterUtils(nextClient as any, { ...options, path: [...path, prop] })
+      let result = cache.get(prop)
 
-      if (typeof value !== 'function') {
-        return nextUtils
+      if (result === undefined) {
+        const nextUtils = createRouterUtils(nextClient as any, { ...options, path: [...path, prop] })
+
+        result = typeof value !== 'function'
+          ? nextUtils
+          : new Proxy(value, {
+              get(target, prop) {
+                if (typeof prop !== 'string' || RECURSIVE_CLIENT_UNWRAP_KEYS.has(prop)) {
+                  return Reflect.get(target, prop)
+                }
+
+                return Reflect.get(nextUtils, prop)
+              },
+            })
+
+        cache.set(prop, result)
       }
 
-      return new Proxy(value, {
-        get(target, prop) {
-          if (typeof prop !== 'string' || RECURSIVE_CLIENT_UNWRAP_KEYS.has(prop)) {
-            return getOrBind(target, prop)
-          }
-
-          return getOrBind(nextUtils, prop)
-        },
-      })
+      return result
     },
   })
 

--- a/packages/swr/src/router-utils.ts
+++ b/packages/swr/src/router-utils.ts
@@ -35,7 +35,7 @@ export function createRouterUtils<T extends AnyNestedClient>(
   const path = toArray(options.path)
 
   const utils = typeof client === 'function'
-    ? bindMethods(new ProcedureUtils(path, client, { prefix: options.prefix }))
+    ? bindMethods(new ProcedureUtils(path, client, { prefix: options.prefix }), { unbound: ['call'] })
     : bindMethods(new SharedUtils(path, { prefix: options.prefix }))
 
   const cache = new Map<string, unknown>()

--- a/packages/tanstack-query/src/router-utils.test.ts
+++ b/packages/tanstack-query/src/router-utils.test.ts
@@ -43,23 +43,31 @@ describe('createRouterUtils', () => {
     expect(generateOperationKeySpy).toHaveBeenNthCalledWith(1, [], { type: 'infinite', prefix: '__prefix__' })
     expect(utils.queryOptions()).toBe(vi.mocked(ProcedureUtils).mock.results[0]?.value.queryOptions.mock.results[0]?.value)
 
-    vi.clearAllMocks()
     const keyUtils = utils.key
 
-    expect(ProcedureUtils).toHaveBeenCalledTimes(1)
-    expect(ProcedureUtils).toHaveBeenCalledWith(['key'], client.key, { prefix: '__prefix__' })
-    expect(keyUtils.key({ type: 'live' })).toBe(generateOperationKeySpy.mock.results[0]?.value)
-    expect(generateOperationKeySpy).toHaveBeenNthCalledWith(1, ['key'], { type: 'live', prefix: '__prefix__' })
-    expect(keyUtils.queryOptions()).toBe(vi.mocked(ProcedureUtils).mock.results[0]?.value.queryOptions.mock.results[0]?.value)
+    expect(ProcedureUtils).toHaveBeenCalledTimes(2)
+    expect(ProcedureUtils).toHaveBeenNthCalledWith(2, ['key'], client.key, { prefix: '__prefix__' })
+    expect(keyUtils.key({ type: 'live' })).toBe(generateOperationKeySpy.mock.results[1]?.value)
+    expect(generateOperationKeySpy).toHaveBeenNthCalledWith(2, ['key'], { type: 'live', prefix: '__prefix__' })
+    expect(keyUtils.queryOptions()).toBe(vi.mocked(ProcedureUtils).mock.results[1]?.value.queryOptions.mock.results[0]?.value)
 
-    vi.clearAllMocks()
     const pongUtils = keyUtils.pong
 
-    expect(ProcedureUtils).toHaveBeenCalledTimes(1)
-    expect(ProcedureUtils).toHaveBeenCalledWith(['key', 'pong'], client.key.pong, { prefix: '__prefix__' })
-    expect(pongUtils.key({ type: 'query' })).toBe(generateOperationKeySpy.mock.results[0]?.value)
-    expect(generateOperationKeySpy).toHaveBeenNthCalledWith(1, ['key', 'pong'], { type: 'query', prefix: '__prefix__' })
-    expect(pongUtils.queryOptions()).toBe(vi.mocked(ProcedureUtils).mock.results[0]?.value.queryOptions.mock.results[0]?.value)
+    expect(ProcedureUtils).toHaveBeenCalledTimes(3)
+    expect(ProcedureUtils).toHaveBeenNthCalledWith(3, ['key', 'pong'], client.key.pong, { prefix: '__prefix__' })
+    expect(pongUtils.key({ type: 'query' })).toBe(generateOperationKeySpy.mock.results[2]?.value)
+    expect(generateOperationKeySpy).toHaveBeenNthCalledWith(3, ['key', 'pong'], { type: 'query', prefix: '__prefix__' })
+    expect(pongUtils.queryOptions()).toBe(vi.mocked(ProcedureUtils).mock.results[2]?.value.queryOptions.mock.results[0]?.value)
+  })
+
+  it('returns strictly equal utils on repeated access', () => {
+    const utils = createRouterUtils(client) as any
+
+    expect(utils.key).toBe(utils.key)
+    expect(utils.key.pong).toBe(utils.key.pong)
+    expect(utils.key.pong).not.toBe(utils.key)
+
+    expect(createRouterUtils(client)).not.toBe(utils)
   })
 
   it('roots utils at the given base path', () => {
@@ -70,13 +78,12 @@ describe('createRouterUtils', () => {
     expect(utils.key({ type: 'infinite' })).toBe(generateOperationKeySpy.mock.results[0]?.value)
     expect(generateOperationKeySpy).toHaveBeenNthCalledWith(1, ['__base__'], { type: 'infinite', prefix: undefined })
 
-    vi.clearAllMocks()
     const keyUtils = utils.key
 
-    expect(ProcedureUtils).toHaveBeenCalledTimes(1)
-    expect(ProcedureUtils).toHaveBeenCalledWith(['__base__', 'key'], client.key, {})
-    expect(keyUtils.key({ type: 'live' })).toBe(generateOperationKeySpy.mock.results[0]?.value)
-    expect(generateOperationKeySpy).toHaveBeenNthCalledWith(1, ['__base__', 'key'], { type: 'live', prefix: undefined })
+    expect(ProcedureUtils).toHaveBeenCalledTimes(2)
+    expect(ProcedureUtils).toHaveBeenNthCalledWith(2, ['__base__', 'key'], client.key, {})
+    expect(keyUtils.key({ type: 'live' })).toBe(generateOperationKeySpy.mock.results[1]?.value)
+    expect(generateOperationKeySpy).toHaveBeenNthCalledWith(2, ['__base__', 'key'], { type: 'live', prefix: undefined })
   })
 
   it('stops recursive on symbol', async () => {

--- a/packages/tanstack-query/src/router-utils.ts
+++ b/packages/tanstack-query/src/router-utils.ts
@@ -106,7 +106,7 @@ function createRouterUtilsInternal<T extends AnyNestedClient>(
           },
           options.scoped ?? {},
         )),
-      ))
+      ), { unbound: ['call'] })
     : bindMethods(new SharedUtils(path, options))
 
   const cache = new Map<string, unknown>()

--- a/packages/tanstack-query/src/router-utils.ts
+++ b/packages/tanstack-query/src/router-utils.ts
@@ -4,7 +4,7 @@ import type { OperationKeyPrefixOptions } from './key'
 import type { RouterUtilsPlugin } from './plugin'
 import type { ProcedureUtilsInfiniteInterceptor, ProcedureUtilsLiveInterceptor, ProcedureUtilsMutationInterceptor, ProcedureUtilsOptions, ProcedureUtilsQueryInterceptor, ProcedureUtilsStreamedInterceptor } from './procedure-utils'
 import { RECURSIVE_CLIENT_UNWRAP_KEYS } from '@orpc/client'
-import { bindMethods, get, getOrBind, isTypescriptObject, toArray } from '@orpc/shared'
+import { bindMethods, isTypescriptObject, toArray } from '@orpc/shared'
 import { CompositeRouterUtilsPlugin } from './plugin'
 import { isProcedureUtilsOptions, mergeProcedureUtilsOptions, ProcedureUtils } from './procedure-utils'
 import { SharedUtils } from './shared-utils'
@@ -109,34 +109,42 @@ function createRouterUtilsInternal<T extends AnyNestedClient>(
       ))
     : bindMethods(new SharedUtils(path, options))
 
+  const cache = new Map<string, unknown>()
+
   const recursive = new Proxy(utils, {
     get(target, prop) {
-      const value = getOrBind(target, prop)
-      const nextClient = (client as Record<PropertyKey, AnyNestedClient>)[prop]
+      const value = Reflect.get(target, prop)
+      const nextClient = Reflect.get(client, prop)
 
       if (typeof prop !== 'string' || RECURSIVE_CLIENT_UNWRAP_KEYS.has(prop) || !isTypescriptObject(nextClient)) {
         return value
       }
 
-      const nextUtils = createRouterUtilsInternal(nextClient as any, {
-        ...options,
-        path: [...path, prop],
-        scoped: get(options.scoped, [prop]) as any,
-      }, plugin)
+      let result = cache.get(prop)
 
-      if (typeof value !== 'function') {
-        return nextUtils
+      if (result === undefined) {
+        const nextUtils = createRouterUtilsInternal(nextClient as any, {
+          ...options,
+          path: [...path, prop],
+          scoped: (options.scoped as undefined | Record<string, RouterUtilsOptions<T>['scoped']>)?.[prop],
+        }, plugin)
+
+        result = typeof value !== 'function'
+          ? nextUtils
+          : new Proxy(value, {
+              get(target, prop) {
+                if (typeof prop !== 'string' || RECURSIVE_CLIENT_UNWRAP_KEYS.has(prop)) {
+                  return Reflect.get(target, prop)
+                }
+
+                return Reflect.get(nextUtils, prop)
+              },
+            })
+
+        cache.set(prop, result)
       }
 
-      return new Proxy(value, {
-        get(target, prop) {
-          if (typeof prop !== 'string' || RECURSIVE_CLIENT_UNWRAP_KEYS.has(prop)) {
-            return getOrBind(target, prop)
-          }
-
-          return getOrBind(nextUtils, prop)
-        },
-      })
+      return result
     },
   })
 


### PR DESCRIPTION
Accessing a nested procedure on a recursive proxy used to build a brand new object every time, so `client.planet.list !== client.planet.list`. Each proxy now memoizes its children in a `Map` keyed by the accessed property, making repeated access strictly equal.

## Fixes

- `createORPCClient`, `createSafeClient`, `createRouterClient`, and `createRouterUtils` (tanstack-query, pinia-colada, swr) all return the same child on repeated access.
- Utils and clients are now safe to pass straight into dependency arrays, memo hooks, and identity comparisons without wrapping them in a `useMemo`.

## Performance

- No proxy, options object, or path array allocated per property access — only on the first one.
- `createRouterClient` no longer repeats its `getRouter` lookup (and lazy-router traversal) on every access.
- Nested proxies read through `Reflect.get` instead of `getOrBind`; per-access binding is unnecessary now that children are stable, and the eslint rule banning `Reflect.get` is dropped.

Caches are per-proxy-instance, so two separate `createORPCClient` calls stay distinct. Symbols, unwrap keys (`then`, `bind`, `toString`, …), and keys with no matching router still fall through untouched and uncached.

## Testing

Each affected package gained a repeated-access equality test; the tanstack-query and pinia-colada suites also assert each procedure client/utils is constructed exactly once. Full suite, `type:check`, and `lint` pass.