### PR TITLE
docs: sync package JSDoc with docs content and add verification script

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,8 @@ jobs:
 
       - run: pnpm run type:check
 
+      - run: pnpm run docs:check-jsdoc
+
   test_matrix:
     runs-on: ubuntu-latest
     services:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,14 +43,32 @@ This repository uses:
    - our PR title should follow the [Conventional Commits Cheatsheet](https://gist.github.com/Zekfad/f51cb06ac76e2457f11c80ed705c95a3), with scope corresponding to the package.
    - In the description, summarize your changes and reference any related issue, e.g., `Fixes #123`.
 
-## Structure
+## JSDoc & Documentation Links
 
-- **@orpc/shared** — shared utilities and types.
-- **@orpc/client** — core library, ORPCError, RPC serializers, RPC link,...
-- **@orpc/contract** — contract definitions (input/output/errors/meta/route, contract builder).
-- **@orpc/server** — contract implementer, procedure/router builder, procedure/router client, RPC handler, ...
-- **@orpc/openapi-client** - OpenAPI serializers, OpenAPI Link, ...
-- **@orpc/openapi** — OpenAPI Spec generator, OpenAPI handler, ...
-- **@orpc/standard-server\*** — environment adapters (`fetch`, `node`, etc.).
-- **playgrounds/** — example applications.
-- **apps/content/** - content, documentation, and website.
+Every public API mentioned in the documentation (`apps/content/docs`) must carry a JSDoc comment with a backlink to the official website. This is enforced in CI:
+
+```bash
+pnpm docs:check-jsdoc # node scripts/verify-docs-jsdoc.ts [--filter server,client] [--strict] [--list]
+```
+
+JSDoc blocks follow this template:
+
+```ts
+/**
+ * <Summary: 1-3 short sentences. Verb-first for functions, noun phrase for types/classes.>
+ *
+ * @remarks
+ * **Warning**: <footguns, breaking behavior>
+ * **Note**: <non-obvious behavior, limits>
+ *
+ * @param name - <only extra info beyond the type>
+ * @returns <only extra info beyond the type>
+ *
+ * @see {@link https://orpc.dev/docs/... | Page Title}
+ */
+```
+
+- `@remarks` is optional (max 1-3 bold lines) and uses `**Warning**:`/`**Note**:` — not `@warning`/`@info` tags.
+- `@param`/`@returns` only when they add information beyond the type signature.
+- No `@example` blocks — examples live on the linked docs page.
+- `@see` is always the last tag. The URL must map to an existing `apps/content/docs/<path>.md` page (plus optional `#anchor` matching a real heading), and the title after `|` is the page's sidebar label from `apps/content/.vitepress/config.ts`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,4 +71,4 @@ JSDoc blocks follow this template:
 - `@remarks` is optional (max 1-3 bold lines) and uses `**Warning**:`/`**Note**:` — not `@warning`/`@info` tags.
 - `@param`/`@returns` only when they add information beyond the type signature.
 - No `@example` blocks — examples live on the linked docs page.
-- `@see` is always the last tag. The URL must map to an existing `apps/content/docs/<path>.md` page (plus optional `#anchor` matching a real heading), and the title after `|` is the page's sidebar label from `apps/content/.vitepress/config.ts`.
+- `@see` is always the last tag. The URL must map to an existing `apps/content/docs/<path>.md` page (plus optional `#anchor` matching a real heading). The title after `|` is the page's title (its first heading), or `Page Title - Heading` when the link targets an anchor.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,3 +72,4 @@ JSDoc blocks follow this template:
 - `@param`/`@returns` only when they add information beyond the type signature.
 - No `@example` blocks — examples live on the linked docs page.
 - `@see` is always the last tag. The URL must map to an existing `apps/content/docs/<path>.md` page (plus optional `#anchor` matching a real heading). The title after `|` is the page's title (its first heading), or `Page Title - Heading` when the link targets an anchor.
+- Every `https://orpc.dev/...` link anywhere in package sources (inline markdown links included) is validated against the content pages in `apps/content`.

--- a/apps/content/docs/adapters/fetch-api.md
+++ b/apps/content/docs/adapters/fetch-api.md
@@ -8,7 +8,7 @@ oRPC supports the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/F
 
 ```ts [RPC]
 import { RPCHandler } from '@orpc/server/fetch'
-import { CORSPlugin } from '@orpc/server/plugins'
+import { CORSHandlerPlugin } from '@orpc/server/plugins'
 import { onError } from '@orpc/server'
 
 const handler = new RPCHandler(router, {
@@ -38,7 +38,7 @@ export async function fetch(request: Request): Promise<Response> {
 
 ```ts [OpenAPI]
 import { OpenAPIHandler } from '@orpc/openapi/fetch'
-import { CORSPlugin } from '@orpc/server/plugins'
+import { CORSHandlerPlugin } from '@orpc/server/plugins'
 import { onError } from '@orpc/server'
 
 const handler = new OpenAPIHandler(router, {

--- a/apps/content/docs/helpers/publisher.md
+++ b/apps/content/docs/helpers/publisher.md
@@ -114,7 +114,7 @@ import { RedisPublisher } from '@orpc/publisher/redis'
 
 const client = createClient({ url: 'redis://localhost:6379' })
 
-// RedisRateLimiter lazily connects to Redis when needed.
+// RedisPublisher lazily connects to Redis when needed.
 // You can still call `client.connect()` manually, but it is optional.
 await client.connect()
 
@@ -124,9 +124,9 @@ const publisher = new RedisPublisher<Events>(client, {
    * Pub/Sub takes over the connection, so a client with subscriptions
    * cannot execute commands and must use a dedicated connection.
    *
-   * @default redis.duplicate()
+   * @default client.duplicate()
    */
-  subscriber: redis.duplicate(),
+  subscriber: client.duplicate(),
 
   /**
    * The prefix to use for Redis keys.

--- a/apps/content/docs/integrations/next.md
+++ b/apps/content/docs/integrations/next.md
@@ -182,13 +182,13 @@ This integration also includes React hooks for server functions. `useServerFunct
 ```tsx [useServerFunction]
 'use client'
 
-import { useServerFunction } from '@orpc/next/hooks'
+import { isInferableError } from '@orpc/client'
 import {
   getIssueMessage,
-  isInferableError,
   onErrorDeferred,
   parseFormData,
-} from '@orpc/next/hooks'
+} from '@orpc/next'
+import { useServerFunction } from '@orpc/next/hooks'
 
 export function MyComponent() {
   const { execute, data, error, status } = useServerFunction(serverFunction, {

--- a/apps/content/docs/openapi/scalar.md
+++ b/apps/content/docs/openapi/scalar.md
@@ -14,7 +14,7 @@ This example serves the OpenAPI document at `/spec.json` and renders Scalar at `
 import { createServer } from 'node:http'
 import { OpenAPIGenerator } from '@orpc/openapi'
 import { OpenAPIHandler } from '@orpc/openapi/node'
-import { CORSPlugin } from '@orpc/server/plugins'
+import { CORSHandlerPlugin } from '@orpc/server/plugins'
 import { ZodToJsonSchemaConverter } from '@orpc/zod'
 
 const openAPIHandler = new OpenAPIHandler(router, {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint --max-warnings=0 .",
     "lint:fix": "eslint --max-warnings=0 --fix .",
     "repo:fix": "sherif --fix",
+    "docs:check-jsdoc": "node scripts/verify-docs-jsdoc.ts",
     "sponsors:sync": "node scripts/sync-sponsors.ts && eslint --max-warnings=0 --fix **/README.md apps/content/.vitepress/theme/sponsors.ts"
   },
   "devDependencies": {

--- a/packages/ai-sdk/src/tool-meta.ts
+++ b/packages/ai-sdk/src/tool-meta.ts
@@ -16,9 +16,10 @@ export type FunctionTool<
  * Base [AI SDK Tool](https://ai-sdk.dev/docs/foundations/tools) options attached to a procedure/contract,
  * used as defaults when creating tools from it.
  *
+ * @remarks
  * **Note**: When defined multiple times, options are overridden by the most recent call.
  *
- * @see {@link https://orpc.dev/docs/integrations/ai-sdk#tool-implementer AI SDK Tool Implementer Docs}
+ * @see {@link https://orpc.dev/docs/integrations/ai-sdk#tool-implementer | AI SDK}
  */
 export type AiSdkToolMeta<
   TInputSchema extends AnySchema = AnySchema,
@@ -46,9 +47,8 @@ export interface AiSdkToolFunction {
  * Attaches base [AI SDK Tool](https://ai-sdk.dev/docs/foundations/tools) options to a procedure/contract,
  * used as defaults when creating tools from it.
  *
+ * @remarks
  * **Note**: When defined multiple times, options are overridden by the most recent call.
- *
- * @see {@link https://orpc.dev/docs/integrations/ai-sdk#tool-implementer AI SDK Tool Implementer Docs}
  *
  * @example
  * ```ts
@@ -59,6 +59,8 @@ export interface AiSdkToolFunction {
  *   }))
  *   .input(z.object({ location: z.string() }))
  * ```
+ *
+ * @see {@link https://orpc.dev/docs/integrations/ai-sdk#tool-implementer | AI SDK}
  */
 export const aiSdkTool: AiSdkToolFunction = incoming => ({
   name: '~ai-sdk/tool',
@@ -76,7 +78,7 @@ export const aiSdkTool: AiSdkToolFunction = incoming => ({
  * Reads the base [AI SDK Tool](https://ai-sdk.dev/docs/foundations/tools) options
  * attached to a procedure/contract by {@link aiSdkTool}.
  *
- * @see {@link https://orpc.dev/docs/integrations/ai-sdk#tool-implementer AI SDK Tool Implementer Docs}
+ * @see {@link https://orpc.dev/docs/integrations/ai-sdk#tool-implementer | AI SDK}
  */
 export function getAiSdkToolMeta(procedureOrLazy: AnyProcedureContract | Lazy<any>): AiSdkToolMeta | undefined {
   return procedureOrLazy['~orpc'].meta['~ai-sdk/tool'] as AiSdkToolMeta | undefined

--- a/packages/ai-sdk/src/tool-meta.ts
+++ b/packages/ai-sdk/src/tool-meta.ts
@@ -19,7 +19,7 @@ export type FunctionTool<
  * @remarks
  * **Note**: When defined multiple times, options are overridden by the most recent call.
  *
- * @see {@link https://orpc.dev/docs/integrations/ai-sdk#tool-implementer | AI SDK}
+ * @see {@link https://orpc.dev/docs/integrations/ai-sdk#tool-implementer | AI SDK Integration - Tool Implementer}
  */
 export type AiSdkToolMeta<
   TInputSchema extends AnySchema = AnySchema,
@@ -60,7 +60,7 @@ export interface AiSdkToolFunction {
  *   .input(z.object({ location: z.string() }))
  * ```
  *
- * @see {@link https://orpc.dev/docs/integrations/ai-sdk#tool-implementer | AI SDK}
+ * @see {@link https://orpc.dev/docs/integrations/ai-sdk#tool-implementer | AI SDK Integration - Tool Implementer}
  */
 export const aiSdkTool: AiSdkToolFunction = incoming => ({
   name: '~ai-sdk/tool',
@@ -78,7 +78,7 @@ export const aiSdkTool: AiSdkToolFunction = incoming => ({
  * Reads the base [AI SDK Tool](https://ai-sdk.dev/docs/foundations/tools) options
  * attached to a procedure/contract by {@link aiSdkTool}.
  *
- * @see {@link https://orpc.dev/docs/integrations/ai-sdk#tool-implementer | AI SDK}
+ * @see {@link https://orpc.dev/docs/integrations/ai-sdk#tool-implementer | AI SDK Integration - Tool Implementer}
  */
 export function getAiSdkToolMeta(procedureOrLazy: AnyProcedureContract | Lazy<any>): AiSdkToolMeta | undefined {
   return procedureOrLazy['~orpc'].meta['~ai-sdk/tool'] as AiSdkToolMeta | undefined

--- a/packages/ai-sdk/src/tool.ts
+++ b/packages/ai-sdk/src/tool.ts
@@ -119,7 +119,7 @@ function combineOutputSchemas(outputSchemas: AnySchema[]): FlexibleSchema | unde
  * each yielded event as a [preliminary result](https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling#preliminary-tool-results)
  * and the last event becomes the final result, so the tool output is the yield type.
  *
- * @see {@link https://orpc.dev/docs/integrations/ai-sdk#streaming-tool-outputs | AI SDK}
+ * @see {@link https://orpc.dev/docs/integrations/ai-sdk#streaming-tool-outputs | AI SDK Integration - Streaming Tool Outputs}
  */
 export type ToolOutput<T> = T extends AsyncIteratorObject<infer TYield, any, any>
   ? TYield
@@ -178,7 +178,7 @@ export interface ToolImplementer {
  * })
  * ```
  *
- * @see {@link https://orpc.dev/docs/integrations/ai-sdk#tool-implementer | AI SDK}
+ * @see {@link https://orpc.dev/docs/integrations/ai-sdk#tool-implementer | AI SDK Integration - Tool Implementer}
  */
 export function implementToolFactory(_options: ImplementToolFactoryOptions = {}): ToolImplementer {
   const factory: ToolImplementer = (contract, ...rest) => {
@@ -249,7 +249,7 @@ export interface ToolFactory<TInitialContext extends Context> {
  * })
  * ```
  *
- * @see {@link https://orpc.dev/docs/integrations/ai-sdk#tool-factory | AI SDK}
+ * @see {@link https://orpc.dev/docs/integrations/ai-sdk#tool-factory | AI SDK Integration - Tool Factory}
  */
 export function createToolFactory<TInitialContext extends Context = object>(
   ...rest: MaybeOptionalOptions<CreateToolFactoryOptions<TInitialContext>>

--- a/packages/ai-sdk/src/tool.ts
+++ b/packages/ai-sdk/src/tool.ts
@@ -119,7 +119,7 @@ function combineOutputSchemas(outputSchemas: AnySchema[]): FlexibleSchema | unde
  * each yielded event as a [preliminary result](https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling#preliminary-tool-results)
  * and the last event becomes the final result, so the tool output is the yield type.
  *
- * @see {@link https://orpc.dev/docs/integrations/ai-sdk#streaming-tool-outputs AI SDK Streaming Tool Outputs Docs}
+ * @see {@link https://orpc.dev/docs/integrations/ai-sdk#streaming-tool-outputs | AI SDK}
  */
 export type ToolOutput<T> = T extends AsyncIteratorObject<infer TYield, any, any>
   ? TYield
@@ -144,8 +144,8 @@ export interface ToolImplementer {
  * The factory accepts oRPC related options, and the resulting builder
  * accepts a contract alongside AI SDK tool options.
  *
- * @info [procedures](https://orpc.dev/docs/procedure) are also compatible with [procedure contracts](https://orpc.dev/docs/contract/procedure).
- * @see {@link https://orpc.dev/docs/integrations/ai-sdk#tool-implementer AI SDK Tool Implementer Docs}
+ * @remarks
+ * **Note**: [Procedures](https://orpc.dev/docs/procedure) are also compatible with [procedure contracts](https://orpc.dev/docs/contract/procedure).
  *
  * @example
  * ```ts
@@ -177,6 +177,8 @@ export interface ToolImplementer {
  *   }),
  * })
  * ```
+ *
+ * @see {@link https://orpc.dev/docs/integrations/ai-sdk#tool-implementer | AI SDK}
  */
 export function implementToolFactory(_options: ImplementToolFactoryOptions = {}): ToolImplementer {
   const factory: ToolImplementer = (contract, ...rest) => {
@@ -217,8 +219,6 @@ export interface ToolFactory<TInitialContext extends Context> {
  * The factory accepts oRPC related options, and the resulting builder
  * accepts a procedure alongside AI SDK tool options.
  *
- * @see {@link https://orpc.dev/docs/integrations/ai-sdk#tool-factory AI SDK Tool Factory Docs}
- *
  * @example
  * ```ts
  * import { aiSdkTool, createToolFactory } from '@orpc/ai-sdk'
@@ -248,6 +248,8 @@ export interface ToolFactory<TInitialContext extends Context> {
  *   // ...AI SDK tool options/overrides here if needed
  * })
  * ```
+ *
+ * @see {@link https://orpc.dev/docs/integrations/ai-sdk#tool-factory | AI SDK}
  */
 export function createToolFactory<TInitialContext extends Context = object>(
   ...rest: MaybeOptionalOptions<CreateToolFactoryOptions<TInitialContext>>

--- a/packages/arktype/src/converter.ts
+++ b/packages/arktype/src/converter.ts
@@ -16,6 +16,12 @@ export interface ArkTypeToJsonSchemaConverterOptions extends Omit<ToJsonSchema.O
   cache?: boolean
 }
 
+/**
+ * Converts ArkType schemas into JSON Schema using ArkType's built-in `toJsonSchema`,
+ * with additional support for types such as `bigint` and `Date`.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/arktype | ArkType}
+ */
 export class ArkTypeToJsonSchemaConverter implements JsonSchemaConverter {
   private readonly toJsonSchemaOptions: ToJsonSchema.Options
   private readonly cache: undefined | { [d in JsonSchemaConverterDirection]: WeakMap<Type, [jsonSchema: JsonSchema, optional: boolean]> }

--- a/packages/arktype/src/converter.ts
+++ b/packages/arktype/src/converter.ts
@@ -20,7 +20,7 @@ export interface ArkTypeToJsonSchemaConverterOptions extends Omit<ToJsonSchema.O
  * Converts ArkType schemas into JSON Schema using ArkType's built-in `toJsonSchema`,
  * with additional support for types such as `bigint` and `Date`.
  *
- * @see {@link https://orpc.dev/docs/integrations/arktype | ArkType}
+ * @see {@link https://orpc.dev/docs/integrations/arktype | ArkType Integration}
  */
 export class ArkTypeToJsonSchemaConverter implements JsonSchemaConverter {
   private readonly toJsonSchemaOptions: ToJsonSchema.Options

--- a/packages/bun/src/redis-publisher.ts
+++ b/packages/bun/src/redis-publisher.ts
@@ -66,7 +66,7 @@ export interface BunRedisPublisherOptions extends PublisherOptions {
  * Publisher adapter for Bun's built-in Redis client. Distributes events across
  * processes via Redis Pub/Sub, with optional resume support backed by Redis Streams.
  *
- * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher}
+ * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher Helpers - Adapters}
  */
 export class BunRedisPublisher<T extends Record<string, object>> extends Publisher<T> {
   private subscriber: BunRedisPublisherOptions['subscriber']

--- a/packages/bun/src/redis-publisher.ts
+++ b/packages/bun/src/redis-publisher.ts
@@ -62,6 +62,12 @@ export interface BunRedisPublisherOptions extends PublisherOptions {
   }
 }
 
+/**
+ * Publisher adapter for Bun's built-in Redis client. Distributes events across
+ * processes via Redis Pub/Sub, with optional resume support backed by Redis Streams.
+ *
+ * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher}
+ */
 export class BunRedisPublisher<T extends Record<string, object>> extends Publisher<T> {
   private subscriber: BunRedisPublisherOptions['subscriber']
   private readonly prefix: Exclude<BunRedisPublisherOptions['prefix'], undefined>

--- a/packages/bun/src/redis-ratelimit.ts
+++ b/packages/bun/src/redis-ratelimit.ts
@@ -49,7 +49,7 @@ export interface BunRedisRateLimiterOptions {
  * Rate limiter adapter for Bun's built-in Redis client. Enforces a fixed-window
  * limit using a Redis Lua script, with optional blocking mode.
  *
- * @see {@link https://orpc.dev/docs/helpers/ratelimit#adapters | Ratelimit}
+ * @see {@link https://orpc.dev/docs/helpers/ratelimit#adapters | Rate Limit Helpers - Adapters}
  */
 export class BunRedisRateLimiter implements RateLimiter {
   private readonly redis: RedisClient

--- a/packages/bun/src/redis-ratelimit.ts
+++ b/packages/bun/src/redis-ratelimit.ts
@@ -45,6 +45,12 @@ export interface BunRedisRateLimiterOptions {
   }
 }
 
+/**
+ * Rate limiter adapter for Bun's built-in Redis client. Enforces a fixed-window
+ * limit using a Redis Lua script, with optional blocking mode.
+ *
+ * @see {@link https://orpc.dev/docs/helpers/ratelimit#adapters | Ratelimit}
+ */
 export class BunRedisRateLimiter implements RateLimiter {
   private readonly redis: RedisClient
   private readonly prefix: string

--- a/packages/client/src/adapters/fetch/rpc-link.ts
+++ b/packages/client/src/adapters/fetch/rpc-link.ts
@@ -11,7 +11,7 @@ export interface RPCLinkOptions<T extends ClientContext>
 /**
  * Client link that communicates with an RPC Handler over the Fetch API (HTTP).
  *
- * @see {@link https://orpc.dev/docs/adapters/fetch-api | Fetch API}
+ * @see {@link https://orpc.dev/docs/adapters/fetch-api | Fetch API Adapter}
  */
 export class RPCLink<T extends ClientContext> extends StandardLink<T> {
   constructor(options: RPCLinkOptions<T>) {

--- a/packages/client/src/adapters/fetch/rpc-link.ts
+++ b/packages/client/src/adapters/fetch/rpc-link.ts
@@ -8,6 +8,11 @@ export interface RPCLinkOptions<T extends ClientContext>
   extends Omit<StandardLinkOptions<T>, 'plugins'>, FetchLinkTransportOptions<T>, RPCLinkCodecOptions<T> {
 }
 
+/**
+ * Client link that communicates with an RPC Handler over the Fetch API (HTTP).
+ *
+ * @see {@link https://orpc.dev/docs/adapters/fetch-api | Fetch API}
+ */
 export class RPCLink<T extends ClientContext> extends StandardLink<T> {
   constructor(options: RPCLinkOptions<T>) {
     const codec = new RPCLinkCodec(options)

--- a/packages/client/src/adapters/message-port/rpc-link.ts
+++ b/packages/client/src/adapters/message-port/rpc-link.ts
@@ -12,7 +12,7 @@ export interface RPCLinkOptions<T extends ClientContext>
  * Client link that communicates with an RPC Handler over a Message Port
  * (e.g. workers, iframes, browser extensions, Electron).
  *
- * @see {@link https://orpc.dev/docs/adapters/message-port | Message Port}
+ * @see {@link https://orpc.dev/docs/adapters/message-port | Message Port Adapter}
  */
 export class RPCLink<T extends ClientContext> extends StandardLink<T> {
   constructor(options: RPCLinkOptions<T>) {

--- a/packages/client/src/adapters/message-port/rpc-link.ts
+++ b/packages/client/src/adapters/message-port/rpc-link.ts
@@ -8,6 +8,12 @@ export interface RPCLinkOptions<T extends ClientContext>
   extends StandardLinkOptions<T>, MessagePortLinkTransportOptions<T>, RPCLinkCodecOptions<T> {
 }
 
+/**
+ * Client link that communicates with an RPC Handler over a Message Port
+ * (e.g. workers, iframes, browser extensions, Electron).
+ *
+ * @see {@link https://orpc.dev/docs/adapters/message-port | Message Port}
+ */
 export class RPCLink<T extends ClientContext> extends StandardLink<T> {
   constructor(options: RPCLinkOptions<T>) {
     const codec = new RPCLinkCodec(options)

--- a/packages/client/src/adapters/message-port/transport.ts
+++ b/packages/client/src/adapters/message-port/transport.ts
@@ -21,9 +21,8 @@ export interface MessagePortLinkTransportOptions<_T extends ClientContext> {
    * such as transferring ownership of objects to the other side or support unserializable objects like `OffscreenCanvas`.
    *
    * @remarks
-   * - return null | undefined to disable this feature
-   *
-   * @warning Make sure your message port supports `transfer` before using this feature.
+   * **Note**: Returning `null` or `undefined` disables this feature.
+   * **Warning**: Make sure your message port supports `transfer` before using this feature.
    */
   experimental_transfer?: Value<Promisable<object[] | null | undefined>, [message: DecodedRequestMessage, port: SupportedMessagePort]>
 

--- a/packages/client/src/adapters/websocket/rpc-link.ts
+++ b/packages/client/src/adapters/websocket/rpc-link.ts
@@ -8,6 +8,11 @@ export interface RPCLinkOptions<T extends ClientContext>
   extends StandardLinkOptions<T>, WebSocketLinkTransportOptions<T>, RPCLinkCodecOptions<T> {
 }
 
+/**
+ * Client link that communicates with an RPC Handler over a WebSocket connection.
+ *
+ * @see {@link https://orpc.dev/docs/adapters/websocket | WebSocket}
+ */
 export class RPCLink<T extends ClientContext> extends StandardLink<T> {
   constructor(options: RPCLinkOptions<T>) {
     const codec = new RPCLinkCodec(options)

--- a/packages/client/src/adapters/websocket/rpc-link.ts
+++ b/packages/client/src/adapters/websocket/rpc-link.ts
@@ -11,7 +11,7 @@ export interface RPCLinkOptions<T extends ClientContext>
 /**
  * Client link that communicates with an RPC Handler over a WebSocket connection.
  *
- * @see {@link https://orpc.dev/docs/adapters/websocket | WebSocket}
+ * @see {@link https://orpc.dev/docs/adapters/websocket | WebSocket Adapters}
  */
 export class RPCLink<T extends ClientContext> extends StandardLink<T> {
   constructor(options: RPCLinkOptions<T>) {

--- a/packages/client/src/client-safe.ts
+++ b/packages/client/src/client-safe.ts
@@ -21,7 +21,7 @@ export type SafeClient<T extends AnyNestedClient>
  * // or const [error, data, inferrableError, isSuccess] = await safeClient.doSomething({ id: '123' })
  * ```
  *
- * @see {@link https://orpc.dev/docs/client/error-handling#using-createsafeclient Safe Client Docs}
+ * @see {@link https://orpc.dev/docs/client/error-handling#safe-client | Error Handling}
  */
 export function createSafeClient<T extends AnyNestedClient>(client: T): SafeClient<T> {
   const cache = new Map<string, SafeClient<AnyNestedClient>>()

--- a/packages/client/src/client-safe.ts
+++ b/packages/client/src/client-safe.ts
@@ -21,7 +21,7 @@ export type SafeClient<T extends AnyNestedClient>
  * // or const [error, data, inferrableError, isSuccess] = await safeClient.doSomething({ id: '123' })
  * ```
  *
- * @see {@link https://orpc.dev/docs/client/error-handling#safe-client | Error Handling}
+ * @see {@link https://orpc.dev/docs/client/error-handling#safe-client | Client Error Handling - Safe Client}
  */
 export function createSafeClient<T extends AnyNestedClient>(client: T): SafeClient<T> {
   const cache = new Map<string, SafeClient<AnyNestedClient>>()

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -51,7 +51,7 @@ export interface ORPCClientOptions<T extends AnyNestedClient> {
  * The returned client mirrors the shape of your router or contract,
  * so calling a procedure is as simple as calling a function.
  *
- * @see {@link https://orpc.dev/docs/client/client-side | Client-Side}
+ * @see {@link https://orpc.dev/docs/client/client-side | Client-Side Clients}
  */
 export function createORPCClient<T extends AnyNestedClient>(
   link: ClientLink<InferClientContext<T>>,

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -46,6 +46,13 @@ export interface ORPCClientOptions<T extends AnyNestedClient> {
   scoped?: ORPCClientScoped<T>
 }
 
+/**
+ * Creates a fully typed oRPC client from a link.
+ * The returned client mirrors the shape of your router or contract,
+ * so calling a procedure is as simple as calling a function.
+ *
+ * @see {@link https://orpc.dev/docs/client/client-side | Client-Side}
+ */
 export function createORPCClient<T extends AnyNestedClient>(
   link: ClientLink<InferClientContext<T>>,
   { path = [], ...options }: NoInfer<ORPCClientOptions<T>> = {},

--- a/packages/client/src/dynamic-link.ts
+++ b/packages/client/src/dynamic-link.ts
@@ -5,7 +5,7 @@ import type { ClientContext, ClientLink, ClientOptions } from './types'
  * DynamicLink provides a way to dynamically resolve and delegate calls to other ClientLinks
  * based on the request path, input, and context.
  *
- * @see {@link https://orpc.dev/docs/client/dynamic-link Dynamic Link Docs}
+ * @see {@link https://orpc.dev/docs/client/dynamic-link | Dynamic Link}
  */
 export class DynamicLink<TClientContext extends ClientContext> implements ClientLink<TClientContext> {
   constructor(

--- a/packages/client/src/dynamic-link.ts
+++ b/packages/client/src/dynamic-link.ts
@@ -5,7 +5,7 @@ import type { ClientContext, ClientLink, ClientOptions } from './types'
  * DynamicLink provides a way to dynamically resolve and delegate calls to other ClientLinks
  * based on the request path, input, and context.
  *
- * @see {@link https://orpc.dev/docs/client/dynamic-link | Dynamic Link}
+ * @see {@link https://orpc.dev/docs/client/dynamic-link | DynamicLink}
  */
 export class DynamicLink<TClientContext extends ClientContext> implements ClientLink<TClientContext> {
   constructor(

--- a/packages/client/src/error-utils.ts
+++ b/packages/client/src/error-utils.ts
@@ -3,6 +3,12 @@ import type { AnyORPCError, ORPCErrorCode, ORPCErrorJSON } from './error'
 import { isPlainObject } from '@orpc/shared'
 import { ORPCError } from './error'
 
+/**
+ * Checks if an error is an `ORPCError` whose type is inferable at the TypeScript level,
+ * narrowing it so `code` and `data` are fully typed.
+ *
+ * @see {@link https://orpc.dev/docs/client/error-handling#using-safe-and-isinferableerror | Error Handling}
+ */
 export function isInferableError<T>(error: T): error is Extract<T, AnyORPCError> {
   return error instanceof ORPCError && error.inferable
 }

--- a/packages/client/src/error-utils.ts
+++ b/packages/client/src/error-utils.ts
@@ -7,7 +7,7 @@ import { ORPCError } from './error'
  * Checks if an error is an `ORPCError` whose type is inferable at the TypeScript level,
  * narrowing it so `code` and `data` are fully typed.
  *
- * @see {@link https://orpc.dev/docs/client/error-handling#using-safe-and-isinferableerror | Error Handling}
+ * @see {@link https://orpc.dev/docs/client/error-handling#using-safe-and-isinferableerror | Client Error Handling - Using safe and isInferableError}
  */
 export function isInferableError<T>(error: T): error is Extract<T, AnyORPCError> {
   return error instanceof ORPCError && error.inferable

--- a/packages/client/src/error.ts
+++ b/packages/client/src/error.ts
@@ -5,8 +5,8 @@ import { getConstructors, resolveMaybeOptionalOptions } from '@orpc/shared'
  * Default mapping between common oRPC error codes and HTTP status codes.
  * Handlers use it to determine response status codes; spread it to build a custom `errorStatusMap`.
  *
- * @see {@link https://orpc.dev/docs/rpc/handler#custom-error-response | RPC Handler}
- * @see {@link https://orpc.dev/docs/openapi/handler#custom-error-response | OpenAPI Handler}
+ * @see {@link https://orpc.dev/docs/rpc/handler#custom-error-response | RPC Handler - Custom Error Response}
+ * @see {@link https://orpc.dev/docs/openapi/handler#custom-error-response | OpenAPI Handler - Custom Error Response}
  */
 export const COMMON_ERROR_STATUS_MAP = {
   BAD_REQUEST: 400,
@@ -49,7 +49,7 @@ let ORPCErrorConstructors: WeakSet<object>
  * Typed error carrying a `code`, a `message`, and optional `data`.
  * Throw it from handlers or middleware to produce typed error responses on the client.
  *
- * @see {@link https://orpc.dev/docs/error-handling#orpcerror-class | Error Handling}
+ * @see {@link https://orpc.dev/docs/error-handling#orpcerror-class | Error Handling - ORPCError Class}
  */
 export class ORPCError<TCode extends ORPCErrorCode, TData> extends Error {
   /**

--- a/packages/client/src/error.ts
+++ b/packages/client/src/error.ts
@@ -1,6 +1,13 @@
 import type { MaybeOptionalOptions, Registry } from '@orpc/shared'
 import { getConstructors, resolveMaybeOptionalOptions } from '@orpc/shared'
 
+/**
+ * Default mapping between common oRPC error codes and HTTP status codes.
+ * Handlers use it to determine response status codes; spread it to build a custom `errorStatusMap`.
+ *
+ * @see {@link https://orpc.dev/docs/rpc/handler#custom-error-response | RPC Handler}
+ * @see {@link https://orpc.dev/docs/openapi/handler#custom-error-response | OpenAPI Handler}
+ */
 export const COMMON_ERROR_STATUS_MAP = {
   BAD_REQUEST: 400,
   UNAUTHORIZED: 401,
@@ -38,6 +45,12 @@ export type ORPCErrorOptions<TData>
 
 let ORPCErrorConstructors: WeakSet<object>
 
+/**
+ * Typed error carrying a `code`, a `message`, and optional `data`.
+ * Throw it from handlers or middleware to produce typed error responses on the client.
+ *
+ * @see {@link https://orpc.dev/docs/error-handling#orpcerror-class | Error Handling}
+ */
 export class ORPCError<TCode extends ORPCErrorCode, TData> extends Error {
   /**
    * Placed inside a static block (rather than at module level) to ensure this
@@ -67,8 +80,8 @@ export class ORPCError<TCode extends ORPCErrorCode, TData> extends Error {
   }
 
   /**
-   * @info
-   * The `__branch` property is used for type branding, helping TypeScript distinguish
+   * @remarks
+   * **Note**: The `__branch` property is used for type branding, helping TypeScript distinguish
    * an `ORPCError` instance from plain objects with a similar structure.
    */
   override readonly name = 'ORPCError' as 'ORPCError' & { __branch: 'ORPCError' }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -74,6 +74,12 @@ export type {
 
 export {
   ErrorEvent,
+  /**
+   * Retrieves event metadata (such as the event id and retry interval)
+   * attached to a single iterator event value.
+   *
+   * @see {@link https://orpc.dev/docs/client/async-iterator-object#event-metadata | AsyncIteratorObject (SSE)}
+   */
   getEventMeta,
   unwrapEvent,
   withEventMeta,

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -78,7 +78,7 @@ export {
    * Retrieves event metadata (such as the event id and retry interval)
    * attached to a single iterator event value.
    *
-   * @see {@link https://orpc.dev/docs/client/async-iterator-object#event-metadata | AsyncIteratorObject (SSE)}
+   * @see {@link https://orpc.dev/docs/client/async-iterator-object#event-metadata | AsyncIteratorObject in Client - Event Metadata}
    */
   getEventMeta,
   unwrapEvent,

--- a/packages/client/src/plugins/batch.ts
+++ b/packages/client/src/plugins/batch.ts
@@ -96,6 +96,15 @@ export interface BatchLinkPluginOptions<T extends ClientContext> {
   mapSubresponse?: (subResponse: StandardLazyResponse, batchResponse: StandardLazyResponse, subOptions: StandardLinkTransportInterceptorOptions<T>) => StandardLazyResponse
 }
 
+/**
+ * Combines multiple client requests into a single batch request
+ * and splits the batch response back into individual responses.
+ *
+ * @remarks
+ * **Note**: HTTP/2 and later already multiplex requests over a single connection, so this plugin is often less useful than it once was.
+ *
+ * @see {@link https://orpc.dev/docs/plugins/batch | Batch}
+ */
 export class BatchLinkPlugin<T extends ClientContext> implements StandardLinkPlugin<T> {
   name = '~batch'
 

--- a/packages/client/src/plugins/batch.ts
+++ b/packages/client/src/plugins/batch.ts
@@ -103,7 +103,7 @@ export interface BatchLinkPluginOptions<T extends ClientContext> {
  * @remarks
  * **Note**: HTTP/2 and later already multiplex requests over a single connection, so this plugin is often less useful than it once was.
  *
- * @see {@link https://orpc.dev/docs/plugins/batch | Batch}
+ * @see {@link https://orpc.dev/docs/plugins/batch | Batch Plugin}
  */
 export class BatchLinkPlugin<T extends ClientContext> implements StandardLinkPlugin<T> {
   name = '~batch'

--- a/packages/client/src/plugins/dedupe.ts
+++ b/packages/client/src/plugins/dedupe.ts
@@ -31,6 +31,12 @@ export interface DedupeLinkPluginOptions<T extends ClientContext> {
   filter?: Value<boolean, [options: StandardLinkTransportInterceptorOptions<T>]>
 }
 
+/**
+ * Prevents redundant requests by deduplicating similar in-flight requests,
+ * reducing the number of requests sent to the server.
+ *
+ * @see {@link https://orpc.dev/docs/plugins/dedupe | Dedupe}
+ */
 export class DedupeLinkPlugin<T extends ClientContext> implements StandardLinkPlugin<T> {
   name = '~dedupe'
   before = ['~batch']

--- a/packages/client/src/plugins/dedupe.ts
+++ b/packages/client/src/plugins/dedupe.ts
@@ -35,7 +35,7 @@ export interface DedupeLinkPluginOptions<T extends ClientContext> {
  * Prevents redundant requests by deduplicating similar in-flight requests,
  * reducing the number of requests sent to the server.
  *
- * @see {@link https://orpc.dev/docs/plugins/dedupe | Dedupe}
+ * @see {@link https://orpc.dev/docs/plugins/dedupe | Dedupe Plugin}
  */
 export class DedupeLinkPlugin<T extends ClientContext> implements StandardLinkPlugin<T> {
   name = '~dedupe'

--- a/packages/client/src/plugins/request-compression.ts
+++ b/packages/client/src/plugins/request-compression.ts
@@ -26,6 +26,12 @@ export interface RequestCompressionLinkPluginOptions<_T extends ClientContext> {
   threshold?: number
 }
 
+/**
+ * Compresses request bodies before sending them to the server,
+ * reducing bandwidth usage for large payloads.
+ *
+ * @see {@link https://orpc.dev/docs/plugins/request-compression | Request Compression}
+ */
 export class RequestCompressionLinkPlugin<T extends ClientContext> implements StandardLinkPlugin<T> {
   name = '~request-compression'
 

--- a/packages/client/src/plugins/request-compression.ts
+++ b/packages/client/src/plugins/request-compression.ts
@@ -30,7 +30,7 @@ export interface RequestCompressionLinkPluginOptions<_T extends ClientContext> {
  * Compresses request bodies before sending them to the server,
  * reducing bandwidth usage for large payloads.
  *
- * @see {@link https://orpc.dev/docs/plugins/request-compression | Request Compression}
+ * @see {@link https://orpc.dev/docs/plugins/request-compression | Request Compression Plugin}
  */
 export class RequestCompressionLinkPlugin<T extends ClientContext> implements StandardLinkPlugin<T> {
   name = '~request-compression'

--- a/packages/client/src/plugins/response-compression.ts
+++ b/packages/client/src/plugins/response-compression.ts
@@ -19,7 +19,7 @@ export interface ResponseCompressionLinkPluginOptions<_T extends ClientContext> 
  * based on the Content-Encoding header. Works at the standard link level,
  * so it supports all adapters.
  *
- * @see {@link https://orpc.dev/docs/plugins/response-compression Response Compression Plugin Docs}
+ * @see {@link https://orpc.dev/docs/plugins/response-compression | Response Compression}
  */
 export class ResponseCompressionLinkPlugin<T extends ClientContext> implements StandardLinkPlugin<T> {
   name = '~response-compression'

--- a/packages/client/src/plugins/response-compression.ts
+++ b/packages/client/src/plugins/response-compression.ts
@@ -19,7 +19,7 @@ export interface ResponseCompressionLinkPluginOptions<_T extends ClientContext> 
  * based on the Content-Encoding header. Works at the standard link level,
  * so it supports all adapters.
  *
- * @see {@link https://orpc.dev/docs/plugins/response-compression | Response Compression}
+ * @see {@link https://orpc.dev/docs/plugins/response-compression | Response Compression Plugin}
  */
 export class ResponseCompressionLinkPlugin<T extends ClientContext> implements StandardLinkPlugin<T> {
   name = '~response-compression'

--- a/packages/client/src/plugins/retry-after.ts
+++ b/packages/client/src/plugins/retry-after.ts
@@ -42,7 +42,7 @@ export interface RetryAfterLinkPluginOptions<T extends ClientContext> {
  * The Retry After Link Plugin automatically retries requests based on server `retry-after` header.
  * This is particularly useful for handling rate limiting and temporary server unavailability.
  *
- * @see {@link https://orpc.dev/docs/plugins/retry-after | Retry After}
+ * @see {@link https://orpc.dev/docs/plugins/retry-after | Retry After Plugin}
  */
 export class RetryAfterLinkPlugin<T extends ClientContext> implements StandardLinkPlugin<T> {
   private readonly condition: Exclude<RetryAfterLinkPluginOptions<T>['condition'], undefined>

--- a/packages/client/src/plugins/retry-after.ts
+++ b/packages/client/src/plugins/retry-after.ts
@@ -42,7 +42,7 @@ export interface RetryAfterLinkPluginOptions<T extends ClientContext> {
  * The Retry After Link Plugin automatically retries requests based on server `retry-after` header.
  * This is particularly useful for handling rate limiting and temporary server unavailability.
  *
- * @see {@link https://orpc.dev/docs/plugins/retry-after Retry After Plugin Docs}
+ * @see {@link https://orpc.dev/docs/plugins/retry-after | Retry After}
  */
 export class RetryAfterLinkPlugin<T extends ClientContext> implements StandardLinkPlugin<T> {
   private readonly condition: Exclude<RetryAfterLinkPluginOptions<T>['condition'], undefined>

--- a/packages/client/src/plugins/retry.ts
+++ b/packages/client/src/plugins/retry.ts
@@ -21,6 +21,12 @@ export interface RetryLinkPluginAttemptOptions<T extends RetryLinkPluginContext>
   error: unknown
 }
 
+/**
+ * Client context options that control retry behavior per call
+ * when the `RetryLinkPlugin` is enabled.
+ *
+ * @see {@link https://orpc.dev/docs/plugins/retry | Retry}
+ */
 export interface RetryLinkPluginContext {
   /**
    * Maximum retry attempts before throwing.
@@ -33,7 +39,9 @@ export interface RetryLinkPluginContext {
   /**
    * Delay (in ms) before retrying.
    *
-   * @info Why 2000ms? The EventSource spec suggests a default retry delay of 2 seconds if it doesn't specify
+   * @remarks
+   * **Note**: Why 2000ms? The EventSource spec suggests a default retry delay of 2 seconds if it doesn't specify
+   *
    * @default (o) => o.lastEventRetry ?? 2000
    */
   retryDelay?: Value<Promisable<number>, [RetryLinkPluginAttemptOptions<RetryLinkPluginContext>]>
@@ -58,6 +66,15 @@ export interface RetryLinkPluginOptions<_T extends RetryLinkPluginContext> {
   default?: RetryLinkPluginContext | undefined
 }
 
+/**
+ * Automatically retries failed requests based on customizable retry strategies,
+ * improving the resilience of your application.
+ *
+ * @remarks
+ * **Note**: Retry behavior is configured through the client context on each call.
+ *
+ * @see {@link https://orpc.dev/docs/plugins/retry | Retry}
+ */
 export class RetryLinkPlugin<T extends RetryLinkPluginContext & ClientContext> implements StandardLinkPlugin<T> {
   private readonly defaultRetry: Exclude<RetryLinkPluginContext['retry'], undefined>
   private readonly defaultRetryDelay: Exclude<RetryLinkPluginContext['retryDelay'], undefined>

--- a/packages/client/src/plugins/retry.ts
+++ b/packages/client/src/plugins/retry.ts
@@ -25,7 +25,7 @@ export interface RetryLinkPluginAttemptOptions<T extends RetryLinkPluginContext>
  * Client context options that control retry behavior per call
  * when the `RetryLinkPlugin` is enabled.
  *
- * @see {@link https://orpc.dev/docs/plugins/retry | Retry}
+ * @see {@link https://orpc.dev/docs/plugins/retry | Retry Plugin}
  */
 export interface RetryLinkPluginContext {
   /**
@@ -73,7 +73,7 @@ export interface RetryLinkPluginOptions<_T extends RetryLinkPluginContext> {
  * @remarks
  * **Note**: Retry behavior is configured through the client context on each call.
  *
- * @see {@link https://orpc.dev/docs/plugins/retry | Retry}
+ * @see {@link https://orpc.dev/docs/plugins/retry | Retry Plugin}
  */
 export class RetryLinkPlugin<T extends RetryLinkPluginContext & ClientContext> implements StandardLinkPlugin<T> {
   private readonly defaultRetry: Exclude<RetryLinkPluginContext['retry'], undefined>

--- a/packages/client/src/plugins/timeout.ts
+++ b/packages/client/src/plugins/timeout.ts
@@ -14,7 +14,7 @@ export interface TimeoutLinkPluginOptions<T extends ClientContext> {
 /**
  * The Timeout Link Plugin aborts requests that exceed a configured timeout with an `AbortError`.
  *
- * @see {@link https://orpc.dev/docs/plugins/timeout | Timeout}
+ * @see {@link https://orpc.dev/docs/plugins/timeout | Timeout Plugin}
  */
 export class TimeoutLinkPlugin<T extends ClientContext> implements StandardLinkPlugin<T> {
   private readonly timeout: TimeoutLinkPluginOptions<T>['timeout']

--- a/packages/client/src/plugins/timeout.ts
+++ b/packages/client/src/plugins/timeout.ts
@@ -14,7 +14,7 @@ export interface TimeoutLinkPluginOptions<T extends ClientContext> {
 /**
  * The Timeout Link Plugin aborts requests that exceed a configured timeout with an `AbortError`.
  *
- * @see {@link https://orpc.dev/docs/plugins/timeout Timeout Plugin Docs}
+ * @see {@link https://orpc.dev/docs/plugins/timeout | Timeout}
  */
 export class TimeoutLinkPlugin<T extends ClientContext> implements StandardLinkPlugin<T> {
   private readonly timeout: TimeoutLinkPluginOptions<T>['timeout']

--- a/packages/client/src/rpc-serializer.ts
+++ b/packages/client/src/rpc-serializer.ts
@@ -23,6 +23,12 @@ export interface RPCSerializerOptions extends RPCJsonSerializerOptions {
   serialize?: RPCSerializerSerializeOptions | undefined
 }
 
+/**
+ * Serializes and deserializes data for the RPC protocol,
+ * preserving native types like Date, BigInt, Set, and Map that plain JSON cannot represent.
+ *
+ * @see {@link https://orpc.dev/docs/rpc/serializer | RPC Serializer}
+ */
 export class RPCSerializer {
   private readonly jsonSerializer: RPCJsonSerializer
   private readonly defaultSerializeOptions: RPCSerializerOptions['serialize']

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -33,7 +33,7 @@ export type AnyNestedClient = NestedClient<any>
 /**
  * Infers the **client context type** required by a client.
  *
- * @see {@link https://orpc.dev/docs/client/client-side#infer-client-context | Client-Side}
+ * @see {@link https://orpc.dev/docs/client/client-side#infer-client-context | Client-Side Clients - Infer Client Context}
  */
 export type InferClientContext<T extends AnyNestedClient> = T extends NestedClient<infer U> ? U : never
 
@@ -46,7 +46,7 @@ export interface ClientLink<TClientContext extends ClientContext> {
  *
  * Produces a nested map where each endpoint's input type is preserved.
  *
- * @see {@link https://orpc.dev/docs/client/client-side#infer-client-inputs | Client-Side}
+ * @see {@link https://orpc.dev/docs/client/client-side#infer-client-inputs | Client-Side Clients - Infer Client Inputs}
  */
 export type InferClientInputs<T extends AnyNestedClient>
   = T extends Client<any, infer U, any, any>
@@ -61,7 +61,7 @@ export type InferClientInputs<T extends AnyNestedClient>
  * If an endpoint's input includes `{ body: ... }`, only the `body` portion is extracted.
  * Produces a nested map of body input types.
  *
- * @see {@link https://orpc.dev/docs/client/client-side#infer-client-body-inputs | Client-Side}
+ * @see {@link https://orpc.dev/docs/client/client-side#infer-client-body-inputs | Client-Side Clients - Infer Client Body Inputs}
  */
 export type InferClientBodyInputs<T extends AnyNestedClient>
   = T extends Client<any, infer U, any, any>
@@ -75,7 +75,7 @@ export type InferClientBodyInputs<T extends AnyNestedClient>
  *
  * Produces a nested map where each endpoint's output type is preserved.
  *
- * @see {@link https://orpc.dev/docs/client/client-side#infer-client-outputs | Client-Side}
+ * @see {@link https://orpc.dev/docs/client/client-side#infer-client-outputs | Client-Side Clients - Infer Client Outputs}
  */
 export type InferClientOutputs<T extends AnyNestedClient>
   = T extends Client<any, any, infer U, any>
@@ -90,7 +90,7 @@ export type InferClientOutputs<T extends AnyNestedClient>
  * If an endpoint's output includes `{ body: ... }`, only the `body` portion is extracted.
  * Produces a nested map of body output types.
  *
- * @see {@link https://orpc.dev/docs/client/client-side#infer-client-body-outputs | Client-Side}
+ * @see {@link https://orpc.dev/docs/client/client-side#infer-client-body-outputs | Client-Side Clients - Infer Client Body Outputs}
  */
 export type InferClientBodyOutputs<T extends AnyNestedClient>
   = T extends Client<any, any, infer U, any>
@@ -104,7 +104,7 @@ export type InferClientBodyOutputs<T extends AnyNestedClient>
  *
  * Produces a nested map where each endpoint's error type is preserved.
  *
- * @see {@link https://orpc.dev/docs/client/client-side#infer-client-errors | Client-Side}
+ * @see {@link https://orpc.dev/docs/client/client-side#infer-client-errors | Client-Side Clients - Infer Client Errors}
  */
 export type InferClientErrors<T extends AnyNestedClient>
   = T extends Client<any, any, any, infer U>
@@ -118,7 +118,7 @@ export type InferClientErrors<T extends AnyNestedClient>
  *
  * Useful when you want to handle all possible errors from any endpoint at once.
  *
- * @see {@link https://orpc.dev/docs/client/client-side#infer-client-error | Client-Side}
+ * @see {@link https://orpc.dev/docs/client/client-side#infer-client-error | Client-Side Clients - Infer Client Error}
  */
 export type InferClientError<T extends AnyNestedClient>
   = T extends Client<any, any, any, infer U>

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -30,6 +30,11 @@ export type NestedClient<TClientContext extends ClientContext> = Client<TClientC
 
 export type AnyNestedClient = NestedClient<any>
 
+/**
+ * Infers the **client context type** required by a client.
+ *
+ * @see {@link https://orpc.dev/docs/client/client-side#infer-client-context | Client-Side}
+ */
 export type InferClientContext<T extends AnyNestedClient> = T extends NestedClient<infer U> ? U : never
 
 export interface ClientLink<TClientContext extends ClientContext> {
@@ -40,6 +45,8 @@ export interface ClientLink<TClientContext extends ClientContext> {
  * Recursively infers the **input types** from a client.
  *
  * Produces a nested map where each endpoint's input type is preserved.
+ *
+ * @see {@link https://orpc.dev/docs/client/client-side#infer-client-inputs | Client-Side}
  */
 export type InferClientInputs<T extends AnyNestedClient>
   = T extends Client<any, infer U, any, any>
@@ -53,6 +60,8 @@ export type InferClientInputs<T extends AnyNestedClient>
  *
  * If an endpoint's input includes `{ body: ... }`, only the `body` portion is extracted.
  * Produces a nested map of body input types.
+ *
+ * @see {@link https://orpc.dev/docs/client/client-side#infer-client-body-inputs | Client-Side}
  */
 export type InferClientBodyInputs<T extends AnyNestedClient>
   = T extends Client<any, infer U, any, any>
@@ -65,6 +74,8 @@ export type InferClientBodyInputs<T extends AnyNestedClient>
  * Recursively infers the **output types** from a client.
  *
  * Produces a nested map where each endpoint's output type is preserved.
+ *
+ * @see {@link https://orpc.dev/docs/client/client-side#infer-client-outputs | Client-Side}
  */
 export type InferClientOutputs<T extends AnyNestedClient>
   = T extends Client<any, any, infer U, any>
@@ -78,6 +89,8 @@ export type InferClientOutputs<T extends AnyNestedClient>
  *
  * If an endpoint's output includes `{ body: ... }`, only the `body` portion is extracted.
  * Produces a nested map of body output types.
+ *
+ * @see {@link https://orpc.dev/docs/client/client-side#infer-client-body-outputs | Client-Side}
  */
 export type InferClientBodyOutputs<T extends AnyNestedClient>
   = T extends Client<any, any, infer U, any>
@@ -87,9 +100,11 @@ export type InferClientBodyOutputs<T extends AnyNestedClient>
       }
 
 /**
- * Recursively infers the **error types** from a client when you use [type-safe errors](https://orpc.dev/docs/error-handling#type‐safe-error-handling).
+ * Recursively infers the **error types** from a client when you use [type-safe errors](https://orpc.dev/docs/error-handling#typesafe-errors).
  *
  * Produces a nested map where each endpoint's error type is preserved.
+ *
+ * @see {@link https://orpc.dev/docs/client/client-side#infer-client-errors | Client-Side}
  */
 export type InferClientErrors<T extends AnyNestedClient>
   = T extends Client<any, any, any, infer U>
@@ -99,9 +114,11 @@ export type InferClientErrors<T extends AnyNestedClient>
       }
 
 /**
- * Recursively infers a **union of all error types** from a client when you use [type-safe errors](https://orpc.dev/docs/error-handling#type‐safe-error-handling).
+ * Recursively infers a **union of all error types** from a client when you use [type-safe errors](https://orpc.dev/docs/error-handling#typesafe-errors).
  *
  * Useful when you want to handle all possible errors from any endpoint at once.
+ *
+ * @see {@link https://orpc.dev/docs/client/client-side#infer-client-error | Client-Side}
  */
 export type InferClientError<T extends AnyNestedClient>
   = T extends Client<any, any, any, infer U>

--- a/packages/client/src/utils.ts
+++ b/packages/client/src/utils.ts
@@ -38,7 +38,7 @@ export type SafeResult<TOutput, TError>
  * }
  * ```
  *
- * @see {@link https://orpc.dev/docs/client/error-handling#using-safe-and-isinferableerror | Error Handling}
+ * @see {@link https://orpc.dev/docs/client/error-handling#using-safe-and-isinferableerror | Client Error Handling - Using safe and isInferableError}
  */
 export async function safe<TOutput, TError = ThrowableError>(promise: PromiseWithError<TOutput, TError>): Promise<SafeResult<TOutput, TError>> {
   try {

--- a/packages/client/src/utils.ts
+++ b/packages/client/src/utils.ts
@@ -36,6 +36,9 @@ export type SafeResult<TOutput, TError>
  * if (inferableError) {
  *  console.log(inferableError) // or error, both are well typed
  * }
+ * ```
+ *
+ * @see {@link https://orpc.dev/docs/client/error-handling#using-safe-and-isinferableerror | Error Handling}
  */
 export async function safe<TOutput, TError = ThrowableError>(promise: PromiseWithError<TOutput, TError>): Promise<SafeResult<TOutput, TError>> {
   try {

--- a/packages/cloudflare/src/publisher-object.ts
+++ b/packages/cloudflare/src/publisher-object.ts
@@ -59,7 +59,7 @@ export interface DurablePublisherObjectOptions {
  * Durable Object base class that backs `DurablePublisher`. Fans published events
  * out to WebSocket subscribers, with optional event storage for resume support.
  *
- * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher}
+ * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher Helpers - Adapters}
  */
 export class DurablePublisherObject<Env = Cloudflare.Env, Props = unknown> extends DurableObject<Env, Props> {
   private readonly resumeStorage: ResumeStorage

--- a/packages/cloudflare/src/publisher-object.ts
+++ b/packages/cloudflare/src/publisher-object.ts
@@ -55,6 +55,12 @@ export interface DurablePublisherObjectOptions {
   resume?: DurablePublisherObjectResumeOptions
 }
 
+/**
+ * Durable Object base class that backs `DurablePublisher`. Fans published events
+ * out to WebSocket subscribers, with optional event storage for resume support.
+ *
+ * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher}
+ */
 export class DurablePublisherObject<Env = Cloudflare.Env, Props = unknown> extends DurableObject<Env, Props> {
   private readonly resumeStorage: ResumeStorage
 

--- a/packages/cloudflare/src/publisher.ts
+++ b/packages/cloudflare/src/publisher.ts
@@ -32,7 +32,7 @@ export interface DurablePublisherOptions extends PublisherOptions {
  * Publisher adapter for Cloudflare Durable Objects. Routes publishes and
  * subscriptions to a `DurablePublisherObject` per event, delivering events over WebSockets.
  *
- * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher}
+ * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher Helpers - Adapters}
  */
 export class DurablePublisher<T extends Record<string, object>> extends Publisher<T> {
   private readonly prefix: string

--- a/packages/cloudflare/src/publisher.ts
+++ b/packages/cloudflare/src/publisher.ts
@@ -28,6 +28,12 @@ export interface DurablePublisherOptions extends PublisherOptions {
   getStubByName?: (namespace: DurableObjectNamespace, event: string) => DurableObjectStub
 }
 
+/**
+ * Publisher adapter for Cloudflare Durable Objects. Routes publishes and
+ * subscriptions to a `DurablePublisherObject` per event, delivering events over WebSockets.
+ *
+ * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher}
+ */
 export class DurablePublisher<T extends Record<string, object>> extends Publisher<T> {
   private readonly prefix: string
   private readonly serializer: Public<RPCSerializer>

--- a/packages/cloudflare/src/ratelimit.ts
+++ b/packages/cloudflare/src/ratelimit.ts
@@ -15,7 +15,7 @@ export interface CloudflareRateLimiterOptions {
  * @remarks
  * **Note**: Blocking mode is not supported by this adapter.
  *
- * @see {@link https://orpc.dev/docs/helpers/ratelimit#adapters | Ratelimit}
+ * @see {@link https://orpc.dev/docs/helpers/ratelimit#adapters | Rate Limit Helpers - Adapters}
  */
 export class CloudflareRateLimiter implements RateLimiter {
   private readonly prefix: string

--- a/packages/cloudflare/src/ratelimit.ts
+++ b/packages/cloudflare/src/ratelimit.ts
@@ -9,6 +9,14 @@ export interface CloudflareRateLimiterOptions {
   prefix?: string
 }
 
+/**
+ * Rate limiter adapter for Cloudflare's Rate Limiting binding.
+ *
+ * @remarks
+ * **Note**: Blocking mode is not supported by this adapter.
+ *
+ * @see {@link https://orpc.dev/docs/helpers/ratelimit#adapters | Ratelimit}
+ */
 export class CloudflareRateLimiter implements RateLimiter {
   private readonly prefix: string
 

--- a/packages/contract/src/builder.ts
+++ b/packages/contract/src/builder.ts
@@ -107,4 +107,10 @@ export class ContractBuilder<
   }
 }
 
+/**
+ * The contract builder — the entry point for defining procedure and router contracts
+ * (input/output schemas, errors, and metadata) without any business logic.
+ *
+ * @see {@link https://orpc.dev/docs/contract/procedure | Procedure Contract}
+ */
 export const oc = ContractBuilder.create()

--- a/packages/contract/src/client-factory.ts
+++ b/packages/contract/src/client-factory.ts
@@ -30,7 +30,7 @@ export interface ContractClientFactoryOptions<
  * @remarks
  * **Warning**: Every procedure contract passed to the factory must define `meta.path` matching its location in the root contract.
  *
- * @see {@link https://orpc.dev/docs/advanced/scaling-large-projects#contract-client-factory | Scaling Large Projects}
+ * @see {@link https://orpc.dev/docs/advanced/scaling-large-projects#contract-client-factory | Scaling Large Projects - Contract Client Factory}
  */
 export function createContractClientFactory<
   TClientContext extends ClientContext,

--- a/packages/contract/src/client-factory.ts
+++ b/packages/contract/src/client-factory.ts
@@ -23,6 +23,15 @@ export interface ContractClientFactoryOptions<
   contractRef?: undefined | RouterContract
 }
 
+/**
+ * Creates a client factory that builds a client from any procedure or router contract,
+ * so large projects can import individual contracts instead of a single root client.
+ *
+ * @remarks
+ * **Warning**: Every procedure contract passed to the factory must define `meta.path` matching its location in the root contract.
+ *
+ * @see {@link https://orpc.dev/docs/advanced/scaling-large-projects#contract-client-factory | Scaling Large Projects}
+ */
 export function createContractClientFactory<
   TClientContext extends ClientContext,
 >(

--- a/packages/contract/src/error-factory.ts
+++ b/packages/contract/src/error-factory.ts
@@ -53,7 +53,7 @@ export interface ORPCErrorFactory<TCode extends ORPCErrorCode, TData> extends Er
  * }
  * ```
  *
- * @see {@link https://orpc.dev/docs/error-handling#error-factory Error Factory Docs}
+ * @see {@link https://orpc.dev/docs/error-handling#error-factory | Error Handling}
  */
 export function error<TCode extends ORPCErrorCode, TData = unknown>(
   code: TCode,

--- a/packages/contract/src/error-factory.ts
+++ b/packages/contract/src/error-factory.ts
@@ -53,7 +53,7 @@ export interface ORPCErrorFactory<TCode extends ORPCErrorCode, TData> extends Er
  * }
  * ```
  *
- * @see {@link https://orpc.dev/docs/error-handling#error-factory | Error Handling}
+ * @see {@link https://orpc.dev/docs/error-handling#error-factory | Error Handling - Error Factory}
  */
 export function error<TCode extends ORPCErrorCode, TData = unknown>(
   code: TCode,

--- a/packages/contract/src/error.ts
+++ b/packages/contract/src/error.ts
@@ -13,6 +13,12 @@ export interface ErrorMapItem {
   data?: undefined | AnySchema
 }
 
+/**
+ * Map of error codes to their definitions, as passed to `.errors(...)`.
+ * Errors defined here remain properly typed on the client.
+ *
+ * @see {@link https://orpc.dev/docs/metadata | Metadata}
+ */
 export type ErrorMap = {
   [key in ORPCErrorCode]?: ErrorMapItem
 }
@@ -32,6 +38,13 @@ export interface ValidationErrorOptions extends ErrorOptions {
   invalidData: unknown
 }
 
+/**
+ * Error thrown when input, output, or error data fails schema validation,
+ * carrying the standard-schema `issues` and the invalid data.
+ * Usually found as the `cause` of an `ORPCError`.
+ *
+ * @see {@link https://orpc.dev/docs/advanced/validation-customization | Validation Customization}
+ */
 export class ValidationError extends Error {
   /**
    * This array is readonly because the upstream Standard Schema returns readonly issues.

--- a/packages/contract/src/meta-built-in.ts
+++ b/packages/contract/src/meta-built-in.ts
@@ -13,6 +13,13 @@ export interface PathMetaPlugin<
   name: '~path'
 }
 
+/**
+ * Built-in metadata plugins.
+ * `meta.path` records a procedure contract's path inside the root contract,
+ * which is required for the contract client factory pattern.
+ *
+ * @see {@link https://orpc.dev/docs/advanced/scaling-large-projects | Scaling Large Projects}
+ */
 export const meta = {
   path<
     TInputSchema extends AnySchema,

--- a/packages/contract/src/meta-utils.ts
+++ b/packages/contract/src/meta-utils.ts
@@ -74,6 +74,8 @@ export function resolveMetaPlugins<
  * @returns A `[metaPlugin, getMeta]` tuple:
  *   - `metaPlugin(metadata)` - Attaches metadata to a procedure under `name`.
  *   - `getMeta(procedureOrLazy)` - Retrieves the metadata, or `undefined` if not set.
+ *
+ * @see {@link https://orpc.dev/docs/metadata | Metadata}
  */
 export function defineMeta<TName extends string, TData>(
   name: TName,

--- a/packages/contract/src/meta.ts
+++ b/packages/contract/src/meta.ts
@@ -2,6 +2,12 @@ import type { ErrorMap } from './error'
 import type { AnySchema } from './schema'
 import { isTypescriptObject } from '@orpc/shared'
 
+/**
+ * Arbitrary metadata attached to a procedure.
+ * Middleware, plugins, and tooling can read it later to control behavior.
+ *
+ * @see {@link https://orpc.dev/docs/metadata | Metadata}
+ */
 export interface Meta {
   [key: PropertyKey]: unknown
 }
@@ -16,6 +22,12 @@ export interface MetaPluginDefinition<
   __TErrorMap?: { type: TErrorMap }
 }
 
+/**
+ * A metadata plugin passed to `.meta(...)`.
+ * Defines how metadata is initialized and merged, and can infer or restrict procedure types.
+ *
+ * @see {@link https://orpc.dev/docs/metadata | Metadata}
+ */
 export interface MetaPlugin<
   TInputSchema extends AnySchema,
   TOutputSchema extends AnySchema,
@@ -40,6 +52,12 @@ export interface MetaPlugin<
   'apply'?: (meta: Meta) => Meta
 }
 
+/**
+ * A `MetaPlugin` with all type parameters relaxed to `any`.
+ *
+ * @see {@link https://orpc.dev/docs/contract/procedure | Procedure Contract}
+ * @see {@link https://orpc.dev/docs/procedure | Procedure}
+ */
 export type AnyMetaPlugin = MetaPlugin<any, any, any>
 
 export const HIDDEN_META_PLUGINS_SYMBOL = Symbol.for('ORPC_HIDDEN_META_PLUGINS')

--- a/packages/contract/src/plugins/request-validation.ts
+++ b/packages/contract/src/plugins/request-validation.ts
@@ -21,6 +21,9 @@ export interface RequestValidationLinkPluginOptions<_T extends ClientContext> {
 
 /**
  * Validates client request input against contract schemas before the request is encoded.
+ * This is useful when your application relies on server-side validation.
+ *
+ * @see {@link https://orpc.dev/docs/plugins/request-validation | Request Validation}
  */
 export class RequestValidationLinkPlugin<T extends ClientContext> implements StandardLinkPlugin<T> {
   name = '~request-validation'

--- a/packages/contract/src/plugins/request-validation.ts
+++ b/packages/contract/src/plugins/request-validation.ts
@@ -23,7 +23,7 @@ export interface RequestValidationLinkPluginOptions<_T extends ClientContext> {
  * Validates client request input against contract schemas before the request is encoded.
  * This is useful when your application relies on server-side validation.
  *
- * @see {@link https://orpc.dev/docs/plugins/request-validation | Request Validation}
+ * @see {@link https://orpc.dev/docs/plugins/request-validation | Request Validation Plugin}
  */
 export class RequestValidationLinkPlugin<T extends ClientContext> implements StandardLinkPlugin<T> {
   name = '~request-validation'

--- a/packages/contract/src/plugins/response-validation.ts
+++ b/packages/contract/src/plugins/response-validation.ts
@@ -11,7 +11,7 @@ import { getProcedureContractOrThrow } from '../router-utils'
  * Validates server responses against contract schemas before your application uses them.
  * This helps ensure the data returned by the server matches the types defined in your contract.
  *
- * @see {@link https://orpc.dev/docs/plugins/response-validation | Response Validation}
+ * @see {@link https://orpc.dev/docs/plugins/response-validation | Response Validation Plugin}
  */
 export class ResponseValidationLinkPlugin<T extends ClientContext> implements StandardLinkPlugin<T> {
   name = '~response-validation'

--- a/packages/contract/src/plugins/response-validation.ts
+++ b/packages/contract/src/plugins/response-validation.ts
@@ -7,6 +7,12 @@ import { ValidationError } from '../error'
 import { reconcileORPCError } from '../error-utils'
 import { getProcedureContractOrThrow } from '../router-utils'
 
+/**
+ * Validates server responses against contract schemas before your application uses them.
+ * This helps ensure the data returned by the server matches the types defined in your contract.
+ *
+ * @see {@link https://orpc.dev/docs/plugins/response-validation | Response Validation}
+ */
 export class ResponseValidationLinkPlugin<T extends ClientContext> implements StandardLinkPlugin<T> {
   name = '~response-validation'
 

--- a/packages/contract/src/procedure.ts
+++ b/packages/contract/src/procedure.ts
@@ -33,7 +33,7 @@ export class ProcedureContract<
   }
 
   /**
-   * Checks if the given instance satisfies the {@see ProcedureContract} class/interface.
+   * Checks if the given instance satisfies the {@link ProcedureContract} class/interface.
    */
   static [Symbol.hasInstance](instance: unknown): boolean {
     if (this !== ProcedureContract) {

--- a/packages/contract/src/router-client.ts
+++ b/packages/contract/src/router-client.ts
@@ -3,6 +3,12 @@ import type { ProcedureContract } from './procedure'
 import type { ProcedureContractClient } from './procedure-client'
 import type { RouterContract } from './router'
 
+/**
+ * Client type inferred from a router contract, preserving its shape.
+ * Useful for typing a client without importing the server router.
+ *
+ * @see {@link https://orpc.dev/docs/client/client-side | Client-Side}
+ */
 export type RouterContractClient<TRouter extends RouterContract, TClientContext extends ClientContext = object>
   = TRouter extends ProcedureContract<infer UInputSchema, infer UOutputSchema, infer UErrorMap>
     ? ProcedureContractClient<TClientContext, UInputSchema, UOutputSchema, UErrorMap>

--- a/packages/contract/src/router-client.ts
+++ b/packages/contract/src/router-client.ts
@@ -7,7 +7,7 @@ import type { RouterContract } from './router'
  * Client type inferred from a router contract, preserving its shape.
  * Useful for typing a client without importing the server router.
  *
- * @see {@link https://orpc.dev/docs/client/client-side | Client-Side}
+ * @see {@link https://orpc.dev/docs/client/client-side | Client-Side Clients}
  */
 export type RouterContractClient<TRouter extends RouterContract, TClientContext extends ClientContext = object>
   = TRouter extends ProcedureContract<infer UInputSchema, infer UOutputSchema, infer UErrorMap>

--- a/packages/contract/src/router-utils.ts
+++ b/packages/contract/src/router-utils.ts
@@ -92,6 +92,15 @@ export function getProcedureContractOrThrow(router: RouterContract, path: readon
   return procedure
 }
 
+/**
+ * Minifies a router contract so it can be safely exported to the client
+ * without exposing internal logic.
+ *
+ * @remarks
+ * **Note**: Only the metadata needed by the client is preserved; all other data is stripped out.
+ *
+ * @see {@link https://orpc.dev/docs/contract/router | Router Contract}
+ */
 export function minifyRouterContract(router: RouterContract): RouterContract {
   if (router instanceof ProcedureContract) {
     const procedure: AnyProcedureContract = {

--- a/packages/contract/src/router.ts
+++ b/packages/contract/src/router.ts
@@ -17,7 +17,7 @@ export type RouterContract
 /**
  * Infer the input types for each procedure-contract, preserving the router-contract shape.
  *
- * @see {@link https://orpc.dev/docs/contract/router#infer-router-contract-inputs | Router Contract}
+ * @see {@link https://orpc.dev/docs/contract/router#infer-router-contract-inputs | Router Contract - Infer Router Contract Inputs}
  */
 export type InferRouterContractInputs<T extends RouterContract>
   = T extends ProcedureContract<infer UInputSchema, any, any>
@@ -29,7 +29,7 @@ export type InferRouterContractInputs<T extends RouterContract>
 /**
  * Infer the output types for each procedure-contract, preserving the router-contract shape.
  *
- * @see {@link https://orpc.dev/docs/contract/router#infer-router-contract-outputs | Router Contract}
+ * @see {@link https://orpc.dev/docs/contract/router#infer-router-contract-outputs | Router Contract - Infer Router Contract Outputs}
  */
 export type InferRouterContractOutputs<T extends RouterContract>
   = T extends ProcedureContract<any, infer UOutputSchema, any>
@@ -41,7 +41,7 @@ export type InferRouterContractOutputs<T extends RouterContract>
 /**
  * Infer the union of error maps defined across the entire router-contract.
  *
- * @see {@link https://orpc.dev/docs/contract/router#infer-router-contract-error-map | Router Contract}
+ * @see {@link https://orpc.dev/docs/contract/router#infer-router-contract-error-map | Router Contract - Infer Router Contract Error Map}
  */
 export type InferRouterContractErrorMap<T extends RouterContract>
   = T extends ProcedureContract<any, any, infer UErrorMap>
@@ -53,7 +53,7 @@ export type InferRouterContractErrorMap<T extends RouterContract>
 /**
  * Infer the union of throwable errors for entire router-contract.
  *
- * @see {@link https://orpc.dev/docs/contract/router#infer-router-contract-error | Router Contract}
+ * @see {@link https://orpc.dev/docs/contract/router#infer-router-contract-error | Router Contract - Infer Router Contract Error}
  */
 export type InferRouterContractError<T extends RouterContract>
   = T extends ProcedureContract<any, any, infer UErrorMap>
@@ -65,7 +65,7 @@ export type InferRouterContractError<T extends RouterContract>
 /**
  * Infer throwable errors for each procedure-contract, preserving the router-contract shape.
  *
- * @see {@link https://orpc.dev/docs/contract/router#infer-router-contract-errors | Router Contract}
+ * @see {@link https://orpc.dev/docs/contract/router#infer-router-contract-errors | Router Contract - Infer Router Contract Errors}
  */
 export type InferRouterContractErrors<T extends RouterContract>
   = T extends ProcedureContract<any, any, infer UErrorMap>

--- a/packages/contract/src/router.ts
+++ b/packages/contract/src/router.ts
@@ -3,12 +3,22 @@ import type { ORPCErrorFromErrorMap } from './error'
 import type { AnyProcedureContract, ProcedureContract } from './procedure'
 import type { InferSchemaInput, InferSchemaOutput } from './schema'
 
+/**
+ * A router contract: a single procedure contract or a nested record of them.
+ *
+ * @see {@link https://orpc.dev/docs/advanced/scaling-large-projects | Scaling Large Projects}
+ */
 export type RouterContract
   = | AnyProcedureContract
     | {
       [k: string]: RouterContract
     }
 
+/**
+ * Infer the input types for each procedure-contract, preserving the router-contract shape.
+ *
+ * @see {@link https://orpc.dev/docs/contract/router#infer-router-contract-inputs | Router Contract}
+ */
 export type InferRouterContractInputs<T extends RouterContract>
   = T extends ProcedureContract<infer UInputSchema, any, any>
     ? InferSchemaInput<UInputSchema>
@@ -16,6 +26,11 @@ export type InferRouterContractInputs<T extends RouterContract>
         [K in keyof T]: T[K] extends RouterContract ? InferRouterContractInputs<T[K]> : never
       }
 
+/**
+ * Infer the output types for each procedure-contract, preserving the router-contract shape.
+ *
+ * @see {@link https://orpc.dev/docs/contract/router#infer-router-contract-outputs | Router Contract}
+ */
 export type InferRouterContractOutputs<T extends RouterContract>
   = T extends ProcedureContract<any, infer UOutputSchema, any>
     ? InferSchemaOutput<UOutputSchema>
@@ -23,6 +38,11 @@ export type InferRouterContractOutputs<T extends RouterContract>
         [K in keyof T]: T[K] extends RouterContract ? InferRouterContractOutputs<T[K]> : never
       }
 
+/**
+ * Infer the union of error maps defined across the entire router-contract.
+ *
+ * @see {@link https://orpc.dev/docs/contract/router#infer-router-contract-error-map | Router Contract}
+ */
 export type InferRouterContractErrorMap<T extends RouterContract>
   = T extends ProcedureContract<any, any, infer UErrorMap>
     ? UErrorMap
@@ -32,6 +52,8 @@ export type InferRouterContractErrorMap<T extends RouterContract>
 
 /**
  * Infer the union of throwable errors for entire router-contract.
+ *
+ * @see {@link https://orpc.dev/docs/contract/router#infer-router-contract-error | Router Contract}
  */
 export type InferRouterContractError<T extends RouterContract>
   = T extends ProcedureContract<any, any, infer UErrorMap>
@@ -42,6 +64,8 @@ export type InferRouterContractError<T extends RouterContract>
 
 /**
  * Infer throwable errors for each procedure-contract, preserving the router-contract shape.
+ *
+ * @see {@link https://orpc.dev/docs/contract/router#infer-router-contract-errors | Router Contract}
  */
 export type InferRouterContractErrors<T extends RouterContract>
   = T extends ProcedureContract<any, any, infer UErrorMap>

--- a/packages/contract/src/schema-built-in.ts
+++ b/packages/contract/src/schema-built-in.ts
@@ -12,7 +12,10 @@ export interface AsyncIteratorObjectSchemaDetails {
 }
 
 /**
- * Define schema for an AsyncIteratorObject.
+ * Defines a schema for an AsyncIteratorObject, validating each yielded value
+ * (and optionally the return value) with the given schemas.
+ *
+ * @see {@link https://orpc.dev/docs/async-iterator-object | AsyncIteratorObject (SSE)}
  */
 export function asyncIteratorObject<TYieldIn, TYieldOut, TReturnIn = unknown, TReturnOut = unknown>(
   yieldSchema: Schema<TYieldIn, TYieldOut>,

--- a/packages/contract/src/schema-utils.ts
+++ b/packages/contract/src/schema-utils.ts
@@ -16,7 +16,7 @@ export type TypeRest<TInput, TOutput>
  * const withMap = type<number, string>(input => input.toString())
  *```
  *
- * @see {@link https://orpc.dev/docs/procedure#type-utility | Procedure}
+ * @see {@link https://orpc.dev/docs/procedure#type-utility | Procedure - type Utility}
  */
 export function type<TInput, TOutput = TInput>(
   ...[map]: TypeRest<TInput, TOutput>

--- a/packages/contract/src/schema-utils.ts
+++ b/packages/contract/src/schema-utils.ts
@@ -16,7 +16,7 @@ export type TypeRest<TInput, TOutput>
  * const withMap = type<number, string>(input => input.toString())
  *```
  *
- * @see {@link https://orpc.dev/docs/procedure#type-utility Type Utility Docs}
+ * @see {@link https://orpc.dev/docs/procedure#type-utility | Procedure}
  */
 export function type<TInput, TOutput = TInput>(
   ...[map]: TypeRest<TInput, TOutput>

--- a/packages/contract/src/schema.ts
+++ b/packages/contract/src/schema.ts
@@ -9,7 +9,7 @@ export type Schema<TInput, TOutput = TInput> = StandardSchemaV1<TInput, TOutput>
 /**
  * Any Standard Schema compatible schema, regardless of its input and output types.
  *
- * @see {@link https://orpc.dev/docs/integrations/standard-schema | Standard Schema}
+ * @see {@link https://orpc.dev/docs/integrations/standard-schema | Standard Schema Integration}
  */
 export type AnySchema = Schema<any>
 

--- a/packages/contract/src/schema.ts
+++ b/packages/contract/src/schema.ts
@@ -6,12 +6,27 @@ import type { StandardSchemaV1 } from '@standard-schema/spec'
  */
 export type Schema<TInput, TOutput = TInput> = StandardSchemaV1<TInput, TOutput>
 
+/**
+ * Any Standard Schema compatible schema, regardless of its input and output types.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/standard-schema | Standard Schema}
+ */
 export type AnySchema = Schema<any>
 
 export type SchemaIssue = StandardSchemaV1.Issue
 
+/**
+ * Infers the input type of a schema.
+ *
+ * @see {@link https://orpc.dev/docs/metadata | Metadata}
+ */
 export type InferSchemaInput<T extends AnySchema> = T extends StandardSchemaV1<infer UInput, any> ? UInput : never
 
+/**
+ * Infers the output type of a schema.
+ *
+ * @see {@link https://orpc.dev/docs/metadata | Metadata}
+ */
 export type InferSchemaOutput<T extends AnySchema> = T extends StandardSchemaV1<any, infer UOutput> ? UOutput : never
 
 export type MergedSchema<T extends AnySchema, U extends AnySchema>

--- a/packages/effect/src/context.ts
+++ b/packages/effect/src/context.ts
@@ -5,7 +5,7 @@ import type { Effect, Context as EffectContext } from 'effect'
  * A context shape that provides Effect services to effectful handlers
  * through the oRPC context in a typesafe way.
  *
- * @see {@link https://orpc.dev/docs/integrations/effect#effect-services | Effect}
+ * @see {@link https://orpc.dev/docs/integrations/effect#effect-services | Effect Integration - Effect Services}
  */
 export interface WithEffectContext<Services> {
   /**

--- a/packages/effect/src/context.ts
+++ b/packages/effect/src/context.ts
@@ -1,6 +1,12 @@
 import type { AnyProcedure } from '@orpc/server'
 import type { Effect, Context as EffectContext } from 'effect'
 
+/**
+ * A context shape that provides Effect services to effectful handlers
+ * through the oRPC context in a typesafe way.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/effect#effect-services | Effect}
+ */
 export interface WithEffectContext<Services> {
   /**
    * A pre-built Effect context providing the services available within this oRPC context.

--- a/packages/effect/src/converter.ts
+++ b/packages/effect/src/converter.ts
@@ -3,6 +3,13 @@ import type { JsonSchema, JsonSchemaConverter, JsonSchemaConverterDirection } fr
 import { StandardJsonSchemaConverter } from '@orpc/json-schema'
 import { Schema as EffectSchema } from 'effect'
 
+/**
+ * A JSON Schema converter for Effect Schema, built on top of
+ * [Effect Schema to JSON Schema](https://effect.website/docs/schema/json-schema/).
+ * Useful with tools such as the OpenAPI Generator.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/effect#json-schema-converter | Effect}
+ */
 export class EffectSchemaToJsonSchemaConverter implements JsonSchemaConverter {
   private readonly converter = new StandardJsonSchemaConverter()
 

--- a/packages/effect/src/converter.ts
+++ b/packages/effect/src/converter.ts
@@ -8,7 +8,7 @@ import { Schema as EffectSchema } from 'effect'
  * [Effect Schema to JSON Schema](https://effect.website/docs/schema/json-schema/).
  * Useful with tools such as the OpenAPI Generator.
  *
- * @see {@link https://orpc.dev/docs/integrations/effect#json-schema-converter | Effect}
+ * @see {@link https://orpc.dev/docs/integrations/effect#json-schema-converter | Effect Integration - JSON Schema Converter}
  */
 export class EffectSchemaToJsonSchemaConverter implements JsonSchemaConverter {
   private readonly converter = new StandardJsonSchemaConverter()

--- a/packages/effect/src/error.ts
+++ b/packages/effect/src/error.ts
@@ -18,7 +18,7 @@ import { Effect, Function } from 'effect'
  * )
  * ```
  *
- * @see {@link https://orpc.dev/docs/integrations/effect#catching-orpcerrors | Effect}
+ * @see {@link https://orpc.dev/docs/integrations/effect#catching-orpcerrors | Effect Integration - Catching ORPCErrors}
  */
 export const catchORPCError: {
   <E, A2, E2, R2>(
@@ -58,7 +58,7 @@ export const catchORPCError: {
  * )
  * ```
  *
- * @see {@link https://orpc.dev/docs/integrations/effect#catching-orpcerrors | Effect}
+ * @see {@link https://orpc.dev/docs/integrations/effect#catching-orpcerrors | Effect Integration - Catching ORPCErrors}
  */
 export const catchORPCErrorCode: {
   <const TCode extends E extends ORPCError<infer TCode, any> ? TCode : never, E, A2, E2, R2>(
@@ -105,7 +105,7 @@ export const catchORPCErrorCode: {
  * )
  * ```
  *
- * @see {@link https://orpc.dev/docs/integrations/effect#catching-orpcerrors | Effect}
+ * @see {@link https://orpc.dev/docs/integrations/effect#catching-orpcerrors | Effect Integration - Catching ORPCErrors}
  */
 export const catchORPCErrorCodes: {
   <

--- a/packages/effect/src/error.ts
+++ b/packages/effect/src/error.ts
@@ -18,7 +18,7 @@ import { Effect, Function } from 'effect'
  * )
  * ```
  *
- * @see {@link https://orpc.dev/docs/integrations/effect#catching-orpcerrors Catching ORPCErrors Docs}
+ * @see {@link https://orpc.dev/docs/integrations/effect#catching-orpcerrors | Effect}
  */
 export const catchORPCError: {
   <E, A2, E2, R2>(
@@ -58,7 +58,7 @@ export const catchORPCError: {
  * )
  * ```
  *
- * @see {@link https://orpc.dev/docs/integrations/effect#catching-orpcerrors Catching ORPCErrors Docs}
+ * @see {@link https://orpc.dev/docs/integrations/effect#catching-orpcerrors | Effect}
  */
 export const catchORPCErrorCode: {
   <const TCode extends E extends ORPCError<infer TCode, any> ? TCode : never, E, A2, E2, R2>(
@@ -105,7 +105,7 @@ export const catchORPCErrorCode: {
  * )
  * ```
  *
- * @see {@link https://orpc.dev/docs/integrations/effect#catching-orpcerrors Catching ORPCErrors Docs}
+ * @see {@link https://orpc.dev/docs/integrations/effect#catching-orpcerrors | Effect}
  */
 export const catchORPCErrorCodes: {
   <

--- a/packages/effect/src/handler.ts
+++ b/packages/effect/src/handler.ts
@@ -34,7 +34,7 @@ const succeedOnORPCError = Effect.catch(error => error instanceof ORPCError ? Ef
  * Inside the generator you can yield Effect operations, and `handlerGen`
  * handles the execution and error handling for you.
  *
- * @see {@link https://orpc.dev/docs/integrations/effect#effectful-handlers | Effect}
+ * @see {@link https://orpc.dev/docs/integrations/effect#effectful-handlers | Effect Integration - Effectful Handlers}
  */
 export function handlerGen<
   TCurrentContext extends Context,

--- a/packages/effect/src/handler.ts
+++ b/packages/effect/src/handler.ts
@@ -29,6 +29,13 @@ export interface HandlerGen<
 
 const succeedOnORPCError = Effect.catch(error => error instanceof ORPCError ? Effect.succeed(error) : Effect.fail(error))
 
+/**
+ * Creates a procedure handler from an Effect generator function.
+ * Inside the generator you can yield Effect operations, and `handlerGen`
+ * handles the execution and error handling for you.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/effect#effectful-handlers | Effect}
+ */
 export function handlerGen<
   TCurrentContext extends Context,
   TInput,

--- a/packages/evlog/src/adapters/node.ts
+++ b/packages/evlog/src/adapters/node.ts
@@ -7,7 +7,7 @@ import { createLoggerStorage as baseCreateLoggerStorage } from 'evlog/toolkit'
  * Creates an AsyncLocalStorage-backed logger store. Pass `storage` to
  * `EvlogHandlerPlugin` and call `useLogger` inside procedures to access the request logger.
  *
- * @see {@link https://orpc.dev/docs/integrations/evlog#using-the-logger-in-your-code | Evlog}
+ * @see {@link https://orpc.dev/docs/integrations/evlog#using-the-logger-in-your-code | Evlog Integration - Using the Logger in Your Code}
  */
 export function createLoggerStorage(): {
   storage: FrameworkIntegrationSpec<{ request: StandardRequest }>['storage']

--- a/packages/evlog/src/adapters/node.ts
+++ b/packages/evlog/src/adapters/node.ts
@@ -3,6 +3,12 @@ import type { RequestLogger } from 'evlog'
 import type { FrameworkIntegrationSpec } from 'evlog/toolkit'
 import { createLoggerStorage as baseCreateLoggerStorage } from 'evlog/toolkit'
 
+/**
+ * Creates an AsyncLocalStorage-backed logger store. Pass `storage` to
+ * `EvlogHandlerPlugin` and call `useLogger` inside procedures to access the request logger.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/evlog#using-the-logger-in-your-code | Evlog}
+ */
 export function createLoggerStorage(): {
   storage: FrameworkIntegrationSpec<{ request: StandardRequest }>['storage']
   useLogger: () => Required<RequestLogger>

--- a/packages/evlog/src/context.ts
+++ b/packages/evlog/src/context.ts
@@ -2,10 +2,20 @@ import type { RequestLogger } from 'evlog'
 
 export const LOGGER_CONTEXT_SYMBOL: unique symbol = Symbol.for('ORPC_EVLOG_LOGGER_CONTEXT')
 
+/**
+ * Context shape that carries the Evlog request logger injected by `EvlogHandlerPlugin`.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/evlog#without-asynclocalstorage | Evlog}
+ */
 export interface LoggerContext {
   [LOGGER_CONTEXT_SYMBOL]?: undefined | RequestLogger
 }
 
+/**
+ * Retrieves the Evlog request logger from the oRPC context, if available.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/evlog#without-asynclocalstorage | Evlog}
+ */
 export function getLogger(context: LoggerContext): RequestLogger | undefined {
   return context[LOGGER_CONTEXT_SYMBOL]
 }

--- a/packages/evlog/src/context.ts
+++ b/packages/evlog/src/context.ts
@@ -5,7 +5,7 @@ export const LOGGER_CONTEXT_SYMBOL: unique symbol = Symbol.for('ORPC_EVLOG_LOGGE
 /**
  * Context shape that carries the Evlog request logger injected by `EvlogHandlerPlugin`.
  *
- * @see {@link https://orpc.dev/docs/integrations/evlog#without-asynclocalstorage | Evlog}
+ * @see {@link https://orpc.dev/docs/integrations/evlog#without-asynclocalstorage | Evlog Integration - Without AsyncLocalStorage}
  */
 export interface LoggerContext {
   [LOGGER_CONTEXT_SYMBOL]?: undefined | RequestLogger
@@ -14,7 +14,7 @@ export interface LoggerContext {
 /**
  * Retrieves the Evlog request logger from the oRPC context, if available.
  *
- * @see {@link https://orpc.dev/docs/integrations/evlog#without-asynclocalstorage | Evlog}
+ * @see {@link https://orpc.dev/docs/integrations/evlog#without-asynclocalstorage | Evlog Integration - Without AsyncLocalStorage}
  */
 export function getLogger(context: LoggerContext): RequestLogger | undefined {
   return context[LOGGER_CONTEXT_SYMBOL]

--- a/packages/evlog/src/handler-plugin.ts
+++ b/packages/evlog/src/handler-plugin.ts
@@ -27,7 +27,7 @@ export interface EvlogHandlerPluginOptions<_T extends Context> extends BaseEvlog
  * Instruments an oRPC handler with Evlog structured logging, request tracking,
  * and error monitoring.
  *
- * @see {@link https://orpc.dev/docs/integrations/evlog | Evlog}
+ * @see {@link https://orpc.dev/docs/integrations/evlog | Evlog Integration}
  */
 export class EvlogHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   name = '~evlog'

--- a/packages/evlog/src/handler-plugin.ts
+++ b/packages/evlog/src/handler-plugin.ts
@@ -23,6 +23,12 @@ export interface EvlogHandlerPluginOptions<_T extends Context> extends BaseEvlog
   logAbort?: boolean
 }
 
+/**
+ * Instruments an oRPC handler with Evlog structured logging, request tracking,
+ * and error monitoring.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/evlog | Evlog}
+ */
 export class EvlogHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   name = '~evlog'
 
@@ -86,8 +92,8 @@ export class EvlogHandlerPlugin<T extends Context> implements StandardHandlerPlu
               response: {
                 ...result.response,
                 /**
-                 * @warning
-                 * Remember use `override` for AsyncIteratorObject to remain other special properties
+                 * @remarks
+                 * **Warning**: Remember use `override` for AsyncIteratorObject to remain other special properties
                  */
                 body: override(result.response.body, wrapAsyncIteratorPreservingEventMeta(result.response.body, {
                   runWith,
@@ -113,8 +119,8 @@ export class EvlogHandlerPlugin<T extends Context> implements StandardHandlerPlu
               response: {
                 ...result.response,
                 /**
-                 * @warning
-                 * Remember use `override` for ReadableStream to remain other special properties
+                 * @remarks
+                 * **Warning**: Remember use `override` for ReadableStream to remain other special properties
                  */
                 body: override(result.response.body, wrapReadableStream(result.response.body, {
                   runWith,
@@ -195,8 +201,8 @@ export class EvlogHandlerPlugin<T extends Context> implements StandardHandlerPlu
 
       if (isAsyncIteratorObject(output)) {
         /**
-         * @warning
-         * Remember use `override` for AsyncIteratorObject to remain other special properties
+         * @remarks
+         * **Warning**: Remember use `override` for AsyncIteratorObject to remain other special properties
          */
         return override(output, wrapAsyncIteratorPreservingEventMeta(output, {
           onError: (error) => {
@@ -207,8 +213,8 @@ export class EvlogHandlerPlugin<T extends Context> implements StandardHandlerPlu
 
       if (output instanceof ReadableStream) {
         /**
-         * @warning
-         * Remember use `override` for ReadableStream to remain other special properties
+         * @remarks
+         * **Warning**: Remember use `override` for ReadableStream to remain other special properties
          */
         return override(output, wrapReadableStream(output, {
           onError: (error) => {

--- a/packages/hibernation/src/encode-event.ts
+++ b/packages/hibernation/src/encode-event.ts
@@ -31,7 +31,7 @@ export interface EncodeHibernationRPCEventOptions {
  * Encodes a Hibernation RPC event for sending to clients subscribed
  * through a `HibernationAsyncIteratorClass`.
  *
- * @see {@link https://orpc.dev/docs/integrations/hibernation | Hibernation}
+ * @see {@link https://orpc.dev/docs/integrations/hibernation | Hibernation Integration}
  */
 export async function encodeHibernationRPCEvent(
   id: string,

--- a/packages/hibernation/src/encode-event.ts
+++ b/packages/hibernation/src/encode-event.ts
@@ -28,9 +28,10 @@ export interface EncodeHibernationRPCEventOptions {
 }
 
 /**
- * Encodes a Hibernation RPC Event
+ * Encodes a Hibernation RPC event for sending to clients subscribed
+ * through a `HibernationAsyncIteratorClass`.
  *
- * @see {@link https://orpc.dev/docs/integrations/hibernation Hibernation Integration}
+ * @see {@link https://orpc.dev/docs/integrations/hibernation | Hibernation}
  */
 export async function encodeHibernationRPCEvent(
   id: string,

--- a/packages/hibernation/src/handler-plugin.ts
+++ b/packages/hibernation/src/handler-plugin.ts
@@ -4,9 +4,11 @@ import { toArray } from '@orpc/shared'
 import { HibernationAsyncIteratorClass } from '@standardserver/peer'
 
 /**
- * Enable Hibernation APIs
+ * A handler plugin that enables the Hibernation APIs, allowing procedures
+ * to return a `HibernationAsyncIteratorClass` for hibernation-friendly
+ * event streaming.
  *
- * @see {@link https://orpc.dev/docs/integrations/hibernation Hibernation Integration}
+ * @see {@link https://orpc.dev/docs/integrations/hibernation | Hibernation}
  */
 export class HibernationHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   name = '~hibernation'

--- a/packages/hibernation/src/handler-plugin.ts
+++ b/packages/hibernation/src/handler-plugin.ts
@@ -8,7 +8,7 @@ import { HibernationAsyncIteratorClass } from '@standardserver/peer'
  * to return a `HibernationAsyncIteratorClass` for hibernation-friendly
  * event streaming.
  *
- * @see {@link https://orpc.dev/docs/integrations/hibernation | Hibernation}
+ * @see {@link https://orpc.dev/docs/integrations/hibernation | Hibernation Integration}
  */
 export class HibernationHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   name = '~hibernation'

--- a/packages/hibernation/src/index.ts
+++ b/packages/hibernation/src/index.ts
@@ -12,7 +12,7 @@ export {
    * events directly, it invokes a callback with an ID you can save and later
    * use to send events via `encodeHibernationRPCEvent`.
    *
-   * @see {@link https://orpc.dev/docs/integrations/hibernation | Hibernation}
+   * @see {@link https://orpc.dev/docs/integrations/hibernation | Hibernation Integration}
    */
   HibernationAsyncIteratorClass,
 } from '@standardserver/peer'

--- a/packages/hibernation/src/index.ts
+++ b/packages/hibernation/src/index.ts
@@ -6,7 +6,16 @@ export {
    */
   HibernationHandlerPlugin as HibernationPlugin,
 } from './handler-plugin'
-export { HibernationAsyncIteratorClass } from '@standardserver/peer'
+export {
+  /**
+   * An async iterator designed for the Hibernation APIs. Instead of streaming
+   * events directly, it invokes a callback with an ID you can save and later
+   * use to send events via `encodeHibernationRPCEvent`.
+   *
+   * @see {@link https://orpc.dev/docs/integrations/hibernation | Hibernation}
+   */
+  HibernationAsyncIteratorClass,
+} from '@standardserver/peer'
 export {
   /**
    * @deprecated Use `HibernationAsyncIteratorClass` instead.

--- a/packages/json-schema/src/convert.ts
+++ b/packages/json-schema/src/convert.ts
@@ -1,8 +1,19 @@
 import type { AnySchema } from '@orpc/contract'
 import type { JsonSchema } from './types'
 
+/**
+ * The conversion direction: `input` targets the schema's input type, `output` targets its output type.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/standard-schema | Standard Schema}
+ */
 export type JsonSchemaConverterDirection = 'input' | 'output'
 
+/**
+ * Interface for converting validation schemas into JSON Schema representations,
+ * used by tools such as the OpenAPI Generator and Smart Coercion plugins.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/standard-schema | Standard Schema}
+ */
 export interface JsonSchemaConverter {
   /**
    * Determines whether this converter can handle the given schema.

--- a/packages/json-schema/src/convert.ts
+++ b/packages/json-schema/src/convert.ts
@@ -4,7 +4,7 @@ import type { JsonSchema } from './types'
 /**
  * The conversion direction: `input` targets the schema's input type, `output` targets its output type.
  *
- * @see {@link https://orpc.dev/docs/integrations/standard-schema | Standard Schema}
+ * @see {@link https://orpc.dev/docs/integrations/standard-schema | Standard Schema Integration}
  */
 export type JsonSchemaConverterDirection = 'input' | 'output'
 
@@ -12,7 +12,7 @@ export type JsonSchemaConverterDirection = 'input' | 'output'
  * Interface for converting validation schemas into JSON Schema representations,
  * used by tools such as the OpenAPI Generator and Smart Coercion plugins.
  *
- * @see {@link https://orpc.dev/docs/integrations/standard-schema | Standard Schema}
+ * @see {@link https://orpc.dev/docs/integrations/standard-schema | Standard Schema Integration}
  */
 export interface JsonSchemaConverter {
   /**

--- a/packages/json-schema/src/smart-coercion-handler-plugin.ts
+++ b/packages/json-schema/src/smart-coercion-handler-plugin.ts
@@ -12,6 +12,12 @@ export interface SmartCoercionHandlerPluginOptions {
   converters?: undefined | JsonSchemaConverter[]
 }
 
+/**
+ * Coerces incoming request data to match the expected `.input` schema types before validation,
+ * based on JSON schemas produced by the configured converters.
+ *
+ * @see {@link https://orpc.dev/docs/plugins/smart-coercion | Smart Coercion}
+ */
 export class SmartCoercionHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   name = '~smart-coercion'
 

--- a/packages/json-schema/src/smart-coercion-handler-plugin.ts
+++ b/packages/json-schema/src/smart-coercion-handler-plugin.ts
@@ -16,7 +16,7 @@ export interface SmartCoercionHandlerPluginOptions {
  * Coerces incoming request data to match the expected `.input` schema types before validation,
  * based on JSON schemas produced by the configured converters.
  *
- * @see {@link https://orpc.dev/docs/plugins/smart-coercion | Smart Coercion}
+ * @see {@link https://orpc.dev/docs/plugins/smart-coercion | Smart Coercion Plugin}
  */
 export class SmartCoercionHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   name = '~smart-coercion'

--- a/packages/json-schema/src/smart-coercion-link-plugin.ts
+++ b/packages/json-schema/src/smart-coercion-link-plugin.ts
@@ -18,7 +18,7 @@ export interface SmartCoercionLinkPluginOptions {
  * Coerces server responses to match the expected `.output` or `.errors` schema types before validation,
  * based on JSON schemas produced by the configured converters.
  *
- * @see {@link https://orpc.dev/docs/plugins/smart-coercion | Smart Coercion}
+ * @see {@link https://orpc.dev/docs/plugins/smart-coercion | Smart Coercion Plugin}
  */
 export class SmartCoercionLinkPlugin<T extends ClientContext> implements StandardLinkPlugin<T> {
   name = '~smart-coercion'

--- a/packages/json-schema/src/smart-coercion-link-plugin.ts
+++ b/packages/json-schema/src/smart-coercion-link-plugin.ts
@@ -14,6 +14,12 @@ export interface SmartCoercionLinkPluginOptions {
   converters?: undefined | JsonSchemaConverter[]
 }
 
+/**
+ * Coerces server responses to match the expected `.output` or `.errors` schema types before validation,
+ * based on JSON schemas produced by the configured converters.
+ *
+ * @see {@link https://orpc.dev/docs/plugins/smart-coercion | Smart Coercion}
+ */
 export class SmartCoercionLinkPlugin<T extends ClientContext> implements StandardLinkPlugin<T> {
   name = '~smart-coercion'
 

--- a/packages/json-schema/src/types.ts
+++ b/packages/json-schema/src/types.ts
@@ -4,7 +4,7 @@ import type * as Draft2020 from 'json-schema-typed/draft-2020-12'
 /**
  * A JSON Schema (draft 2020-12) representation used across oRPC's JSON schema tooling.
  *
- * @see {@link https://orpc.dev/docs/integrations/standard-schema | Standard Schema}
+ * @see {@link https://orpc.dev/docs/integrations/standard-schema | Standard Schema Integration}
  */
 export type JsonSchema<Value = any> = Draft2020.JSONSchema<Value>
 export type JsonSchemaKeywords = typeof Draft2020.keywords[number]

--- a/packages/json-schema/src/types.ts
+++ b/packages/json-schema/src/types.ts
@@ -1,6 +1,11 @@
 // eslint-disable-next-line no-restricted-imports
 import type * as Draft2020 from 'json-schema-typed/draft-2020-12'
 
+/**
+ * A JSON Schema (draft 2020-12) representation used across oRPC's JSON schema tooling.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/standard-schema | Standard Schema}
+ */
 export type JsonSchema<Value = any> = Draft2020.JSONSchema<Value>
 export type JsonSchemaKeywords = typeof Draft2020.keywords[number]
 

--- a/packages/nest/src/implement.ts
+++ b/packages/nest/src/implement.ts
@@ -32,6 +32,17 @@ const MethodDecoratorMap = {
   OPTIONS: Options,
 }
 
+/**
+ * Decorator that implements an oRPC contract (procedure or router contract)
+ * on a NestJS controller method. It registers the corresponding NestJS routes
+ * and handles request decoding and response encoding for you.
+ *
+ * @remarks
+ * **Note**: Every procedure contract must define an `openapi.path` meta;
+ * use `populateRouterContractOpenAPIPaths` from `@orpc/openapi` to fill in missing paths.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/nest#implement-your-contract | NestJS}
+ */
 export function Implement<T extends RouterContract>(
   contract: T,
 ): <U extends Promisable<ContractedRouter<T, DefaultInitialContext>>>(

--- a/packages/nest/src/implement.ts
+++ b/packages/nest/src/implement.ts
@@ -41,7 +41,7 @@ const MethodDecoratorMap = {
  * **Note**: Every procedure contract must define an `openapi.path` meta;
  * use `populateRouterContractOpenAPIPaths` from `@orpc/openapi` to fill in missing paths.
  *
- * @see {@link https://orpc.dev/docs/integrations/nest#implement-your-contract | NestJS}
+ * @see {@link https://orpc.dev/docs/integrations/nest#implement-your-contract | Implement oRPC contract with NestJS - Implement Your Contract}
  */
 export function Implement<T extends RouterContract>(
   contract: T,

--- a/packages/nest/src/module.ts
+++ b/packages/nest/src/module.ts
@@ -14,7 +14,7 @@ export const ORPC_MODULE_CONFIG_SYMBOL = Symbol.for('ORPC_NEST_MODULE_CONFIG')
  * A standard lazy request extended with NestJS route parameters,
  * used as the request representation inside the `@orpc/nest` integration.
  *
- * @see {@link https://orpc.dev/docs/integrations/nest#toneststandardlazyrequest-option | NestJS}
+ * @see {@link https://orpc.dev/docs/integrations/nest#toneststandardlazyrequest-option | Implement oRPC contract with NestJS - toNestStandardLazyRequest option}
  */
 export interface NestStandardLazyRequest extends StandardLazyRequest {
   /**
@@ -52,7 +52,7 @@ export type ORPCModuleConfig
  * or `forRootAsync`, providing options such as initial context, plugins,
  * and interceptors to `@Implement` handlers.
  *
- * @see {@link https://orpc.dev/docs/integrations/nest#configuration | NestJS}
+ * @see {@link https://orpc.dev/docs/integrations/nest#configuration | Implement oRPC contract with NestJS - Configuration}
  */
 @Module({})
 export class ORPCModule {

--- a/packages/nest/src/module.ts
+++ b/packages/nest/src/module.ts
@@ -10,6 +10,12 @@ import { ImplementInterceptor } from './implement'
 
 export const ORPC_MODULE_CONFIG_SYMBOL = Symbol.for('ORPC_NEST_MODULE_CONFIG')
 
+/**
+ * A standard lazy request extended with NestJS route parameters,
+ * used as the request representation inside the `@orpc/nest` integration.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/nest#toneststandardlazyrequest-option | NestJS}
+ */
 export interface NestStandardLazyRequest extends StandardLazyRequest {
   /**
    * Route parameters extracted from the request path.
@@ -41,6 +47,13 @@ export type ORPCModuleConfig
       }
     }
 
+/**
+ * NestJS module that configures the `@orpc/nest` integration via `forRoot`
+ * or `forRootAsync`, providing options such as initial context, plugins,
+ * and interceptors to `@Implement` handlers.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/nest#configuration | NestJS}
+ */
 @Module({})
 export class ORPCModule {
   static forRoot(config: ORPCModuleConfig): DynamicModule {

--- a/packages/next/src/deferred-interceptors.ts
+++ b/packages/next/src/deferred-interceptors.ts
@@ -3,7 +3,7 @@ import { onError, onFinish, onStart, onSuccess } from '@orpc/shared'
 /**
  * Like `onStart`, but defers execution, useful for updating states.
  *
- * @see {@link https://orpc.dev/docs/integrations/next#hooks | Next.js}
+ * @see {@link https://orpc.dev/docs/integrations/next#hooks | Next.js Integration - Hooks}
  */
 export const onStartDeferred: typeof onStart = (callback, ...rest) => {
   return onStart((...args) => {
@@ -16,7 +16,7 @@ export const onStartDeferred: typeof onStart = (callback, ...rest) => {
 /**
  * Like `onSuccess`, but defers execution, useful for updating states.
  *
- * @see {@link https://orpc.dev/docs/integrations/next#hooks | Next.js}
+ * @see {@link https://orpc.dev/docs/integrations/next#hooks | Next.js Integration - Hooks}
  */
 export const onSuccessDeferred: typeof onSuccess = (callback, ...rest) => {
   return onSuccess((...args) => {
@@ -29,7 +29,7 @@ export const onSuccessDeferred: typeof onSuccess = (callback, ...rest) => {
 /**
  * Like `onError`, but defers execution, useful for updating states.
  *
- * @see {@link https://orpc.dev/docs/integrations/next#hooks | Next.js}
+ * @see {@link https://orpc.dev/docs/integrations/next#hooks | Next.js Integration - Hooks}
  */
 export const onErrorDeferred: typeof onError = (callback, ...rest) => {
   return onError((...args) => {
@@ -42,7 +42,7 @@ export const onErrorDeferred: typeof onError = (callback, ...rest) => {
 /**
  * Like `onFinish`, but defers execution, useful for updating states.
  *
- * @see {@link https://orpc.dev/docs/integrations/next#hooks | Next.js}
+ * @see {@link https://orpc.dev/docs/integrations/next#hooks | Next.js Integration - Hooks}
  */
 export const onFinishDeferred: typeof onFinish = (callback, ...rest) => {
   return onFinish((...args) => {

--- a/packages/next/src/deferred-interceptors.ts
+++ b/packages/next/src/deferred-interceptors.ts
@@ -2,6 +2,8 @@ import { onError, onFinish, onStart, onSuccess } from '@orpc/shared'
 
 /**
  * Like `onStart`, but defers execution, useful for updating states.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/next#hooks | Next.js}
  */
 export const onStartDeferred: typeof onStart = (callback, ...rest) => {
   return onStart((...args) => {
@@ -13,6 +15,8 @@ export const onStartDeferred: typeof onStart = (callback, ...rest) => {
 
 /**
  * Like `onSuccess`, but defers execution, useful for updating states.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/next#hooks | Next.js}
  */
 export const onSuccessDeferred: typeof onSuccess = (callback, ...rest) => {
   return onSuccess((...args) => {
@@ -24,6 +28,8 @@ export const onSuccessDeferred: typeof onSuccess = (callback, ...rest) => {
 
 /**
  * Like `onError`, but defers execution, useful for updating states.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/next#hooks | Next.js}
  */
 export const onErrorDeferred: typeof onError = (callback, ...rest) => {
   return onError((...args) => {
@@ -35,6 +41,8 @@ export const onErrorDeferred: typeof onError = (callback, ...rest) => {
 
 /**
  * Like `onFinish`, but defers execution, useful for updating states.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/next#hooks | Next.js}
  */
 export const onFinishDeferred: typeof onFinish = (callback, ...rest) => {
   return onFinish((...args) => {

--- a/packages/next/src/hooks/optimistic-server-function.ts
+++ b/packages/next/src/hooks/optimistic-server-function.ts
@@ -19,7 +19,7 @@ export type UseOptimisticServerFunctionResult<TInput, TOutput, TError, TOptimist
  * Like `useServerFunction`, but additionally applies optimistic state updates
  * while the server function executes.
  *
- * @see {@link https://orpc.dev/docs/integrations/next#hooks | Next.js}
+ * @see {@link https://orpc.dev/docs/integrations/next#hooks | Next.js Integration - Hooks}
  */
 export function useOptimisticServerFunction<TInput, TOutput, TError extends AnyORPCErrorJSON, TOptimisticState>(
   fn: ServerFunction<TInput, TOutput, TError>,

--- a/packages/next/src/hooks/optimistic-server-function.ts
+++ b/packages/next/src/hooks/optimistic-server-function.ts
@@ -15,6 +15,12 @@ export type UseOptimisticServerFunctionResult<TInput, TOutput, TError, TOptimist
   optimisticState: TOptimisticState
 }
 
+/**
+ * Like `useServerFunction`, but additionally applies optimistic state updates
+ * while the server function executes.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/next#hooks | Next.js}
+ */
 export function useOptimisticServerFunction<TInput, TOutput, TError extends AnyORPCErrorJSON, TOptimisticState>(
   fn: ServerFunction<TInput, TOutput, TError>,
   options: UseOptimisticServerFunctionOptions<TInput, TOutput, ServerFunctionError<TError>, TOptimisticState>,

--- a/packages/next/src/hooks/server-function.ts
+++ b/packages/next/src/hooks/server-function.ts
@@ -96,6 +96,15 @@ const PENDING_STATE = {
   status: 'pending',
 }
 
+/**
+ * A React hook that executes a server function and tracks its status.
+ *
+ * @remarks
+ * **Note**: Unlike direct server function calls, errors are deserialized into native
+ * `ORPCError` instances instead of plain JSON (`ORPCErrorJSON`).
+ *
+ * @see {@link https://orpc.dev/docs/integrations/next#hooks | Next.js}
+ */
 export function useServerFunction<TInput, TOutput, TError extends AnyORPCErrorJSON>(
   fn: ServerFunction<TInput, TOutput, TError>,
   options: UserSeverFunctionOptions<TInput, TOutput, ServerFunctionError<TError>> = {},

--- a/packages/next/src/hooks/server-function.ts
+++ b/packages/next/src/hooks/server-function.ts
@@ -103,7 +103,7 @@ const PENDING_STATE = {
  * **Note**: Unlike direct server function calls, errors are deserialized into native
  * `ORPCError` instances instead of plain JSON (`ORPCErrorJSON`).
  *
- * @see {@link https://orpc.dev/docs/integrations/next#hooks | Next.js}
+ * @see {@link https://orpc.dev/docs/integrations/next#hooks | Next.js Integration - Hooks}
  */
 export function useServerFunction<TInput, TOutput, TError extends AnyORPCErrorJSON>(
   fn: ServerFunction<TInput, TOutput, TError>,

--- a/packages/next/src/server-form-functionable.ts
+++ b/packages/next/src/server-form-functionable.ts
@@ -23,7 +23,7 @@ export interface ServerFormFunctionable<TInitialContext extends Context> {
  * server form functions. The helper takes a procedure and returns a value that
  * works as both a server form function and the original procedure.
  *
- * @see {@link https://orpc.dev/docs/integrations/next#createserverformfunctionable | Next.js}
+ * @see {@link https://orpc.dev/docs/integrations/next#createserverformfunctionable | Next.js Integration - createServerFormFunctionable}
  */
 export function createServerFormFunctionable<TInitialContext extends Context = object>(
   ...rest: MaybeOptionalOptions<

--- a/packages/next/src/server-form-functionable.ts
+++ b/packages/next/src/server-form-functionable.ts
@@ -18,6 +18,13 @@ export interface ServerFormFunctionable<TInitialContext extends Context> {
     & Procedure<TInitialContext, TInjectedContext, TInputSchema, TOutputSchema, TErrorMap, TReturnedError>
 }
 
+/**
+ * Creates a preconfigured helper for reusing the same options across multiple
+ * server form functions. The helper takes a procedure and returns a value that
+ * works as both a server form function and the original procedure.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/next#createserverformfunctionable | Next.js}
+ */
 export function createServerFormFunctionable<TInitialContext extends Context = object>(
   ...rest: MaybeOptionalOptions<
     ProcedureClientOptions<

--- a/packages/next/src/server-function.ts
+++ b/packages/next/src/server-function.ts
@@ -44,7 +44,7 @@ export type ProcedureServerFunction<
  * **Note**: Instead of throwing, the returned function resolves an `[error, data]` tuple
  * with errors serialized as plain JSON (`ORPCErrorJSON`).
  *
- * @see {@link https://orpc.dev/docs/integrations/next#server-functions | Next.js}
+ * @see {@link https://orpc.dev/docs/integrations/next#server-functions | Next.js Integration - Server Functions}
  */
 export function createServerFunction<
   TInitialContext extends Context,

--- a/packages/next/src/server-function.ts
+++ b/packages/next/src/server-function.ts
@@ -35,6 +35,17 @@ export type ProcedureServerFunction<
   ServerFunctionORPCErrorJSON<ORPCErrorFromErrorMap<TErrorMap> | TReturnedORPCError | ThrowableError>
 >
 
+/**
+ * Creates a Next.js [server function](https://nextjs.org/docs/app/api-reference/directives/use-server)
+ * from a [procedure](https://orpc.dev/docs/procedure). It accepts the same options as server-side
+ * clients, and the returned function accepts the same input as the original procedure.
+ *
+ * @remarks
+ * **Note**: Instead of throwing, the returned function resolves an `[error, data]` tuple
+ * with errors serialized as plain JSON (`ORPCErrorJSON`).
+ *
+ * @see {@link https://orpc.dev/docs/integrations/next#server-functions | Next.js}
+ */
 export function createServerFunction<
   TInitialContext extends Context,
   TInputSchema extends AnySchema,

--- a/packages/next/src/server-functionable.ts
+++ b/packages/next/src/server-functionable.ts
@@ -18,6 +18,13 @@ export interface ServerFunctionable<TInitialContext extends Context> {
     & Procedure<TInitialContext, TInjectedContext, TInputSchema, TOutputSchema, TErrorMap, TReturnedError>
 }
 
+/**
+ * Creates a preconfigured helper for reusing the same options across multiple
+ * server functions. The helper takes a procedure and returns a value that works
+ * as both a server function and the original procedure.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/next#createserverfunctionable | Next.js}
+ */
 export function createServerFunctionable<TInitialContext extends Context = object>(
   ...rest: MaybeOptionalOptions<
     ProcedureClientOptions<

--- a/packages/next/src/server-functionable.ts
+++ b/packages/next/src/server-functionable.ts
@@ -23,7 +23,7 @@ export interface ServerFunctionable<TInitialContext extends Context> {
  * server functions. The helper takes a procedure and returns a value that works
  * as both a server function and the original procedure.
  *
- * @see {@link https://orpc.dev/docs/integrations/next#createserverfunctionable | Next.js}
+ * @see {@link https://orpc.dev/docs/integrations/next#createserverfunctionable | Next.js Integration - createServerFunctionable}
  */
 export function createServerFunctionable<TInitialContext extends Context = object>(
   ...rest: MaybeOptionalOptions<

--- a/packages/openapi/src/adapters/aws-lambda/openapi-handler.ts
+++ b/packages/openapi/src/adapters/aws-lambda/openapi-handler.ts
@@ -10,8 +10,12 @@ export interface OpenAPIHandlerOptions<T extends Context>
   extends AwsLambdaHandlerOptions<T>, Omit<StandardHandlerOptions<T>, 'plugins'>, OpenAPIHandlerCodecOptions<T> {}
 
 /**
- * Requires the AWS Lambda Node.js runtime with response streaming enabled,
- * handlers should be wrapped with `awslambda.streamifyResponse`.
+ * Serves oRPC procedures over the OpenAPI (RESTful) protocol on AWS Lambda.
+ *
+ * @remarks
+ * **Warning**: Requires the AWS Lambda Node.js runtime with response streaming enabled — handlers should be wrapped with `awslambda.streamifyResponse`.
+ *
+ * @see {@link https://orpc.dev/docs/adapters/aws-lambda | AWS Lambda}
  */
 export class OpenAPIHandler<T extends Context> extends AwsLambdaHandler<T> {
   constructor(

--- a/packages/openapi/src/adapters/aws-lambda/openapi-handler.ts
+++ b/packages/openapi/src/adapters/aws-lambda/openapi-handler.ts
@@ -15,7 +15,7 @@ export interface OpenAPIHandlerOptions<T extends Context>
  * @remarks
  * **Warning**: Requires the AWS Lambda Node.js runtime with response streaming enabled — handlers should be wrapped with `awslambda.streamifyResponse`.
  *
- * @see {@link https://orpc.dev/docs/adapters/aws-lambda | AWS Lambda}
+ * @see {@link https://orpc.dev/docs/adapters/aws-lambda | AWS Lambda Adapter}
  */
 export class OpenAPIHandler<T extends Context> extends AwsLambdaHandler<T> {
   constructor(

--- a/packages/openapi/src/adapters/fastify/openapi-handler.ts
+++ b/packages/openapi/src/adapters/fastify/openapi-handler.ts
@@ -9,6 +9,11 @@ import { OpenAPIHandlerCodec } from '../standard'
 export interface OpenAPIHandlerOptions<T extends Context>
   extends FastifyHandlerOptions<T>, Omit<StandardHandlerOptions<T>, 'plugins'>, OpenAPIHandlerCodecOptions<T> {}
 
+/**
+ * Serves oRPC procedures over the OpenAPI (RESTful) protocol as part of a Fastify server.
+ *
+ * @see {@link https://orpc.dev/docs/adapters/fastify | Fastify}
+ */
 export class OpenAPIHandler<T extends Context> extends FastifyHandler<T> {
   constructor(
     router: Router<T>,

--- a/packages/openapi/src/adapters/fastify/openapi-handler.ts
+++ b/packages/openapi/src/adapters/fastify/openapi-handler.ts
@@ -12,7 +12,7 @@ export interface OpenAPIHandlerOptions<T extends Context>
 /**
  * Serves oRPC procedures over the OpenAPI (RESTful) protocol as part of a Fastify server.
  *
- * @see {@link https://orpc.dev/docs/adapters/fastify | Fastify}
+ * @see {@link https://orpc.dev/docs/adapters/fastify | Fastify Adapter}
  */
 export class OpenAPIHandler<T extends Context> extends FastifyHandler<T> {
   constructor(

--- a/packages/openapi/src/adapters/fetch/openapi-handler.ts
+++ b/packages/openapi/src/adapters/fetch/openapi-handler.ts
@@ -12,7 +12,7 @@ export interface OpenAPIHandlerOptions<T extends Context>
 /**
  * Serves oRPC procedures over the OpenAPI (RESTful) protocol using the Fetch API `Request`/`Response`.
  *
- * @see {@link https://orpc.dev/docs/adapters/fetch-api | Fetch API}
+ * @see {@link https://orpc.dev/docs/adapters/fetch-api | Fetch API Adapter}
  */
 export class OpenAPIHandler<T extends Context> extends FetchHandler<T> {
   constructor(

--- a/packages/openapi/src/adapters/fetch/openapi-handler.ts
+++ b/packages/openapi/src/adapters/fetch/openapi-handler.ts
@@ -9,6 +9,11 @@ import { OpenAPIHandlerCodec } from '../standard'
 export interface OpenAPIHandlerOptions<T extends Context>
   extends FetchHandlerOptions<T>, Omit<StandardHandlerOptions<T>, 'plugins'>, OpenAPIHandlerCodecOptions<T> {}
 
+/**
+ * Serves oRPC procedures over the OpenAPI (RESTful) protocol using the Fetch API `Request`/`Response`.
+ *
+ * @see {@link https://orpc.dev/docs/adapters/fetch-api | Fetch API}
+ */
 export class OpenAPIHandler<T extends Context> extends FetchHandler<T> {
   constructor(
     router: Router<T>,

--- a/packages/openapi/src/adapters/fetch/openapi-link.ts
+++ b/packages/openapi/src/adapters/fetch/openapi-link.ts
@@ -11,6 +11,11 @@ export interface OpenAPILinkOptions<T extends ClientContext>
   extends Omit<StandardLinkOptions<T>, 'plugins'>, FetchLinkTransportOptions<T>, OpenAPILinkCodecOptions<T> {
 }
 
+/**
+ * Client link that calls an OpenAPI (RESTful) oRPC server over HTTP using the Fetch API.
+ *
+ * @see {@link https://orpc.dev/docs/openapi/link | OpenAPI Link}
+ */
 export class OpenAPILink<T extends ClientContext> extends StandardLink<T> {
   constructor(
     router: RouterContract,

--- a/packages/openapi/src/adapters/node/openapi-handler.ts
+++ b/packages/openapi/src/adapters/node/openapi-handler.ts
@@ -9,6 +9,11 @@ import { OpenAPIHandlerCodec } from '../standard'
 export interface OpenAPIHandlerOptions<T extends Context>
   extends NodeHttpHandlerOptions<T>, Omit<StandardHandlerOptions<T>, 'plugins'>, OpenAPIHandlerCodecOptions<T> {}
 
+/**
+ * Serves oRPC procedures over the OpenAPI (RESTful) protocol using Node.js built-in HTTP request/response.
+ *
+ * @see {@link https://orpc.dev/docs/adapters/node-http | Node HTTP}
+ */
 export class OpenAPIHandler<T extends Context> extends NodeHttpHandler<T> {
   constructor(
     router: Router<T>,

--- a/packages/openapi/src/adapters/node/openapi-handler.ts
+++ b/packages/openapi/src/adapters/node/openapi-handler.ts
@@ -12,7 +12,7 @@ export interface OpenAPIHandlerOptions<T extends Context>
 /**
  * Serves oRPC procedures over the OpenAPI (RESTful) protocol using Node.js built-in HTTP request/response.
  *
- * @see {@link https://orpc.dev/docs/adapters/node-http | Node HTTP}
+ * @see {@link https://orpc.dev/docs/adapters/node-http | Node HTTP Adapter}
  */
 export class OpenAPIHandler<T extends Context> extends NodeHttpHandler<T> {
   constructor(

--- a/packages/openapi/src/helpers/form-data.ts
+++ b/packages/openapi/src/helpers/form-data.ts
@@ -27,6 +27,8 @@ import { BracketNotationSerializer } from '../bracket-notation'
  * //   thumb: form.get('thumb'),
  * // }
  * ```
+ *
+ * @see {@link https://orpc.dev/docs/helpers/form-data#parseformdata | Form Data}
  */
 export function parseFormData(form: FormData): any {
   const serializer = new BracketNotationSerializer()
@@ -34,7 +36,10 @@ export function parseFormData(form: FormData): any {
 }
 
 /**
- * Get the issue message from the error.
+ * Gets the issue message from the error for a given field path.
+ *
+ * @remarks
+ * **Note**: Requires validation errors to follow the standard schema issue format, stored under `data.issues` — customized validation errors may not be found.
  *
  * @example
  * ```tsx
@@ -50,9 +55,12 @@ export function parseFormData(form: FormData): any {
  *   <input name="images[]" type="file" />
  *   <p>{getIssueMessage(error, 'images[]')}</p>
  * </form>
+ * ```
  *
  * @param error - The error (can be anything) can contain `data.issues` (standard schema issues)
  * @param path - The path of the field that has the issue follow [bracket notation](https://orpc.dev/docs/openapi/bracket-notation)
+ *
+ * @see {@link https://orpc.dev/docs/helpers/form-data#getissuemessage | Form Data}
  */
 export function getIssueMessage(error: unknown, path: string): string | undefined {
   if (!isTypescriptObject(error) || !isTypescriptObject(error.data) || !Array.isArray(error.data.issues)) {

--- a/packages/openapi/src/helpers/form-data.ts
+++ b/packages/openapi/src/helpers/form-data.ts
@@ -28,7 +28,7 @@ import { BracketNotationSerializer } from '../bracket-notation'
  * // }
  * ```
  *
- * @see {@link https://orpc.dev/docs/helpers/form-data#parseformdata | Form Data}
+ * @see {@link https://orpc.dev/docs/helpers/form-data#parseformdata | Form Data Helpers - parseFormData}
  */
 export function parseFormData(form: FormData): any {
   const serializer = new BracketNotationSerializer()
@@ -60,7 +60,7 @@ export function parseFormData(form: FormData): any {
  * @param error - The error (can be anything) can contain `data.issues` (standard schema issues)
  * @param path - The path of the field that has the issue follow [bracket notation](https://orpc.dev/docs/openapi/bracket-notation)
  *
- * @see {@link https://orpc.dev/docs/helpers/form-data#getissuemessage | Form Data}
+ * @see {@link https://orpc.dev/docs/helpers/form-data#getissuemessage | Form Data Helpers - getIssueMessage}
  */
 export function getIssueMessage(error: unknown, path: string): string | undefined {
   if (!isTypescriptObject(error) || !isTypescriptObject(error.data) || !Array.isArray(error.data.issues)) {

--- a/packages/openapi/src/meta.ts
+++ b/packages/openapi/src/meta.ts
@@ -356,6 +356,13 @@ export interface OpenAPIFunction {
   prefix(method: OpenAPIMeta['prefix']): OpenAPIPrefixMetaPlugin<any, any, any>
 }
 
+/**
+ * Creates OpenAPI meta plugins that control how a procedure is exposed over HTTP,
+ * such as its method, path, prefix, and OpenAPI operation spec.
+ *
+ * @see {@link https://orpc.dev/docs/openapi/routing | OpenAPI Routing}
+ * @see {@link https://orpc.dev/docs/openapi/specification | OpenAPI Specification}
+ */
 export const openapi: OpenAPIFunction = incoming => ({
   name: '~openapi',
   init(meta) {

--- a/packages/openapi/src/openapi-generator.ts
+++ b/packages/openapi/src/openapi-generator.ts
@@ -77,6 +77,12 @@ export interface OpenAPIGeneratorGenerateOptions {
   errorStatusMap?: Record<string, number> | undefined
 }
 
+/**
+ * Generates an OpenAPI 3.1 document from a contract or a router.
+ * Relies on JSON schema converters to translate input, output, and error schemas into JSON Schemas.
+ *
+ * @see {@link https://orpc.dev/docs/openapi/specification#openapi-generator | OpenAPI Specification}
+ */
 export class OpenAPIGenerator {
   private readonly serializer: Pick<OpenAPISerializer, keyof OpenAPISerializer>
   private readonly converter: Pick<JsonSchemaConverter, 'convert'>

--- a/packages/openapi/src/openapi-generator.ts
+++ b/packages/openapi/src/openapi-generator.ts
@@ -81,7 +81,7 @@ export interface OpenAPIGeneratorGenerateOptions {
  * Generates an OpenAPI 3.1 document from a contract or a router.
  * Relies on JSON schema converters to translate input, output, and error schemas into JSON Schemas.
  *
- * @see {@link https://orpc.dev/docs/openapi/specification#openapi-generator | OpenAPI Specification}
+ * @see {@link https://orpc.dev/docs/openapi/specification#openapi-generator | OpenAPI Specification - OpenAPI Generator}
  */
 export class OpenAPIGenerator {
   private readonly serializer: Pick<OpenAPISerializer, keyof OpenAPISerializer>

--- a/packages/openapi/src/openapi-serializer.ts
+++ b/packages/openapi/src/openapi-serializer.ts
@@ -36,6 +36,12 @@ export interface OpenAPISerializerOptions extends OpenAPIJsonSerializerOptions {
   serialize?: OpenAPISerializerSerializeOptions | undefined
 }
 
+/**
+ * Handles one-way serialization of oRPC payloads into JSON-friendly formats,
+ * partially supporting complex data types beyond plain JSON such as `Date`, `BigInt`, and `Set`.
+ *
+ * @see {@link https://orpc.dev/docs/openapi/serializer | OpenAPI Serializer}
+ */
 export class OpenAPISerializer {
   private readonly jsonSerializer: OpenAPIJsonSerializer
   private readonly bracketNotation: BracketNotationSerializer

--- a/packages/openapi/src/plugins/openapi-reference.ts
+++ b/packages/openapi/src/plugins/openapi-reference.ts
@@ -86,6 +86,15 @@ export interface OpenAPIReferenceHandlerPluginOptions<T extends Context, TProvid
   docsHead?: Value<Promisable<string>, [StandardHandlerRoutingInterceptorOptions<T>]>
 }
 
+/**
+ * Serves API reference documentation powered by Scalar or Swagger UI,
+ * and exposes the OpenAPI specification as JSON.
+ *
+ * @remarks
+ * **Note**: By default, the API reference UI is served from `/` and the OpenAPI specification from `/spec.json`.
+ *
+ * @see {@link https://orpc.dev/docs/plugins/openapi-reference | OpenAPI Reference}
+ */
 export class OpenAPIReferenceHandlerPlugin<
   T extends Context,
   TProvider extends OpenAPIReferenceHandlerPluginProvider,

--- a/packages/openapi/src/plugins/openapi-reference.ts
+++ b/packages/openapi/src/plugins/openapi-reference.ts
@@ -93,7 +93,7 @@ export interface OpenAPIReferenceHandlerPluginOptions<T extends Context, TProvid
  * @remarks
  * **Note**: By default, the API reference UI is served from `/` and the OpenAPI specification from `/spec.json`.
  *
- * @see {@link https://orpc.dev/docs/plugins/openapi-reference | OpenAPI Reference}
+ * @see {@link https://orpc.dev/docs/plugins/openapi-reference | OpenAPI Reference Plugin (Swagger/Scalar)}
  */
 export class OpenAPIReferenceHandlerPlugin<
   T extends Context,

--- a/packages/openapi/src/router-utils.ts
+++ b/packages/openapi/src/router-utils.ts
@@ -22,6 +22,8 @@ export interface PopulateRouterContractOpenAPIPathsOptions {
  *
  * Builds paths by joining router keys with `/`.
  * Useful when you want to ensure all contracts define openapi.path, such as for NestJS integration requirements.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/nest | NestJS}
  */
 export function populateRouterContractOpenAPIPaths<T extends RouterContract>(
   router: T,

--- a/packages/openapi/src/router-utils.ts
+++ b/packages/openapi/src/router-utils.ts
@@ -23,7 +23,7 @@ export interface PopulateRouterContractOpenAPIPathsOptions {
  * Builds paths by joining router keys with `/`.
  * Useful when you want to ensure all contracts define openapi.path, such as for NestJS integration requirements.
  *
- * @see {@link https://orpc.dev/docs/integrations/nest | NestJS}
+ * @see {@link https://orpc.dev/docs/integrations/nest | Implement oRPC contract with NestJS}
  */
 export function populateRouterContractOpenAPIPaths<T extends RouterContract>(
   router: T,

--- a/packages/openapi/src/types.ts
+++ b/packages/openapi/src/types.ts
@@ -38,7 +38,9 @@ export type JsonifiedClientError<T>
     : T
 
 /**
- * Convert types that JSON not support to corresponding json types
+ * Client type whose outputs and error data replace types JSON cannot represent with their JSON equivalents.
+ *
+ * @see {@link https://orpc.dev/docs/openapi/link | OpenAPI Link}
  */
 export type JsonifiedClient<T extends AnyNestedClient>
   = T extends Client<infer UClientContext, infer UInput, infer UOutput, infer UError>

--- a/packages/opentelemetry/src/instrumentation.ts
+++ b/packages/opentelemetry/src/instrumentation.ts
@@ -16,6 +16,12 @@ export interface ORPCInstrumentationConfig extends InstrumentationConfig {
   propagationEnabled?: boolean
 }
 
+/**
+ * OpenTelemetry instrumentation for oRPC. Automatically instruments both
+ * client and server for distributed tracing.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/opentelemetry | OpenTelemetry}
+ */
 export class ORPCInstrumentation extends InstrumentationBase<ORPCInstrumentationConfig> {
   constructor(config: ORPCInstrumentationConfig = {}) {
     super(pkg.name, pkg.version, config)

--- a/packages/opentelemetry/src/instrumentation.ts
+++ b/packages/opentelemetry/src/instrumentation.ts
@@ -20,7 +20,7 @@ export interface ORPCInstrumentationConfig extends InstrumentationConfig {
  * OpenTelemetry instrumentation for oRPC. Automatically instruments both
  * client and server for distributed tracing.
  *
- * @see {@link https://orpc.dev/docs/integrations/opentelemetry | OpenTelemetry}
+ * @see {@link https://orpc.dev/docs/integrations/opentelemetry | OpenTelemetry Integration}
  */
 export class ORPCInstrumentation extends InstrumentationBase<ORPCInstrumentationConfig> {
   constructor(config: ORPCInstrumentationConfig = {}) {

--- a/packages/pinia-colada/src/contract-utils.ts
+++ b/packages/pinia-colada/src/contract-utils.ts
@@ -23,7 +23,7 @@ export interface ContractUtilsFactoryOptions<
  * @remarks
  * **Note**: The contract must define a `path` meta matching its position in the root router contract.
  *
- * @see {@link https://orpc.dev/docs/advanced/scaling-large-projects#pinia-colada-integration | Scaling Large Projects}
+ * @see {@link https://orpc.dev/docs/advanced/scaling-large-projects#pinia-colada-integration | Scaling Large Projects - Pinia Colada Integration}
  */
 export function createContractUtilsFactory<
   TClientContext extends ClientContext,

--- a/packages/pinia-colada/src/contract-utils.ts
+++ b/packages/pinia-colada/src/contract-utils.ts
@@ -15,6 +15,16 @@ export interface ContractUtilsFactoryOptions<
 > extends Omit<RouterUtilsOptions<RouterContractClient<RouterContract, TClientContext>>, 'path'> {
 }
 
+/**
+ * Creates a factory that builds Pinia Colada utils directly from a contract,
+ * using the given contract client factory. Useful for scaling large projects
+ * where each part only needs a slice of the router.
+ *
+ * @remarks
+ * **Note**: The contract must define a `path` meta matching its position in the root router contract.
+ *
+ * @see {@link https://orpc.dev/docs/advanced/scaling-large-projects#pinia-colada-integration | Scaling Large Projects}
+ */
 export function createContractUtilsFactory<
   TClientContext extends ClientContext,
 >(

--- a/packages/pinia-colada/src/key.ts
+++ b/packages/pinia-colada/src/key.ts
@@ -32,7 +32,7 @@ const serializer = new RPCJsonSerializer()
  * The input is serialized to JSON-compatible values because Pinia Colada
  * requires entry keys to be serializable.
  *
- * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key Pinia Colada Query/Mutation Key Docs}
+ * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key | Pinia Colada Query/Mutation Key}
  */
 export function generateOperationKey<TType extends OperationType, TInput>(
   path: string[],

--- a/packages/pinia-colada/src/key.ts
+++ b/packages/pinia-colada/src/key.ts
@@ -32,7 +32,7 @@ const serializer = new RPCJsonSerializer()
  * The input is serialized to JSON-compatible values because Pinia Colada
  * requires entry keys to be serializable.
  *
- * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key | Pinia Colada Query/Mutation Key}
+ * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key | Pinia Colada Integration - Query/Mutation Key}
  */
 export function generateOperationKey<TType extends OperationType, TInput>(
   path: string[],

--- a/packages/pinia-colada/src/meta.ts
+++ b/packages/pinia-colada/src/meta.ts
@@ -25,7 +25,7 @@ export interface PiniaColadaMetaPlugin<
  *
  * Apply them to router utils with {@link ContractOptionsUtilsPlugin}.
  *
- * @see {@link https://orpc.dev/docs/integrations/pinia-colada#contract-options-plugin Pinia Colada Contract Options Plugin Docs}
+ * @see {@link https://orpc.dev/docs/integrations/pinia-colada#contract-options-plugin | Pinia Colada}
  */
 export function piniaColada<
   TInputSchema extends AnySchema,
@@ -66,7 +66,7 @@ export function getPiniaColadaMeta(
  * The contract shape must match the client the utils are created from,
  * so pass the root router contract when utils paths start from the root.
  *
- * @see {@link https://orpc.dev/docs/integrations/pinia-colada#contract-options-plugin Pinia Colada Contract Options Plugin Docs}
+ * @see {@link https://orpc.dev/docs/integrations/pinia-colada#contract-options-plugin | Pinia Colada}
  */
 export class ContractOptionsUtilsPlugin<T extends AnyNestedClient = AnyNestedClient> implements RouterUtilsPlugin<T> {
   readonly name = '~contract-options'

--- a/packages/pinia-colada/src/meta.ts
+++ b/packages/pinia-colada/src/meta.ts
@@ -25,7 +25,7 @@ export interface PiniaColadaMetaPlugin<
  *
  * Apply them to router utils with {@link ContractOptionsUtilsPlugin}.
  *
- * @see {@link https://orpc.dev/docs/integrations/pinia-colada#contract-options-plugin | Pinia Colada}
+ * @see {@link https://orpc.dev/docs/integrations/pinia-colada#contract-options-plugin | Pinia Colada Integration - Contract Options Plugin}
  */
 export function piniaColada<
   TInputSchema extends AnySchema,
@@ -66,7 +66,7 @@ export function getPiniaColadaMeta(
  * The contract shape must match the client the utils are created from,
  * so pass the root router contract when utils paths start from the root.
  *
- * @see {@link https://orpc.dev/docs/integrations/pinia-colada#contract-options-plugin | Pinia Colada}
+ * @see {@link https://orpc.dev/docs/integrations/pinia-colada#contract-options-plugin | Pinia Colada Integration - Contract Options Plugin}
  */
 export class ContractOptionsUtilsPlugin<T extends AnyNestedClient = AnyNestedClient> implements RouterUtilsPlugin<T> {
   readonly name = '~contract-options'

--- a/packages/pinia-colada/src/procedure-utils.ts
+++ b/packages/pinia-colada/src/procedure-utils.ts
@@ -265,7 +265,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Calling corresponding procedure client
    *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#calling-procedure-clients | Pinia Colada Calling Procedure Client}
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#calling-procedure-clients | Pinia Colada Integration - Calling Procedure Clients}
    */
   call: Client<TClientContext, TInput, TOutput, TError>
 
@@ -281,7 +281,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate a **full matching** key for useQuery/...
    *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key | Pinia Colada Query/Mutation Key}
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key | Pinia Colada Integration - Query/Mutation Key}
    */
   queryKey(
     ...rest: MaybeOptionalOptions<QueryKeyOptions<TInput>>
@@ -304,7 +304,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate options used for useQuery/...
    *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-options-utility | Pinia Colada Query Options Utility}
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-options-utility | Pinia Colada Integration - Query Options Utility}
    */
   queryOptions<UInitialData extends TOutput | undefined = TOutput | undefined>(
     ...rest: MaybeOptionalOptions<
@@ -357,7 +357,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate a **full matching** key for [Streamed Query Options](https://orpc.dev/docs/integrations/pinia-colada#streamed-query-options-utility).
    *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key | Pinia Colada Query/Mutation Key}
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key | Pinia Colada Integration - Query/Mutation Key}
    */
   streamedKey(
     ...rest: MaybeOptionalOptions<StreamedKeyOptions<TInput>>
@@ -444,7 +444,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate a **full matching** key for [Live Query Options](https://orpc.dev/docs/integrations/pinia-colada#live-query-options-utility).
    *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key | Pinia Colada Query/Mutation Key}
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key | Pinia Colada Integration - Query/Mutation Key}
    */
   liveKey(
     ...rest: MaybeOptionalOptions<QueryKeyOptions<TInput>>
@@ -528,7 +528,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate a **full matching** key for useInfiniteQuery/...
    *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key | Pinia Colada Query/Mutation Key}
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key | Pinia Colada Integration - Query/Mutation Key}
    */
   infiniteKey<UPageParam>(
     optionsIn: InfiniteKeyOptions<TInput, UPageParam>,
@@ -557,7 +557,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate options used for useInfiniteQuery/...
    *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#infinite-query-options-utility | Pinia Colada Infinite Query Options Utility}
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#infinite-query-options-utility | Pinia Colada Integration - Infinite Query Options Utility}
    */
   infiniteOptions<UPageParam, UInitialData extends UseInfiniteQueryData<TOutput, UPageParam> | undefined = undefined>(
     optionsIn: InfiniteOptionsIn<TClientContext, TInput, TOutput, TError, UPageParam, UInitialData>,
@@ -606,7 +606,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate a **full matching** key for useMutation/...
    *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key | Pinia Colada Query/Mutation Key}
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key | Pinia Colada Integration - Query/Mutation Key}
    */
   mutationKey(
     ...rest: MaybeOptionalOptions<MutationKeyOptions<TInput>>
@@ -629,7 +629,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate options used for useMutation/...
    *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#mutation-options | Pinia Colada Mutation Options}
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#mutation-options | Pinia Colada Integration - Mutation Options}
    */
   mutationOptions<UMutationContext extends Record<any, any> = _EmptyObject>(
     ...rest: MaybeOptionalOptions<

--- a/packages/pinia-colada/src/procedure-utils.ts
+++ b/packages/pinia-colada/src/procedure-utils.ts
@@ -265,7 +265,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Calling corresponding procedure client
    *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#calling-procedure-clients Pinia Colada Calling Procedure Client Docs}
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#calling-procedure-clients | Pinia Colada Calling Procedure Client}
    */
   call: Client<TClientContext, TInput, TOutput, TError>
 
@@ -281,7 +281,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate a **full matching** key for useQuery/...
    *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key Pinia Colada Query/Mutation Key Docs}
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key | Pinia Colada Query/Mutation Key}
    */
   queryKey(
     ...rest: MaybeOptionalOptions<QueryKeyOptions<TInput>>
@@ -304,7 +304,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate options used for useQuery/...
    *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-options-utility Pinia Colada Query Options Utility Docs}
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-options-utility | Pinia Colada Query Options Utility}
    */
   queryOptions<UInitialData extends TOutput | undefined = TOutput | undefined>(
     ...rest: MaybeOptionalOptions<
@@ -357,7 +357,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate a **full matching** key for [Streamed Query Options](https://orpc.dev/docs/integrations/pinia-colada#streamed-query-options-utility).
    *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key Pinia Colada Query/Mutation Key Docs}
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key | Pinia Colada Query/Mutation Key}
    */
   streamedKey(
     ...rest: MaybeOptionalOptions<StreamedKeyOptions<TInput>>
@@ -444,7 +444,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate a **full matching** key for [Live Query Options](https://orpc.dev/docs/integrations/pinia-colada#live-query-options-utility).
    *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key Pinia Colada Query/Mutation Key Docs}
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key | Pinia Colada Query/Mutation Key}
    */
   liveKey(
     ...rest: MaybeOptionalOptions<QueryKeyOptions<TInput>>
@@ -528,7 +528,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate a **full matching** key for useInfiniteQuery/...
    *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key Pinia Colada Query/Mutation Key Docs}
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key | Pinia Colada Query/Mutation Key}
    */
   infiniteKey<UPageParam>(
     optionsIn: InfiniteKeyOptions<TInput, UPageParam>,
@@ -557,7 +557,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate options used for useInfiniteQuery/...
    *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#infinite-query-options-utility Pinia Colada Infinite Query Options Utility Docs}
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#infinite-query-options-utility | Pinia Colada Infinite Query Options Utility}
    */
   infiniteOptions<UPageParam, UInitialData extends UseInfiniteQueryData<TOutput, UPageParam> | undefined = undefined>(
     optionsIn: InfiniteOptionsIn<TClientContext, TInput, TOutput, TError, UPageParam, UInitialData>,
@@ -606,7 +606,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate a **full matching** key for useMutation/...
    *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key Pinia Colada Query/Mutation Key Docs}
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key | Pinia Colada Query/Mutation Key}
    */
   mutationKey(
     ...rest: MaybeOptionalOptions<MutationKeyOptions<TInput>>
@@ -629,7 +629,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate options used for useMutation/...
    *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#mutation-options Pinia Colada Mutation Options Docs}
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#mutation-options | Pinia Colada Mutation Options}
    */
   mutationOptions<UMutationContext extends Record<any, any> = _EmptyObject>(
     ...rest: MaybeOptionalOptions<

--- a/packages/pinia-colada/src/router-utils.ts
+++ b/packages/pinia-colada/src/router-utils.ts
@@ -13,7 +13,7 @@ import { SharedUtils } from './shared-utils'
  * The utils shape derived from a client: procedure clients map to procedure
  * utils, and routers map recursively to nested utils.
  *
- * @see {@link https://orpc.dev/docs/integrations/pinia-colada | Pinia Colada}
+ * @see {@link https://orpc.dev/docs/integrations/pinia-colada | Pinia Colada Integration}
  */
 export type RouterUtils<T extends AnyNestedClient>
   = T extends Client<infer UClientContext, infer UInput, infer UOutput, infer UError>
@@ -82,7 +82,7 @@ export interface RouterUtilsOptions<T extends AnyNestedClient> extends Operation
  * @remarks
  * **Note**: Both client-side and server-side clients are supported.
  *
- * @see {@link https://orpc.dev/docs/integrations/pinia-colada | Pinia Colada}
+ * @see {@link https://orpc.dev/docs/integrations/pinia-colada | Pinia Colada Integration}
  */
 export function createRouterUtils<T extends AnyNestedClient>(
   client: T,

--- a/packages/pinia-colada/src/router-utils.ts
+++ b/packages/pinia-colada/src/router-utils.ts
@@ -9,6 +9,12 @@ import { CompositeRouterUtilsPlugin } from './plugin'
 import { isProcedureUtilsOptions, mergeProcedureUtilsOptions, ProcedureUtils } from './procedure-utils'
 import { SharedUtils } from './shared-utils'
 
+/**
+ * The utils shape derived from a client: procedure clients map to procedure
+ * utils, and routers map recursively to nested utils.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/pinia-colada | Pinia Colada}
+ */
 export type RouterUtils<T extends AnyNestedClient>
   = T extends Client<infer UClientContext, infer UInput, infer UOutput, infer UError>
     ? Public<ProcedureUtils<UClientContext, UInput, UOutput, UError>>
@@ -70,10 +76,13 @@ export interface RouterUtilsOptions<T extends AnyNestedClient> extends Operation
 }
 
 /**
- * Create a router utils from a client.
+ * Creates Pinia Colada utils from a client, exposing query/mutation
+ * option builders for every procedure in the router.
  *
- * @info Both client-side and server-side clients are supported.
- * @see {@link https://orpc.dev/docs/integrations/pinia-colada Pinia Colada Docs}
+ * @remarks
+ * **Note**: Both client-side and server-side clients are supported.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/pinia-colada | Pinia Colada}
  */
 export function createRouterUtils<T extends AnyNestedClient>(
   client: T,

--- a/packages/pinia-colada/src/shared-utils.ts
+++ b/packages/pinia-colada/src/shared-utils.ts
@@ -11,7 +11,7 @@ export class SharedUtils<TInput> {
   /**
    * Generate a **partial matching** key for actions like revalidating queries, checking mutation status, etc.
    *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key | Pinia Colada Query/Mutation Key}
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key | Pinia Colada Integration - Query/Mutation Key}
    */
   key<TType extends OperationType>(options: Omit<OperationKeyOptions<TType, TInput>, 'prefix'> = {}): OperationKey<TType, TInput> {
     return generateOperationKey(this.path, { ...options, prefix: this.options.prefix })

--- a/packages/pinia-colada/src/shared-utils.ts
+++ b/packages/pinia-colada/src/shared-utils.ts
@@ -11,7 +11,7 @@ export class SharedUtils<TInput> {
   /**
    * Generate a **partial matching** key for actions like revalidating queries, checking mutation status, etc.
    *
-   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key Pinia Colada Query/Mutation Key Docs}
+   * @see {@link https://orpc.dev/docs/integrations/pinia-colada#query-mutation-key | Pinia Colada Query/Mutation Key}
    */
   key<TType extends OperationType>(options: Omit<OperationKeyOptions<TType, TInput>, 'prefix'> = {}): OperationKey<TType, TInput> {
     return generateOperationKey(this.path, { ...options, prefix: this.options.prefix })

--- a/packages/pinia-colada/src/types.ts
+++ b/packages/pinia-colada/src/types.ts
@@ -13,10 +13,22 @@ export type UseQueryFnContext = Parameters<UseQueryOptions<any>['query']>[0]
  */
 export type UseMutationFnContext = Parameters<NonNullable<UseMutationOptionsGlobal['onSuccess']>>[2]
 
+/**
+ * The symbol under which Pinia Colada utils attach operation details
+ * (key and operation type) to the client context.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/pinia-colada#client-context | Pinia Colada}
+ */
 export const OPERATION_CONTEXT_SYMBOL: unique symbol = Symbol.for('ORPC_PINIA_COLADA_OPERATION_CONTEXT') as any
 
 export type OperationType = 'query' | 'streamed' | 'live' | 'infinite' | 'mutation'
 
+/**
+ * A client context automatically populated by Pinia Colada utils,
+ * exposing the operation key and type of the calling operation.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/pinia-colada#client-context | Pinia Colada}
+ */
 export interface OperationContext {
   [OPERATION_CONTEXT_SYMBOL]?: {
     key: EntryKey

--- a/packages/pinia-colada/src/types.ts
+++ b/packages/pinia-colada/src/types.ts
@@ -17,7 +17,7 @@ export type UseMutationFnContext = Parameters<NonNullable<UseMutationOptionsGlob
  * The symbol under which Pinia Colada utils attach operation details
  * (key and operation type) to the client context.
  *
- * @see {@link https://orpc.dev/docs/integrations/pinia-colada#client-context | Pinia Colada}
+ * @see {@link https://orpc.dev/docs/integrations/pinia-colada#client-context | Pinia Colada Integration - Client Context}
  */
 export const OPERATION_CONTEXT_SYMBOL: unique symbol = Symbol.for('ORPC_PINIA_COLADA_OPERATION_CONTEXT') as any
 
@@ -27,7 +27,7 @@ export type OperationType = 'query' | 'streamed' | 'live' | 'infinite' | 'mutati
  * A client context automatically populated by Pinia Colada utils,
  * exposing the operation key and type of the calling operation.
  *
- * @see {@link https://orpc.dev/docs/integrations/pinia-colada#client-context | Pinia Colada}
+ * @see {@link https://orpc.dev/docs/integrations/pinia-colada#client-context | Pinia Colada Integration - Client Context}
  */
 export interface OperationContext {
   [OPERATION_CONTEXT_SYMBOL]?: {

--- a/packages/pino/src/context.ts
+++ b/packages/pino/src/context.ts
@@ -1,11 +1,27 @@
 import type { Logger } from 'pino'
 
+/**
+ * Context symbol under which the Pino logger is stored. Use it to provide a
+ * custom logger instance per request, e.g. when integrating with pino-http.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/pino#providing-custom-logger-per-request | Pino}
+ */
 export const LOGGER_CONTEXT_SYMBOL: unique symbol = Symbol.for('ORPC_PINO_LOGGER_CONTEXT')
 
+/**
+ * Context shape that carries the Pino logger injected by `PinoHandlerPlugin`.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/pino#using-the-logger-in-your-code | Pino}
+ */
 export interface LoggerContext {
   [LOGGER_CONTEXT_SYMBOL]?: undefined | Logger
 }
 
+/**
+ * Retrieves the Pino logger from the oRPC context, if available.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/pino#using-the-logger-in-your-code | Pino}
+ */
 export function getLogger(context: LoggerContext): Logger | undefined {
   return context[LOGGER_CONTEXT_SYMBOL]
 }

--- a/packages/pino/src/context.ts
+++ b/packages/pino/src/context.ts
@@ -4,14 +4,14 @@ import type { Logger } from 'pino'
  * Context symbol under which the Pino logger is stored. Use it to provide a
  * custom logger instance per request, e.g. when integrating with pino-http.
  *
- * @see {@link https://orpc.dev/docs/integrations/pino#providing-custom-logger-per-request | Pino}
+ * @see {@link https://orpc.dev/docs/integrations/pino#providing-custom-logger-per-request | Pino Integration - Providing Custom Logger per Request}
  */
 export const LOGGER_CONTEXT_SYMBOL: unique symbol = Symbol.for('ORPC_PINO_LOGGER_CONTEXT')
 
 /**
  * Context shape that carries the Pino logger injected by `PinoHandlerPlugin`.
  *
- * @see {@link https://orpc.dev/docs/integrations/pino#using-the-logger-in-your-code | Pino}
+ * @see {@link https://orpc.dev/docs/integrations/pino#using-the-logger-in-your-code | Pino Integration - Using the Logger in Your Code}
  */
 export interface LoggerContext {
   [LOGGER_CONTEXT_SYMBOL]?: undefined | Logger
@@ -20,7 +20,7 @@ export interface LoggerContext {
 /**
  * Retrieves the Pino logger from the oRPC context, if available.
  *
- * @see {@link https://orpc.dev/docs/integrations/pino#using-the-logger-in-your-code | Pino}
+ * @see {@link https://orpc.dev/docs/integrations/pino#using-the-logger-in-your-code | Pino Integration - Using the Logger in Your Code}
  */
 export function getLogger(context: LoggerContext): Logger | undefined {
   return context[LOGGER_CONTEXT_SYMBOL]

--- a/packages/pino/src/handler-plugin.ts
+++ b/packages/pino/src/handler-plugin.ts
@@ -39,6 +39,12 @@ export interface PinoHandlerPluginOptions<T extends Context> {
   logAbort?: boolean
 }
 
+/**
+ * Instruments an oRPC handler with Pino structured logging, request tracking,
+ * and error monitoring.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/pino | Pino}
+ */
 export class PinoHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   name = '~pino'
 
@@ -163,8 +169,8 @@ export class PinoHandlerPlugin<T extends Context> implements StandardHandlerPlug
 
       if (isAsyncIteratorObject(output)) {
         /**
-         * @warning
-         * Remember use `override` for AsyncIteratorObject to remain other special properties
+         * @remarks
+         * **Warning**: Remember use `override` for AsyncIteratorObject to remain other special properties
          */
         return override(output, wrapAsyncIteratorPreservingEventMeta(output, {
           onError: (error) => {
@@ -175,8 +181,8 @@ export class PinoHandlerPlugin<T extends Context> implements StandardHandlerPlug
 
       if (output instanceof ReadableStream) {
         /**
-         * @warning
-         * Remember use `override` for ReadableStream to remain other special properties
+         * @remarks
+         * **Warning**: Remember use `override` for ReadableStream to remain other special properties
          */
         return override(output, wrapReadableStream(output, {
           onError: (error) => {

--- a/packages/pino/src/handler-plugin.ts
+++ b/packages/pino/src/handler-plugin.ts
@@ -43,7 +43,7 @@ export interface PinoHandlerPluginOptions<T extends Context> {
  * Instruments an oRPC handler with Pino structured logging, request tracking,
  * and error monitoring.
  *
- * @see {@link https://orpc.dev/docs/integrations/pino | Pino}
+ * @see {@link https://orpc.dev/docs/integrations/pino | Pino Integration}
  */
 export class PinoHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   name = '~pino'

--- a/packages/publisher/src/adapters/memory.ts
+++ b/packages/publisher/src/adapters/memory.ts
@@ -44,7 +44,7 @@ interface StoredEvent<T> {
  * Publisher adapter backed by in-memory storage, with optional resume support.
  * Events are delivered to subscribers within the same process only.
  *
- * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher}
+ * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher Helpers - Adapters}
  */
 export class MemoryPublisher<T extends Record<string, object>> extends Publisher<T> {
   private readonly listenersMap: Map<keyof T, ((payload: any) => void)[]> = new Map()

--- a/packages/publisher/src/adapters/memory.ts
+++ b/packages/publisher/src/adapters/memory.ts
@@ -40,6 +40,12 @@ interface StoredEvent<T> {
   payload: T
 }
 
+/**
+ * Publisher adapter backed by in-memory storage, with optional resume support.
+ * Events are delivered to subscribers within the same process only.
+ *
+ * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher}
+ */
 export class MemoryPublisher<T extends Record<string, object>> extends Publisher<T> {
   private readonly listenersMap: Map<keyof T, ((payload: any) => void)[]> = new Map()
   private readonly idGenerator = new SequentialIdGenerator()

--- a/packages/publisher/src/adapters/redis.ts
+++ b/packages/publisher/src/adapters/redis.ts
@@ -62,6 +62,12 @@ export interface RedisPublisherOptions extends PublisherOptions {
   }
 }
 
+/**
+ * Publisher adapter for Redis. Distributes events across processes via
+ * Redis Pub/Sub, with optional resume support backed by Redis Streams.
+ *
+ * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher}
+ */
 export class RedisPublisher<T extends Record<string, object>> extends Publisher<T> {
   private readonly subscriber: Exclude<RedisPublisherOptions['subscriber'], undefined>
   private readonly prefix: Exclude<RedisPublisherOptions['prefix'], undefined>

--- a/packages/publisher/src/adapters/redis.ts
+++ b/packages/publisher/src/adapters/redis.ts
@@ -66,7 +66,7 @@ export interface RedisPublisherOptions extends PublisherOptions {
  * Publisher adapter for Redis. Distributes events across processes via
  * Redis Pub/Sub, with optional resume support backed by Redis Streams.
  *
- * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher}
+ * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher Helpers - Adapters}
  */
 export class RedisPublisher<T extends Record<string, object>> extends Publisher<T> {
   private readonly subscriber: Exclude<RedisPublisherOptions['subscriber'], undefined>

--- a/packages/publisher/src/adapters/upstash.ts
+++ b/packages/publisher/src/adapters/upstash.ts
@@ -57,7 +57,7 @@ export interface UpstashPublisherOptions extends PublisherOptions {
  * Publisher adapter for Upstash Redis. Distributes events across processes via
  * Upstash Pub/Sub, with optional resume support backed by Redis Streams.
  *
- * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher}
+ * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher Helpers - Adapters}
  */
 export class UpstashPublisher<T extends Record<string, object>> extends Publisher<T> {
   private readonly prefix: string

--- a/packages/publisher/src/adapters/upstash.ts
+++ b/packages/publisher/src/adapters/upstash.ts
@@ -53,6 +53,12 @@ export interface UpstashPublisherOptions extends PublisherOptions {
   }
 }
 
+/**
+ * Publisher adapter for Upstash Redis. Distributes events across processes via
+ * Upstash Pub/Sub, with optional resume support backed by Redis Streams.
+ *
+ * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher}
+ */
 export class UpstashPublisher<T extends Record<string, object>> extends Publisher<T> {
   private readonly prefix: string
   private readonly serializer: Pick<RPCSerializer, keyof RPCSerializer>

--- a/packages/ratelimit/src/adapters/memory.ts
+++ b/packages/ratelimit/src/adapters/memory.ts
@@ -32,6 +32,12 @@ export interface MemoryRateLimiterOptions {
   }
 }
 
+/**
+ * Rate limiter adapter backed by in-memory storage. Enforces a fixed-window
+ * limit, with optional blocking mode.
+ *
+ * @see {@link https://orpc.dev/docs/helpers/ratelimit#adapters | Ratelimit}
+ */
 export class MemoryRateLimiter implements RateLimiter {
   private readonly maxRequests: number
   private readonly window: number

--- a/packages/ratelimit/src/adapters/memory.ts
+++ b/packages/ratelimit/src/adapters/memory.ts
@@ -36,7 +36,7 @@ export interface MemoryRateLimiterOptions {
  * Rate limiter adapter backed by in-memory storage. Enforces a fixed-window
  * limit, with optional blocking mode.
  *
- * @see {@link https://orpc.dev/docs/helpers/ratelimit#adapters | Ratelimit}
+ * @see {@link https://orpc.dev/docs/helpers/ratelimit#adapters | Rate Limit Helpers - Adapters}
  */
 export class MemoryRateLimiter implements RateLimiter {
   private readonly maxRequests: number

--- a/packages/ratelimit/src/adapters/redis.ts
+++ b/packages/ratelimit/src/adapters/redis.ts
@@ -56,6 +56,12 @@ export interface RedisRateLimiterOptions {
   }
 }
 
+/**
+ * Rate limiter adapter for Redis. Enforces a fixed-window limit using a
+ * Redis Lua script, with optional blocking mode.
+ *
+ * @see {@link https://orpc.dev/docs/helpers/ratelimit#adapters | Ratelimit}
+ */
 export class RedisRateLimiter implements RateLimiter {
   private readonly redis: RedisClientType<any, any, any, any, any>
   private readonly prefix: string

--- a/packages/ratelimit/src/adapters/redis.ts
+++ b/packages/ratelimit/src/adapters/redis.ts
@@ -60,7 +60,7 @@ export interface RedisRateLimiterOptions {
  * Rate limiter adapter for Redis. Enforces a fixed-window limit using a
  * Redis Lua script, with optional blocking mode.
  *
- * @see {@link https://orpc.dev/docs/helpers/ratelimit#adapters | Ratelimit}
+ * @see {@link https://orpc.dev/docs/helpers/ratelimit#adapters | Rate Limit Helpers - Adapters}
  */
 export class RedisRateLimiter implements RateLimiter {
   private readonly redis: RedisClientType<any, any, any, any, any>

--- a/packages/ratelimit/src/adapters/upstash.ts
+++ b/packages/ratelimit/src/adapters/upstash.ts
@@ -30,6 +30,12 @@ export interface UpstashRateLimiterOptions {
   waitUntil?: (promise: Promise<any>) => any
 }
 
+/**
+ * Rate limiter adapter for Upstash Rate Limit. Delegates limit checks to a
+ * configured `Ratelimit` instance, with optional blocking mode.
+ *
+ * @see {@link https://orpc.dev/docs/helpers/ratelimit#adapters | Ratelimit}
+ */
 export class UpstashRateLimiter implements RateLimiter {
   private blockingUntilReady: UpstashRateLimiterOptions['blockingUntilReady']
   private waitUntil: UpstashRateLimiterOptions['waitUntil']

--- a/packages/ratelimit/src/adapters/upstash.ts
+++ b/packages/ratelimit/src/adapters/upstash.ts
@@ -34,7 +34,7 @@ export interface UpstashRateLimiterOptions {
  * Rate limiter adapter for Upstash Rate Limit. Delegates limit checks to a
  * configured `Ratelimit` instance, with optional blocking mode.
  *
- * @see {@link https://orpc.dev/docs/helpers/ratelimit#adapters | Ratelimit}
+ * @see {@link https://orpc.dev/docs/helpers/ratelimit#adapters | Rate Limit Helpers - Adapters}
  */
 export class UpstashRateLimiter implements RateLimiter {
   private blockingUntilReady: UpstashRateLimiterOptions['blockingUntilReady']

--- a/packages/ratelimit/src/handler-plugin.ts
+++ b/packages/ratelimit/src/handler-plugin.ts
@@ -19,7 +19,7 @@ export interface RateLimitHandlerPluginContext {
  * Automatically adds HTTP rate limiting headers (`RateLimit-*` and `Retry-After`)
  * to responses when used with the `ratelimit` middleware.
  *
- * @see {@link https://orpc.dev/docs/helpers/ratelimit#handler-plugin | Ratelimit}
+ * @see {@link https://orpc.dev/docs/helpers/ratelimit#handler-plugin | Rate Limit Helpers - Handler Plugin}
  */
 export class RateLimitHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   name = '~ratelimit'

--- a/packages/ratelimit/src/handler-plugin.ts
+++ b/packages/ratelimit/src/handler-plugin.ts
@@ -16,10 +16,10 @@ export interface RateLimitHandlerPluginContext {
 }
 
 /**
- * Automatically adds HTTP rate-limiting headers (RateLimit-* and Retry-After) to responses
- * when used with middleware created by createRatelimitMiddleware.
+ * Automatically adds HTTP rate limiting headers (`RateLimit-*` and `Retry-After`)
+ * to responses when used with the `ratelimit` middleware.
  *
- * @see {@link https://orpc.dev/docs/helpers/ratelimit#handler-plugin Ratelimit handler plugin}
+ * @see {@link https://orpc.dev/docs/helpers/ratelimit#handler-plugin | Ratelimit}
  */
 export class RateLimitHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   name = '~ratelimit'

--- a/packages/ratelimit/src/middleware.ts
+++ b/packages/ratelimit/src/middleware.ts
@@ -54,7 +54,7 @@ export interface RateLimitMiddlewareOptions<
  * Creates a middleware that enforces rate limits in oRPC procedures.
  * Supports per-request deduplication and integrates with the ratelimit handler plugin.
  *
- * @see {@link https://orpc.dev/docs/helpers/ratelimit#ratelimit-middleware | Ratelimit}
+ * @see {@link https://orpc.dev/docs/helpers/ratelimit#ratelimit-middleware | Rate Limit Helpers - Ratelimit Middleware}
  */
 export function ratelimit<
   TInContext extends Context,

--- a/packages/ratelimit/src/middleware.ts
+++ b/packages/ratelimit/src/middleware.ts
@@ -54,7 +54,7 @@ export interface RateLimitMiddlewareOptions<
  * Creates a middleware that enforces rate limits in oRPC procedures.
  * Supports per-request deduplication and integrates with the ratelimit handler plugin.
  *
- * @see {@link https://orpc.dev/docs/helpers/ratelimit#createratelimitmiddleware Ratelimit middleware}
+ * @see {@link https://orpc.dev/docs/helpers/ratelimit#ratelimit-middleware | Ratelimit}
  */
 export function ratelimit<
   TInContext extends Context,

--- a/packages/ratelimit/src/types.ts
+++ b/packages/ratelimit/src/types.ts
@@ -27,6 +27,12 @@ export interface RateLimitOptions {
   weight?: number
 }
 
+/**
+ * Standard interface for checking and enforcing rate limits.
+ * Implement it for custom strategies, or use one of the provided adapters.
+ *
+ * @see {@link https://orpc.dev/docs/helpers/ratelimit | Ratelimit}
+ */
 export interface RateLimiter {
   limit(key: string, options?: RateLimitOptions): Promise<RateLimitResult>
 }

--- a/packages/ratelimit/src/types.ts
+++ b/packages/ratelimit/src/types.ts
@@ -31,7 +31,7 @@ export interface RateLimitOptions {
  * Standard interface for checking and enforcing rate limits.
  * Implement it for custom strategies, or use one of the provided adapters.
  *
- * @see {@link https://orpc.dev/docs/helpers/ratelimit | Ratelimit}
+ * @see {@link https://orpc.dev/docs/helpers/ratelimit | Rate Limit Helpers}
  */
 export interface RateLimiter {
   limit(key: string, options?: RateLimitOptions): Promise<RateLimitResult>

--- a/packages/server/src/adapters/aws-lambda/rpc-handler.ts
+++ b/packages/server/src/adapters/aws-lambda/rpc-handler.ts
@@ -30,7 +30,7 @@ export interface RPCHandlerOptions<T extends Context>
  * @remarks
  * **Warning**: Requires the Lambda Node.js runtime with response streaming enabled, so handlers must be wrapped with `awslambda.streamifyResponse`.
  *
- * @see {@link https://orpc.dev/docs/adapters/aws-lambda | AWS Lambda}
+ * @see {@link https://orpc.dev/docs/adapters/aws-lambda | AWS Lambda Adapter}
  */
 export class RPCHandler<T extends Context> extends AwsLambdaHandler<T> {
   constructor(

--- a/packages/server/src/adapters/aws-lambda/rpc-handler.ts
+++ b/packages/server/src/adapters/aws-lambda/rpc-handler.ts
@@ -24,8 +24,13 @@ export interface RPCHandlerOptions<T extends Context>
 }
 
 /**
- * Requires the AWS Lambda Node.js runtime with response streaming enabled,
- * handlers should be wrapped with `awslambda.streamifyResponse`.
+ * Serves an oRPC router over the RPC protocol on AWS Lambda,
+ * behind API Gateway or Lambda Function URLs.
+ *
+ * @remarks
+ * **Warning**: Requires the Lambda Node.js runtime with response streaming enabled, so handlers must be wrapped with `awslambda.streamifyResponse`.
+ *
+ * @see {@link https://orpc.dev/docs/adapters/aws-lambda | AWS Lambda}
  */
 export class RPCHandler<T extends Context> extends AwsLambdaHandler<T> {
   constructor(

--- a/packages/server/src/adapters/crossws/rpc-handler.ts
+++ b/packages/server/src/adapters/crossws/rpc-handler.ts
@@ -8,6 +8,12 @@ import { experimental_CrosswsHandler as CrosswsHandler } from './handler'
 export interface experimental_RPCHandlerOptions<T extends Context>
   extends StandardHandlerOptions<T>, RPCHandlerCodecOptions<T>, CrosswsHandlerOptions<T> {}
 
+/**
+ * Serves an oRPC router over the RPC protocol on a WebSocket connection
+ * managed by [crossws](https://github.com/h3js/crossws).
+ *
+ * @see {@link https://orpc.dev/docs/adapters/websocket | WebSocket}
+ */
 export class experimental_RPCHandler<T extends Context> extends CrosswsHandler<T> {
   constructor(
     router: Router<T>,

--- a/packages/server/src/adapters/crossws/rpc-handler.ts
+++ b/packages/server/src/adapters/crossws/rpc-handler.ts
@@ -12,7 +12,7 @@ export interface experimental_RPCHandlerOptions<T extends Context>
  * Serves an oRPC router over the RPC protocol on a WebSocket connection
  * managed by [crossws](https://github.com/h3js/crossws).
  *
- * @see {@link https://orpc.dev/docs/adapters/websocket | WebSocket}
+ * @see {@link https://orpc.dev/docs/adapters/websocket | WebSocket Adapters}
  */
 export class experimental_RPCHandler<T extends Context> extends CrosswsHandler<T> {
   constructor(

--- a/packages/server/src/adapters/fastify/rpc-handler.ts
+++ b/packages/server/src/adapters/fastify/rpc-handler.ts
@@ -23,6 +23,11 @@ export interface RPCHandlerOptions<T extends Context>
   }
 }
 
+/**
+ * Serves an oRPC router over the RPC protocol inside a Fastify server.
+ *
+ * @see {@link https://orpc.dev/docs/adapters/fastify | Fastify}
+ */
 export class RPCHandler<T extends Context> extends FastifyHandler<T> {
   constructor(
     router: Router<T>,

--- a/packages/server/src/adapters/fastify/rpc-handler.ts
+++ b/packages/server/src/adapters/fastify/rpc-handler.ts
@@ -26,7 +26,7 @@ export interface RPCHandlerOptions<T extends Context>
 /**
  * Serves an oRPC router over the RPC protocol inside a Fastify server.
  *
- * @see {@link https://orpc.dev/docs/adapters/fastify | Fastify}
+ * @see {@link https://orpc.dev/docs/adapters/fastify | Fastify Adapter}
  */
 export class RPCHandler<T extends Context> extends FastifyHandler<T> {
   constructor(

--- a/packages/server/src/adapters/fetch/rpc-handler.ts
+++ b/packages/server/src/adapters/fetch/rpc-handler.ts
@@ -22,6 +22,13 @@ export interface RPCHandlerOptions<T extends Context>
   }
 }
 
+/**
+ * Serves an oRPC router over the RPC protocol using the Fetch API
+ * (Request/Response), supported by modern runtimes like Deno, Bun,
+ * Cloudflare Workers, and browsers.
+ *
+ * @see {@link https://orpc.dev/docs/adapters/fetch-api | Fetch API}
+ */
 export class RPCHandler<T extends Context> extends FetchHandler<T> {
   constructor(
     router: Router<T>,

--- a/packages/server/src/adapters/fetch/rpc-handler.ts
+++ b/packages/server/src/adapters/fetch/rpc-handler.ts
@@ -27,7 +27,7 @@ export interface RPCHandlerOptions<T extends Context>
  * (Request/Response), supported by modern runtimes like Deno, Bun,
  * Cloudflare Workers, and browsers.
  *
- * @see {@link https://orpc.dev/docs/adapters/fetch-api | Fetch API}
+ * @see {@link https://orpc.dev/docs/adapters/fetch-api | Fetch API Adapter}
  */
 export class RPCHandler<T extends Context> extends FetchHandler<T> {
   constructor(

--- a/packages/server/src/adapters/message-port/handler.ts
+++ b/packages/server/src/adapters/message-port/handler.ts
@@ -21,9 +21,8 @@ export interface MessagePortHandlerOptions<_T extends Context> {
    * such as transferring object ownership or supporting non-serializable objects like `OffscreenCanvas` or improving performance.
    *
    * @remarks
-   * - Returning `null` or `undefined` disables this feature.
-   *
-   * @warning Ensure your message port implementation supports `transferable` objects before enabling this.
+   * **Note**: Returning `null` or `undefined` disables this feature.
+   * **Warning**: Ensure your message port implementation supports `transferable` objects before enabling this.
    */
   experimental_transfer?: Value<Promisable<object[] | null | undefined>, [message: DecodedResponseMessage, port: SupportedMessagePort]>
 

--- a/packages/server/src/adapters/message-port/rpc-handler.ts
+++ b/packages/server/src/adapters/message-port/rpc-handler.ts
@@ -12,7 +12,7 @@ export interface RPCHandlerOptions<T extends Context>
  * Serves an oRPC router over the RPC protocol on a message port,
  * such as browser extensions, Electron, or worker threads.
  *
- * @see {@link https://orpc.dev/docs/adapters/message-port | Message Port}
+ * @see {@link https://orpc.dev/docs/adapters/message-port | Message Port Adapter}
  */
 export class RPCHandler<T extends Context> extends MessagePortHandler<T> {
   constructor(

--- a/packages/server/src/adapters/message-port/rpc-handler.ts
+++ b/packages/server/src/adapters/message-port/rpc-handler.ts
@@ -8,6 +8,12 @@ import { MessagePortHandler } from './handler'
 export interface RPCHandlerOptions<T extends Context>
   extends StandardHandlerOptions<T>, RPCHandlerCodecOptions<T>, MessagePortHandlerOptions<T> {}
 
+/**
+ * Serves an oRPC router over the RPC protocol on a message port,
+ * such as browser extensions, Electron, or worker threads.
+ *
+ * @see {@link https://orpc.dev/docs/adapters/message-port | Message Port}
+ */
 export class RPCHandler<T extends Context> extends MessagePortHandler<T> {
   constructor(
     router: Router<T>,

--- a/packages/server/src/adapters/node/rpc-handler.ts
+++ b/packages/server/src/adapters/node/rpc-handler.ts
@@ -23,6 +23,12 @@ export interface RPCHandlerOptions<T extends Context>
   }
 }
 
+/**
+ * Serves an oRPC router over the RPC protocol using Node.js built-in
+ * HTTP request/response objects.
+ *
+ * @see {@link https://orpc.dev/docs/adapters/node-http | Node HTTP}
+ */
 export class RPCHandler<T extends Context> extends NodeHttpHandler<T> {
   constructor(
     router: Router<T>,

--- a/packages/server/src/adapters/node/rpc-handler.ts
+++ b/packages/server/src/adapters/node/rpc-handler.ts
@@ -27,7 +27,7 @@ export interface RPCHandlerOptions<T extends Context>
  * Serves an oRPC router over the RPC protocol using Node.js built-in
  * HTTP request/response objects.
  *
- * @see {@link https://orpc.dev/docs/adapters/node-http | Node HTTP}
+ * @see {@link https://orpc.dev/docs/adapters/node-http | Node HTTP Adapter}
  */
 export class RPCHandler<T extends Context> extends NodeHttpHandler<T> {
   constructor(

--- a/packages/server/src/adapters/websocket/rpc-handler.ts
+++ b/packages/server/src/adapters/websocket/rpc-handler.ts
@@ -8,6 +8,12 @@ import { WebSocketHandler } from './handler'
 export interface RPCHandlerOptions<T extends Context>
   extends StandardHandlerOptions<T>, RPCHandlerCodecOptions<T>, WebSocketHandlerOptions<T> {}
 
+/**
+ * Serves an oRPC router over the RPC protocol on a standard WebSocket
+ * connection (Deno, Bun, Cloudflare Durable Objects, and more).
+ *
+ * @see {@link https://orpc.dev/docs/adapters/websocket | WebSocket}
+ */
 export class RPCHandler<T extends Context> extends WebSocketHandler<T> {
   constructor(
     router: Router<T>,

--- a/packages/server/src/adapters/websocket/rpc-handler.ts
+++ b/packages/server/src/adapters/websocket/rpc-handler.ts
@@ -12,7 +12,7 @@ export interface RPCHandlerOptions<T extends Context>
  * Serves an oRPC router over the RPC protocol on a standard WebSocket
  * connection (Deno, Bun, Cloudflare Durable Objects, and more).
  *
- * @see {@link https://orpc.dev/docs/adapters/websocket | WebSocket}
+ * @see {@link https://orpc.dev/docs/adapters/websocket | WebSocket Adapters}
  */
 export class RPCHandler<T extends Context> extends WebSocketHandler<T> {
   constructor(

--- a/packages/server/src/builder.ts
+++ b/packages/server/src/builder.ts
@@ -234,4 +234,10 @@ export class Builder<
   }
 }
 
+/**
+ * The oRPC procedure builder. Chain methods like `.input`, `.use`, and `.handler`
+ * to define procedures, then compose them into routers.
+ *
+ * @see {@link https://orpc.dev/docs/procedure | Procedure}
+ */
 export const os = Builder.create()

--- a/packages/server/src/helpers/base64url.ts
+++ b/packages/server/src/helpers/base64url.ts
@@ -9,6 +9,8 @@
  * const decoded = decodeBase64url(encoded)
  * expect(new TextDecoder().decode(decoded)).toEqual(text)
  * ```
+ *
+ * @see {@link https://orpc.dev/docs/helpers/base64url | Base64Url}
  */
 export function encodeBase64url(data: Uint8Array): string {
   const chunkSize = 8192 // 8KB chunks to stay well below call stack limits
@@ -37,6 +39,8 @@ export function encodeBase64url(data: Uint8Array): string {
  * const decoded = decodeBase64url(encoded)
  * expect(new TextDecoder().decode(decoded)).toEqual(text)
  * ```
+ *
+ * @see {@link https://orpc.dev/docs/helpers/base64url | Base64Url}
  */
 export function decodeBase64url(base64url: string | undefined | null): Uint8Array<ArrayBuffer> | undefined {
   try {

--- a/packages/server/src/helpers/base64url.ts
+++ b/packages/server/src/helpers/base64url.ts
@@ -10,7 +10,7 @@
  * expect(new TextDecoder().decode(decoded)).toEqual(text)
  * ```
  *
- * @see {@link https://orpc.dev/docs/helpers/base64url | Base64Url}
+ * @see {@link https://orpc.dev/docs/helpers/base64url | Base64Url Helpers}
  */
 export function encodeBase64url(data: Uint8Array): string {
   const chunkSize = 8192 // 8KB chunks to stay well below call stack limits
@@ -40,7 +40,7 @@ export function encodeBase64url(data: Uint8Array): string {
  * expect(new TextDecoder().decode(decoded)).toEqual(text)
  * ```
  *
- * @see {@link https://orpc.dev/docs/helpers/base64url | Base64Url}
+ * @see {@link https://orpc.dev/docs/helpers/base64url | Base64Url Helpers}
  */
 export function decodeBase64url(base64url: string | undefined | null): Uint8Array<ArrayBuffer> | undefined {
   try {

--- a/packages/server/src/helpers/cookie.ts
+++ b/packages/server/src/helpers/cookie.ts
@@ -11,7 +11,7 @@ export interface SetCookieOptions extends Omit<SetCookie, 'name' | 'value'>, Str
 }
 
 /**
- * Sets a cookie in the response headers,
+ * Sets a cookie in the response headers.
  *
  * Does nothing if `headers` is `undefined`.
  *
@@ -24,6 +24,7 @@ export interface SetCookieOptions extends Omit<SetCookie, 'name' | 'value'>, Str
  * expect(headers.get('Set-Cookie')).toBe('sessionId=abc123; Max-Age=3600; Path=/; HttpOnly')
  * ```
  *
+ * @see {@link https://orpc.dev/docs/helpers/cookie | Cookie}
  */
 export function setCookie(
   headers: Headers | undefined,
@@ -63,6 +64,8 @@ export interface GetCookieOptions extends ParseOptions {}
  *
  * expect(sessionId).toEqual('abc123')
  * ```
+ *
+ * @see {@link https://orpc.dev/docs/helpers/cookie | Cookie}
  */
 export function getCookie(
   headers: Headers | undefined,
@@ -84,6 +87,8 @@ export function getCookie(
 
 /**
  * Deletes a cookie by marking it expired.
+ *
+ * @see {@link https://orpc.dev/docs/helpers/cookie | Cookie}
  */
 export function deleteCookie(
   headers: Headers | undefined,

--- a/packages/server/src/helpers/cookie.ts
+++ b/packages/server/src/helpers/cookie.ts
@@ -24,7 +24,7 @@ export interface SetCookieOptions extends Omit<SetCookie, 'name' | 'value'>, Str
  * expect(headers.get('Set-Cookie')).toBe('sessionId=abc123; Max-Age=3600; Path=/; HttpOnly')
  * ```
  *
- * @see {@link https://orpc.dev/docs/helpers/cookie | Cookie}
+ * @see {@link https://orpc.dev/docs/helpers/cookie | Cookie Helpers}
  */
 export function setCookie(
   headers: Headers | undefined,
@@ -65,7 +65,7 @@ export interface GetCookieOptions extends ParseOptions {}
  * expect(sessionId).toEqual('abc123')
  * ```
  *
- * @see {@link https://orpc.dev/docs/helpers/cookie | Cookie}
+ * @see {@link https://orpc.dev/docs/helpers/cookie | Cookie Helpers}
  */
 export function getCookie(
   headers: Headers | undefined,
@@ -88,7 +88,7 @@ export function getCookie(
 /**
  * Deletes a cookie by marking it expired.
  *
- * @see {@link https://orpc.dev/docs/helpers/cookie | Cookie}
+ * @see {@link https://orpc.dev/docs/helpers/cookie | Cookie Helpers}
  */
 export function deleteCookie(
   headers: Headers | undefined,

--- a/packages/server/src/helpers/encryption.ts
+++ b/packages/server/src/helpers/encryption.ts
@@ -27,7 +27,7 @@ const CRYPTO_CONSTANTS = {
  * expect(decrypted).toBe("Hello, World!")
  * ```
  *
- * @see {@link https://orpc.dev/docs/helpers/encryption | Encryption}
+ * @see {@link https://orpc.dev/docs/helpers/encryption | Encryption Helpers}
  */
 export async function encrypt(value: string, secret: string): Promise<string> {
   const encoder = new TextEncoder()
@@ -77,7 +77,7 @@ export async function encrypt(value: string, secret: string): Promise<string> {
  * expect(decrypted).toBe("Hello, World!")
  * ```
  *
- * @see {@link https://orpc.dev/docs/helpers/encryption | Encryption}
+ * @see {@link https://orpc.dev/docs/helpers/encryption | Encryption Helpers}
  */
 export async function decrypt(encrypted: string | undefined | null, secret: string): Promise<string | undefined> {
   try {

--- a/packages/server/src/helpers/encryption.ts
+++ b/packages/server/src/helpers/encryption.ts
@@ -26,6 +26,8 @@ const CRYPTO_CONSTANTS = {
  * const decrypted = await decrypt(encrypted, "test-secret-key")
  * expect(decrypted).toBe("Hello, World!")
  * ```
+ *
+ * @see {@link https://orpc.dev/docs/helpers/encryption | Encryption}
  */
 export async function encrypt(value: string, secret: string): Promise<string> {
   const encoder = new TextEncoder()
@@ -74,6 +76,8 @@ export async function encrypt(value: string, secret: string): Promise<string> {
  * const decrypted = await decrypt(encrypted, "test-secret-key")
  * expect(decrypted).toBe("Hello, World!")
  * ```
+ *
+ * @see {@link https://orpc.dev/docs/helpers/encryption | Encryption}
  */
 export async function decrypt(encrypted: string | undefined | null, secret: string): Promise<string | undefined> {
   try {

--- a/packages/server/src/helpers/signing.ts
+++ b/packages/server/src/helpers/signing.ts
@@ -15,7 +15,7 @@ const ALGORITHM = { name: 'HMAC', hash: 'SHA-256' }
  * expect(signedValue).toEqual("user123.oneQsU0r5dvwQFHFEjjV1uOI_IR3gZfkYHij3TRauVA")
  * ```
  *
- * @see {@link https://orpc.dev/docs/helpers/signing | Signing}
+ * @see {@link https://orpc.dev/docs/helpers/signing | Signing Helpers}
  */
 export async function sign(value: string, secret: string): Promise<string> {
   const encoder = new TextEncoder()
@@ -51,7 +51,7 @@ export async function sign(value: string, secret: string): Promise<string> {
  * expect(originalValue).toEqual("user123")
  * ```
  *
- * @see {@link https://orpc.dev/docs/helpers/signing | Signing}
+ * @see {@link https://orpc.dev/docs/helpers/signing | Signing Helpers}
  */
 export async function unsign(signedValue: string | undefined | null, secret: string): Promise<string | undefined> {
   if (typeof signedValue !== 'string') {
@@ -105,7 +105,7 @@ export async function unsign(signedValue: string | undefined | null, secret: str
  * expect(value).toEqual("user123")
  * ```
  *
- * @see {@link https://orpc.dev/docs/helpers/signing | Signing}
+ * @see {@link https://orpc.dev/docs/helpers/signing | Signing Helpers}
  */
 export function getSignedValue(signedValue: string | undefined | null): string | undefined {
   if (typeof signedValue !== 'string') {

--- a/packages/server/src/helpers/signing.ts
+++ b/packages/server/src/helpers/signing.ts
@@ -9,12 +9,13 @@ const ALGORITHM = { name: 'HMAC', hash: 'SHA-256' }
  * the integrity and authenticity of the data. The signature is appended to
  * the original value, separated by a dot, using base64url encoding (no padding).
  *
- *
  * @example
  * ```ts
  * const signedValue = await sign("user123", "my-secret-key")
  * expect(signedValue).toEqual("user123.oneQsU0r5dvwQFHFEjjV1uOI_IR3gZfkYHij3TRauVA")
  * ```
+ *
+ * @see {@link https://orpc.dev/docs/helpers/signing | Signing}
  */
 export async function sign(value: string, secret: string): Promise<string> {
   const encoder = new TextEncoder()
@@ -43,13 +44,14 @@ export async function sign(value: string, secret: string): Promise<string> {
  * secret key. If the signature is valid, it returns the original value. If the
  * signature is invalid or the format is incorrect, it returns undefined.
  *
- *
  * @example
  * ```ts
  * const signedValue = "user123.oneQsU0r5dvwQFHFEjjV1uOI_IR3gZfkYHij3TRauVA"
  * const originalValue = await unsign(signedValue, "my-secret-key")
  * expect(originalValue).toEqual("user123")
  * ```
+ *
+ * @see {@link https://orpc.dev/docs/helpers/signing | Signing}
  */
 export async function unsign(signedValue: string | undefined | null, secret: string): Promise<string | undefined> {
   if (typeof signedValue !== 'string') {
@@ -102,6 +104,8 @@ export async function unsign(signedValue: string | undefined | null, secret: str
  * const value = getSignedValue(signedValue)
  * expect(value).toEqual("user123")
  * ```
+ *
+ * @see {@link https://orpc.dev/docs/helpers/signing | Signing}
  */
 export function getSignedValue(signedValue: string | undefined | null): string | undefined {
   if (typeof signedValue !== 'string') {

--- a/packages/server/src/implementer.ts
+++ b/packages/server/src/implementer.ts
@@ -21,7 +21,7 @@ export type Implementer<
  * Turns a contract into an implementer, used to implement the contract's
  * procedures, routers, and middleware with full type safety.
  *
- * @see {@link https://orpc.dev/docs/contract/implementation#implementer | Contract Implementation}
+ * @see {@link https://orpc.dev/docs/contract/implementation#implementer | Contract Implementation - Implementer}
  */
 export function implement<TContract extends RouterContract, TInitialContext extends Context = DefaultInitialContext>(
   contract: TContract,

--- a/packages/server/src/implementer.ts
+++ b/packages/server/src/implementer.ts
@@ -17,6 +17,12 @@ export type Implementer<
   }
   & RouterImplementer<TContract, TInitialContext>
 
+/**
+ * Turns a contract into an implementer, used to implement the contract's
+ * procedures, routers, and middleware with full type safety.
+ *
+ * @see {@link https://orpc.dev/docs/contract/implementation#implementer | Contract Implementation}
+ */
 export function implement<TContract extends RouterContract, TInitialContext extends Context = DefaultInitialContext>(
   contract: TContract,
   config: ProcedureConfig = {},

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -130,7 +130,17 @@ export type {
 
 export {
   ErrorEvent,
+  /**
+   * Retrieves metadata attached to a single iterator event value.
+   *
+   * @see {@link https://orpc.dev/docs/helpers/publisher | Publisher}
+   */
   getEventMeta,
   unwrapEvent,
+  /**
+   * Returns a new iterator event value with attached, validated metadata.
+   *
+   * @see {@link https://orpc.dev/docs/async-iterator-object#last-event-id-event-metadata | AsyncIteratorObject (SSE)}
+   */
   withEventMeta,
 } from '@standardserver/core'

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -133,14 +133,14 @@ export {
   /**
    * Retrieves metadata attached to a single iterator event value.
    *
-   * @see {@link https://orpc.dev/docs/helpers/publisher | Publisher}
+   * @see {@link https://orpc.dev/docs/helpers/publisher | Publisher Helpers}
    */
   getEventMeta,
   unwrapEvent,
   /**
    * Returns a new iterator event value with attached, validated metadata.
    *
-   * @see {@link https://orpc.dev/docs/async-iterator-object#last-event-id-event-metadata | AsyncIteratorObject (SSE)}
+   * @see {@link https://orpc.dev/docs/async-iterator-object#last-event-id-event-metadata | AsyncIteratorObject (SSE) - Last Event ID & Event Metadata}
    */
   withEventMeta,
 } from '@standardserver/core'

--- a/packages/server/src/lazy.ts
+++ b/packages/server/src/lazy.ts
@@ -17,7 +17,7 @@ export class Lazy<T> {
   }
 
   /**
-   * Checks if the given instance satisfies the {@see Lazy} class/interface.
+   * Checks if the given instance satisfies the {@link Lazy} class/interface.
    */
   static [Symbol.hasInstance](instance: unknown): boolean {
     if (this !== Lazy) {

--- a/packages/server/src/plugins/batch.ts
+++ b/packages/server/src/plugins/batch.ts
@@ -78,7 +78,7 @@ export interface BatchHandlerPluginOptions<T extends Context> {
  * @remarks
  * **Note**: HTTP/2 and later already multiplex requests over a single connection, which often makes this plugin unnecessary.
  *
- * @see {@link https://orpc.dev/docs/plugins/batch | Batch}
+ * @see {@link https://orpc.dev/docs/plugins/batch | Batch Plugin}
  */
 export class BatchHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   name = '~batch'

--- a/packages/server/src/plugins/batch.ts
+++ b/packages/server/src/plugins/batch.ts
@@ -71,6 +71,15 @@ export interface BatchHandlerPluginOptions<T extends Context> {
   }
 }
 
+/**
+ * Handles batch requests sent by the client Batch Link Plugin, splitting each
+ * batch into sub-requests and streaming their responses back together.
+ *
+ * @remarks
+ * **Note**: HTTP/2 and later already multiplex requests over a single connection, which often makes this plugin unnecessary.
+ *
+ * @see {@link https://orpc.dev/docs/plugins/batch | Batch}
+ */
 export class BatchHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   name = '~batch'
 

--- a/packages/server/src/plugins/cors.ts
+++ b/packages/server/src/plugins/cors.ts
@@ -60,9 +60,10 @@ export interface CORSHandlerPluginOptions<T extends Context> {
 }
 
 /**
- * CORSHandlerPlugin is a plugin for oRPC that allows you to configure CORS for your API.
+ * Configures the [CORS Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
+ * for your API, including preflight requests.
  *
- * @see {@link https://orpc.dev/docs/plugins/cors CORS Plugin Docs}
+ * @see {@link https://orpc.dev/docs/plugins/cors | CORS}
  */
 export class CORSHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   private readonly options: CORSHandlerPluginOptions<T>

--- a/packages/server/src/plugins/cors.ts
+++ b/packages/server/src/plugins/cors.ts
@@ -63,7 +63,7 @@ export interface CORSHandlerPluginOptions<T extends Context> {
  * Configures the [CORS Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
  * for your API, including preflight requests.
  *
- * @see {@link https://orpc.dev/docs/plugins/cors | CORS}
+ * @see {@link https://orpc.dev/docs/plugins/cors | CORS Handler Plugin}
  */
 export class CORSHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   private readonly options: CORSHandlerPluginOptions<T>

--- a/packages/server/src/plugins/csrf-guard.ts
+++ b/packages/server/src/plugins/csrf-guard.ts
@@ -9,7 +9,10 @@ import { flattenStandardHeader } from '@standardserver/core'
  * When a request includes cookies, it helps ensure the request originates from JavaScript
  * (for example, fetch/XHR) rather than from standard HTML forms or direct browser navigation.
  *
- * @info This plugin is enabled by default for `RPCHandler` over HTTP.
+ * @remarks
+ * **Note**: This plugin is enabled by default for `RPCHandler` over HTTP.
+ *
+ * @see {@link https://orpc.dev/docs/plugins/csrf-guard | CSRF Guard}
  */
 export class CSRFGuardHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   name = '~csrf-guard'

--- a/packages/server/src/plugins/csrf-guard.ts
+++ b/packages/server/src/plugins/csrf-guard.ts
@@ -12,7 +12,7 @@ import { flattenStandardHeader } from '@standardserver/core'
  * @remarks
  * **Note**: This plugin is enabled by default for `RPCHandler` over HTTP.
  *
- * @see {@link https://orpc.dev/docs/plugins/csrf-guard | CSRF Guard}
+ * @see {@link https://orpc.dev/docs/plugins/csrf-guard | CSRF Guard Plugin}
  */
 export class CSRFGuardHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   name = '~csrf-guard'

--- a/packages/server/src/plugins/request-compression.ts
+++ b/packages/server/src/plugins/request-compression.ts
@@ -8,7 +8,7 @@ import { toFetchHeaders, toStandardBody } from '@standardserver/fetch'
  * Decompresses incoming request bodies based on the Content-Encoding header,
  * supporting gzip, deflate, and deflate-raw.
  *
- * @see {@link https://orpc.dev/docs/plugins/request-compression | Request Compression}
+ * @see {@link https://orpc.dev/docs/plugins/request-compression | Request Compression Plugin}
  */
 export class RequestCompressionHandlerPlugin<T extends Context> implements StandardHandlerPlugin <T> {
   name = '~request-compression'

--- a/packages/server/src/plugins/request-compression.ts
+++ b/packages/server/src/plugins/request-compression.ts
@@ -4,6 +4,12 @@ import { toArray } from '@orpc/shared'
 import { flattenStandardHeader } from '@standardserver/core'
 import { toFetchHeaders, toStandardBody } from '@standardserver/fetch'
 
+/**
+ * Decompresses incoming request bodies based on the Content-Encoding header,
+ * supporting gzip, deflate, and deflate-raw.
+ *
+ * @see {@link https://orpc.dev/docs/plugins/request-compression | Request Compression}
+ */
 export class RequestCompressionHandlerPlugin<T extends Context> implements StandardHandlerPlugin <T> {
   name = '~request-compression'
 

--- a/packages/server/src/plugins/request-headers.ts
+++ b/packages/server/src/plugins/request-headers.ts
@@ -5,7 +5,7 @@ import { toFetchHeaders } from '@standardserver/fetch'
 /**
  * The context shape into which the Request Headers Plugin injects `reqHeaders`.
  *
- * @see {@link https://orpc.dev/docs/plugins/request-headers | Request Headers}
+ * @see {@link https://orpc.dev/docs/plugins/request-headers | Request Headers Plugin}
  */
 export interface RequestHeadersHandlerPluginContext {
   /**
@@ -18,7 +18,7 @@ export interface RequestHeadersHandlerPluginContext {
  * The Request Headers Plugin injects a `reqHeaders` instance into the context,
  * allowing access to request headers in oRPC.
  *
- * @see {@link https://orpc.dev/docs/plugins/request-headers | Request Headers}
+ * @see {@link https://orpc.dev/docs/plugins/request-headers | Request Headers Plugin}
  */
 export class RequestHeadersHandlerPlugin<T extends RequestHeadersHandlerPluginContext> implements StandardHandlerPlugin<T> {
   name = '~request-headers'

--- a/packages/server/src/plugins/request-headers.ts
+++ b/packages/server/src/plugins/request-headers.ts
@@ -2,6 +2,11 @@ import type { StandardHandlerOptions, StandardHandlerPlugin } from '../adapters/
 import { toArray } from '@orpc/shared'
 import { toFetchHeaders } from '@standardserver/fetch'
 
+/**
+ * The context shape into which the Request Headers Plugin injects `reqHeaders`.
+ *
+ * @see {@link https://orpc.dev/docs/plugins/request-headers | Request Headers}
+ */
 export interface RequestHeadersHandlerPluginContext {
   /**
    * Request headers as a Headers instance. This is injected by the Request Headers Plugin.
@@ -13,7 +18,7 @@ export interface RequestHeadersHandlerPluginContext {
  * The Request Headers Plugin injects a `reqHeaders` instance into the context,
  * allowing access to request headers in oRPC.
  *
- * @see {@link https://orpc.dev/docs/plugins/request-headers Request Headers Plugin Docs}
+ * @see {@link https://orpc.dev/docs/plugins/request-headers | Request Headers}
  */
 export class RequestHeadersHandlerPlugin<T extends RequestHeadersHandlerPluginContext> implements StandardHandlerPlugin<T> {
   name = '~request-headers'

--- a/packages/server/src/plugins/request-limit.ts
+++ b/packages/server/src/plugins/request-limit.ts
@@ -18,7 +18,7 @@ export interface RequestLimitHandlerPluginOptions {
  * When used with the request compression plugin, the limit applies to the
  * decompressed payload rather than the compressed wire size.
  *
- * @see {@link https://orpc.dev/docs/plugins/request-limit | Request Limit}
+ * @see {@link https://orpc.dev/docs/plugins/request-limit | Request Limit Plugin}
  */
 export class RequestLimitHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   name = '~request-limit'

--- a/packages/server/src/plugins/request-limit.ts
+++ b/packages/server/src/plugins/request-limit.ts
@@ -18,7 +18,7 @@ export interface RequestLimitHandlerPluginOptions {
  * When used with the request compression plugin, the limit applies to the
  * decompressed payload rather than the compressed wire size.
  *
- * @see {@link https://orpc.dev/docs/plugins/request-limit Request Limit Plugin Docs}
+ * @see {@link https://orpc.dev/docs/plugins/request-limit | Request Limit}
  */
 export class RequestLimitHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   name = '~request-limit'

--- a/packages/server/src/plugins/response-compression.ts
+++ b/packages/server/src/plugins/response-compression.ts
@@ -32,7 +32,7 @@ export interface ResponseCompressionHandlerPluginOptions<_T extends Context> {
  * Compresses response bodies based on the client's Accept-Encoding header.
  * Works at the standard handler level, so it supports all adapters.
  *
- * @see {@link https://orpc.dev/docs/plugins/response-compression Response Compression Plugin Docs}
+ * @see {@link https://orpc.dev/docs/plugins/response-compression | Response Compression}
  */
 export class ResponseCompressionHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   name = '~response-compression'

--- a/packages/server/src/plugins/response-compression.ts
+++ b/packages/server/src/plugins/response-compression.ts
@@ -32,7 +32,7 @@ export interface ResponseCompressionHandlerPluginOptions<_T extends Context> {
  * Compresses response bodies based on the client's Accept-Encoding header.
  * Works at the standard handler level, so it supports all adapters.
  *
- * @see {@link https://orpc.dev/docs/plugins/response-compression | Response Compression}
+ * @see {@link https://orpc.dev/docs/plugins/response-compression | Response Compression Plugin}
  */
 export class ResponseCompressionHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   name = '~response-compression'

--- a/packages/server/src/plugins/response-headers.ts
+++ b/packages/server/src/plugins/response-headers.ts
@@ -3,6 +3,11 @@ import { toArray } from '@orpc/shared'
 import { mergeStandardHeaders } from '@standardserver/core'
 import { toStandardHeaders } from '@standardserver/fetch'
 
+/**
+ * The context shape into which the Response Headers Plugin injects `resHeaders`.
+ *
+ * @see {@link https://orpc.dev/docs/plugins/response-headers | Response Headers}
+ */
 export interface ResponseHeadersHandlerPluginContext {
   /**
    * Response headers as a Headers instance. This is injected by the Response Headers Plugin.
@@ -15,7 +20,7 @@ export interface ResponseHeadersHandlerPluginContext {
  * The Response Headers Plugin allows you to set response headers in oRPC.
  * It injects a resHeaders instance into the context, enabling you to modify response headers easily.
  *
- * @see {@link https://orpc.dev/docs/plugins/response-headers Response Headers Plugin Docs}
+ * @see {@link https://orpc.dev/docs/plugins/response-headers | Response Headers}
  */
 export class ResponseHeadersHandlerPlugin<T extends ResponseHeadersHandlerPluginContext> implements StandardHandlerPlugin<T> {
   name = '~response-headers'

--- a/packages/server/src/plugins/response-headers.ts
+++ b/packages/server/src/plugins/response-headers.ts
@@ -6,7 +6,7 @@ import { toStandardHeaders } from '@standardserver/fetch'
 /**
  * The context shape into which the Response Headers Plugin injects `resHeaders`.
  *
- * @see {@link https://orpc.dev/docs/plugins/response-headers | Response Headers}
+ * @see {@link https://orpc.dev/docs/plugins/response-headers | Response Headers Plugin}
  */
 export interface ResponseHeadersHandlerPluginContext {
   /**
@@ -20,7 +20,7 @@ export interface ResponseHeadersHandlerPluginContext {
  * The Response Headers Plugin allows you to set response headers in oRPC.
  * It injects a resHeaders instance into the context, enabling you to modify response headers easily.
  *
- * @see {@link https://orpc.dev/docs/plugins/response-headers | Response Headers}
+ * @see {@link https://orpc.dev/docs/plugins/response-headers | Response Headers Plugin}
  */
 export class ResponseHeadersHandlerPlugin<T extends ResponseHeadersHandlerPluginContext> implements StandardHandlerPlugin<T> {
   name = '~response-headers'

--- a/packages/server/src/plugins/rethrow.ts
+++ b/packages/server/src/plugins/rethrow.ts
@@ -25,7 +25,7 @@ export interface RethrowHandlerPluginOptions<T extends Context> {
  * and rethrow matching errors directly to your framework's error handling mechanism
  * (e.g., NestJS exception filters, Express error middleware).
  *
- * @see {@link https://orpc.dev/docs/plugins/rethrow Rethrow Plugin Documentation}
+ * @see {@link https://orpc.dev/docs/plugins/rethrow | Rethrow}
  */
 export class RethrowHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   name = '~rethrow'

--- a/packages/server/src/plugins/rethrow.ts
+++ b/packages/server/src/plugins/rethrow.ts
@@ -25,7 +25,7 @@ export interface RethrowHandlerPluginOptions<T extends Context> {
  * and rethrow matching errors directly to your framework's error handling mechanism
  * (e.g., NestJS exception filters, Express error middleware).
  *
- * @see {@link https://orpc.dev/docs/plugins/rethrow | Rethrow}
+ * @see {@link https://orpc.dev/docs/plugins/rethrow | Rethrow Handler Plugin}
  */
 export class RethrowHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   name = '~rethrow'

--- a/packages/server/src/procedure-utils.ts
+++ b/packages/server/src/procedure-utils.ts
@@ -85,7 +85,7 @@ export type CallRest<
  * const output = await call(getting, 'input', { context: { db: 'postgres' } })
  * ```
  *
- * @see {@link https://orpc.dev/docs/client/server-side#one-off-calls | Server-Side}
+ * @see {@link https://orpc.dev/docs/client/server-side#one-off-calls | Server-Side Clients - One-Off Calls}
  */
 export function call<
   TInitialContext extends Context,

--- a/packages/server/src/procedure-utils.ts
+++ b/packages/server/src/procedure-utils.ts
@@ -84,6 +84,8 @@ export type CallRest<
  * const output = await call(getting, 'input')
  * const output = await call(getting, 'input', { context: { db: 'postgres' } })
  * ```
+ *
+ * @see {@link https://orpc.dev/docs/client/server-side#one-off-calls | Server-Side}
  */
 export function call<
   TInitialContext extends Context,

--- a/packages/server/src/procedure.ts
+++ b/packages/server/src/procedure.ts
@@ -55,7 +55,8 @@ export interface ProcedureConfig {
    * When enabled, input schemas are not validated at runtime.
    * Schemas are still used for type inference and OpenAPI generation.
    *
-   * @warning Do not disable validation for schemas that transform values.
+   * @remarks
+   * **Warning**: Do not disable validation for schemas that transform values.
    *
    * @default false
    */
@@ -67,7 +68,8 @@ export interface ProcedureConfig {
    *
    * Useful when output schemas exist only for specification generation.
    *
-   * @warning Do not disable validation for schemas that transform values.
+   * @remarks
+   * **Warning**: Do not disable validation for schemas that transform values.
    *
    * @default false
    */
@@ -116,7 +118,7 @@ export class Procedure<
   }
 
   /**
-   * Checks if the given instance satisfies the {@see Procedure} class/interface.
+   * Checks if the given instance satisfies the {@link Procedure} class/interface.
    */
   static [Symbol.hasInstance](instance: unknown): boolean {
     if (this !== Procedure) {

--- a/packages/server/src/router-client.ts
+++ b/packages/server/src/router-client.ts
@@ -16,7 +16,7 @@ import { getRouter } from './router-utils'
  * The client type derived from a router, exposing every procedure as a callable
  * function while preserving the router's shape.
  *
- * @see {@link https://orpc.dev/docs/client/client-side#creating-a-client | Client-Side}
+ * @see {@link https://orpc.dev/docs/client/client-side#creating-a-client | Client-Side Clients - Creating a Client}
  */
 export type RouterClient<TRouter extends AnyRouter, TClientContext extends ClientContext = object>
   = TRouter extends Procedure<any, any, infer $InputSchema, infer $OutputSchema, infer $ErrorMap, infer $ReturnedError>
@@ -29,7 +29,7 @@ export type RouterClient<TRouter extends AnyRouter, TClientContext extends Clien
  * Creates a server-side client that calls the router's procedures directly,
  * within the same process, without any network layer.
  *
- * @see {@link https://orpc.dev/docs/client/server-side#router-clients | Server-Side}
+ * @see {@link https://orpc.dev/docs/client/server-side#router-clients | Server-Side Clients - Router Clients}
  */
 export function createRouterClient<T extends AnyRouter, TClientContext extends ClientContext = object>(
   router: Lazyable<T | undefined>,

--- a/packages/server/src/router-client.ts
+++ b/packages/server/src/router-client.ts
@@ -12,6 +12,12 @@ import { createProcedureClient } from './procedure-client'
 import { createGuardedProcedureLazy } from './procedure-utils'
 import { getRouter } from './router-utils'
 
+/**
+ * The client type derived from a router, exposing every procedure as a callable
+ * function while preserving the router's shape.
+ *
+ * @see {@link https://orpc.dev/docs/client/client-side#creating-a-client | Client-Side}
+ */
 export type RouterClient<TRouter extends AnyRouter, TClientContext extends ClientContext = object>
   = TRouter extends Procedure<any, any, infer $InputSchema, infer $OutputSchema, infer $ErrorMap, infer $ReturnedError>
     ? ProcedureClient<TClientContext, $InputSchema, $OutputSchema, $ErrorMap, $ReturnedError>
@@ -19,6 +25,12 @@ export type RouterClient<TRouter extends AnyRouter, TClientContext extends Clien
         [K in keyof TRouter]: TRouter[K] extends Lazyable<infer U extends AnyRouter> ? RouterClient<U, TClientContext> : never
       }
 
+/**
+ * Creates a server-side client that calls the router's procedures directly,
+ * within the same process, without any network layer.
+ *
+ * @see {@link https://orpc.dev/docs/client/server-side#router-clients | Server-Side}
+ */
 export function createRouterClient<T extends AnyRouter, TClientContext extends ClientContext = object>(
   router: Lazyable<T | undefined>,
   ...rest: MaybeOptionalOptions<

--- a/packages/server/src/router-utils.ts
+++ b/packages/server/src/router-utils.ts
@@ -328,7 +328,7 @@ export type UnlaziedRouter<T extends AnyRouter>
  * Fully resolves all lazy routers inside a router, returning a plain router.
  * Useful for making a router with lazy parts contract-compatible.
  *
- * @see {@link https://orpc.dev/docs/contract/router#router-to-contract | Router Contract}
+ * @see {@link https://orpc.dev/docs/contract/router#router-to-contract | Router Contract - Router to Contract}
  */
 export async function unlazyRouter<T extends AnyRouter>(router: T): Promise<UnlaziedRouter<T>> {
   if (router instanceof Procedure) {

--- a/packages/server/src/router-utils.ts
+++ b/packages/server/src/router-utils.ts
@@ -324,6 +324,12 @@ export type UnlaziedRouter<T extends AnyRouter>
         [K in keyof T]: T[K] extends Lazyable<infer U extends AnyRouter> ? UnlaziedRouter<U> : never
       }
 
+/**
+ * Fully resolves all lazy routers inside a router, returning a plain router.
+ * Useful for making a router with lazy parts contract-compatible.
+ *
+ * @see {@link https://orpc.dev/docs/contract/router#router-to-contract | Router Contract}
+ */
 export async function unlazyRouter<T extends AnyRouter>(router: T): Promise<UnlaziedRouter<T>> {
   if (router instanceof Procedure) {
     return router as any

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -26,7 +26,7 @@ export type InferRouterInitialContext<T extends AnyRouter> = T extends Router<in
  * @remarks
  * **Note**: A procedure is a router too.
  *
- * @see {@link https://orpc.dev/docs/router#infer-router-initial-contexts | Router}
+ * @see {@link https://orpc.dev/docs/router#infer-router-initial-contexts | Router - Infer Router Initial Contexts}
  */
 export type InferRouterInitialContexts<T extends AnyRouter>
   = T extends Procedure<infer UInitialContext, any, any, any, any, any>
@@ -41,7 +41,7 @@ export type InferRouterInitialContexts<T extends AnyRouter>
  * @remarks
  * **Note**: A procedure is a router too.
  *
- * @see {@link https://orpc.dev/docs/router#infer-router-final-contexts | Router}
+ * @see {@link https://orpc.dev/docs/router#infer-router-final-contexts | Router - Infer Router Final Contexts}
  */
 export type InferRouterFinalContexts<T extends AnyRouter>
   = T extends Procedure<infer UInitialContext, infer UInjectedContext, any, any, any, any>
@@ -56,7 +56,7 @@ export type InferRouterFinalContexts<T extends AnyRouter>
  * @remarks
  * **Note**: A procedure is a router too.
  *
- * @see {@link https://orpc.dev/docs/router#infer-router-inputs | Router}
+ * @see {@link https://orpc.dev/docs/router#infer-router-inputs | Router - Infer Router Inputs}
  */
 export type InferRouterInputs<T extends AnyRouter>
   = T extends Procedure<any, any, infer UInputSchema, any, any, any>
@@ -71,7 +71,7 @@ export type InferRouterInputs<T extends AnyRouter>
  * @remarks
  * **Note**: A procedure is a router too.
  *
- * @see {@link https://orpc.dev/docs/router#infer-router-outputs | Router}
+ * @see {@link https://orpc.dev/docs/router#infer-router-outputs | Router - Infer Router Outputs}
  */
 export type InferRouterOutputs<T extends AnyRouter>
   = T extends Procedure<any, any, any, infer UOutputSchema, any, any>
@@ -83,7 +83,7 @@ export type InferRouterOutputs<T extends AnyRouter>
 /**
  * Infer the union of throwable errors for entire router.
  *
- * @see {@link https://orpc.dev/docs/router#infer-router-error | Router}
+ * @see {@link https://orpc.dev/docs/router#infer-router-error | Router - Infer Router Error}
  */
 export type InferRouterError<T extends AnyRouter>
   = T extends Procedure<any, any, any, any, infer UErrorMap, infer UReturnedError>
@@ -95,7 +95,7 @@ export type InferRouterError<T extends AnyRouter>
 /**
  * Infer throwable errors for each procedure, preserving the router shape.
  *
- * @see {@link https://orpc.dev/docs/router#infer-router-errors | Router}
+ * @see {@link https://orpc.dev/docs/router#infer-router-errors | Router - Infer Router Errors}
  */
 export type InferRouterErrors<T extends AnyRouter>
   = T extends Procedure<any, any, any, any, infer UErrorMap, infer UReturnedError>

--- a/packages/server/src/router.ts
+++ b/packages/server/src/router.ts
@@ -23,8 +23,10 @@ export type InferRouterInitialContext<T extends AnyRouter> = T extends Router<in
 /**
  * Infer all initial context of the router.
  *
- * @info A procedure is a router too.
- * @see {@link https://orpc.dev/docs/router#utilities Router Utilities Docs}
+ * @remarks
+ * **Note**: A procedure is a router too.
+ *
+ * @see {@link https://orpc.dev/docs/router#infer-router-initial-contexts | Router}
  */
 export type InferRouterInitialContexts<T extends AnyRouter>
   = T extends Procedure<infer UInitialContext, any, any, any, any, any>
@@ -36,8 +38,10 @@ export type InferRouterInitialContexts<T extends AnyRouter>
 /**
  * Infer all current context of the router.
  *
- * @info A procedure is a router too.
- * @see {@link https://orpc.dev/docs/router#utilities Router Utilities Docs}
+ * @remarks
+ * **Note**: A procedure is a router too.
+ *
+ * @see {@link https://orpc.dev/docs/router#infer-router-final-contexts | Router}
  */
 export type InferRouterFinalContexts<T extends AnyRouter>
   = T extends Procedure<infer UInitialContext, infer UInjectedContext, any, any, any, any>
@@ -47,10 +51,12 @@ export type InferRouterFinalContexts<T extends AnyRouter>
       }
 
 /**
- * Infer all router inputs
+ * Infer all router inputs.
  *
- * @info A procedure is a router too.
- * @see {@link https://orpc.dev/docs/router#utilities Router Utilities Docs}
+ * @remarks
+ * **Note**: A procedure is a router too.
+ *
+ * @see {@link https://orpc.dev/docs/router#infer-router-inputs | Router}
  */
 export type InferRouterInputs<T extends AnyRouter>
   = T extends Procedure<any, any, infer UInputSchema, any, any, any>
@@ -60,10 +66,12 @@ export type InferRouterInputs<T extends AnyRouter>
       }
 
 /**
- * Infer all router outputs
+ * Infer all router outputs.
  *
- * @info A procedure is a router too.
- * @see {@link https://orpc.dev/docs/router#utilities Router Utilities Docs}
+ * @remarks
+ * **Note**: A procedure is a router too.
+ *
+ * @see {@link https://orpc.dev/docs/router#infer-router-outputs | Router}
  */
 export type InferRouterOutputs<T extends AnyRouter>
   = T extends Procedure<any, any, any, infer UOutputSchema, any, any>
@@ -74,6 +82,8 @@ export type InferRouterOutputs<T extends AnyRouter>
 
 /**
  * Infer the union of throwable errors for entire router.
+ *
+ * @see {@link https://orpc.dev/docs/router#infer-router-error | Router}
  */
 export type InferRouterError<T extends AnyRouter>
   = T extends Procedure<any, any, any, any, infer UErrorMap, infer UReturnedError>
@@ -84,6 +94,8 @@ export type InferRouterError<T extends AnyRouter>
 
 /**
  * Infer throwable errors for each procedure, preserving the router shape.
+ *
+ * @see {@link https://orpc.dev/docs/router#infer-router-errors | Router}
  */
 export type InferRouterErrors<T extends AnyRouter>
   = T extends Procedure<any, any, any, any, infer UErrorMap, infer UReturnedError>

--- a/packages/shared/src/interceptor.ts
+++ b/packages/shared/src/interceptor.ts
@@ -48,7 +48,7 @@ export function onSuccess<T, TOptions extends { next: () => any }, TRest extends
  * Creates an interceptor or middleware that invokes a callback whenever an error
  * is thrown. The error is rethrown after the callback completes.
  *
- * @see {@link https://orpc.dev/docs/adapters/fetch-api | Fetch API}
+ * @see {@link https://orpc.dev/docs/adapters/fetch-api | Fetch API Adapter}
  */
 export function onError<T, TOptions extends { next: () => any }, TRest extends any[]>(
   callback: NoInfer<(

--- a/packages/shared/src/interceptor.ts
+++ b/packages/shared/src/interceptor.ts
@@ -45,7 +45,10 @@ export function onSuccess<T, TOptions extends { next: () => any }, TRest extends
 }
 
 /**
- * Can used for interceptors or middlewares
+ * Creates an interceptor or middleware that invokes a callback whenever an error
+ * is thrown. The error is rethrown after the callback completes.
+ *
+ * @see {@link https://orpc.dev/docs/adapters/fetch-api | Fetch API}
  */
 export function onError<T, TOptions extends { next: () => any }, TRest extends any[]>(
   callback: NoInfer<(

--- a/packages/shared/src/iterator.ts
+++ b/packages/shared/src/iterator.ts
@@ -190,7 +190,7 @@ export interface ConsumeAsyncIteratorOptions<T, TReturn, TError> {
  * **Warning**: If no `onError` or `onFinish` is provided, errors are thrown into the unhandled rejection channel.
  *
  * @returns An unsubscribe callback that stops consuming and cleans up the iterator.
- * @see {@link https://orpc.dev/docs/client/async-iterator-object#using-consumeasynciterator | AsyncIteratorObject (SSE)}
+ * @see {@link https://orpc.dev/docs/client/async-iterator-object#using-consumeasynciterator | AsyncIteratorObject in Client - Using consumeAsyncIterator}
  */
 export function consumeAsyncIterator<T, TReturn, TError = ThrowableError>(
   iterator: AsyncIterator<T, TReturn> | PromiseWithError<AsyncIterator<T, TReturn>, TError>,

--- a/packages/shared/src/iterator.ts
+++ b/packages/shared/src/iterator.ts
@@ -170,22 +170,27 @@ export interface ConsumeAsyncIteratorOptions<T, TReturn, TError> {
   /**
    * Called once AsyncIteratorObject is done
    *
-   * @info If iterator is canceled, `undefined` can be passed on success
+   * @remarks
+   * **Note**: If iterator is canceled, `undefined` can be passed on success
    */
   onSuccess?: (value: TReturn | undefined) => void
   /**
    * Called once after onError or onSuccess
    *
-   * @info If iterator is canceled, `undefined` can be passed on success
+   * @remarks
+   * **Note**: If iterator is canceled, `undefined` can be passed on success
    */
   onFinish?: (state: [error: TError, data: undefined, isSuccess: false] | [error: null, data: TReturn | undefined, isSuccess: true]) => void
 }
 
 /**
- * Consumes an AsyncIteratorObject with lifecycle callbacks
+ * Consumes an AsyncIteratorObject with lifecycle callbacks.
  *
- * @warning If no `onError` or `onFinish` is provided, error will be thrown into unhandled rejection channel.
- * @return unsubscribe callback
+ * @remarks
+ * **Warning**: If no `onError` or `onFinish` is provided, errors are thrown into the unhandled rejection channel.
+ *
+ * @returns An unsubscribe callback that stops consuming and cleans up the iterator.
+ * @see {@link https://orpc.dev/docs/client/async-iterator-object#using-consumeasynciterator | AsyncIteratorObject (SSE)}
  */
 export function consumeAsyncIterator<T, TReturn, TError = ThrowableError>(
   iterator: AsyncIterator<T, TReturn> | PromiseWithError<AsyncIterator<T, TReturn>, TError>,

--- a/packages/shared/src/stream.ts
+++ b/packages/shared/src/stream.ts
@@ -125,6 +125,8 @@ export function traceReadableStream<T>(
 
 /**
  * Converts a {@link ReadableStream} into an {@link AsyncIteratorClass}.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/ai-sdk | AI SDK}
  */
 export function streamToAsyncIteratorObject<T>(
   stream: ReadableStream<T>,
@@ -195,6 +197,8 @@ export function asyncIteratorToStream<T>(
 /**
  * Converts an `AsyncIterator` into a `ReadableStream`, ensuring that
  * all emitted object values are *unproxied* before enqueuing.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/ai-sdk | AI SDK}
  */
 export function asyncIteratorToUnproxiedDataStream<T>(
   iterator: AsyncIterator<T>,

--- a/packages/shared/src/stream.ts
+++ b/packages/shared/src/stream.ts
@@ -126,7 +126,7 @@ export function traceReadableStream<T>(
 /**
  * Converts a {@link ReadableStream} into an {@link AsyncIteratorClass}.
  *
- * @see {@link https://orpc.dev/docs/integrations/ai-sdk | AI SDK}
+ * @see {@link https://orpc.dev/docs/integrations/ai-sdk | AI SDK Integration}
  */
 export function streamToAsyncIteratorObject<T>(
   stream: ReadableStream<T>,
@@ -198,7 +198,7 @@ export function asyncIteratorToStream<T>(
  * Converts an `AsyncIterator` into a `ReadableStream`, ensuring that
  * all emitted object values are *unproxied* before enqueuing.
  *
- * @see {@link https://orpc.dev/docs/integrations/ai-sdk | AI SDK}
+ * @see {@link https://orpc.dev/docs/integrations/ai-sdk | AI SDK Integration}
  */
 export function asyncIteratorToUnproxiedDataStream<T>(
   iterator: AsyncIterator<T>,

--- a/packages/swr/src/key.ts
+++ b/packages/swr/src/key.ts
@@ -19,7 +19,7 @@ export type OperationKey<TInput>
 /**
  * Generate a **full matching** key for SWR operations.
  *
- * @see {@link https://orpc.dev/docs/integrations/swr#data-fetching SWR Key Docs}
+ * @see {@link https://orpc.dev/docs/integrations/swr#data-fetching | SWR Key}
  */
 export function generateOperationKey<TInput>(
   path: string[],

--- a/packages/swr/src/key.ts
+++ b/packages/swr/src/key.ts
@@ -19,7 +19,7 @@ export type OperationKey<TInput>
 /**
  * Generate a **full matching** key for SWR operations.
  *
- * @see {@link https://orpc.dev/docs/integrations/swr#data-fetching | SWR Key}
+ * @see {@link https://orpc.dev/docs/integrations/swr#data-fetching | SWR Integration - Data Fetching}
  */
 export function generateOperationKey<TInput>(
   path: string[],

--- a/packages/swr/src/procedure-utils.ts
+++ b/packages/swr/src/procedure-utils.ts
@@ -25,7 +25,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Calling corresponding procedure client
    *
-   * @see {@link https://orpc.dev/docs/integrations/swr#calling-clients | SWR Calling Procedure Client}
+   * @see {@link https://orpc.dev/docs/integrations/swr#calling-clients | SWR Integration - Calling Clients}
    */
   call: Client<TClientContext, TInput, TOutput, TError>
 
@@ -41,7 +41,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate a **full matching** key for SWR operations.
    *
-   * @see {@link https://orpc.dev/docs/integrations/swr#data-fetching | SWR Key}
+   * @see {@link https://orpc.dev/docs/integrations/swr#data-fetching | SWR Integration - Data Fetching}
    */
   key(
     ...rest: MaybeOptionalOptions<KeyOptions<TInput>>
@@ -54,7 +54,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate a fetcher function for use with useSWR, useSWRInfinite, and other SWR hooks.
    *
-   * @see {@link https://orpc.dev/docs/integrations/swr#data-fetching | SWR Data Fetching}
+   * @see {@link https://orpc.dev/docs/integrations/swr#data-fetching | SWR Integration - Data Fetching}
    */
   fetcher(
     ...rest: MaybeOptionalOptions<FetcherOptions<TClientContext>>
@@ -80,7 +80,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate a subscriber function that subscribes to an [AsyncIteratorObject](https://orpc.dev/docs/async-iterator-object) for use with useSWRSubscription, etc.
    *
-   * @see {@link https://orpc.dev/docs/integrations/swr#subscriptions | SWR Subscriptions}
+   * @see {@link https://orpc.dev/docs/integrations/swr#subscriptions | SWR Integration - Subscriptions}
    */
   subscriber(
     ...rest: MaybeOptionalOptions<SubscriberOptions<TClientContext>>
@@ -173,7 +173,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate a live subscriber that subscribes to the latest events from an [AsyncIteratorObject](https://orpc.dev/docs/async-iterator-object) for use with useSWRSubscription, etc.
    *
-   * @see {@link https://orpc.dev/docs/integrations/swr#subscriptions | SWR Subscriptions}
+   * @see {@link https://orpc.dev/docs/integrations/swr#subscriptions | SWR Integration - Subscriptions}
    */
   liveSubscriber(
     ...rest: MaybeOptionalOptions<FetcherOptions<TClientContext>>
@@ -226,7 +226,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate a mutator function for use with useSWRMutation, etc.
    *
-   * @see {@link https://orpc.dev/docs/integrations/swr#mutations | SWR Mutations}
+   * @see {@link https://orpc.dev/docs/integrations/swr#mutations | SWR Integration - Mutations}
    */
   mutator(
     ...rest: MaybeOptionalOptions<MutatorOptions<TClientContext>>

--- a/packages/swr/src/procedure-utils.ts
+++ b/packages/swr/src/procedure-utils.ts
@@ -25,7 +25,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Calling corresponding procedure client
    *
-   * @see {@link https://orpc.dev/docs/integrations/swr#calling-clients SWR Calling Procedure Client Docs}
+   * @see {@link https://orpc.dev/docs/integrations/swr#calling-clients | SWR Calling Procedure Client}
    */
   call: Client<TClientContext, TInput, TOutput, TError>
 
@@ -41,7 +41,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate a **full matching** key for SWR operations.
    *
-   * @see {@link https://orpc.dev/docs/integrations/swr#data-fetching SWR Key Docs}
+   * @see {@link https://orpc.dev/docs/integrations/swr#data-fetching | SWR Key}
    */
   key(
     ...rest: MaybeOptionalOptions<KeyOptions<TInput>>
@@ -54,7 +54,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate a fetcher function for use with useSWR, useSWRInfinite, and other SWR hooks.
    *
-   * @see {@link https://orpc.dev/docs/integrations/swr#data-fetching SWR Data Fetching Docs}
+   * @see {@link https://orpc.dev/docs/integrations/swr#data-fetching | SWR Data Fetching}
    */
   fetcher(
     ...rest: MaybeOptionalOptions<FetcherOptions<TClientContext>>
@@ -80,7 +80,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate a subscriber function that subscribes to an [AsyncIteratorObject](https://orpc.dev/docs/async-iterator-object) for use with useSWRSubscription, etc.
    *
-   * @see {@link https://orpc.dev/docs/integrations/swr#subscriptions SWR Subscriptions Docs}
+   * @see {@link https://orpc.dev/docs/integrations/swr#subscriptions | SWR Subscriptions}
    */
   subscriber(
     ...rest: MaybeOptionalOptions<SubscriberOptions<TClientContext>>
@@ -173,7 +173,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate a live subscriber that subscribes to the latest events from an [AsyncIteratorObject](https://orpc.dev/docs/async-iterator-object) for use with useSWRSubscription, etc.
    *
-   * @see {@link https://orpc.dev/docs/integrations/swr#subscriptions SWR Subscriptions Docs}
+   * @see {@link https://orpc.dev/docs/integrations/swr#subscriptions | SWR Subscriptions}
    */
   liveSubscriber(
     ...rest: MaybeOptionalOptions<FetcherOptions<TClientContext>>
@@ -226,7 +226,7 @@ export class ProcedureUtils<TClientContext extends ClientContext, TInput, TOutpu
   /**
    * Generate a mutator function for use with useSWRMutation, etc.
    *
-   * @see {@link https://orpc.dev/docs/integrations/swr#mutations SWR Mutations Docs}
+   * @see {@link https://orpc.dev/docs/integrations/swr#mutations | SWR Mutations}
    */
   mutator(
     ...rest: MaybeOptionalOptions<MutatorOptions<TClientContext>>

--- a/packages/swr/src/router-utils.ts
+++ b/packages/swr/src/router-utils.ts
@@ -23,10 +23,13 @@ export interface RouterUtilsOptions extends OperationKeyPrefixOptions {
 }
 
 /**
- * Create a swr router utils from a client.
+ * Creates SWR utils from a client, exposing fetcher/mutator/subscriber
+ * helpers for every procedure in the router.
  *
- * @info Both client-side and server-side clients are supported.
- * @see {@link https://orpc.dev/docs/integrations/swr SWR Integration}
+ * @remarks
+ * **Note**: Both client-side and server-side clients are supported.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/swr | SWR}
  */
 export function createRouterUtils<T extends AnyNestedClient>(
   client: T,

--- a/packages/swr/src/router-utils.ts
+++ b/packages/swr/src/router-utils.ts
@@ -29,7 +29,7 @@ export interface RouterUtilsOptions extends OperationKeyPrefixOptions {
  * @remarks
  * **Note**: Both client-side and server-side clients are supported.
  *
- * @see {@link https://orpc.dev/docs/integrations/swr | SWR}
+ * @see {@link https://orpc.dev/docs/integrations/swr | SWR Integration}
  */
 export function createRouterUtils<T extends AnyNestedClient>(
   client: T,

--- a/packages/swr/src/shared-utils.ts
+++ b/packages/swr/src/shared-utils.ts
@@ -14,7 +14,7 @@ export class SharedUtils<TInput> {
   /**
    * Generate a matcher function that returns `true` if the key matches the specified conditions.
    *
-   * @see {@link https://orpc.dev/docs/integrations/swr#manual-revalidation SWR Manual Revalidation Docs}
+   * @see {@link https://orpc.dev/docs/integrations/swr#manual-revalidation | SWR Manual Revalidation}
    */
   matcher<TStrategy extends MatcherStrategy>(
     ...rest: MaybeOptionalOptions<MatcherOptions<TStrategy, TInput>>

--- a/packages/swr/src/shared-utils.ts
+++ b/packages/swr/src/shared-utils.ts
@@ -14,7 +14,7 @@ export class SharedUtils<TInput> {
   /**
    * Generate a matcher function that returns `true` if the key matches the specified conditions.
    *
-   * @see {@link https://orpc.dev/docs/integrations/swr#manual-revalidation | SWR Manual Revalidation}
+   * @see {@link https://orpc.dev/docs/integrations/swr#manual-revalidation | SWR Integration - Manual Revalidation}
    */
   matcher<TStrategy extends MatcherStrategy>(
     ...rest: MaybeOptionalOptions<MatcherOptions<TStrategy, TInput>>

--- a/packages/swr/src/types.ts
+++ b/packages/swr/src/types.ts
@@ -8,8 +8,20 @@ export type InferLiveSubscriberOutput<TOutput> = TOutput extends AsyncIterable<i
 
 export type OperationType = 'fetcher' | 'mutator' | 'subscriber' | 'liveSubscriber'
 
+/**
+ * The symbol under which SWR utils attach operation details
+ * (key and operation type) to the client context.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/swr#operation-context | SWR}
+ */
 export const OPERATION_CONTEXT_SYMBOL: unique symbol = Symbol.for('ORPC_SWR_OPERATION_CONTEXT')
 
+/**
+ * A client context automatically populated by SWR utils,
+ * exposing the operation key and type of the calling operation.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/swr#operation-context | SWR}
+ */
 export interface OperationContext {
   [OPERATION_CONTEXT_SYMBOL]?: {
     key: unknown

--- a/packages/swr/src/types.ts
+++ b/packages/swr/src/types.ts
@@ -12,7 +12,7 @@ export type OperationType = 'fetcher' | 'mutator' | 'subscriber' | 'liveSubscrib
  * The symbol under which SWR utils attach operation details
  * (key and operation type) to the client context.
  *
- * @see {@link https://orpc.dev/docs/integrations/swr#operation-context | SWR}
+ * @see {@link https://orpc.dev/docs/integrations/swr#operation-context | SWR Integration - Operation Context}
  */
 export const OPERATION_CONTEXT_SYMBOL: unique symbol = Symbol.for('ORPC_SWR_OPERATION_CONTEXT')
 
@@ -20,7 +20,7 @@ export const OPERATION_CONTEXT_SYMBOL: unique symbol = Symbol.for('ORPC_SWR_OPER
  * A client context automatically populated by SWR utils,
  * exposing the operation key and type of the calling operation.
  *
- * @see {@link https://orpc.dev/docs/integrations/swr#operation-context | SWR}
+ * @see {@link https://orpc.dev/docs/integrations/swr#operation-context | SWR Integration - Operation Context}
  */
 export interface OperationContext {
   [OPERATION_CONTEXT_SYMBOL]?: {

--- a/packages/tanstack-query/src/contract-utils.ts
+++ b/packages/tanstack-query/src/contract-utils.ts
@@ -15,6 +15,16 @@ export interface ContractUtilsFactoryOptions<
 > extends Omit<RouterUtilsOptions<RouterContractClient<RouterContract, TClientContext>>, 'path'> {
 }
 
+/**
+ * Creates a factory that builds TanStack Query utils directly from a contract,
+ * using the given contract client factory. Useful for scaling large projects
+ * where each part only needs a slice of the router.
+ *
+ * @remarks
+ * **Note**: The contract must define a `path` meta matching its position in the root router contract.
+ *
+ * @see {@link https://orpc.dev/docs/advanced/scaling-large-projects#tanstack-query-integration | Scaling Large Projects}
+ */
 export function createContractUtilsFactory<
   TClientContext extends ClientContext,
 >(

--- a/packages/tanstack-query/src/contract-utils.ts
+++ b/packages/tanstack-query/src/contract-utils.ts
@@ -23,7 +23,7 @@ export interface ContractUtilsFactoryOptions<
  * @remarks
  * **Note**: The contract must define a `path` meta matching its position in the root router contract.
  *
- * @see {@link https://orpc.dev/docs/advanced/scaling-large-projects#tanstack-query-integration | Scaling Large Projects}
+ * @see {@link https://orpc.dev/docs/advanced/scaling-large-projects#tanstack-query-integration | Scaling Large Projects - TanStack Query Integration}
  */
 export function createContractUtilsFactory<
   TClientContext extends ClientContext,

--- a/packages/tanstack-query/src/meta.ts
+++ b/packages/tanstack-query/src/meta.ts
@@ -25,7 +25,7 @@ export interface TanstackQueryMetaPlugin<
  *
  * Apply them to router utils with {@link ContractOptionsUtilsPlugin}.
  *
- * @see {@link https://orpc.dev/docs/integrations/tanstack-query#contract-options-plugin TanStack Query Contract Options Plugin Docs}
+ * @see {@link https://orpc.dev/docs/integrations/tanstack-query#contract-options-plugin | Tanstack Query}
  */
 export function tanstackQuery<
   TInputSchema extends AnySchema,
@@ -66,7 +66,7 @@ export function getTanstackQueryMeta(
  * The contract shape must match the client the utils are created from,
  * so pass the root router contract when utils paths start from the root.
  *
- * @see {@link https://orpc.dev/docs/integrations/tanstack-query#contract-options-plugin TanStack Query Contract Options Plugin Docs}
+ * @see {@link https://orpc.dev/docs/integrations/tanstack-query#contract-options-plugin | Tanstack Query}
  */
 export class ContractOptionsUtilsPlugin<T extends AnyNestedClient = AnyNestedClient> implements RouterUtilsPlugin<T> {
   readonly name = '~contract-options'

--- a/packages/tanstack-query/src/meta.ts
+++ b/packages/tanstack-query/src/meta.ts
@@ -25,7 +25,7 @@ export interface TanstackQueryMetaPlugin<
  *
  * Apply them to router utils with {@link ContractOptionsUtilsPlugin}.
  *
- * @see {@link https://orpc.dev/docs/integrations/tanstack-query#contract-options-plugin | Tanstack Query}
+ * @see {@link https://orpc.dev/docs/integrations/tanstack-query#contract-options-plugin | TanStack Query Integration - Contract Options Plugin}
  */
 export function tanstackQuery<
   TInputSchema extends AnySchema,
@@ -66,7 +66,7 @@ export function getTanstackQueryMeta(
  * The contract shape must match the client the utils are created from,
  * so pass the root router contract when utils paths start from the root.
  *
- * @see {@link https://orpc.dev/docs/integrations/tanstack-query#contract-options-plugin | Tanstack Query}
+ * @see {@link https://orpc.dev/docs/integrations/tanstack-query#contract-options-plugin | TanStack Query Integration - Contract Options Plugin}
  */
 export class ContractOptionsUtilsPlugin<T extends AnyNestedClient = AnyNestedClient> implements RouterUtilsPlugin<T> {
   readonly name = '~contract-options'

--- a/packages/tanstack-query/src/router-utils.ts
+++ b/packages/tanstack-query/src/router-utils.ts
@@ -9,6 +9,12 @@ import { CompositeRouterUtilsPlugin } from './plugin'
 import { isProcedureUtilsOptions, mergeProcedureUtilsOptions, ProcedureUtils } from './procedure-utils'
 import { SharedUtils } from './shared-utils'
 
+/**
+ * The utils shape derived from a client: procedure clients map to procedure
+ * utils, and routers map recursively to nested utils.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/tanstack-query | Tanstack Query}
+ */
 export type RouterUtils<T extends AnyNestedClient>
   = T extends Client<infer UClientContext, infer UInput, infer UOutput, infer UError>
     ? Public<ProcedureUtils<UClientContext, UInput, UOutput, UError>>
@@ -70,9 +76,13 @@ export interface RouterUtilsOptions<T extends AnyNestedClient> extends Operation
 }
 
 /**
- * Create a router utils from a client.
+ * Creates TanStack Query utils from a client, exposing query/mutation
+ * option builders for every procedure in the router.
  *
- * @info Both client-side and server-side clients are supported.
+ * @remarks
+ * **Note**: Both client-side and server-side clients are supported.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/tanstack-query | Tanstack Query}
  */
 export function createRouterUtils<T extends AnyNestedClient>(
   client: T,

--- a/packages/tanstack-query/src/router-utils.ts
+++ b/packages/tanstack-query/src/router-utils.ts
@@ -13,7 +13,7 @@ import { SharedUtils } from './shared-utils'
  * The utils shape derived from a client: procedure clients map to procedure
  * utils, and routers map recursively to nested utils.
  *
- * @see {@link https://orpc.dev/docs/integrations/tanstack-query | Tanstack Query}
+ * @see {@link https://orpc.dev/docs/integrations/tanstack-query | TanStack Query Integration}
  */
 export type RouterUtils<T extends AnyNestedClient>
   = T extends Client<infer UClientContext, infer UInput, infer UOutput, infer UError>
@@ -82,7 +82,7 @@ export interface RouterUtilsOptions<T extends AnyNestedClient> extends Operation
  * @remarks
  * **Note**: Both client-side and server-side clients are supported.
  *
- * @see {@link https://orpc.dev/docs/integrations/tanstack-query | Tanstack Query}
+ * @see {@link https://orpc.dev/docs/integrations/tanstack-query | TanStack Query Integration}
  */
 export function createRouterUtils<T extends AnyNestedClient>(
   client: T,

--- a/packages/tanstack-query/src/types.ts
+++ b/packages/tanstack-query/src/types.ts
@@ -7,8 +7,20 @@ export type InferLiveQueryOutput<TOutput> = TOutput extends AsyncIterable<infer 
 
 export type OperationType = 'query' | 'streamed' | 'live' | 'infinite' | 'mutation'
 
+/**
+ * The symbol under which TanStack Query utils attach operation details
+ * (key and operation type) to the client context.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/tanstack-query#client-context | Tanstack Query}
+ */
 export const OPERATION_CONTEXT_SYMBOL: unique symbol = Symbol.for('ORPC_TANSTACK_QUERY_OPERATION_CONTEXT') as any
 
+/**
+ * A client context automatically populated by TanStack Query utils,
+ * exposing the operation key and type of the calling operation.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/tanstack-query#client-context | Tanstack Query}
+ */
 export interface OperationContext {
   [OPERATION_CONTEXT_SYMBOL]?: {
     key: QueryKey

--- a/packages/tanstack-query/src/types.ts
+++ b/packages/tanstack-query/src/types.ts
@@ -11,7 +11,7 @@ export type OperationType = 'query' | 'streamed' | 'live' | 'infinite' | 'mutati
  * The symbol under which TanStack Query utils attach operation details
  * (key and operation type) to the client context.
  *
- * @see {@link https://orpc.dev/docs/integrations/tanstack-query#client-context | Tanstack Query}
+ * @see {@link https://orpc.dev/docs/integrations/tanstack-query#client-context | TanStack Query Integration - Client Context}
  */
 export const OPERATION_CONTEXT_SYMBOL: unique symbol = Symbol.for('ORPC_TANSTACK_QUERY_OPERATION_CONTEXT') as any
 
@@ -19,7 +19,7 @@ export const OPERATION_CONTEXT_SYMBOL: unique symbol = Symbol.for('ORPC_TANSTACK
  * A client context automatically populated by TanStack Query utils,
  * exposing the operation key and type of the calling operation.
  *
- * @see {@link https://orpc.dev/docs/integrations/tanstack-query#client-context | Tanstack Query}
+ * @see {@link https://orpc.dev/docs/integrations/tanstack-query#client-context | TanStack Query Integration - Client Context}
  */
 export interface OperationContext {
   [OPERATION_CONTEXT_SYMBOL]?: {

--- a/packages/trpc/src/to-orpc-router.ts
+++ b/packages/trpc/src/to-orpc-router.ts
@@ -34,7 +34,7 @@ export type ToORPCRouterResult<TContext extends ORPC.Context, TRecord extends Re
  * @remarks
  * **Note**: tRPC Error Formatting is not supported — errors thrown by tRPC are wrapped in `ORPCError`.
  *
- * @see {@link https://orpc.dev/docs/integrations/trpc | tRPC}
+ * @see {@link https://orpc.dev/docs/integrations/trpc | tRPC Integration}
  */
 export function toORPCRouter<T extends AnyRouter>(
   router: T,

--- a/packages/trpc/src/to-orpc-router.ts
+++ b/packages/trpc/src/to-orpc-router.ts
@@ -29,7 +29,12 @@ export type ToORPCRouterResult<TContext extends ORPC.Context, TRecord extends Re
   }
 
 /**
- * Convert a tRPC router to an oRPC router.
+ * Converts a tRPC router into an oRPC router that works with any oRPC feature.
+ *
+ * @remarks
+ * **Note**: tRPC Error Formatting is not supported — errors thrown by tRPC are wrapped in `ORPCError`.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/trpc | tRPC}
  */
 export function toORPCRouter<T extends AnyRouter>(
   router: T,

--- a/packages/trpc/src/to-trpc-meta.ts
+++ b/packages/trpc/src/to-trpc-meta.ts
@@ -28,7 +28,7 @@ import { resolveMetaPlugins } from '@orpc/contract'
  *   .mutation(() => 'Hello, World!')
  * ```
  *
- * @see {@link https://orpc.dev/docs/integrations/trpc | tRPC}
+ * @see {@link https://orpc.dev/docs/integrations/trpc | tRPC Integration}
  */
 export function toTRPCMeta(...plugins: AnyMetaPlugin[]): Record<string, any> {
   const [meta] = resolveMetaPlugins({}, undefined, plugins)

--- a/packages/trpc/src/to-trpc-meta.ts
+++ b/packages/trpc/src/to-trpc-meta.ts
@@ -7,6 +7,10 @@ import { resolveMetaPlugins } from '@orpc/contract'
  * This simulates how oRPC builders apply meta plugins, so well-known plugins
  * like `openapi` from `@orpc/openapi` can be used with tRPC builders.
  *
+ * @remarks
+ * **Warning**: Chained tRPC `.meta` calls merge shallowly, so oRPC metadata merge logic
+ * (e.g. accumulating openapi `tags`) only works within a single `toTRPCMeta` call.
+ *
  * @example
  * ```ts
  * const example = t.procedure
@@ -24,9 +28,7 @@ import { resolveMetaPlugins } from '@orpc/contract'
  *   .mutation(() => 'Hello, World!')
  * ```
  *
- * @warning Chained tRPC `.meta` calls merge shallowly, so oRPC metadata merge logic
- * (e.g. accumulating openapi `tags`) only works within a single `toTRPCMeta`
- * call.
+ * @see {@link https://orpc.dev/docs/integrations/trpc | tRPC}
  */
 export function toTRPCMeta(...plugins: AnyMetaPlugin[]): Record<string, any> {
   const [meta] = resolveMetaPlugins({}, undefined, plugins)

--- a/packages/valibot/src/converter.ts
+++ b/packages/valibot/src/converter.ts
@@ -21,7 +21,7 @@ export interface ValibotToJsonSchemaConverterOptions extends Omit<ConversionConf
  * Converts Valibot schemas into JSON Schema using Valibot's built-in `toJsonSchema`,
  * with additional support for types such as `v.bigint()`, `v.date()`, `v.set()`, and `v.map()`.
  *
- * @see {@link https://orpc.dev/docs/integrations/valibot | Valibot}
+ * @see {@link https://orpc.dev/docs/integrations/valibot | Valibot Integration}
  */
 export class ValibotToJsonSchemaConverter implements JsonSchemaConverter {
   private readonly conversionConfig: ConversionConfig

--- a/packages/valibot/src/converter.ts
+++ b/packages/valibot/src/converter.ts
@@ -17,6 +17,12 @@ export interface ValibotToJsonSchemaConverterOptions extends Omit<ConversionConf
   cache?: boolean
 }
 
+/**
+ * Converts Valibot schemas into JSON Schema using Valibot's built-in `toJsonSchema`,
+ * with additional support for types such as `v.bigint()`, `v.date()`, `v.set()`, and `v.map()`.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/valibot | Valibot}
+ */
 export class ValibotToJsonSchemaConverter implements JsonSchemaConverter {
   private readonly conversionConfig: ConversionConfig
   private readonly cache: undefined | { [d in JsonSchemaConverterDirection]: WeakMap<BaseSchema<any, any, any>, [jsonSchema: JsonSchema, optional: boolean]> }

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -17,6 +17,12 @@ export interface ZodToJsonSchemaConverterOptions extends Omit<ToJSONSchemaParams
   cache?: boolean
 }
 
+/**
+ * Converts Zod schemas into JSON Schema using Zod's built-in `toJSONSchema`,
+ * with additional support for types such as `z.bigint()`, `z.date()`, `z.set()`, and `z.map()`.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/zod | Zod}
+ */
 export class ZodToJsonSchemaConverter implements JsonSchemaConverter {
   private readonly toJSONSchemaParams: ToJSONSchemaParams
   private readonly cache: undefined | { [d in JsonSchemaConverterDirection]: WeakMap<$ZodType, [jsonSchema: JsonSchema, optional: boolean]> }

--- a/packages/zod/src/converter.ts
+++ b/packages/zod/src/converter.ts
@@ -21,7 +21,7 @@ export interface ZodToJsonSchemaConverterOptions extends Omit<ToJSONSchemaParams
  * Converts Zod schemas into JSON Schema using Zod's built-in `toJSONSchema`,
  * with additional support for types such as `z.bigint()`, `z.date()`, `z.set()`, and `z.map()`.
  *
- * @see {@link https://orpc.dev/docs/integrations/zod | Zod}
+ * @see {@link https://orpc.dev/docs/integrations/zod | Zod Integration}
  */
 export class ZodToJsonSchemaConverter implements JsonSchemaConverter {
   private readonly toJSONSchemaParams: ToJSONSchemaParams

--- a/packages/zod/src/registries.ts
+++ b/packages/zod/src/registries.ts
@@ -19,7 +19,7 @@ import { registry } from 'zod/v4/core'
  * })
  * ```
  *
- * @see {@link https://orpc.dev/docs/integrations/zod | Zod}
+ * @see {@link https://orpc.dev/docs/integrations/zod | Zod Integration}
  */
 export const JSON_SCHEMA_REGISTRY = registry<Exclude<JsonSchema<$input | $output>, boolean>>()
 
@@ -40,7 +40,7 @@ export const JSON_SCHEMA_REGISTRY = registry<Exclude<JsonSchema<$input | $output
  * })
  * ```
  *
- * @see {@link https://orpc.dev/docs/integrations/zod | Zod}
+ * @see {@link https://orpc.dev/docs/integrations/zod | Zod Integration}
  */
 export const JSON_SCHEMA_INPUT_REGISTRY = registry<Exclude<JsonSchema<$input>, boolean>>()
 
@@ -61,6 +61,6 @@ export const JSON_SCHEMA_INPUT_REGISTRY = registry<Exclude<JsonSchema<$input>, b
  * })
  * ```
  *
- * @see {@link https://orpc.dev/docs/integrations/zod | Zod}
+ * @see {@link https://orpc.dev/docs/integrations/zod | Zod Integration}
  */
 export const JSON_SCHEMA_OUTPUT_REGISTRY = registry<Exclude<JsonSchema<$output>, boolean>>()

--- a/packages/zod/src/registries.ts
+++ b/packages/zod/src/registries.ts
@@ -18,6 +18,8 @@ import { registry } from 'zod/v4/core'
  *   examples: [{ name: 'John', age: 20 }],
  * })
  * ```
+ *
+ * @see {@link https://orpc.dev/docs/integrations/zod | Zod}
  */
 export const JSON_SCHEMA_REGISTRY = registry<Exclude<JsonSchema<$input | $output>, boolean>>()
 
@@ -37,6 +39,8 @@ export const JSON_SCHEMA_REGISTRY = registry<Exclude<JsonSchema<$input | $output
  *   examples: [{ name: 'John', age: "20" }],
  * })
  * ```
+ *
+ * @see {@link https://orpc.dev/docs/integrations/zod | Zod}
  */
 export const JSON_SCHEMA_INPUT_REGISTRY = registry<Exclude<JsonSchema<$input>, boolean>>()
 
@@ -56,5 +60,7 @@ export const JSON_SCHEMA_INPUT_REGISTRY = registry<Exclude<JsonSchema<$input>, b
  *   examples: [{ name: 'John', age: 20 }],
  * })
  * ```
+ *
+ * @see {@link https://orpc.dev/docs/integrations/zod | Zod}
  */
 export const JSON_SCHEMA_OUTPUT_REGISTRY = registry<Exclude<JsonSchema<$output>, boolean>>()

--- a/scripts/verify-docs-jsdoc.ts
+++ b/scripts/verify-docs-jsdoc.ts
@@ -40,8 +40,12 @@ interface Issue {
   severity: 'error' | 'warning'
   code: string
   message: string
-  mention: Mention
+  /** Display group, e.g. the mention's specifier or `packages/<dir>` for scanned links. */
+  group: string
+  /** Display label, e.g. the mentioned symbol name or `link` for scanned links. */
+  label: string
   location?: string
+  note?: string
 }
 
 async function findFiles(dir: string, extension: string): Promise<string[]> {
@@ -336,7 +340,15 @@ function checkMention(
   const jsDocText = declarations.map(getJsDocText).filter(Boolean).join('\n')
 
   const report = (severity: 'error' | 'warning', code: string, message: string): void => {
-    issues.push({ severity, code, message, mention, location })
+    issues.push({
+      severity,
+      code,
+      message,
+      group: mention.specifier,
+      label: mention.name,
+      location,
+      note: `mentioned in: ${[...mention.pages].sort().slice(0, 3).join(', ')}`,
+    })
   }
 
   if (!jsDocText.trim()) {
@@ -393,6 +405,74 @@ function checkMention(
       report('warning', 'W2', description)
     }
   }
+}
+
+const ORPC_DOCS_URL_RE = /https:\/\/orpc\.dev\/docs\/[^\s)}\]|'"`]+/g
+
+/**
+ * Validates that every `https://orpc.dev/docs/...` URL appearing anywhere in package
+ * sources (inline markdown links, member-level docs, ...) points to an existing
+ * content page and heading. Existence only — titles are enforced on `@see` tags.
+ */
+async function scanSourceLinks(context: CheckContext, filterDirs: Set<string> | undefined): Promise<number> {
+  let scanned = 0
+  const entries = await readdir(PACKAGES_DIR, { withFileTypes: true })
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || (filterDirs && !filterDirs.has(entry.name))) {
+      continue
+    }
+
+    const srcDir = path.join(PACKAGES_DIR, entry.name, 'src')
+    let files: string[]
+
+    try {
+      files = [...await findFiles(srcDir, '.ts'), ...await findFiles(srcDir, '.tsx')]
+    }
+    catch {
+      continue
+    }
+
+    for (const file of files) {
+      if (/\.(?:test|test-d|bench)\./.test(file) || file.includes('__tests__') || file.includes('__mocks__')) {
+        continue
+      }
+
+      const lines = (await readFile(file, 'utf8')).split('\n')
+
+      for (const [index, line] of lines.entries()) {
+        for (const match of line.matchAll(ORPC_DOCS_URL_RE)) {
+          const url = match[0].replace(/[.,;:]+$/, '')
+          scanned += 1
+
+          const report = (code: string, message: string): void => {
+            context.issues.push({
+              severity: 'error',
+              code,
+              message,
+              group: `packages/${entry.name}`,
+              label: 'link',
+              location: `${path.relative(ROOT_DIR, file)}:${index + 1}`,
+            })
+          }
+
+          const [pagePath = '', anchor] = url.slice(DOCS_URL_PREFIX.length).split('#')
+          const page = context.pages.get(pagePath)
+
+          if (!page) {
+            report('E4', `link page "${pagePath}" has no apps/content/docs/${pagePath}.md`)
+            continue
+          }
+
+          if (anchor !== undefined && !page.slugs.has(anchor)) {
+            report('E5', `anchor "#${anchor}" not found in apps/content/docs/${pagePath}.md`)
+          }
+        }
+      }
+    }
+  }
+
+  return scanned
 }
 
 async function main(): Promise<void> {
@@ -490,7 +570,8 @@ async function main(): Promise<void> {
         severity: 'error',
         code: 'E1',
         message: `docs import from unknown entrypoint "${mention.specifier}"`,
-        mention,
+        group: mention.specifier,
+        label: mention.name,
       })
       continue
     }
@@ -504,7 +585,8 @@ async function main(): Promise<void> {
         severity: 'error',
         code: 'E1',
         message: `"${mention.name}" is not exported from ${mention.specifier}`,
-        mention,
+        group: mention.specifier,
+        label: mention.name,
       })
       continue
     }
@@ -521,30 +603,30 @@ async function main(): Promise<void> {
     checkMention(context, mention, declarations)
   }
 
+  const scannedLinks = await scanSourceLinks(context, filterDirs)
+
   const errors = context.issues.filter(issue => issue.severity === 'error')
   const warnings = context.issues.filter(issue => issue.severity === 'warning')
-  const bySpecifier = new Map<string, Issue[]>()
+  const byGroup = new Map<string, Issue[]>()
 
   for (const issue of context.issues) {
-    const group = bySpecifier.get(issue.mention.specifier) ?? []
+    const group = byGroup.get(issue.group) ?? []
     group.push(issue)
-    bySpecifier.set(issue.mention.specifier, group)
+    byGroup.set(issue.group, group)
   }
 
-  for (const [specifier, issues] of [...bySpecifier.entries()].sort(([a], [b]) => a.localeCompare(b))) {
-    console.log(`\n${specifier}`)
+  for (const [group, issues] of [...byGroup.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    console.log(`\n${group}`)
 
     for (const issue of issues) {
-      const label = issue.severity === 'error' ? 'error' : 'warn '
-      const location = issue.location ?? '(unresolved)'
-      const pagesNote = [...issue.mention.pages].sort().slice(0, 3).join(', ')
-      console.log(`  ${label} [${issue.code}] ${issue.mention.name}  ${location}`)
-      console.log(`        ${issue.message} (mentioned in: ${pagesNote})`)
+      const severityLabel = issue.severity === 'error' ? 'error' : 'warn '
+      console.log(`  ${severityLabel} [${issue.code}] ${issue.label}  ${issue.location ?? '(unresolved)'}`)
+      console.log(`        ${issue.message}${issue.note ? ` (${issue.note})` : ''}`)
     }
   }
 
   const allowlistNote = allowlisted > 0 ? `, ${allowlisted} allowlisted` : ''
-  console.log(`\n${errors.length} errors, ${warnings.length} warnings across ${selected.length} docs-mentioned symbols${allowlistNote}`)
+  console.log(`\n${errors.length} errors, ${warnings.length} warnings across ${selected.length} docs-mentioned symbols and ${scannedLinks} orpc.dev links${allowlistNote}`)
 
   if (errors.length > 0) {
     process.exitCode = 1

--- a/scripts/verify-docs-jsdoc.ts
+++ b/scripts/verify-docs-jsdoc.ts
@@ -12,8 +12,9 @@ import ts from 'typescript'
  */
 
 const ROOT_DIR = process.cwd()
-const DOCS_DIR = path.join(ROOT_DIR, 'apps/content/docs')
+const CONTENT_DIR = path.join(ROOT_DIR, 'apps/content')
 const PACKAGES_DIR = path.join(ROOT_DIR, 'packages')
+const SITE_URL_PREFIX = 'https://orpc.dev/'
 const DOCS_URL_PREFIX = 'https://orpc.dev/docs/'
 
 /**
@@ -48,6 +49,8 @@ interface Issue {
   note?: string
 }
 
+const SKIP_DIRS = new Set(['node_modules', '.vitepress', 'public', 'dist'])
+
 async function findFiles(dir: string, extension: string): Promise<string[]> {
   const entries = await readdir(dir, { withFileTypes: true })
   const result: string[] = []
@@ -56,6 +59,10 @@ async function findFiles(dir: string, extension: string): Promise<string[]> {
     const fullPath = path.join(dir, entry.name)
 
     if (entry.isDirectory()) {
+      if (SKIP_DIRS.has(entry.name)) {
+        continue
+      }
+
       result.push(...await findFiles(fullPath, extension))
     }
     else if (entry.isFile() && entry.name.endsWith(extension)) {
@@ -187,20 +194,28 @@ function extractHeadings(outsideFenceLines: string[]): { title: string, slugs: M
   return { title, slugs }
 }
 
+/**
+ * Collects every content page (keyed by site path, `''` for the homepage) and, for
+ * `docs/` pages only, the `@orpc/*` APIs their code fences import.
+ */
 async function collectDocs(): Promise<{ mentions: Map<string, Mention>, pages: Map<string, DocPage> }> {
   const mentions = new Map<string, Mention>()
   const pages = new Map<string, DocPage>()
 
-  for (const file of await findFiles(DOCS_DIR, '.md')) {
+  for (const file of await findFiles(CONTENT_DIR, '.md')) {
     const raw = await readFile(file, 'utf8')
-    const relPage = path.relative(DOCS_DIR, file).replace(/\.md$/, '').replaceAll(path.sep, '/')
+    const relPage = path.relative(CONTENT_DIR, file).replace(/\.md$/, '').replaceAll(path.sep, '/')
     const { code, outside } = extractCodeFences(raw)
 
-    pages.set(relPage.replace(/\/index$/, '') || 'index', {
+    pages.set(relPage === 'index' ? '' : relPage.replace(/\/index$/, ''), {
       file,
       raw,
       ...extractHeadings(outside),
     })
+
+    if (!relPage.startsWith('docs/')) {
+      continue
+    }
 
     for (const fence of code) {
       for (const [specifier, names] of collectImportedNames(fence)) {
@@ -370,16 +385,16 @@ function checkMention(
       continue
     }
 
-    const [pagePath = '', anchor] = url.slice(DOCS_URL_PREFIX.length).split('#')
+    const [pagePath = '', anchor] = url.slice(SITE_URL_PREFIX.length).split('#')
     const page = pages.get(pagePath)
 
     if (!page) {
-      report('error', 'E4', `backlink page "${pagePath}" has no apps/content/docs/${pagePath}.md`)
+      report('error', 'E4', `backlink page "${pagePath}" has no apps/content/${pagePath}.md`)
       continue
     }
 
     if (anchor !== undefined && !page.slugs.has(anchor)) {
-      report('error', 'E5', `anchor "#${anchor}" not found in apps/content/docs/${pagePath}.md`)
+      report('error', 'E5', `anchor "#${anchor}" not found in apps/content/${pagePath}.md`)
       continue
     }
 
@@ -407,10 +422,10 @@ function checkMention(
   }
 }
 
-const ORPC_DOCS_URL_RE = /https:\/\/orpc\.dev\/docs\/[^\s)}\]|'"`]+/g
+const ORPC_URL_RE = /https:\/\/orpc\.dev[^\s)}\]|'"`]*/g
 
 /**
- * Validates that every `https://orpc.dev/docs/...` URL appearing anywhere in package
+ * Validates that every `https://orpc.dev...` URL appearing anywhere in package
  * sources (inline markdown links, member-level docs, ...) points to an existing
  * content page and heading. Existence only — titles are enforced on `@see` tags.
  */
@@ -441,7 +456,7 @@ async function scanSourceLinks(context: CheckContext, filterDirs: Set<string> | 
       const lines = (await readFile(file, 'utf8')).split('\n')
 
       for (const [index, line] of lines.entries()) {
-        for (const match of line.matchAll(ORPC_DOCS_URL_RE)) {
+        for (const match of line.matchAll(ORPC_URL_RE)) {
           const url = match[0].replace(/[.,;:]+$/, '')
           scanned += 1
 
@@ -456,16 +471,17 @@ async function scanSourceLinks(context: CheckContext, filterDirs: Set<string> | 
             })
           }
 
-          const [pagePath = '', anchor] = url.slice(DOCS_URL_PREFIX.length).split('#')
+          const [rawPath = '', anchor] = url.slice(SITE_URL_PREFIX.length - 1).split('#')
+          const pagePath = rawPath.replace(/^\/+/, '').replace(/\/+$/, '')
           const page = context.pages.get(pagePath)
 
           if (!page) {
-            report('E4', `link page "${pagePath}" has no apps/content/docs/${pagePath}.md`)
+            report('E4', `link page "/${pagePath}" has no apps/content/${pagePath || 'index'}.md`)
             continue
           }
 
           if (anchor !== undefined && !page.slugs.has(anchor)) {
-            report('E5', `anchor "#${anchor}" not found in apps/content/docs/${pagePath}.md`)
+            report('E5', `anchor "#${anchor}" not found in apps/content/${pagePath || 'index'}.md`)
           }
         }
       }

--- a/scripts/verify-docs-jsdoc.ts
+++ b/scripts/verify-docs-jsdoc.ts
@@ -1,0 +1,532 @@
+import { readdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import { parseArgs } from 'node:util'
+import ts from 'typescript'
+
+/**
+ * Verifies that every `@orpc/*` API mentioned in the docs content (apps/content/docs)
+ * carries a JSDoc comment with a valid backlink to https://orpc.dev on its declaration.
+ *
+ * Usage: node scripts/verify-docs-jsdoc.ts [--filter server,client] [--strict] [--list]
+ */
+
+const ROOT_DIR = process.cwd()
+const DOCS_DIR = path.join(ROOT_DIR, 'apps/content/docs')
+const PACKAGES_DIR = path.join(ROOT_DIR, 'packages')
+const DOCS_URL_PREFIX = 'https://orpc.dev/docs/'
+
+/**
+ * Justified exceptions, keyed by `<specifier>#<name>`, value is the reason.
+ */
+const ALLOWLIST: Record<string, string> = {}
+
+interface Mention {
+  specifier: string
+  name: string
+  pages: Set<string>
+}
+
+interface DocPage {
+  file: string
+  raw: string
+  slugs: Set<string>
+}
+
+interface Issue {
+  severity: 'error' | 'warning'
+  code: string
+  message: string
+  mention: Mention
+  location?: string
+}
+
+async function findFiles(dir: string, extension: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true })
+  const result: string[] = []
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      result.push(...await findFiles(fullPath, extension))
+    }
+    else if (entry.isFile() && entry.name.endsWith(extension)) {
+      result.push(fullPath)
+    }
+  }
+
+  return result.sort()
+}
+
+const FENCE_OPEN_RE = /^\s*(`{3,})(\S*)/
+const CODE_LANGS = new Set(['ts', 'typescript', 'tsx', 'js', 'jsx', 'vue', 'svelte'])
+
+function extractCodeFences(markdown: string): { code: string[], outside: string[] } {
+  const code: string[] = []
+  const outside: string[] = []
+  let fence: { marker: string, lines: string[], isCode: boolean } | undefined
+
+  for (const line of markdown.split('\n')) {
+    if (fence) {
+      const close = line.match(/^\s*(`{3,})\s*$/)
+
+      if (close && close[1]!.length >= fence.marker.length) {
+        if (fence.isCode) {
+          code.push(fence.lines.join('\n'))
+        }
+        fence = undefined
+        continue
+      }
+
+      fence.lines.push(line)
+      continue
+    }
+
+    const open = line.match(FENCE_OPEN_RE)
+
+    if (open) {
+      const lang = open[2]!.split(/[\s[{:]/)[0] ?? ''
+      fence = { marker: open[1]!, lines: [], isCode: CODE_LANGS.has(lang) }
+      continue
+    }
+
+    outside.push(line)
+  }
+
+  return { code, outside }
+}
+
+const IMPORT_RE = /import\s+(?:type\s+)?(?:[\w$]+\s*,\s*)?\{([^}]+)\}\s*from\s*['"](@orpc\/[^'"]+)['"]/g
+
+function collectImportedNames(code: string): Map<string, Set<string>> {
+  const result = new Map<string, Set<string>>()
+
+  for (const match of code.matchAll(IMPORT_RE)) {
+    const specifier = match[2]!
+    let names = result.get(specifier)
+
+    if (!names) {
+      names = new Set()
+      result.set(specifier, names)
+    }
+
+    for (const rawName of match[1]!.split(',')) {
+      const name = rawName.trim().replace(/^type\s+/, '').split(/\s+as\s+/)[0]?.trim()
+
+      if (name && /^[\w$]+$/.test(name)) {
+        names.add(name)
+      }
+    }
+  }
+
+  return result
+}
+
+/**
+ * Mirrors VitePress' default heading slugification (lowercase, strip punctuation,
+ * spaces to dashes) closely enough to validate anchors.
+ */
+function slugify(text: string): string {
+  return text
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036F]/g, '')
+    .replace(/[!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .toLowerCase()
+}
+
+function extractHeadingSlugs(outsideFenceLines: string[]): Set<string> {
+  const slugs = new Set<string>()
+  const counts = new Map<string, number>()
+
+  for (const line of outsideFenceLines) {
+    const heading = line.match(/^#{1,6}\s(.*)$/)
+
+    if (!heading) {
+      continue
+    }
+
+    let text = heading[1]!.trim()
+    const custom = text.match(/\{#([\w-]+)\}\s*$/)
+
+    if (custom) {
+      slugs.add(custom[1]!)
+      continue
+    }
+
+    text = text
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+      .replace(/[`*]/g, '')
+
+    const slug = slugify(text)
+    const count = counts.get(slug) ?? 0
+    counts.set(slug, count + 1)
+    slugs.add(count === 0 ? slug : `${slug}-${count}`)
+  }
+
+  return slugs
+}
+
+async function collectDocs(): Promise<{ mentions: Map<string, Mention>, pages: Map<string, DocPage> }> {
+  const mentions = new Map<string, Mention>()
+  const pages = new Map<string, DocPage>()
+
+  for (const file of await findFiles(DOCS_DIR, '.md')) {
+    const raw = await readFile(file, 'utf8')
+    const relPage = path.relative(DOCS_DIR, file).replace(/\.md$/, '').replaceAll(path.sep, '/')
+    const { code, outside } = extractCodeFences(raw)
+
+    pages.set(relPage.replace(/\/index$/, '') || 'index', {
+      file,
+      raw,
+      slugs: extractHeadingSlugs(outside),
+    })
+
+    for (const fence of code) {
+      for (const [specifier, names] of collectImportedNames(fence)) {
+        for (const name of names) {
+          const key = `${specifier}#${name}`
+          let mention = mentions.get(key)
+
+          if (!mention) {
+            mention = { specifier, name, pages: new Set() }
+            mentions.set(key, mention)
+          }
+
+          mention.pages.add(relPage)
+        }
+      }
+    }
+  }
+
+  return { mentions, pages }
+}
+
+interface Entrypoints {
+  /** `@orpc/name[/sub]` -> absolute source file */
+  specifierToFile: Map<string, string>
+  /** `@orpc/name` -> package directory name under packages/ */
+  packageNameToDir: Map<string, string>
+}
+
+function firstStringValue(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value
+  }
+
+  if (value && typeof value === 'object') {
+    for (const nested of Object.values(value)) {
+      const found = firstStringValue(nested)
+
+      if (found) {
+        return found
+      }
+    }
+  }
+
+  return undefined
+}
+
+async function loadEntrypoints(): Promise<Entrypoints> {
+  const specifierToFile = new Map<string, string>()
+  const packageNameToDir = new Map<string, string>()
+  const entries = await readdir(PACKAGES_DIR, { withFileTypes: true })
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue
+    }
+
+    const packageDir = path.join(PACKAGES_DIR, entry.name)
+    let packageJson: { name?: string, exports?: Record<string, unknown> }
+
+    try {
+      packageJson = JSON.parse(await readFile(path.join(packageDir, 'package.json'), 'utf8'))
+    }
+    catch {
+      continue
+    }
+
+    const packageName = packageJson.name
+
+    if (!packageName || !packageJson.exports) {
+      continue
+    }
+
+    packageNameToDir.set(packageName, entry.name)
+
+    for (const [subpath, value] of Object.entries(packageJson.exports)) {
+      if (subpath === './package.json') {
+        continue
+      }
+
+      const target = firstStringValue(value)
+
+      if (!target || !target.endsWith('.ts')) {
+        continue
+      }
+
+      const specifier = subpath === '.' ? packageName : `${packageName}/${subpath.slice(2)}`
+      specifierToFile.set(specifier, path.resolve(packageDir, target))
+    }
+  }
+
+  return { specifierToFile, packageNameToDir }
+}
+
+function getJsDocText(declaration: ts.Declaration): string {
+  const sourceFile = declaration.getSourceFile()
+
+  return ts.getJSDocCommentsAndTags(declaration)
+    .filter(ts.isJSDoc)
+    .map(doc => doc.getText(sourceFile))
+    .join('\n')
+}
+
+function formatLocation(declaration: ts.Declaration): string {
+  const sourceFile = declaration.getSourceFile()
+  const { line } = sourceFile.getLineAndCharacterOfPosition(declaration.getStart())
+
+  return `${path.relative(ROOT_DIR, sourceFile.fileName)}:${line + 1}`
+}
+
+const SEE_LINK_RE = /@see\s+\{@link\s+(https:\/\/orpc\.dev\/[^\s}|]+)/g
+const LEGACY_TAG_RES: [RegExp, string][] = [
+  [/@info\b/, 'non-standard @info tag (use @remarks with **Note**:)'],
+  [/@warning\b/, 'non-standard @warning tag (use @remarks with **Warning**:)'],
+  [/\{@see\s/, '{@see ...} misuse (use {@link ...})'],
+  [/@return\s/, '@return tag (use @returns)'],
+  [/\{@link\s+https:\/\/orpc\.dev\/\S+[^\S\n]+[^|}\s]/, 'space-form {@link url Title} (use {@link url | Title})'],
+]
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+interface CheckContext {
+  pages: Map<string, DocPage>
+  strict: boolean
+  issues: Issue[]
+}
+
+function checkMention(
+  context: CheckContext,
+  mention: Mention,
+  declarations: ts.Declaration[],
+): void {
+  const { pages, strict, issues } = context
+  const primary = declarations[0]
+  const location = primary ? formatLocation(primary) : undefined
+  const jsDocText = declarations.map(getJsDocText).filter(Boolean).join('\n')
+
+  const report = (severity: 'error' | 'warning', code: string, message: string): void => {
+    issues.push({ severity, code, message, mention, location })
+  }
+
+  if (!jsDocText.trim()) {
+    report('error', 'E2', 'declaration has no JSDoc comment')
+    return
+  }
+
+  const links = [...jsDocText.matchAll(SEE_LINK_RE)].map(match => match[1]!)
+
+  if (links.length === 0) {
+    report('error', 'E3', 'JSDoc has no @see {@link https://orpc.dev/docs/...} backlink')
+    return
+  }
+
+  for (const link of links) {
+    if (!link.startsWith(DOCS_URL_PREFIX)) {
+      report('error', 'E4', `backlink ${link} does not point under ${DOCS_URL_PREFIX}`)
+      continue
+    }
+
+    const [pagePath = '', anchor] = link.slice(DOCS_URL_PREFIX.length).split('#')
+    const page = pages.get(pagePath)
+
+    if (!page) {
+      report('error', 'E4', `backlink page "${pagePath}" has no apps/content/docs/${pagePath}.md`)
+      continue
+    }
+
+    if (anchor !== undefined && !page.slugs.has(anchor)) {
+      report('error', 'E5', `anchor "#${anchor}" not found in apps/content/docs/${pagePath}.md`)
+      continue
+    }
+
+    const wordRe = new RegExp(`\\b${escapeRegExp(mention.name)}\\b`)
+
+    if (!wordRe.test(page.raw)) {
+      report(strict ? 'error' : 'warning', 'W1', `linked page "${pagePath}" never mentions "${mention.name}"`)
+    }
+  }
+
+  for (const [legacyRe, description] of LEGACY_TAG_RES) {
+    if (legacyRe.test(jsDocText)) {
+      report('warning', 'W2', description)
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    options: {
+      filter: { type: 'string' },
+      strict: { type: 'boolean', default: false },
+      list: { type: 'boolean', default: false },
+    },
+  })
+
+  const [{ mentions, pages }, entrypoints] = await Promise.all([collectDocs(), loadEntrypoints()])
+
+  const packageDirOf = (specifier: string): string | undefined => {
+    const packageName = specifier.split('/').slice(0, 2).join('/')
+    return entrypoints.packageNameToDir.get(packageName)
+  }
+
+  const filterDirs = values.filter ? new Set(values.filter.split(',').map(part => part.trim())) : undefined
+  const selected = [...mentions.values()]
+    .filter(mention => !filterDirs || filterDirs.has(packageDirOf(mention.specifier) ?? ''))
+    .sort((a, b) => a.specifier.localeCompare(b.specifier) || a.name.localeCompare(b.name))
+
+  if (values.list) {
+    for (const mention of selected) {
+      console.log(`${mention.specifier}#${mention.name}\t${[...mention.pages].sort().join(', ')}`)
+    }
+
+    console.log(`\n${selected.length} docs-mentioned symbols`)
+    return
+  }
+
+  const entryFiles = new Set<string>()
+  const unknownSpecifiers = new Set<string>()
+
+  for (const mention of selected) {
+    const entryFile = entrypoints.specifierToFile.get(mention.specifier)
+
+    if (entryFile) {
+      entryFiles.add(entryFile)
+    }
+    else {
+      unknownSpecifiers.add(mention.specifier)
+    }
+  }
+
+  const program = ts.createProgram([...entryFiles], {
+    target: ts.ScriptTarget.ESNext,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    skipLibCheck: true,
+    noEmit: true,
+  })
+
+  const checker = program.getTypeChecker()
+  const moduleExportsCache = new Map<string, Map<string, ts.Symbol>>()
+
+  const getModuleExports = (entryFile: string): Map<string, ts.Symbol> | undefined => {
+    const cached = moduleExportsCache.get(entryFile)
+
+    if (cached) {
+      return cached
+    }
+
+    const sourceFile = program.getSourceFile(entryFile)
+    const moduleSymbol = sourceFile && checker.getSymbolAtLocation(sourceFile)
+
+    if (!moduleSymbol) {
+      return undefined
+    }
+
+    const exportsMap = new Map<string, ts.Symbol>()
+
+    for (const exportSymbol of checker.getExportsOfModule(moduleSymbol)) {
+      exportsMap.set(exportSymbol.name, exportSymbol)
+    }
+
+    moduleExportsCache.set(entryFile, exportsMap)
+    return exportsMap
+  }
+
+  const context: CheckContext = { pages, strict: values.strict, issues: [] }
+  let allowlisted = 0
+
+  for (const mention of selected) {
+    const key = `${mention.specifier}#${mention.name}`
+
+    if (ALLOWLIST[key]) {
+      allowlisted += 1
+      continue
+    }
+
+    if (unknownSpecifiers.has(mention.specifier)) {
+      context.issues.push({
+        severity: 'error',
+        code: 'E1',
+        message: `docs import from unknown entrypoint "${mention.specifier}"`,
+        mention,
+      })
+      continue
+    }
+
+    const entryFile = entrypoints.specifierToFile.get(mention.specifier)!
+    const moduleExports = getModuleExports(entryFile)
+    const symbol = moduleExports?.get(mention.name)
+
+    if (!symbol) {
+      context.issues.push({
+        severity: 'error',
+        code: 'E1',
+        message: `"${mention.name}" is not exported from ${mention.specifier}`,
+        mention,
+      })
+      continue
+    }
+
+    const symbols = [symbol]
+
+    if (symbol.flags & ts.SymbolFlags.Alias) {
+      symbols.push(checker.getAliasedSymbol(symbol))
+    }
+
+    const declarations = symbols.flatMap(part => part.declarations ?? [])
+      .sort((a, b) => (ts.isExportSpecifier(a) ? 1 : 0) - (ts.isExportSpecifier(b) ? 1 : 0))
+
+    checkMention(context, mention, declarations)
+  }
+
+  const errors = context.issues.filter(issue => issue.severity === 'error')
+  const warnings = context.issues.filter(issue => issue.severity === 'warning')
+  const bySpecifier = new Map<string, Issue[]>()
+
+  for (const issue of context.issues) {
+    const group = bySpecifier.get(issue.mention.specifier) ?? []
+    group.push(issue)
+    bySpecifier.set(issue.mention.specifier, group)
+  }
+
+  for (const [specifier, issues] of [...bySpecifier.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    console.log(`\n${specifier}`)
+
+    for (const issue of issues) {
+      const label = issue.severity === 'error' ? 'error' : 'warn '
+      const location = issue.location ?? '(unresolved)'
+      const pagesNote = [...issue.mention.pages].sort().slice(0, 3).join(', ')
+      console.log(`  ${label} [${issue.code}] ${issue.mention.name}  ${location}`)
+      console.log(`        ${issue.message} (mentioned in: ${pagesNote})`)
+    }
+  }
+
+  const allowlistNote = allowlisted > 0 ? `, ${allowlisted} allowlisted` : ''
+  console.log(`\n${errors.length} errors, ${warnings.length} warnings across ${selected.length} docs-mentioned symbols${allowlistNote}`)
+
+  if (errors.length > 0) {
+    process.exitCode = 1
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/scripts/verify-docs-jsdoc.ts
+++ b/scripts/verify-docs-jsdoc.ts
@@ -30,7 +30,10 @@ interface Mention {
 interface DocPage {
   file: string
   raw: string
-  slugs: Set<string>
+  /** Cleaned text of the page's first heading. */
+  title: string
+  /** Heading slug -> cleaned heading text. */
+  slugs: Map<string, string>
 }
 
 interface Issue {
@@ -124,22 +127,35 @@ function collectImportedNames(code: string): Map<string, Set<string>> {
 }
 
 /**
- * Mirrors VitePress' default heading slugification (lowercase, strip punctuation,
- * spaces to dashes) closely enough to validate anchors.
+ * Mirrors VitePress' default heading slugification (the @mdit-vue/shared `slugify`):
+ * special characters become dashes, dashes collapse, leading digits get a `_` prefix.
  */
 function slugify(text: string): string {
   return text
     .normalize('NFKD')
     .replace(/[\u0300-\u036F]/g, '')
-    .replace(/[!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~]/g, '')
-    .trim()
-    .replace(/\s+/g, '-')
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001F]/g, '')
+    .replace(/[\s~`!@#$%^&*()\-_+=[\]{}|\\;:"'\u201C\u201D\u2018\u2019<>,.?/]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/^(\d)/, '_$1')
     .toLowerCase()
 }
 
-function extractHeadingSlugs(outsideFenceLines: string[]): Set<string> {
-  const slugs = new Set<string>()
+function cleanHeadingText(text: string): string {
+  return text
+    .replace(/\{#[\w-]+\}\s*$/, '')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/[`*]/g, '')
+    .replace(/\\(.)/g, '$1')
+    .trim()
+}
+
+function extractHeadings(outsideFenceLines: string[]): { title: string, slugs: Map<string, string> } {
+  const slugs = new Map<string, string>()
   const counts = new Map<string, number>()
+  let title = ''
 
   for (const line of outsideFenceLines) {
     const heading = line.match(/^#{1,6}\s(.*)$/)
@@ -148,25 +164,23 @@ function extractHeadingSlugs(outsideFenceLines: string[]): Set<string> {
       continue
     }
 
-    let text = heading[1]!.trim()
-    const custom = text.match(/\{#([\w-]+)\}\s*$/)
+    const rawText = heading[1]!.trim()
+    const text = cleanHeadingText(rawText)
+    title ||= text
+    const custom = rawText.match(/\{#([\w-]+)\}\s*$/)
 
     if (custom) {
-      slugs.add(custom[1]!)
+      slugs.set(custom[1]!, text)
       continue
     }
-
-    text = text
-      .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
-      .replace(/[`*]/g, '')
 
     const slug = slugify(text)
     const count = counts.get(slug) ?? 0
     counts.set(slug, count + 1)
-    slugs.add(count === 0 ? slug : `${slug}-${count}`)
+    slugs.set(count === 0 ? slug : `${slug}-${count}`, text)
   }
 
-  return slugs
+  return { title, slugs }
 }
 
 async function collectDocs(): Promise<{ mentions: Map<string, Mention>, pages: Map<string, DocPage> }> {
@@ -181,7 +195,7 @@ async function collectDocs(): Promise<{ mentions: Map<string, Mention>, pages: M
     pages.set(relPage.replace(/\/index$/, '') || 'index', {
       file,
       raw,
-      slugs: extractHeadingSlugs(outside),
+      ...extractHeadings(outside),
     })
 
     for (const fence of code) {
@@ -292,7 +306,7 @@ function formatLocation(declaration: ts.Declaration): string {
   return `${path.relative(ROOT_DIR, sourceFile.fileName)}:${line + 1}`
 }
 
-const SEE_LINK_RE = /@see\s+\{@link\s+(https:\/\/orpc\.dev\/[^\s}|]+)/g
+const SEE_LINK_RE = /@see\s+\{@link\s+(https:\/\/orpc\.dev\/[^\s}|]+)(?:\s*\|([^}]*))?\}/g
 const LEGACY_TAG_RES: [RegExp, string][] = [
   [/@info\b/, 'non-standard @info tag (use @remarks with **Note**:)'],
   [/@warning\b/, 'non-standard @warning tag (use @remarks with **Warning**:)'],
@@ -330,20 +344,21 @@ function checkMention(
     return
   }
 
-  const links = [...jsDocText.matchAll(SEE_LINK_RE)].map(match => match[1]!)
+  const links = [...jsDocText.matchAll(SEE_LINK_RE)]
+    .map(match => ({ url: match[1]!, title: match[2]?.trim() }))
 
   if (links.length === 0) {
     report('error', 'E3', 'JSDoc has no @see {@link https://orpc.dev/docs/...} backlink')
     return
   }
 
-  for (const link of links) {
-    if (!link.startsWith(DOCS_URL_PREFIX)) {
-      report('error', 'E4', `backlink ${link} does not point under ${DOCS_URL_PREFIX}`)
+  for (const { url, title } of links) {
+    if (!url.startsWith(DOCS_URL_PREFIX)) {
+      report('error', 'E4', `backlink ${url} does not point under ${DOCS_URL_PREFIX}`)
       continue
     }
 
-    const [pagePath = '', anchor] = link.slice(DOCS_URL_PREFIX.length).split('#')
+    const [pagePath = '', anchor] = url.slice(DOCS_URL_PREFIX.length).split('#')
     const page = pages.get(pagePath)
 
     if (!page) {
@@ -353,6 +368,16 @@ function checkMention(
 
     if (anchor !== undefined && !page.slugs.has(anchor)) {
       report('error', 'E5', `anchor "#${anchor}" not found in apps/content/docs/${pagePath}.md`)
+      continue
+    }
+
+    const anchorHeading = anchor !== undefined ? page.slugs.get(anchor) : undefined
+    const expectedTitle = anchorHeading && anchorHeading !== page.title
+      ? `${page.title} - ${anchorHeading}`
+      : page.title
+
+    if (title !== expectedTitle) {
+      report('error', 'E6', `link title should be "| ${expectedTitle}"${title ? ` (found "| ${title}")` : ' (title missing)'}`)
       continue
     }
 


### PR DESCRIPTION
Every `@orpc/*` API mentioned in the docs content now carries JSDoc with a backlink to orpc.dev, and a new verification script keeps the two in sync. The script runs in CI, so docs and JSDoc can no longer drift.

## JSDoc sweep

- ~124 source files across all packages now follow one template: 1-3 sentence summary, optional `@remarks` with `**Warning**:`/`**Note**:`, and `@see {@link https://orpc.dev/docs/... | Page Title}` as the last tag (titles taken from the real page titles, or "Page Title - Heading" for anchored links).
- Previously undocumented flagship APIs are covered: `os`, `oc`, `createORPCClient`, every `RPCHandler`/`RPCLink`/`OpenAPIHandler` adapter, `OpenAPIGenerator`, all plugins, schema converters, publisher/ratelimit backends, and the previously zero-coverage packages (bun, cloudflare, nest, next, pino, opentelemetry, evlog, arktype, valibot).
- Legacy forms are gone repo-wide: `@info`/`@warning` tags became `@remarks` notes, space-form `{@link url Title Docs}` links became pipe form, `{@see}` misuses and a stray `@return` are fixed, and two broken `@example` fences are closed.
- Third-party re-exports (`getEventMeta`, `withEventMeta`, `HibernationAsyncIteratorClass`) are documented on their re-export specifiers.

## Verification script

`pnpm docs:check-jsdoc` (`scripts/verify-docs-jsdoc.ts`, no new dependencies) extracts every `import { X } from '@orpc/...'` in docs code fences, resolves each identifier to its declaration through the TypeScript compiler API (including `export * from` chains and aliases), and fails CI when a declaration lacks JSDoc, lacks an orpc.dev backlink, links a nonexistent page, or uses an anchor that matches no heading, or titles a link with anything but the real page title (+ heading for anchors). It also warns when a linked page never mentions the symbol (`--strict` promotes this to an error). It also validates every `https://orpc.dev/...` URL anywhere in package sources (markdown links in prose, member-level docs; docs, blog, and homepage paths all resolve against apps/content) for page and anchor existence. Supports `--filter`, `--list` for incremental work. Added to the `lint_and_typecheck` job.

## Docs bugs the script caught (fixed here)

- `integrations/next.md` imported four helpers from the wrong specifier (`@orpc/next/hooks` instead of `@orpc/next` / `@orpc/client`).
- `adapters/fetch-api.md` and `openapi/scalar.md` imported the deprecated `CORSPlugin` while instantiating `CORSHandlerPlugin`.
- `helpers/publisher.md` redis example referenced an undefined `redis` variable and carried a copy-pasted ratelimit comment.
- Several stale anchors in existing JSDoc (e.g. `#using-createsafeclient`) now point at real headings.

## Testing

- `pnpm docs:check-jsdoc`: 0 errors, 0 warnings across 196 docs-mentioned symbols (also clean with `--strict`).
- `pnpm lint`, `pnpm type:check`, and `pnpm --filter @orpc/bun type:check` all pass (cloudflare/nest type-check as part of the recursive run).
- All changes to package sources are comment-only.

CONTRIBUTING.md documents the convention in a new "JSDoc & Documentation Links" section.



