### PR TITLE
fix(client): match subclasses in ORPCError cross-context instanceof check

### DIFF
--- a/packages/client/src/error.test.ts
+++ b/packages/client/src/error.test.ts
@@ -80,4 +80,27 @@ describe('oRPCError', () => {
     expect(notRelated instanceof NotRelated).toBe(true)
     expect(nullProtoObj instanceof NotRelated).toBe(false)
   })
+
+  it('instanceof matches cross-context ORPCError instances', ({ onTestFinished }) => {
+    /**
+     * Stands in for an ORPCError constructor from a separate dependency graph:
+     * unrelated prototype chain, but registered in the shared global WeakSet.
+     */
+    class CrossContextORPCError extends Error {}
+    class ExtendedCrossContextORPCError extends CrossContextORPCError {}
+
+    expect(new Error('message') instanceof ORPCError).toBe(false)
+    expect(new CrossContextORPCError() instanceof ORPCError).toBe(false)
+    expect(new ExtendedCrossContextORPCError() instanceof ORPCError).toBe(false)
+
+    const constructors: WeakSet<object> = (globalThis as any)[Symbol.for('ORPC_ERROR_CONSTRUCTORS')]
+    constructors.add(CrossContextORPCError)
+    onTestFinished(() => {
+      constructors.delete(CrossContextORPCError)
+    })
+
+    expect(new Error('message') instanceof ORPCError).toBe(false)
+    expect(new CrossContextORPCError() instanceof ORPCError).toBe(true)
+    expect(new ExtendedCrossContextORPCError() instanceof ORPCError).toBe(true)
+  })
 })

--- a/packages/client/src/error.ts
+++ b/packages/client/src/error.ts
@@ -1,5 +1,5 @@
 import type { MaybeOptionalOptions, Registry } from '@orpc/shared'
-import { getConstructor, resolveMaybeOptionalOptions } from '@orpc/shared'
+import { getConstructors, resolveMaybeOptionalOptions } from '@orpc/shared'
 
 export const COMMON_ERROR_STATUS_MAP = {
   BAD_REQUEST: 400,
@@ -125,9 +125,10 @@ export class ORPCError<TCode extends ORPCErrorCode, TData> extends Error {
       return super[Symbol.hasInstance](instance)
     }
 
-    const constructor = getConstructor(instance)
-    if (constructor && ORPCErrorConstructors.has(constructor)) {
-      return true
+    for (const constructor of getConstructors(instance)) {
+      if (ORPCErrorConstructors.has(constructor)) {
+        return true
+      }
     }
 
     // fallback to default instanceof check

--- a/packages/shared/src/object.test.ts
+++ b/packages/shared/src/object.test.ts
@@ -1,7 +1,7 @@
 import * as a from 'arktype'
 import * as v from 'valibot'
 import z from 'zod'
-import { bindMethods, clone, findDeepMatches, get, getConstructor, isPlainObject, isPropertyKey, NullProtoObj, omit, set } from './object'
+import { bindMethods, clone, findDeepMatches, get, getConstructor, getConstructors, isPlainObject, isPropertyKey, NullProtoObj, omit, set } from './object'
 
 it('findDeepMatches', () => {
   const { maps, values } = findDeepMatches(v => typeof v === 'string', {
@@ -41,6 +41,61 @@ it('getConstructor', () => {
   expect(getConstructor({})).toBe(Object)
   expect(getConstructor(new Error('hi'))).toBe(Error)
   expect(getConstructor(() => { })).toBe(Function)
+})
+
+describe('getConstructors', () => {
+  it('returns nothing for primitives', () => {
+    expect([...getConstructors(null)]).toEqual([])
+    expect([...getConstructors(undefined)]).toEqual([])
+    expect([...getConstructors(123)]).toEqual([])
+    expect([...getConstructors('string')]).toEqual([])
+    expect([...getConstructors(true)]).toEqual([])
+    expect([...getConstructors(Symbol('s'))]).toEqual([])
+  })
+
+  it('works with plain objects and built-ins', () => {
+    expect([...getConstructors({})]).toEqual([Object])
+    expect([...getConstructors([])]).toEqual([Array, Object])
+    expect([...getConstructors(new Map())]).toEqual([Map, Object])
+    expect([...getConstructors(new Error('hi'))]).toEqual([Error, Object])
+  })
+
+  it('returns the full chain for class inheritance', () => {
+    class GrandParent {}
+    class Parent extends GrandParent {}
+    class Child extends Parent {}
+
+    expect([...getConstructors(new Child())]).toEqual([Child, Parent, GrandParent, Object])
+    expect([...getConstructors(new Parent())]).toEqual([Parent, GrandParent, Object])
+    expect([...getConstructors(new GrandParent())]).toEqual([GrandParent, Object])
+  })
+
+  it('works with classes extending built-ins', () => {
+    class MyError extends Error {}
+    class SubError extends MyError {}
+
+    expect([...getConstructors(new SubError())]).toEqual([SubError, MyError, Error, Object])
+  })
+
+  it('returns nothing for null-prototype objects', () => {
+    expect([...getConstructors(Object.create(null))]).toEqual([])
+  })
+
+  it('skips levels without a constructor', () => {
+    const proto = Object.create(null) // no constructor
+    const instance = Object.create(proto)
+
+    expect([...getConstructors(instance)]).toEqual([])
+  })
+
+  it('is lazy', () => {
+    class Parent {}
+    class Child extends Parent {}
+
+    const generator = getConstructors(new Child())
+    expect(generator.next().value).toBe(Child)
+    expect(generator.next().value).toBe(Parent)
+  })
 })
 
 it('isPlainObject', () => {

--- a/packages/shared/src/object.ts
+++ b/packages/shared/src/object.ts
@@ -41,6 +41,20 @@ export function getConstructor(value: unknown): Function | null | undefined { //
   return Object.getPrototypeOf(value)?.constructor
 }
 
+export function* getConstructors(value: unknown): Generator<Function> { // eslint-disable-line ts/no-unsafe-function-type
+  if (!isTypescriptObject(value)) {
+    return
+  }
+
+  let proto = Object.getPrototypeOf(value)
+  while (proto != null) {
+    if (proto.constructor) {
+      yield proto.constructor
+    }
+    proto = Object.getPrototypeOf(proto)
+  }
+}
+
 /**
  * Checks whether a value is a plain object, including objects created with
  * `Object.create(null)`.


### PR DESCRIPTION
The cross-context `instanceof ORPCError` workaround only checked an instance's direct constructor against the registered constructor set, so instances of classes extending an `ORPCError` from another dependency graph (e.g. Next.js Optimized SSR contexts) failed the check. `Symbol.hasInstance` now walks the instance's whole prototype chain, so such subclass instances are recognized as `ORPCError` too.

## Fixes

- Subclasses of a foreign-context `ORPCError` now pass `instanceof ORPCError`; previously only direct instances matched.
- Same-context behavior is unchanged — the default `instanceof` fallback and the extended-class guard are untouched, and only registered `ORPCError` constructors can match, so no false positives.

## Testing

- New `getConstructors` helper in `@orpc/shared` is covered for primitives, built-ins, inheritance chains, null-prototype objects, and laziness.
- New test simulates a foreign dependency graph by registering an unrelated class in the global constructor set, verifying both it and its subclass pass `instanceof ORPCError`, and that they stop matching once deregistered.