### PR TITLE
feat(effect): add catchORPCError, catchORPCErrorCode and catchORPCErrorCodes utils

### DIFF
--- a/apps/content/docs/integrations/effect.md
+++ b/apps/content/docs/integrations/effect.md
@@ -194,6 +194,27 @@ if (isInferableError(error)) {
 }
 ```
 
+### Catching ORPCErrors
+
+Use `catchORPCError` to recover from every `ORPCError` failure in the error channel of an effect, or `catchORPCErrorByCode` to recover from a specific code only. Recovered errors are excluded from the resulting effect, and other failures re-fail with their original cause:
+
+```ts
+import { catchORPCError, catchORPCErrorByCode } from '@orpc/experimental-effect'
+import { Effect } from 'effect'
+
+const recovered = program.pipe(
+  catchORPCError(error => Effect.succeed(`caught ${error.code}`)),
+)
+
+const fallback = program.pipe(
+  catchORPCErrorByCode('NOT_FOUND', error => Effect.succeed(error.data.id)),
+)
+```
+
+::: info
+Both utilities support data-first `catchORPCError(program, handler)` and data-last `program.pipe(catchORPCError(handler))` styles.
+:::
+
 ## Effect Schema
 
 oRPC natively supports [Standard Schema](https://standardschema.dev/schema#what-schema-libraries-implement-the-spec), and [Effect Schema](https://effect.website/docs/schema/introduction/) implements that spec through [Schema.toStandardSchemaV1](https://effect.website/docs/schema/standard-schema/):

--- a/apps/content/docs/integrations/effect.md
+++ b/apps/content/docs/integrations/effect.md
@@ -196,10 +196,10 @@ if (isInferableError(error)) {
 
 ### Catching ORPCErrors
 
-Use `catchORPCError` to recover from every `ORPCError` failure in the error channel of an effect, or `catchORPCErrorByCode` to recover from a specific code only. Recovered errors are excluded from the resulting effect, and other failures re-fail with their original cause:
+Use `catchORPCError` to recover from every `ORPCError` failure in the error channel of an effect, or `catchORPCErrorCode` and `catchORPCErrorCodes` to recover from specific codes only. Recovered errors are excluded from the resulting effect, and other failures re-fail with their original cause:
 
 ```ts
-import { catchORPCError, catchORPCErrorByCode } from '@orpc/experimental-effect'
+import { catchORPCError, catchORPCErrorCode, catchORPCErrorCodes } from '@orpc/experimental-effect'
 import { Effect } from 'effect'
 
 const recovered = program.pipe(
@@ -207,12 +207,19 @@ const recovered = program.pipe(
 )
 
 const fallback = program.pipe(
-  catchORPCErrorByCode('NOT_FOUND', error => Effect.succeed(error.data.id)),
+  catchORPCErrorCode('NOT_FOUND', error => Effect.succeed(error.data.id)),
+)
+
+const handled = program.pipe(
+  catchORPCErrorCodes({
+    NOT_FOUND: error => Effect.succeed(error.data.id),
+    CONFLICT: error => Effect.succeed(error.message),
+  }),
 )
 ```
 
 ::: info
-Both utilities support data-first `catchORPCError(program, handler)` and data-last `program.pipe(catchORPCError(handler))` styles.
+All utilities support data-first `catchORPCError(program, handler)` and data-last `program.pipe(catchORPCError(handler))` styles.
 :::
 
 ## Effect Schema

--- a/packages/effect/src/error.test-d.ts
+++ b/packages/effect/src/error.test-d.ts
@@ -1,0 +1,106 @@
+import type { ORPCError } from '@orpc/server'
+import { Effect } from 'effect'
+import { catchORPCError, catchORPCErrorByCode } from './error'
+
+class Service1 {
+  declare id: 'Service1'
+}
+
+class Service2 {
+  declare id: 'Service2'
+}
+
+const effect = {} as Effect.Effect<
+  'output',
+  ORPCError<'NOT_FOUND', { id: string }> | ORPCError<'CONFLICT', number> | TypeError,
+  Service1
+>
+
+describe('catchORPCError', () => {
+  it('catches every ORPCError and excludes them from the error channel (data-last)', () => {
+    const recovered = effect.pipe(catchORPCError((error) => {
+      expectTypeOf(error).toEqualTypeOf<ORPCError<'NOT_FOUND', { id: string }> | ORPCError<'CONFLICT', number>>()
+      return Effect.succeed('recovered' as const)
+    }))
+
+    expectTypeOf(recovered).toEqualTypeOf<Effect.Effect<'output' | 'recovered', TypeError, Service1>>()
+  })
+
+  it('catches every ORPCError and excludes them from the error channel (data-first)', () => {
+    const recovered = catchORPCError(effect, (error) => {
+      expectTypeOf(error).toEqualTypeOf<ORPCError<'NOT_FOUND', { id: string }> | ORPCError<'CONFLICT', number>>()
+      return Effect.succeed('recovered' as const)
+    })
+
+    expectTypeOf(recovered).toEqualTypeOf<Effect.Effect<'output' | 'recovered', TypeError, Service1>>()
+  })
+
+  it('merges handler error and requirement channels into the result', () => {
+    const recovered = effect.pipe(
+      catchORPCError(() => ({} as Effect.Effect<'recovered', RangeError, Service2>)),
+    )
+
+    expectTypeOf(recovered).toEqualTypeOf<Effect.Effect<'output' | 'recovered', RangeError | TypeError, Service1 | Service2>>()
+  })
+
+  it('handler receives never when the error channel contains no ORPCError', () => {
+    const safe = {} as Effect.Effect<'output', TypeError>
+
+    void safe.pipe(catchORPCError((error) => {
+      expectTypeOf(error).toEqualTypeOf<never>()
+      return Effect.succeed('recovered' as const)
+    }))
+  })
+})
+
+describe('catchORPCErrorByCode', () => {
+  it('catches ORPCErrors with a matching code and excludes them from the error channel (data-last)', () => {
+    const recovered = effect.pipe(catchORPCErrorByCode('NOT_FOUND', (error) => {
+      expectTypeOf(error).toEqualTypeOf<ORPCError<'NOT_FOUND', { id: string }>>()
+      return Effect.succeed('recovered' as const)
+    }))
+
+    expectTypeOf(recovered).toEqualTypeOf<Effect.Effect<'output' | 'recovered', ORPCError<'CONFLICT', number> | TypeError, Service1>>()
+  })
+
+  it('catches ORPCErrors with a matching code and excludes them from the error channel (data-first)', () => {
+    const recovered = catchORPCErrorByCode(effect, 'CONFLICT', (error) => {
+      expectTypeOf(error).toEqualTypeOf<ORPCError<'CONFLICT', number>>()
+      return Effect.succeed('recovered' as const)
+    })
+
+    expectTypeOf(recovered).toEqualTypeOf<Effect.Effect<'output' | 'recovered', ORPCError<'NOT_FOUND', { id: string }> | TypeError, Service1>>()
+  })
+
+  it('merges handler error and requirement channels into the result', () => {
+    const recovered = effect.pipe(
+      catchORPCErrorByCode('NOT_FOUND', () => ({} as Effect.Effect<'recovered', RangeError, Service2>)),
+    )
+
+    expectTypeOf(recovered).toEqualTypeOf<
+      Effect.Effect<'output' | 'recovered', ORPCError<'CONFLICT', number> | RangeError | TypeError, Service1 | Service2>
+    >()
+  })
+
+  it('supports custom error codes', () => {
+    const custom = {} as Effect.Effect<'output', ORPCError<'__CUSTOM__', undefined> | TypeError>
+
+    const recovered = custom.pipe(catchORPCErrorByCode('__CUSTOM__', (error) => {
+      expectTypeOf(error).toEqualTypeOf<ORPCError<'__CUSTOM__', undefined>>()
+      return Effect.succeed('recovered' as const)
+    }))
+
+    expectTypeOf(recovered).toEqualTypeOf<Effect.Effect<'output' | 'recovered', TypeError, never>>()
+  })
+
+  it('suggests and restricts the code to those present in the error channel', () => {
+    // @ts-expect-error - BAD_GATEWAY is not present in the error channel (data-last)
+    void effect.pipe(catchORPCErrorByCode('BAD_GATEWAY', () => Effect.succeed('recovered')))
+
+    // @ts-expect-error - BAD_GATEWAY is not present in the error channel (data-first)
+    void catchORPCErrorByCode(effect, 'BAD_GATEWAY', () => Effect.succeed('recovered'))
+
+    // @ts-expect-error - code must be a string
+    void effect.pipe(catchORPCErrorByCode(123, () => Effect.succeed('recovered')))
+  })
+})

--- a/packages/effect/src/error.test-d.ts
+++ b/packages/effect/src/error.test-d.ts
@@ -1,6 +1,6 @@
 import type { ORPCError } from '@orpc/server'
 import { Effect } from 'effect'
-import { catchORPCError, catchORPCErrorByCode } from './error'
+import { catchORPCError, catchORPCErrorCode, catchORPCErrorCodes } from './error'
 
 class Service1 {
   declare id: 'Service1'
@@ -53,9 +53,9 @@ describe('catchORPCError', () => {
   })
 })
 
-describe('catchORPCErrorByCode', () => {
+describe('catchORPCErrorCode', () => {
   it('catches ORPCErrors with a matching code and excludes them from the error channel (data-last)', () => {
-    const recovered = effect.pipe(catchORPCErrorByCode('NOT_FOUND', (error) => {
+    const recovered = effect.pipe(catchORPCErrorCode('NOT_FOUND', (error) => {
       expectTypeOf(error).toEqualTypeOf<ORPCError<'NOT_FOUND', { id: string }>>()
       return Effect.succeed('recovered' as const)
     }))
@@ -64,7 +64,7 @@ describe('catchORPCErrorByCode', () => {
   })
 
   it('catches ORPCErrors with a matching code and excludes them from the error channel (data-first)', () => {
-    const recovered = catchORPCErrorByCode(effect, 'CONFLICT', (error) => {
+    const recovered = catchORPCErrorCode(effect, 'CONFLICT', (error) => {
       expectTypeOf(error).toEqualTypeOf<ORPCError<'CONFLICT', number>>()
       return Effect.succeed('recovered' as const)
     })
@@ -74,7 +74,7 @@ describe('catchORPCErrorByCode', () => {
 
   it('merges handler error and requirement channels into the result', () => {
     const recovered = effect.pipe(
-      catchORPCErrorByCode('NOT_FOUND', () => ({} as Effect.Effect<'recovered', RangeError, Service2>)),
+      catchORPCErrorCode('NOT_FOUND', () => ({} as Effect.Effect<'recovered', RangeError, Service2>)),
     )
 
     expectTypeOf(recovered).toEqualTypeOf<
@@ -85,7 +85,7 @@ describe('catchORPCErrorByCode', () => {
   it('supports custom error codes', () => {
     const custom = {} as Effect.Effect<'output', ORPCError<'__CUSTOM__', undefined> | TypeError>
 
-    const recovered = custom.pipe(catchORPCErrorByCode('__CUSTOM__', (error) => {
+    const recovered = custom.pipe(catchORPCErrorCode('__CUSTOM__', (error) => {
       expectTypeOf(error).toEqualTypeOf<ORPCError<'__CUSTOM__', undefined>>()
       return Effect.succeed('recovered' as const)
     }))
@@ -95,12 +95,48 @@ describe('catchORPCErrorByCode', () => {
 
   it('suggests and restricts the code to those present in the error channel', () => {
     // @ts-expect-error - BAD_GATEWAY is not present in the error channel (data-last)
-    void effect.pipe(catchORPCErrorByCode('BAD_GATEWAY', () => Effect.succeed('recovered')))
+    void effect.pipe(catchORPCErrorCode('BAD_GATEWAY', () => Effect.succeed('recovered')))
 
     // @ts-expect-error - BAD_GATEWAY is not present in the error channel (data-first)
-    void catchORPCErrorByCode(effect, 'BAD_GATEWAY', () => Effect.succeed('recovered'))
+    void catchORPCErrorCode(effect, 'BAD_GATEWAY', () => Effect.succeed('recovered'))
 
     // @ts-expect-error - code must be a string
-    void effect.pipe(catchORPCErrorByCode(123, () => Effect.succeed('recovered')))
+    void effect.pipe(catchORPCErrorCode(123, () => Effect.succeed('recovered')))
+  })
+})
+
+describe('catchORPCErrorCodes', () => {
+  it('narrows each handler and excludes handled codes from the error channel (data-last)', () => {
+    const recovered = effect.pipe(catchORPCErrorCodes({
+      NOT_FOUND: (error) => {
+        expectTypeOf(error).toEqualTypeOf<ORPCError<'NOT_FOUND', { id: string }>>()
+        return Effect.succeed('nf' as const)
+      },
+      CONFLICT: (error) => {
+        expectTypeOf(error).toEqualTypeOf<ORPCError<'CONFLICT', number>>()
+        return {} as Effect.Effect<'cf', RangeError, Service2>
+      },
+    }))
+
+    expectTypeOf(recovered).toEqualTypeOf<Effect.Effect<'output' | 'nf' | 'cf', RangeError | TypeError, Service1 | Service2>>()
+  })
+
+  it('keeps unhandled codes in the error channel (data-first)', () => {
+    const recovered = catchORPCErrorCodes(effect, {
+      NOT_FOUND: (error) => {
+        expectTypeOf(error).toEqualTypeOf<ORPCError<'NOT_FOUND', { id: string }>>()
+        return Effect.succeed('nf' as const)
+      },
+    })
+
+    expectTypeOf(recovered).toEqualTypeOf<Effect.Effect<'output' | 'nf', ORPCError<'CONFLICT', number> | TypeError, Service1>>()
+  })
+
+  it('suggests and restricts keys to the codes present in the error channel', () => {
+    // @ts-expect-error - BAD_GATEWAY is not present in the error channel (data-last)
+    void effect.pipe(catchORPCErrorCodes({ BAD_GATEWAY: () => Effect.succeed('recovered') }))
+
+    // @ts-expect-error - BAD_GATEWAY is not present in the error channel (data-first)
+    void catchORPCErrorCodes(effect, { BAD_GATEWAY: () => Effect.succeed('recovered') })
   })
 })

--- a/packages/effect/src/error.test.ts
+++ b/packages/effect/src/error.test.ts
@@ -1,0 +1,127 @@
+import { ORPCError } from '@orpc/server'
+import { Cause, Effect, Exit } from 'effect'
+import { catchORPCError, catchORPCErrorByCode } from './error'
+
+describe('catchORPCError', () => {
+  it('catches any ORPCError failure (data-last)', async () => {
+    const handled = Effect.fail(new ORPCError('NOT_FOUND', { data: 'data' })).pipe(
+      catchORPCError(error => Effect.succeed(`caught:${error.code}`)),
+    )
+
+    await expect(Effect.runPromise(handled)).resolves.toEqual('caught:NOT_FOUND')
+  })
+
+  it('catches any ORPCError failure (data-first)', async () => {
+    const handled = catchORPCError(
+      Effect.fail(new ORPCError('CONFLICT')),
+      error => Effect.succeed(`caught:${error.code}`),
+    )
+
+    await expect(Effect.runPromise(handled)).resolves.toEqual('caught:CONFLICT')
+  })
+
+  it('does not catch non-ORPCError failures', async () => {
+    const error = new Error('__TEST__')
+    const handler = vi.fn(() => Effect.succeed('caught'))
+
+    const exit = await Effect.runPromiseExit(catchORPCError(Effect.fail(error), handler))
+
+    expect(exit).toEqual(Exit.fail(error))
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('does not catch defects', async () => {
+    const error = new ORPCError('NOT_FOUND')
+    const handler = vi.fn(() => Effect.succeed('caught'))
+
+    const exit = await Effect.runPromiseExit(catchORPCError(Effect.die(error), handler))
+
+    expect(exit).toEqual(Exit.failCause(Cause.die(error)))
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('does not touch successful effects', async () => {
+    const handler = vi.fn(() => Effect.succeed('caught'))
+
+    await expect(Effect.runPromise(catchORPCError(Effect.succeed('output'), handler))).resolves.toEqual('output')
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('can fail again inside the handler', async () => {
+    const error = new Error('__TEST__')
+
+    const exit = await Effect.runPromiseExit(
+      Effect.fail(new ORPCError('NOT_FOUND')).pipe(
+        catchORPCError(() => Effect.fail(error)),
+      ),
+    )
+
+    expect(exit).toEqual(Exit.fail(error))
+  })
+})
+
+describe('catchORPCErrorByCode', () => {
+  it('catches ORPCError failures with a matching code (data-last)', async () => {
+    const handled = Effect.fail(new ORPCError('NOT_FOUND', { data: 'data' })).pipe(
+      catchORPCErrorByCode('NOT_FOUND', error => Effect.succeed(`caught:${error.data}`)),
+    )
+
+    await expect(Effect.runPromise(handled)).resolves.toEqual('caught:data')
+  })
+
+  it('catches ORPCError failures with a matching code (data-first)', async () => {
+    const handled = catchORPCErrorByCode(
+      Effect.fail(new ORPCError('CONFLICT', { data: 'data' })),
+      'CONFLICT',
+      error => Effect.succeed(`caught:${error.data}`),
+    )
+
+    await expect(Effect.runPromise(handled)).resolves.toEqual('caught:data')
+  })
+
+  it('does not catch ORPCError failures with a different code', async () => {
+    const error = new ORPCError('CONFLICT') as ORPCError<'CONFLICT', undefined> | ORPCError<'NOT_FOUND', undefined>
+    const handler = vi.fn(() => Effect.succeed('caught'))
+
+    const exit = await Effect.runPromiseExit(
+      catchORPCErrorByCode(Effect.fail(error), 'NOT_FOUND', handler),
+    )
+
+    expect(exit).toEqual(Exit.fail(error))
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('does not catch non-ORPCError failures, even with a matching code property', async () => {
+    const error = Object.assign(new Error('__TEST__'), { code: 'NOT_FOUND' }) as Error | ORPCError<'NOT_FOUND', undefined>
+    const handler = vi.fn(() => Effect.succeed('caught'))
+
+    const exit = await Effect.runPromiseExit(
+      catchORPCErrorByCode(Effect.fail(error), 'NOT_FOUND', handler),
+    )
+
+    expect(exit).toEqual(Exit.fail(error))
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('does not touch successful effects', async () => {
+    const handler = vi.fn(() => Effect.succeed('caught'))
+    const effect = Effect.succeed('output') as Effect.Effect<string, ORPCError<'NOT_FOUND', undefined>>
+
+    await expect(
+      Effect.runPromise(catchORPCErrorByCode(effect, 'NOT_FOUND', handler)),
+    ).resolves.toEqual('output')
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('can fail again inside the handler', async () => {
+    const error = new Error('__TEST__')
+
+    const exit = await Effect.runPromiseExit(
+      Effect.fail(new ORPCError('NOT_FOUND')).pipe(
+        catchORPCErrorByCode('NOT_FOUND', () => Effect.fail(error)),
+      ),
+    )
+
+    expect(exit).toEqual(Exit.fail(error))
+  })
+})

--- a/packages/effect/src/error.test.ts
+++ b/packages/effect/src/error.test.ts
@@ -1,6 +1,6 @@
 import { ORPCError } from '@orpc/server'
 import { Cause, Effect, Exit } from 'effect'
-import { catchORPCError, catchORPCErrorByCode } from './error'
+import { catchORPCError, catchORPCErrorCode, catchORPCErrorCodes } from './error'
 
 describe('catchORPCError', () => {
   it('catches any ORPCError failure (data-last)', async () => {
@@ -60,17 +60,17 @@ describe('catchORPCError', () => {
   })
 })
 
-describe('catchORPCErrorByCode', () => {
+describe('catchORPCErrorCode', () => {
   it('catches ORPCError failures with a matching code (data-last)', async () => {
     const handled = Effect.fail(new ORPCError('NOT_FOUND', { data: 'data' })).pipe(
-      catchORPCErrorByCode('NOT_FOUND', error => Effect.succeed(`caught:${error.data}`)),
+      catchORPCErrorCode('NOT_FOUND', error => Effect.succeed(`caught:${error.data}`)),
     )
 
     await expect(Effect.runPromise(handled)).resolves.toEqual('caught:data')
   })
 
   it('catches ORPCError failures with a matching code (data-first)', async () => {
-    const handled = catchORPCErrorByCode(
+    const handled = catchORPCErrorCode(
       Effect.fail(new ORPCError('CONFLICT', { data: 'data' })),
       'CONFLICT',
       error => Effect.succeed(`caught:${error.data}`),
@@ -84,7 +84,7 @@ describe('catchORPCErrorByCode', () => {
     const handler = vi.fn(() => Effect.succeed('caught'))
 
     const exit = await Effect.runPromiseExit(
-      catchORPCErrorByCode(Effect.fail(error), 'NOT_FOUND', handler),
+      catchORPCErrorCode(Effect.fail(error), 'NOT_FOUND', handler),
     )
 
     expect(exit).toEqual(Exit.fail(error))
@@ -96,7 +96,7 @@ describe('catchORPCErrorByCode', () => {
     const handler = vi.fn(() => Effect.succeed('caught'))
 
     const exit = await Effect.runPromiseExit(
-      catchORPCErrorByCode(Effect.fail(error), 'NOT_FOUND', handler),
+      catchORPCErrorCode(Effect.fail(error), 'NOT_FOUND', handler),
     )
 
     expect(exit).toEqual(Exit.fail(error))
@@ -108,7 +108,7 @@ describe('catchORPCErrorByCode', () => {
     const effect = Effect.succeed('output') as Effect.Effect<string, ORPCError<'NOT_FOUND', undefined>>
 
     await expect(
-      Effect.runPromise(catchORPCErrorByCode(effect, 'NOT_FOUND', handler)),
+      Effect.runPromise(catchORPCErrorCode(effect, 'NOT_FOUND', handler)),
     ).resolves.toEqual('output')
     expect(handler).not.toHaveBeenCalled()
   })
@@ -118,7 +118,89 @@ describe('catchORPCErrorByCode', () => {
 
     const exit = await Effect.runPromiseExit(
       Effect.fail(new ORPCError('NOT_FOUND')).pipe(
-        catchORPCErrorByCode('NOT_FOUND', () => Effect.fail(error)),
+        catchORPCErrorCode('NOT_FOUND', () => Effect.fail(error)),
+      ),
+    )
+
+    expect(exit).toEqual(Exit.fail(error))
+  })
+})
+
+describe('catchORPCErrorCodes', () => {
+  it('catches ORPCError failures with the matching handler (data-last)', async () => {
+    const conflictHandler = vi.fn(() => Effect.succeed('caught:conflict'))
+    const error = new ORPCError('NOT_FOUND', { data: 'data' }) as ORPCError<'NOT_FOUND', string> | ORPCError<'CONFLICT', undefined>
+
+    const handled = Effect.fail(error).pipe(
+      catchORPCErrorCodes({
+        NOT_FOUND: error => Effect.succeed(`caught:${error.data}`),
+        CONFLICT: conflictHandler,
+      }),
+    )
+
+    await expect(Effect.runPromise(handled)).resolves.toEqual('caught:data')
+    expect(conflictHandler).not.toHaveBeenCalled()
+  })
+
+  it('catches ORPCError failures with the matching handler (data-first)', async () => {
+    const handled = catchORPCErrorCodes(
+      Effect.fail(new ORPCError('CONFLICT', { data: 'data' })),
+      { CONFLICT: error => Effect.succeed(`caught:${error.data}`) },
+    )
+
+    await expect(Effect.runPromise(handled)).resolves.toEqual('caught:data')
+  })
+
+  it('does not catch ORPCError failures without a matching handler', async () => {
+    const error = new ORPCError('CONFLICT') as ORPCError<'CONFLICT', undefined> | ORPCError<'NOT_FOUND', undefined>
+    const handler = vi.fn(() => Effect.succeed('caught'))
+
+    const exit = await Effect.runPromiseExit(
+      catchORPCErrorCodes(Effect.fail(error), { NOT_FOUND: handler }),
+    )
+
+    expect(exit).toEqual(Exit.fail(error))
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('does not catch ORPCError failures whose handler is undefined', async () => {
+    const error = new ORPCError('NOT_FOUND')
+
+    const exit = await Effect.runPromiseExit(
+      catchORPCErrorCodes(Effect.fail(error), { NOT_FOUND: undefined }),
+    )
+
+    expect(exit).toEqual(Exit.fail(error))
+  })
+
+  it('does not catch non-ORPCError failures, even with a matching code property', async () => {
+    const error = Object.assign(new Error('__TEST__'), { code: 'NOT_FOUND' }) as Error | ORPCError<'NOT_FOUND', undefined>
+    const handler = vi.fn(() => Effect.succeed('caught'))
+
+    const exit = await Effect.runPromiseExit(
+      catchORPCErrorCodes(Effect.fail(error), { NOT_FOUND: handler }),
+    )
+
+    expect(exit).toEqual(Exit.fail(error))
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('does not touch successful effects', async () => {
+    const handler = vi.fn(() => Effect.succeed('caught'))
+    const effect = Effect.succeed('output') as Effect.Effect<string, ORPCError<'NOT_FOUND', undefined>>
+
+    await expect(
+      Effect.runPromise(catchORPCErrorCodes(effect, { NOT_FOUND: handler })),
+    ).resolves.toEqual('output')
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('can fail again inside a handler', async () => {
+    const error = new Error('__TEST__')
+
+    const exit = await Effect.runPromiseExit(
+      Effect.fail(new ORPCError('NOT_FOUND')).pipe(
+        catchORPCErrorCodes({ NOT_FOUND: () => Effect.fail(error) }),
       ),
     )
 

--- a/packages/effect/src/error.ts
+++ b/packages/effect/src/error.ts
@@ -43,8 +43,8 @@ export const catchORPCError: {
  * Other failures re-fail with their original cause. The `code` argument is
  * suggested and restricted to the codes present in the error channel.
  *
- * Supports both data-first `catchORPCErrorByCode(effect, code, handler)` and
- * data-last `effect.pipe(catchORPCErrorByCode(code, handler))` styles.
+ * Supports both data-first `catchORPCErrorCode(effect, code, handler)` and
+ * data-last `effect.pipe(catchORPCErrorCode(code, handler))` styles.
  *
  * @example
  * ```ts
@@ -54,13 +54,13 @@ export const catchORPCError: {
  * >
  *
  * const recovered = program.pipe(
- *   catchORPCErrorByCode('NOT_FOUND', error => Effect.succeed(error.data.id)),
+ *   catchORPCErrorCode('NOT_FOUND', error => Effect.succeed(error.data.id)),
  * )
  * ```
  *
  * @see {@link https://orpc.dev/docs/integrations/effect#catching-orpcerrors Catching ORPCErrors Docs}
  */
-export const catchORPCErrorByCode: {
+export const catchORPCErrorCode: {
   <const TCode extends E extends ORPCError<infer TCode, any> ? TCode : never, E, A2, E2, R2>(
     code: TCode,
     f: (error: Extract<E, ORPCError<TCode, any>>) => Effect.Effect<A2, E2, R2>,
@@ -78,5 +78,74 @@ export const catchORPCErrorByCode: {
     f: (error: AnyORPCError) => Effect.Effect<any, any, any>,
   ) => self.pipe(
     Effect.catchIf((error): error is AnyORPCError => error instanceof ORPCError && error.code === code, f),
+  ),
+)
+
+/**
+ * Recovers from `ORPCError` failures using a map of codes to handlers in the
+ * error channel of an effect. Other failures re-fail with their original
+ * cause. The keys are suggested and restricted to the codes present in the
+ * error channel.
+ *
+ * Supports both data-first `catchORPCErrorCodes(effect, cases)` and data-last
+ * `effect.pipe(catchORPCErrorCodes(cases))` styles.
+ *
+ * @example
+ * ```ts
+ * declare const program: Effect.Effect<
+ *   string,
+ *   ORPCError<'NOT_FOUND', { id: string }> | ORPCError<'CONFLICT', undefined> | TypeError
+ * >
+ *
+ * const recovered = program.pipe(
+ *   catchORPCErrorCodes({
+ *     NOT_FOUND: error => Effect.succeed(error.data.id),
+ *     CONFLICT: error => Effect.succeed(error.message),
+ *   }),
+ * )
+ * ```
+ *
+ * @see {@link https://orpc.dev/docs/integrations/effect#catching-orpcerrors Catching ORPCErrors Docs}
+ */
+export const catchORPCErrorCodes: {
+  <
+    E,
+    Cases extends
+    & { [K in Extract<E, AnyORPCError>['code']]?: (error: Extract<E, ORPCError<K, any>>) => Effect.Effect<any, any, any> }
+    & (unknown extends E ? object : { [K in Exclude<keyof Cases, Extract<E, AnyORPCError>['code']>]: never }),
+  >(
+    cases: Cases,
+  ): <A, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<
+    A | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<infer A2, any, any> ? A2 : never }[keyof Cases],
+    | Exclude<E, ORPCError<keyof Cases & ORPCErrorCode, any>>
+    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<any, infer E2, any> ? E2 : never }[keyof Cases],
+    R | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<any, any, infer R2> ? R2 : never }[keyof Cases]
+  >
+  <
+    A,
+    E,
+    R,
+    Cases extends
+    & { [K in Extract<E, AnyORPCError>['code']]?: (error: Extract<E, ORPCError<K, any>>) => Effect.Effect<any, any, any> }
+    & (unknown extends E ? object : { [K in Exclude<keyof Cases, Extract<E, AnyORPCError>['code']>]: never }),
+  >(
+    self: Effect.Effect<A, E, R>,
+    cases: Cases,
+  ): Effect.Effect<
+    A | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<infer A2, any, any> ? A2 : never }[keyof Cases],
+    | Exclude<E, ORPCError<keyof Cases & ORPCErrorCode, any>>
+    | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<any, infer E2, any> ? E2 : never }[keyof Cases],
+    R | { [K in keyof Cases]: Cases[K] extends (...args: any[]) => Effect.Effect<any, any, infer R2> ? R2 : never }[keyof Cases]
+  >
+} = Function.dual(
+  2,
+  (
+    self: Effect.Effect<any, any, any>,
+    cases: Record<string, ((error: AnyORPCError) => Effect.Effect<any, any, any>) | undefined>,
+  ) => self.pipe(
+    Effect.catchIf(
+      (error): error is AnyORPCError => error instanceof ORPCError && typeof cases[error.code] === 'function',
+      error => cases[error.code]!(error),
+    ),
   ),
 )

--- a/packages/effect/src/error.ts
+++ b/packages/effect/src/error.ts
@@ -1,0 +1,82 @@
+import type { AnyORPCError, ORPCErrorCode } from '@orpc/server'
+import { ORPCError } from '@orpc/server'
+import { Effect, Function } from 'effect'
+
+/**
+ * Recovers from `ORPCError` failures in the error channel of an effect.
+ * Other failures re-fail with their original cause.
+ *
+ * Supports both data-first `catchORPCError(effect, handler)` and data-last
+ * `effect.pipe(catchORPCError(handler))` styles.
+ *
+ * @example
+ * ```ts
+ * declare const program: Effect.Effect<string, ORPCError<'NOT_FOUND', undefined> | TypeError>
+ *
+ * const recovered = program.pipe(
+ *   catchORPCError(error => Effect.succeed(`caught ${error.code}`)),
+ * )
+ * ```
+ *
+ * @see {@link https://orpc.dev/docs/integrations/effect#catching-orpcerrors Catching ORPCErrors Docs}
+ */
+export const catchORPCError: {
+  <E, A2, E2, R2>(
+    f: (error: Extract<E, AnyORPCError>) => Effect.Effect<A2, E2, R2>,
+  ): <A, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A | A2, E2 | Exclude<E, AnyORPCError>, R | R2>
+  <A, E, R, A2, E2, R2>(
+    self: Effect.Effect<A, E, R>,
+    f: (error: Extract<E, AnyORPCError>) => Effect.Effect<A2, E2, R2>,
+  ): Effect.Effect<A | A2, E2 | Exclude<E, AnyORPCError>, R | R2>
+} = Function.dual(
+  2,
+  (
+    self: Effect.Effect<any, any, any>,
+    f: (error: AnyORPCError) => Effect.Effect<any, any, any>,
+  ) => self.pipe(
+    Effect.catchIf((error): error is AnyORPCError => error instanceof ORPCError, f),
+  ),
+)
+
+/**
+ * Recovers from `ORPCError` failures with a matching code in the error channel of an effect.
+ * Other failures re-fail with their original cause. The `code` argument is
+ * suggested and restricted to the codes present in the error channel.
+ *
+ * Supports both data-first `catchORPCErrorByCode(effect, code, handler)` and
+ * data-last `effect.pipe(catchORPCErrorByCode(code, handler))` styles.
+ *
+ * @example
+ * ```ts
+ * declare const program: Effect.Effect<
+ *   string,
+ *   ORPCError<'NOT_FOUND', { id: string }> | ORPCError<'CONFLICT', undefined> | TypeError
+ * >
+ *
+ * const recovered = program.pipe(
+ *   catchORPCErrorByCode('NOT_FOUND', error => Effect.succeed(error.data.id)),
+ * )
+ * ```
+ *
+ * @see {@link https://orpc.dev/docs/integrations/effect#catching-orpcerrors Catching ORPCErrors Docs}
+ */
+export const catchORPCErrorByCode: {
+  <const TCode extends E extends ORPCError<infer TCode, any> ? TCode : never, E, A2, E2, R2>(
+    code: TCode,
+    f: (error: Extract<E, ORPCError<TCode, any>>) => Effect.Effect<A2, E2, R2>,
+  ): <A, R>(self: Effect.Effect<A, E, R>) => Effect.Effect<A | A2, E2 | Exclude<E, ORPCError<TCode, any>>, R | R2>
+  <A, E, R, const TCode extends E extends ORPCError<infer TCode, any> ? TCode : never, A2, E2, R2>(
+    self: Effect.Effect<A, E, R>,
+    code: TCode,
+    f: (error: Extract<E, ORPCError<TCode, any>>) => Effect.Effect<A2, E2, R2>,
+  ): Effect.Effect<A | A2, E2 | Exclude<E, ORPCError<TCode, any>>, R | R2>
+} = Function.dual(
+  3,
+  (
+    self: Effect.Effect<any, any, any>,
+    code: ORPCErrorCode,
+    f: (error: AnyORPCError) => Effect.Effect<any, any, any>,
+  ) => self.pipe(
+    Effect.catchIf((error): error is AnyORPCError => error instanceof ORPCError && error.code === code, f),
+  ),
+)

--- a/packages/effect/src/index.test.ts
+++ b/packages/effect/src/index.test.ts
@@ -1,9 +1,10 @@
-it('exports EffectSchemaToJsonSchemaConverter, handlerGen, toStandardSchema, catchORPCError, catchORPCErrorByCode', async () => {
+it('exports EffectSchemaToJsonSchemaConverter, handlerGen, toStandardSchema, catchORPCError, catchORPCErrorCode, catchORPCErrorCodes', async () => {
   await expect(import('./index')).resolves.toMatchObject({
     handlerGen: expect.any(Function),
     EffectSchemaToJsonSchemaConverter: expect.any(Function),
     toStandardSchema: expect.any(Function),
     catchORPCError: expect.any(Function),
-    catchORPCErrorByCode: expect.any(Function),
+    catchORPCErrorCode: expect.any(Function),
+    catchORPCErrorCodes: expect.any(Function),
   })
 })

--- a/packages/effect/src/index.test.ts
+++ b/packages/effect/src/index.test.ts
@@ -1,7 +1,9 @@
-it('exports EffectSchemaToJsonSchemaConverter, handlerGen, toStandardSchema', async () => {
+it('exports EffectSchemaToJsonSchemaConverter, handlerGen, toStandardSchema, catchORPCError, catchORPCErrorByCode', async () => {
   await expect(import('./index')).resolves.toMatchObject({
     handlerGen: expect.any(Function),
     EffectSchemaToJsonSchemaConverter: expect.any(Function),
     toStandardSchema: expect.any(Function),
+    catchORPCError: expect.any(Function),
+    catchORPCErrorByCode: expect.any(Function),
   })
 })

--- a/packages/effect/src/index.ts
+++ b/packages/effect/src/index.ts
@@ -1,5 +1,6 @@
 export * from './context'
 export * from './converter'
+export * from './error'
 export * from './handler'
 export * from './runtime'
 export * from './schema'


### PR DESCRIPTION
Adds `catchORPCError`, `catchORPCErrorCode` and `catchORPCErrorCodes` to `@orpc/experimental-effect` for recovering from `ORPCError` failures in an effect's error channel. Recovered errors are excluded from the resulting effect's error channel, and non-matching failures re-fail with their original cause.

## Details

- All utilities support data-first and data-last (`.pipe`) styles, following Effect's `dual` convention.
- Handlers receive the matching errors narrowed from the error channel, with per-code data types preserved.
- `catchORPCErrorCode` and `catchORPCErrorCodes` mirror Effect's `catchTag`/`catchTags` naming and suggest/restrict codes to those present in the error channel.
- Defects and interruptions are not caught.

## Testing

- Logic tests cover all call styles, code matching/mismatch, partial and undefined handler maps, non-`ORPCError` passthrough, defects, successes, and re-failing handlers — 100% statement/branch/function/line coverage on the new module.
- Type tests verify handler narrowing, error-channel exclusion, requirement merging, custom codes, and rejection of out-of-channel codes and map keys.
- Docs: new "Catching ORPCErrors" section on the Effect integration page.