### PR TITLE
feat: re-export renamed v1 APIs as deprecated aliases

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -14,6 +14,12 @@ export * from './error-utils'
 export * from './rpc-json-serializer'
 export * from './rpc-serializer'
 export * from './types'
+export type {
+  /**
+   * @deprecated Use `InferClientError` instead.
+   */
+  InferClientError as InferClientErrorUnion,
+} from './types'
 export * from './utils'
 
 export type {
@@ -53,6 +59,13 @@ export {
    * @deprecated Use `streamToAsyncIteratorObject` instead.
    */
   streamToAsyncIteratorObject as streamToEventIterator,
+} from '@orpc/shared'
+
+export type {
+  /**
+   * @deprecated Use `PromiseWithError` instead.
+   */
+  PromiseWithError as ClientPromiseResult,
 } from '@orpc/shared'
 
 export type {

--- a/packages/client/src/plugins/index.ts
+++ b/packages/client/src/plugins/index.ts
@@ -1,7 +1,31 @@
 export * from './batch'
 export * from './dedupe'
+export {
+  /**
+   * @deprecated Use `DedupeLinkPlugin` instead.
+   */
+  DedupeLinkPlugin as DedupeRequestsPlugin,
+} from './dedupe'
 export * from './request-compression'
 export * from './response-compression'
 export * from './retry'
+export {
+  /**
+   * @deprecated Use `RetryLinkPlugin` instead.
+   */
+  RetryLinkPlugin as ClientRetryPlugin,
+} from './retry'
+export type {
+  /**
+   * @deprecated Use `RetryLinkPluginContext` instead.
+   */
+  RetryLinkPluginContext as ClientRetryPluginContext,
+} from './retry'
 export * from './retry-after'
+export {
+  /**
+   * @deprecated Use `RetryAfterLinkPlugin` instead.
+   */
+  RetryAfterLinkPlugin as RetryAfterPlugin,
+} from './retry-after'
 export * from './timeout'

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -7,10 +7,44 @@ export * from './meta'
 export * from './meta-built-in'
 export * from './meta-utils'
 export * from './procedure'
+export type {
+  /**
+   * @deprecated Use `AnyProcedureContract` instead.
+   */
+  AnyProcedureContract as AnyContractProcedure,
+} from './procedure'
 export * from './procedure-client'
 export * from './router'
+export type {
+  /**
+   * @deprecated Use `RouterContract` instead.
+   */
+  RouterContract as AnyContractRouter,
+  /**
+   * @deprecated Use `InferRouterContractErrorMap` instead.
+   */
+  InferRouterContractErrorMap as InferContractRouterErrorMap,
+  /**
+   * @deprecated Use `InferRouterContractInputs` instead.
+   */
+  InferRouterContractInputs as InferContractRouterInputs,
+  /**
+   * @deprecated Use `InferRouterContractOutputs` instead.
+   */
+  InferRouterContractOutputs as InferContractRouterOutputs,
+} from './router'
 export * from './router-client'
 export * from './router-utils'
+export {
+  /**
+   * @deprecated Use `getRouterContract` instead.
+   */
+  getRouterContract as getContractRouter,
+  /**
+   * @deprecated Use `minifyRouterContract` instead.
+   */
+  minifyRouterContract as minifyContractRouter,
+} from './router-utils'
 export * from './schema'
 export * from './schema-built-in'
 export {

--- a/packages/contract/src/plugins/index.ts
+++ b/packages/contract/src/plugins/index.ts
@@ -1,2 +1,14 @@
 export * from './request-validation'
+export {
+  /**
+   * @deprecated Use `RequestValidationLinkPlugin` instead.
+   */
+  RequestValidationLinkPlugin as RequestValidationPlugin,
+} from './request-validation'
 export * from './response-validation'
+export {
+  /**
+   * @deprecated Use `ResponseValidationLinkPlugin` instead.
+   */
+  ResponseValidationLinkPlugin as ResponseValidationPlugin,
+} from './response-validation'

--- a/packages/next/src/hooks/index.ts
+++ b/packages/next/src/hooks/index.ts
@@ -1,2 +1,14 @@
 export * from './optimistic-server-function'
+export {
+  /**
+   * @deprecated Use `useOptimisticServerFunction` instead.
+   */
+  useOptimisticServerFunction as useOptimisticServerAction,
+} from './optimistic-server-function'
 export * from './server-function'
+export {
+  /**
+   * @deprecated Use `useServerFunction` instead.
+   */
+  useServerFunction as useServerAction,
+} from './server-function'

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1,5 +1,17 @@
 export * from './deferred-interceptors'
 export * from './server-form-function'
+export {
+  /**
+   * @deprecated Use `createServerFormFunction` instead.
+   */
+  createServerFormFunction as createFormAction,
+} from './server-form-function'
+export type {
+  /**
+   * @deprecated Use `ServerFormFunction` instead.
+   */
+  ServerFormFunction as FormAction,
+} from './server-form-function'
 export * from './server-form-functionable'
 export * from './server-function'
 export * from './server-functionable'

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -6,12 +6,6 @@ export {
    */
   createServerFormFunction as createFormAction,
 } from './server-form-function'
-export type {
-  /**
-   * @deprecated Use `ServerFormFunction` instead.
-   */
-  ServerFormFunction as FormAction,
-} from './server-form-function'
 export * from './server-form-functionable'
 export * from './server-function'
 export * from './server-functionable'

--- a/packages/pinia-colada/src/index.ts
+++ b/packages/pinia-colada/src/index.ts
@@ -6,6 +6,12 @@ export * from './plugin'
 export * from './procedure-utils'
 export * from './router-utils'
 export {
+  /**
+   * @deprecated Use `createRouterUtils` instead.
+   */
+  createRouterUtils as createORPCVueColadaUtils,
+} from './router-utils'
+export {
   createRouterUtils as createPiniaColadaUtils,
 } from './router-utils'
 export * from './shared-utils'

--- a/packages/server/src/adapters/fetch/index.ts
+++ b/packages/server/src/adapters/fetch/index.ts
@@ -1,3 +1,9 @@
+export {
+  /**
+   * @deprecated Use `RequestLimitHandlerPlugin` from `@orpc/server/plugins` instead.
+   */
+  RequestLimitHandlerPlugin as BodyLimitPlugin,
+} from '../../plugins/request-limit'
 export * from './handler'
 export * from './plugin'
 export * from './rpc-handler'

--- a/packages/server/src/adapters/node/index.ts
+++ b/packages/server/src/adapters/node/index.ts
@@ -1,3 +1,9 @@
+export {
+  /**
+   * @deprecated Use `RequestLimitHandlerPlugin` from `@orpc/server/plugins` instead.
+   */
+  RequestLimitHandlerPlugin as BodyLimitPlugin,
+} from '../../plugins/request-limit'
 export * from './handler'
 export * from './plugin'
 export * from './rpc-handler'

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,12 +2,6 @@ export * from './builder'
 export * from './builder-variants'
 export * from './constants'
 export * from './context'
-export type {
-  /**
-   * @deprecated Use `MergedContext` instead.
-   */
-  MergedContext as MergedCurrentContext,
-} from './context'
 export * from './error'
 export * from './implementer'
 export * from './implementer-procedure'

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -2,6 +2,12 @@ export * from './builder'
 export * from './builder-variants'
 export * from './constants'
 export * from './context'
+export type {
+  /**
+   * @deprecated Use `MergedContext` instead.
+   */
+  MergedContext as MergedCurrentContext,
+} from './context'
 export * from './error'
 export * from './implementer'
 export * from './implementer-procedure'
@@ -14,6 +20,12 @@ export * from './procedure-client'
 export * from './procedure-decorated'
 export * from './procedure-utils'
 export * from './router'
+export type {
+  /**
+   * @deprecated Use `InferRouterFinalContexts` instead.
+   */
+  InferRouterFinalContexts as InferRouterCurrentContexts,
+} from './router'
 export * from './router-client'
 export * from './router-hidden'
 export * from './router-utils'

--- a/packages/server/src/plugins/index.ts
+++ b/packages/server/src/plugins/index.ts
@@ -1,9 +1,39 @@
 export * from './batch'
 export * from './cors'
+export {
+  /**
+   * @deprecated Use `CORSHandlerPlugin` instead.
+   */
+  CORSHandlerPlugin as CORSPlugin,
+} from './cors'
 export * from './csrf-guard'
 export * from './request-compression'
 export * from './request-headers'
+export {
+  /**
+   * @deprecated Use `RequestHeadersHandlerPlugin` instead.
+   */
+  RequestHeadersHandlerPlugin as RequestHeadersPlugin,
+} from './request-headers'
+export type {
+  /**
+   * @deprecated Use `RequestHeadersHandlerPluginContext` instead.
+   */
+  RequestHeadersHandlerPluginContext as RequestHeadersPluginContext,
+} from './request-headers'
 export * from './request-limit'
 export * from './response-compression'
 export * from './response-headers'
+export {
+  /**
+   * @deprecated Use `ResponseHeadersHandlerPlugin` instead.
+   */
+  ResponseHeadersHandlerPlugin as ResponseHeadersPlugin,
+} from './response-headers'
+export type {
+  /**
+   * @deprecated Use `ResponseHeadersHandlerPluginContext` instead.
+   */
+  ResponseHeadersHandlerPluginContext as ResponseHeadersPluginContext,
+} from './response-headers'
 export * from './rethrow'


### PR DESCRIPTION
Code written against v1 breaks on v2 for a set of APIs that were only renamed, not changed — the import fails with "no exported member" and gives no hint at the new name. This adds deprecated aliases for those, so v1 code keeps compiling and the IDE points at the current name via `@deprecated`.