### PR TITLE
fix(nest): apply method-level decorators to router-contract `@Implement` routes

### DIFF
--- a/apps/content/docs/integrations/nest.md
+++ b/apps/content/docs/integrations/nest.md
@@ -105,6 +105,8 @@ export class PlanetController {
 
 ::: info
 When you use the `@Implement` decorator with a router contract, under the hood it creates a corresponding NestJS method for each procedure contract. Method-level decorators like `@UseGuards` or `@UseInterceptors` are automatically carried over to these methods, so you can combine them with `@Implement` in any order.
+
+Execution order follows decorator order, just like on regular NestJS methods. For example, an interceptor applied below `@Implement` runs outside oRPC's response encoding and observes the encoded response, while one applied above it runs inside and observes the raw implemented procedure.
 :::
 
 ## Error Handling

--- a/apps/content/docs/integrations/nest.md
+++ b/apps/content/docs/integrations/nest.md
@@ -104,9 +104,7 @@ export class PlanetController {
 ```
 
 ::: info
-When you use the `@Implement` decorator with a router contract, under the hood it creates a corresponding NestJS method for each procedure contract. Method-level decorators like `@UseGuards` or `@UseInterceptors` are automatically carried over to these methods, so you can combine them with `@Implement` in any order.
-
-Execution order follows decorator order, just like on regular NestJS methods. For example, an interceptor applied below `@Implement` runs outside oRPC's response encoding and observes the encoded response, while one applied above it runs inside and observes the raw implemented procedure.
+When you use the `@Implement` decorator with a router contract, under the hood it creates a corresponding NestJS method for each procedure contract. All decorators applied to the original method are reflected on these methods.
 :::
 
 ## Error Handling

--- a/apps/content/docs/integrations/nest.md
+++ b/apps/content/docs/integrations/nest.md
@@ -103,22 +103,8 @@ export class PlanetController {
 }
 ```
 
-::: warning
-If you using `@Implement` decorator for router contract, underhook it creates corresponding NestJS method for each procedure contract. Therefore, all other decorator should be applied before `@Implement` decorator, otherwise it will not be applied to corresponding NestJS methods.
-
-```ts
-@Controller()
-export class PlanetController {
-  @Implement(contract.planet) // ⬇️ other decorators should be below this line
-  @UseGuards(AuthGuard)
-  planet(@Req() req: Request) {
-    return {
-      // your implementation
-    }
-  }
-}
-```
-
+::: info
+When you use the `@Implement` decorator with a router contract, under the hood it creates a corresponding NestJS method for each procedure contract. Method-level decorators like `@UseGuards` or `@UseInterceptors` are automatically carried over to these methods, so you can combine them with `@Implement` in any order.
 :::
 
 ## Error Handling

--- a/packages/nest/src/implement.test.ts
+++ b/packages/nest/src/implement.test.ts
@@ -10,7 +10,7 @@ import { FastifyAdapter } from '@nestjs/platform-fastify'
 import { Test } from '@nestjs/testing'
 import { meta, oc } from '@orpc/contract'
 import { openapi } from '@orpc/openapi'
-import { implement, ORPCError, os } from '@orpc/server'
+import { implement, ORPCError, os, Procedure } from '@orpc/server'
 import { getOrBind } from '@orpc/shared'
 import { catchError, tap } from 'rxjs'
 import supertest from 'supertest'
@@ -186,7 +186,7 @@ describe('routing', () => {
         staticPath: implement(contract.staticPath).handler(() => 'static'),
         dynamicPath: implement(contract.dynamicPath).handler(({ input }) => `param: ${input.param}`),
         restPath: implement(contract.restPath).handler(({ input }) => `rest: ${input.rest}`),
-        prefixedPath: implement(contract.prefixedPath).handler(({ input }) => `prefixed path`),
+        prefixedPath: implement(contract.prefixedPath).handler(() => `prefixed path`),
         dynamicPrefix: implement(contract.dynamicPrefix).handler(({ input }) => `prefix: ${input.prefix}`),
         styledParams: implement(contract.styledParams).handler(({ input }) => `params: ${input.params}`),
         mixed201Path: implement(contract.mixed201Path).handler(({ input }) => `prefixes: ${input.prefixes} param: ${input.param}, rest: ${input.rest}`),
@@ -984,7 +984,15 @@ describe('compatibility', () => {
       },
     }
 
-    const intercept = vi.fn((ctx: ExecutionContext, next: CallHandler) => next.handle())
+    const intercepted: unknown[] = []
+
+    beforeEach(() => {
+      intercepted.length = 0
+    })
+
+    const intercept = vi.fn((ctx: ExecutionContext, next: CallHandler) => {
+      return next.handle().pipe(tap(value => intercepted.push(value)))
+    })
 
     class SpyInterceptor implements NestInterceptor {
       intercept = intercept
@@ -1018,7 +1026,7 @@ describe('compatibility', () => {
     describe.each([
       [InterceptorAboveController, '@UseInterceptors above @Implement'],
       [InterceptorBelowController, '@UseInterceptors below @Implement'],
-    ] as const)('order: $1', async (Controller, _) => {
+    ] as const)('order: $1', async (Controller, order) => {
       const moduleRef = await Test.createTestingModule({
         controllers: [Controller],
       }).compile()
@@ -1026,7 +1034,7 @@ describe('compatibility', () => {
       const app = moduleRef.createNestApplication()
       await app.init()
 
-      it('runs the interceptor on synthesized methods', async () => {
+      it('runs the interceptor on synthesized methods following decorator order', async () => {
         const pingRes = await supertest(app.getHttpServer()).post('/intercepted/ping')
         expect(pingRes.status).toBe(200)
         expect(pingRes.body).toEqual('pong')
@@ -1036,6 +1044,82 @@ describe('compatibility', () => {
         expect(pongRes.body).toEqual('peng')
 
         expect(intercept).toHaveBeenCalledTimes(2)
+
+        if (order === '@UseInterceptors above @Implement') {
+          // evaluates after @Implement, so it runs inside ImplementInterceptor and observes the raw procedures
+          expect(intercepted).toHaveLength(2)
+          intercepted.forEach(value => expect(value).toBeInstanceOf(Procedure))
+        }
+        else {
+          // evaluates before @Implement, so it runs outside ImplementInterceptor and observes the encoded responses
+          expect(intercepted).toEqual(['"pong"', '"peng"'])
+        }
+      })
+    })
+  })
+
+  describe('procedure-based implementation applies method-level interceptors following decorator order', () => {
+    const contract = oc.meta(openapi({ path: '/intercepted/procedure' }))
+
+    const intercepted: unknown[] = []
+
+    beforeEach(() => {
+      intercepted.length = 0
+    })
+
+    const intercept = vi.fn((ctx: ExecutionContext, next: CallHandler) => {
+      return next.handle().pipe(tap(value => intercepted.push(value)))
+    })
+
+    class SpyInterceptor implements NestInterceptor {
+      intercept = intercept
+    }
+
+    @Controller()
+    class InterceptorAboveController {
+      @UseInterceptors(SpyInterceptor)
+      @Implement(contract)
+      procedure() {
+        return implement(contract).handler(() => 'pong')
+      }
+    }
+
+    @Controller()
+    class InterceptorBelowController {
+      @Implement(contract)
+      @UseInterceptors(SpyInterceptor)
+      procedure() {
+        return implement(contract).handler(() => 'pong')
+      }
+    }
+
+    describe.each([
+      [InterceptorAboveController, '@UseInterceptors above @Implement'],
+      [InterceptorBelowController, '@UseInterceptors below @Implement'],
+    ] as const)('order: $1', async (Controller, order) => {
+      const moduleRef = await Test.createTestingModule({
+        controllers: [Controller],
+      }).compile()
+
+      const app = moduleRef.createNestApplication()
+      await app.init()
+
+      it('runs the interceptor following decorator order', async () => {
+        const res = await supertest(app.getHttpServer()).post('/intercepted/procedure')
+        expect(res.status).toBe(200)
+        expect(res.body).toEqual('pong')
+
+        expect(intercept).toHaveBeenCalledTimes(1)
+
+        if (order === '@UseInterceptors above @Implement') {
+          // evaluates after @Implement, so it runs inside ImplementInterceptor and observes the raw procedure
+          expect(intercepted).toHaveLength(1)
+          expect(intercepted[0]).toBeInstanceOf(Procedure)
+        }
+        else {
+          // evaluates before @Implement, so it runs outside ImplementInterceptor and observes the encoded response
+          expect(intercepted).toEqual(['"pong"'])
+        }
       })
     })
   })

--- a/packages/nest/src/implement.test.ts
+++ b/packages/nest/src/implement.test.ts
@@ -1,10 +1,10 @@
-import type { CallHandler, ExecutionContext, NestInterceptor } from '@nestjs/common'
+import type { CallHandler, CanActivate, ExecutionContext, NestInterceptor } from '@nestjs/common'
 import type { Request as ExpressRequest } from 'express'
 import type { FastifyReply } from 'fastify'
 import type { NestStandardLazyRequest } from './module'
 import { Buffer } from 'node:buffer'
 import FastifyCookie from '@fastify/cookie'
-import { Controller, HttpException, Req, Res, StreamableFile } from '@nestjs/common'
+import { Controller, HttpException, Req, Res, StreamableFile, UseGuards } from '@nestjs/common'
 import { FastifyAdapter } from '@nestjs/platform-fastify'
 import { Test } from '@nestjs/testing'
 import { meta, oc } from '@orpc/contract'
@@ -849,6 +849,8 @@ describe('compatibility', () => {
 
     const Meta: MethodDecorator = (target, propertyKey, descriptor) => {
       Reflect.defineMetadata('orpc:meta', 'value', target, propertyKey)
+      // NestJS enhancers like @UseGuards store metadata on the function object itself
+      Reflect.defineMetadata('orpc:fn-meta', 'fn-value', descriptor.value!)
     }
 
     @Controller()
@@ -873,6 +875,60 @@ describe('compatibility', () => {
 
     expect(Reflect.getMetadata('orpc:meta', controller, 'router_ping_2')).toEqual('value')
     expect(Reflect.getMetadata('orpc:meta', controller, 'router_pong')).toEqual('value')
+
+    expect(Reflect.getMetadata('orpc:fn-meta', (controller as any).router_ping_2)).toEqual('fn-value')
+    expect(Reflect.getMetadata('orpc:fn-meta', (controller as any).router_pong)).toEqual('fn-value')
+  })
+
+  it.each(['below @Implement', 'above @Implement'])('router-based implementation applies method-level guards to synthesized methods (%s)', async (order) => {
+    const contract = {
+      ping: oc.meta(openapi({ path: '/guarded/ping' })),
+      nested: {
+        pong: oc.meta(openapi({ path: '/guarded/pong' })),
+      },
+    }
+
+    const canActivate = vi.fn(() => false)
+
+    class DenyGuard implements CanActivate {
+      canActivate = canActivate
+    }
+
+    const router = () => ({
+      ping: implement(contract.ping).handler(() => {}),
+      nested: {
+        pong: implement(contract.nested.pong).handler(() => {}),
+      },
+    })
+
+    @Controller()
+    class BelowController {
+      @Implement(contract)
+      @UseGuards(DenyGuard)
+      router() {
+        return router()
+      }
+    }
+
+    @Controller()
+    class AboveController {
+      @UseGuards(DenyGuard)
+      @Implement(contract)
+      router() {
+        return router()
+      }
+    }
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [order === 'below @Implement' ? BelowController : AboveController],
+    }).compile()
+
+    const app = moduleRef.createNestApplication()
+    await app.init()
+
+    expect((await supertest(app.getHttpServer()).post('/guarded/ping')).status).toBe(403)
+    expect((await supertest(app.getHttpServer()).post('/guarded/pong')).status).toBe(403)
+    expect(canActivate).toHaveBeenCalledTimes(2)
   })
 
   it('should support lazy router/procedure in router-based implementation controller', async () => {

--- a/packages/nest/src/implement.test.ts
+++ b/packages/nest/src/implement.test.ts
@@ -4,7 +4,8 @@ import type { FastifyReply } from 'fastify'
 import type { NestStandardLazyRequest } from './module'
 import { Buffer } from 'node:buffer'
 import FastifyCookie from '@fastify/cookie'
-import { Controller, HttpException, Req, Res, StreamableFile, UseGuards } from '@nestjs/common'
+import { Controller, HttpException, Req, Res, SetMetadata, StreamableFile, UseGuards, UseInterceptors } from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
 import { FastifyAdapter } from '@nestjs/platform-fastify'
 import { Test } from '@nestjs/testing'
 import { meta, oc } from '@orpc/contract'
@@ -841,27 +842,39 @@ describe('compatibility', () => {
     expect(req!.url).toBe('/injection')
   })
 
-  it('router-based implementation controller can handle conflict method names and reflect all metadata on new methods', async () => {
+  it('router-based implementation controller can handle conflict method names and reflect all metadata on new methods regardless of decorator order', async () => {
     const contract = {
       ping: oc.meta(openapi({ path: '/ping' })),
       pong: oc.meta(openapi({ path: '/pong' })),
     }
 
-    const Meta: MethodDecorator = (target, propertyKey, descriptor) => {
-      Reflect.defineMetadata('orpc:meta', 'value', target, propertyKey)
-      // NestJS enhancers like @UseGuards store metadata on the function object itself
-      Reflect.defineMetadata('orpc:fn-meta', 'fn-value', descriptor.value!)
+    // custom decorator metadata keyed by method name, like some third-party decorators use
+    const Meta = (key: string): MethodDecorator => (target, propertyKey) => {
+      Reflect.defineMetadata(key, 'value', target, propertyKey)
+    }
+
+    const handlerMeta = vi.fn()
+
+    class MetaGuard implements CanActivate {
+      canActivate(ctx: ExecutionContext) {
+        const reflector = new Reflector()
+        handlerMeta(reflector.get('above', ctx.getHandler()), reflector.get('below', ctx.getHandler()))
+        return true
+      }
     }
 
     @Controller()
+    @UseGuards(MetaGuard)
     class ImplController {
+      @SetMetadata('above', 'above-value')
+      @Meta('orpc:above')
       @Implement(contract)
-      // There is a limitation: @Meta must be used after @Implement.
-      @Meta
-      router() {
+      @Meta('orpc:below')
+      @SetMetadata('below', 'below-value')
+      router(@Req() req: ExpressRequest) {
         return {
-          ping: implement(contract.ping).handler(() => {}),
-          pong: implement(contract.pong).handler(() => {}),
+          ping: implement(contract.ping).handler(() => `ping:${req.url}`),
+          pong: implement(contract.pong).handler(() => `pong:${req.url}`),
         }
       }
 
@@ -871,16 +884,37 @@ describe('compatibility', () => {
       router_ping_1() {}
     }
 
-    const controller = new ImplController()
+    const moduleRef = await Test.createTestingModule({
+      controllers: [ImplController],
+    }).compile()
 
-    expect(Reflect.getMetadata('orpc:meta', controller, 'router_ping_2')).toEqual('value')
-    expect(Reflect.getMetadata('orpc:meta', controller, 'router_pong')).toEqual('value')
+    const app = moduleRef.createNestApplication()
+    await app.init()
 
-    expect(Reflect.getMetadata('orpc:fn-meta', (controller as any).router_ping_2)).toEqual('fn-value')
-    expect(Reflect.getMetadata('orpc:fn-meta', (controller as any).router_pong)).toEqual('fn-value')
+    const pingRes = await supertest(app.getHttpServer()).post('/ping')
+    expect(pingRes.status).toBe(200)
+    expect(pingRes.body).toEqual('ping:/ping')
+
+    const pongRes = await supertest(app.getHttpServer()).post('/pong')
+    expect(pongRes.status).toBe(200)
+    expect(pongRes.body).toEqual('pong:/pong')
+
+    // @SetMetadata from both sides of @Implement is visible on the runtime handlers
+    expect(handlerMeta).toHaveBeenCalledTimes(2)
+    expect(handlerMeta).toHaveBeenNthCalledWith(1, 'above-value', 'below-value')
+    expect(handlerMeta).toHaveBeenNthCalledWith(2, 'above-value', 'below-value')
+
+    const controller = app.get(ImplController)
+
+    for (const key of ['orpc:above', 'orpc:below']) {
+      expect(Reflect.getMetadata(key, controller, 'router_ping_2')).toEqual('value')
+      expect(Reflect.getMetadata(key, controller, 'router_pong')).toEqual('value')
+    }
   })
 
-  it.each(['below @Implement', 'above @Implement'])('router-based implementation applies method-level guards to synthesized methods (%s)', async (order) => {
+  it.each(
+    ['below @Implement', 'above @Implement'] as const,
+  )('router-based implementation applies method-level guards to synthesized methods (%s)', async (order) => {
     const contract = {
       ping: oc.meta(openapi({ path: '/guarded/ping' })),
       nested: {
@@ -888,9 +922,11 @@ describe('compatibility', () => {
       },
     }
 
-    const canActivate = vi.fn(() => false)
+    const canActivate = vi.fn((ctx: ExecutionContext) => {
+      return ctx.switchToHttp().getRequest().headers.authorization === 'valid-token'
+    })
 
-    class DenyGuard implements CanActivate {
+    class AuthGuard implements CanActivate {
       canActivate = canActivate
     }
 
@@ -904,7 +940,7 @@ describe('compatibility', () => {
     @Controller()
     class BelowController {
       @Implement(contract)
-      @UseGuards(DenyGuard)
+      @UseGuards(AuthGuard)
       router() {
         return router()
       }
@@ -912,7 +948,7 @@ describe('compatibility', () => {
 
     @Controller()
     class AboveController {
-      @UseGuards(DenyGuard)
+      @UseGuards(AuthGuard)
       @Implement(contract)
       router() {
         return router()
@@ -928,7 +964,70 @@ describe('compatibility', () => {
 
     expect((await supertest(app.getHttpServer()).post('/guarded/ping')).status).toBe(403)
     expect((await supertest(app.getHttpServer()).post('/guarded/pong')).status).toBe(403)
-    expect(canActivate).toHaveBeenCalledTimes(2)
+
+    expect((await supertest(app.getHttpServer()).post('/guarded/ping').set('authorization', 'valid-token')).status).toBe(200)
+    expect((await supertest(app.getHttpServer()).post('/guarded/pong').set('authorization', 'valid-token')).status).toBe(200)
+
+    expect(canActivate).toHaveBeenCalledTimes(4)
+  })
+
+  it.each(
+    ['below @Implement', 'above @Implement'] as const,
+  )('router-based implementation applies method-level interceptors to synthesized methods (%s)', async (order) => {
+    const contract = {
+      ping: oc.meta(openapi({ path: '/intercepted/ping' })),
+      nested: {
+        pong: oc.meta(openapi({ path: '/intercepted/pong' })),
+      },
+    }
+
+    const intercept = vi.fn((ctx: ExecutionContext, next: CallHandler) => next.handle())
+
+    class SpyInterceptor implements NestInterceptor {
+      intercept = intercept
+    }
+
+    const router = () => ({
+      ping: implement(contract.ping).handler(() => 'pong'),
+      nested: {
+        pong: implement(contract.nested.pong).handler(() => 'peng'),
+      },
+    })
+
+    @Controller()
+    class BelowController {
+      @Implement(contract)
+      @UseInterceptors(SpyInterceptor)
+      router() {
+        return router()
+      }
+    }
+
+    @Controller()
+    class AboveController {
+      @UseInterceptors(SpyInterceptor)
+      @Implement(contract)
+      router() {
+        return router()
+      }
+    }
+
+    const moduleRef = await Test.createTestingModule({
+      controllers: [order === 'below @Implement' ? BelowController : AboveController],
+    }).compile()
+
+    const app = moduleRef.createNestApplication()
+    await app.init()
+
+    const pingRes = await supertest(app.getHttpServer()).post('/intercepted/ping')
+    expect(pingRes.status).toBe(200)
+    expect(pingRes.body).toEqual('pong')
+
+    const pongRes = await supertest(app.getHttpServer()).post('/intercepted/pong')
+    expect(pongRes.status).toBe(200)
+    expect(pongRes.body).toEqual('peng')
+
+    expect(intercept).toHaveBeenCalledTimes(2)
   })
 
   it('should support lazy router/procedure in router-based implementation controller', async () => {

--- a/packages/nest/src/implement.test.ts
+++ b/packages/nest/src/implement.test.ts
@@ -912,9 +912,7 @@ describe('compatibility', () => {
     }
   })
 
-  it.each(
-    ['below @Implement', 'above @Implement'] as const,
-  )('router-based implementation applies method-level guards to synthesized methods (%s)', async (order) => {
+  describe('router-based implementation applies method-level guards to synthesized methods', () => {
     const contract = {
       ping: oc.meta(openapi({ path: '/guarded/ping' })),
       nested: {
@@ -938,42 +936,47 @@ describe('compatibility', () => {
     })
 
     @Controller()
-    class BelowController {
-      @Implement(contract)
+    class GuardAboveController {
       @UseGuards(AuthGuard)
+      @Implement(contract)
       router() {
         return router()
       }
     }
 
     @Controller()
-    class AboveController {
-      @UseGuards(AuthGuard)
+    class GuardBelowController {
       @Implement(contract)
+      @UseGuards(AuthGuard)
       router() {
         return router()
       }
     }
 
-    const moduleRef = await Test.createTestingModule({
-      controllers: [order === 'below @Implement' ? BelowController : AboveController],
-    }).compile()
+    describe.each([
+      [GuardAboveController, '@UseGuards above @Implement'],
+      [GuardBelowController, '@UseGuards below @Implement'],
+    ] as const)('order: $1', async (Controller, _) => {
+      const moduleRef = await Test.createTestingModule({
+        controllers: [Controller],
+      }).compile()
 
-    const app = moduleRef.createNestApplication()
-    await app.init()
+      const app = moduleRef.createNestApplication()
+      await app.init()
 
-    expect((await supertest(app.getHttpServer()).post('/guarded/ping')).status).toBe(403)
-    expect((await supertest(app.getHttpServer()).post('/guarded/pong')).status).toBe(403)
+      it('rejects or allows based on the request header', async () => {
+        expect((await supertest(app.getHttpServer()).post('/guarded/ping')).status).toBe(403)
+        expect((await supertest(app.getHttpServer()).post('/guarded/pong')).status).toBe(403)
 
-    expect((await supertest(app.getHttpServer()).post('/guarded/ping').set('authorization', 'valid-token')).status).toBe(200)
-    expect((await supertest(app.getHttpServer()).post('/guarded/pong').set('authorization', 'valid-token')).status).toBe(200)
+        expect((await supertest(app.getHttpServer()).post('/guarded/ping').set('authorization', 'valid-token')).status).toBe(200)
+        expect((await supertest(app.getHttpServer()).post('/guarded/pong').set('authorization', 'valid-token')).status).toBe(200)
 
-    expect(canActivate).toHaveBeenCalledTimes(4)
+        expect(canActivate).toHaveBeenCalledTimes(4)
+      })
+    })
   })
 
-  it.each(
-    ['below @Implement', 'above @Implement'] as const,
-  )('router-based implementation applies method-level interceptors to synthesized methods (%s)', async (order) => {
+  describe('router-based implementation applies method-level interceptors to synthesized methods', () => {
     const contract = {
       ping: oc.meta(openapi({ path: '/intercepted/ping' })),
       nested: {
@@ -995,39 +998,46 @@ describe('compatibility', () => {
     })
 
     @Controller()
-    class BelowController {
-      @Implement(contract)
+    class InterceptorAboveController {
       @UseInterceptors(SpyInterceptor)
+      @Implement(contract)
       router() {
         return router()
       }
     }
 
     @Controller()
-    class AboveController {
-      @UseInterceptors(SpyInterceptor)
+    class InterceptorBelowController {
       @Implement(contract)
+      @UseInterceptors(SpyInterceptor)
       router() {
         return router()
       }
     }
 
-    const moduleRef = await Test.createTestingModule({
-      controllers: [order === 'below @Implement' ? BelowController : AboveController],
-    }).compile()
+    describe.each([
+      [InterceptorAboveController, '@UseInterceptors above @Implement'],
+      [InterceptorBelowController, '@UseInterceptors below @Implement'],
+    ] as const)('order: $1', async (Controller, _) => {
+      const moduleRef = await Test.createTestingModule({
+        controllers: [Controller],
+      }).compile()
 
-    const app = moduleRef.createNestApplication()
-    await app.init()
+      const app = moduleRef.createNestApplication()
+      await app.init()
 
-    const pingRes = await supertest(app.getHttpServer()).post('/intercepted/ping')
-    expect(pingRes.status).toBe(200)
-    expect(pingRes.body).toEqual('pong')
+      it('runs the interceptor on synthesized methods', async () => {
+        const pingRes = await supertest(app.getHttpServer()).post('/intercepted/ping')
+        expect(pingRes.status).toBe(200)
+        expect(pingRes.body).toEqual('pong')
 
-    const pongRes = await supertest(app.getHttpServer()).post('/intercepted/pong')
-    expect(pongRes.status).toBe(200)
-    expect(pongRes.body).toEqual('peng')
+        const pongRes = await supertest(app.getHttpServer()).post('/intercepted/pong')
+        expect(pongRes.status).toBe(200)
+        expect(pongRes.body).toEqual('peng')
 
-    expect(intercept).toHaveBeenCalledTimes(2)
+        expect(intercept).toHaveBeenCalledTimes(2)
+      })
+    })
   })
 
   it('should support lazy router/procedure in router-based implementation controller', async () => {

--- a/packages/nest/src/implement.ts
+++ b/packages/nest/src/implement.ts
@@ -69,8 +69,11 @@ export function Implement<T extends RouterContract>(
       applyDecorators(
         MethodDecoratorMap[method](path),
         HttpCode(successStatus),
-        UseInterceptors(ImplementInterceptor),
       )(target, propertyKey, descriptor)
+
+      queueMicrotask(() => {
+        UseInterceptors(ImplementInterceptor)(target, propertyKey, descriptor)
+      })
     }
   }
 
@@ -90,13 +93,15 @@ export function Implement<T extends RouterContract>(
 
       Object.setPrototypeOf(target[methodName], descriptor.value!)
 
-      for (const p of Reflect.getOwnMetadataKeys(target, propertyKey)) {
-        Reflect.defineMetadata(p, Reflect.getOwnMetadata(p, target, propertyKey), target, methodName)
-      }
+      queueMicrotask(() => {
+        for (const p of Reflect.getOwnMetadataKeys(target, propertyKey)) {
+          Reflect.defineMetadata(p, Reflect.getOwnMetadata(p, target, propertyKey), target, methodName)
+        }
 
-      for (const p of Reflect.getOwnMetadataKeys(target.constructor, propertyKey)) {
-        Reflect.defineMetadata(p, Reflect.getOwnMetadata(p, target.constructor, propertyKey), target.constructor, methodName)
-      }
+        for (const p of Reflect.getOwnMetadataKeys(target.constructor, propertyKey)) {
+          Reflect.defineMetadata(p, Reflect.getOwnMetadata(p, target.constructor, propertyKey), target.constructor, methodName)
+        }
+      })
 
       Implement(contract[key] as any)(target, methodName, Object.getOwnPropertyDescriptor(target, methodName)!)
     }

--- a/packages/nest/src/implement.ts
+++ b/packages/nest/src/implement.ts
@@ -51,59 +51,88 @@ export function Implement<T extends RouterContract>(
   descriptor: TypedPropertyDescriptor<(...args: any[]) => U>,
 ) => void {
   if (contract instanceof ProcedureContract) {
-    const meta = getOpenAPIMeta(contract)
-
-    if (meta?.path === undefined) {
-      throw new TypeError(`
-        @Implement decorator requires contract to have a 'openapi.path' meta.
-        Please define one using '.meta(openapi({ path: '/example' }))'.
-        Or use "populateRouterContractOpenAPIPaths" from "@orpc/openapi" utility to automatically fill in any missing paths.
-      `)
-    }
-
-    const method = meta.method ?? DEFAULT_OPENAPI_METHOD
-    const path = toNestPattern(meta.prefix ? mergeHttpPath(meta.prefix, meta.path) : meta.path)
-    const successStatus = meta.successStatus ?? DEFAULT_SUCCESS_STATUS
-
     return (target, propertyKey, descriptor) => {
       applyDecorators(
-        MethodDecoratorMap[method](path),
-        HttpCode(successStatus),
+        toNestRouteDecorator(contract),
+        UseInterceptors(ImplementInterceptor),
       )(target, propertyKey, descriptor)
-
-      queueMicrotask(() => {
-        UseInterceptors(ImplementInterceptor)(target, propertyKey, descriptor)
-      })
     }
   }
 
   return (target, propertyKey, descriptor) => {
-    for (const key in contract) {
-      let methodName = `${propertyKey}_${key}`
+    // applied at the decorated method level so interceptor order follows decorator order,
+    // and synthesized methods inherit the full ordered list through the prototype chain
+    UseInterceptors(ImplementInterceptor)(target, propertyKey, descriptor)
 
-      let i = 0
-      while (methodName in target) {
-        methodName = `${propertyKey}_${key}_${i++}`
+    implementRouterContract(contract, target, propertyKey, descriptor)
+  }
+}
+
+function toNestRouteDecorator(contract: AnyProcedureContract): MethodDecorator {
+  const meta = getOpenAPIMeta(contract)
+
+  if (meta?.path === undefined) {
+    throw new TypeError(`
+      @Implement decorator requires contract to have a 'openapi.path' meta.
+      Please define one using '.meta(openapi({ path: '/example' }))'.
+      Or use "populateRouterContractOpenAPIPaths" from "@orpc/openapi" utility to automatically fill in any missing paths.
+    `)
+  }
+
+  const method = meta.method ?? DEFAULT_OPENAPI_METHOD
+  const path = toNestPattern(meta.prefix ? mergeHttpPath(meta.prefix, meta.path) : meta.path)
+  const successStatus = meta.successStatus ?? DEFAULT_SUCCESS_STATUS
+
+  return applyDecorators(
+    MethodDecoratorMap[method](path),
+    HttpCode(successStatus),
+  )
+}
+
+function implementRouterContract(
+  contract: RouterContract,
+  target: Record<PropertyKey, any>,
+  propertyKey: string,
+  descriptor: TypedPropertyDescriptor<(...args: any[]) => any>,
+): void {
+  for (const key in contract) {
+    let methodName = `${propertyKey}_${key}`
+
+    let i = 0
+    while (methodName in target) {
+      methodName = `${propertyKey}_${key}_${i++}`
+    }
+
+    target[methodName] = async function (...args: any[]) {
+      const router = await descriptor.value!.apply(this, args)
+      return getRouter(router, [key])
+    }
+
+    Object.setPrototypeOf(target[methodName], descriptor.value!)
+
+    queueMicrotask(() => {
+      for (const p of Reflect.getOwnMetadataKeys(target, propertyKey)) {
+        Reflect.defineMetadata(p, Reflect.getOwnMetadata(p, target, propertyKey), target, methodName)
       }
 
-      target[methodName] = async function (...args: any[]) {
-        const router = await descriptor.value!.apply(this, args)
-        return getRouter(router, [key])
+      for (const p of Reflect.getOwnMetadataKeys(target.constructor, propertyKey)) {
+        Reflect.defineMetadata(p, Reflect.getOwnMetadata(p, target.constructor, propertyKey), target.constructor, methodName)
       }
+    })
 
-      Object.setPrototypeOf(target[methodName], descriptor.value!)
+    const childContract = (contract as any)[key]
+    const childDescriptor = Object.getOwnPropertyDescriptor(target, methodName)!
 
+    if (childContract instanceof ProcedureContract) {
+      const routeDecorator = toNestRouteDecorator(childContract)
+
+      // applied after the deferred metadata copies so route metadata cannot be overridden
       queueMicrotask(() => {
-        for (const p of Reflect.getOwnMetadataKeys(target, propertyKey)) {
-          Reflect.defineMetadata(p, Reflect.getOwnMetadata(p, target, propertyKey), target, methodName)
-        }
-
-        for (const p of Reflect.getOwnMetadataKeys(target.constructor, propertyKey)) {
-          Reflect.defineMetadata(p, Reflect.getOwnMetadata(p, target.constructor, propertyKey), target.constructor, methodName)
-        }
+        routeDecorator(target, methodName, childDescriptor)
       })
-
-      Implement(contract[key] as any)(target, methodName, Object.getOwnPropertyDescriptor(target, methodName)!)
+    }
+    else {
+      implementRouterContract(childContract, target, methodName, childDescriptor)
     }
   }
 }

--- a/packages/nest/src/implement.ts
+++ b/packages/nest/src/implement.ts
@@ -88,6 +88,8 @@ export function Implement<T extends RouterContract>(
         return getRouter(router, [key])
       }
 
+      Object.setPrototypeOf(target[methodName], descriptor.value!)
+
       for (const p of Reflect.getOwnMetadataKeys(target, propertyKey)) {
         Reflect.defineMetadata(p, Reflect.getOwnMetadata(p, target, propertyKey), target, methodName)
       }


### PR DESCRIPTION
Method-level NestJS enhancers (`@UseGuards`, `@UsePipes`, `@UseFilters`, `@SetMetadata`, ...) on a router-contract `@Implement` method never reached the synthesized route handlers — guards silently never ran, leaving those routes unprotected regardless of decorator order. Enhancer metadata now reaches every synthesized route, decorator placement around `@Implement` no longer matters for whether enhancers apply, and interceptor execution order follows decorator order exactly like on plain NestJS methods.

## Fixes

- Synthesized methods inherit from the original method via the prototype chain, so guards, pipes, filters, and `@SetMetadata` resolve through NestJS's `Reflect.getMetadata` lookups and now run on every route, including nested routers.
- `ImplementInterceptor` is registered at the decorated method level, so the interceptor list carries user interceptors and `ImplementInterceptor` in native decorator-evaluation order: interceptors below `@Implement` observe the encoded response, interceptors above it run inside and observe the raw implemented procedure — identical between single-procedure and router-contract implementations.
- The router branch no longer recurses through `Implement` itself: routing and status decorators are applied directly to synthesized methods, deferred (with the method-name-keyed metadata copies) until the whole decorator stack has run, so late-running decorators are picked up and route metadata is always written last.
- The documented ordering restriction is gone; the docs warning is replaced with a note that decorators combine with `@Implement` in any order and that execution order follows decorator order.

## Testing

- Header-based `AuthGuard` e2e test: requests without the token are rejected (403) and with it succeed (200) on all synthesized routes including a nested procedure, in both decorator orders. Before the fix the guard never executed.
- Interceptor-order e2e tests for both single-procedure and router-contract `@Implement`, in both decorator orders, asserting what the user interceptor observes (encoded response vs raw procedure).
- The conflict-method-names test boots a real app: routes serve correctly, `@Req()` injection works on synthesized methods, and `@SetMetadata` from both sides of `@Implement` is visible via `Reflector` on `ctx.getHandler()` at runtime.