### PR TITLE
feat(rpc): restrict RPC handlers to POST, PUT, PATCH and DELETE by default

### DIFF
--- a/apps/content/docs/plugins/csrf-guard.md
+++ b/apps/content/docs/plugins/csrf-guard.md
@@ -19,19 +19,6 @@ const handler = new OpenAPIHandler(router, {
 })
 ```
 
-::: info
-HTTP-based `RPCHandler` implementations enable this plugin by default. Disable it with `csrfGuardHandlerPlugin.enabled`.
-
-```ts
-const handler = new RPCHandler(router, {
-  csrfGuardHandlerPlugin: {
-    enabled: false,
-  },
-})
-```
-
-:::
-
 <!--@include: @/shared/any-handler-support-info.md -->
 
 ## Learn More

--- a/apps/content/docs/rpc/handler.md
+++ b/apps/content/docs/rpc/handler.md
@@ -50,6 +50,69 @@ export async function fetch(request: Request) {
 
 <!--@include: @/shared/standard-server-cors-warning.md -->
 
+## Supported HTTP Methods
+
+By default, `RPCHandler` only responds to `POST`, `PUT`, `PATCH`, and `DELETE` requests. Any other method, such as `GET` or `HEAD`, is treated as unmatched, as if no procedure exists at that path.
+
+This is a security default: cross-site, browsers can only send these methods via a [CORS preflight](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) or an HTML form, never from a plain link. Safe methods like `GET` or `HEAD` are excluded because invoking a procedure can modify data.
+
+Use `allowMethods` to replace the allowlist: tighten it to `POST` only, or also accept [`QUERY`](https://datatracker.ietf.org/doc/draft-ietf-httpbis-safe-method-w-body/), which reads input from the request body and stays preflight-protected:
+
+```ts
+const handler = new RPCHandler(router, {
+  allowMethods: ['POST', 'PUT', 'PATCH', 'DELETE', 'QUERY'],
+})
+```
+
+### Enabling the GET Method
+
+::: danger Dangerous with cookie-based authentication
+Enabling `GET` is dangerous when your application stores tokens in cookies with `SameSite=Lax` (the browser default) or `SameSite=None`. These cookies **are still sent on cross-site top-level navigations**, so an attacker only needs a signed-in user to click a link like `https://example.com/rpc/planet/delete?data=...` and the procedure runs with the victim's cookies. No JavaScript, no CORS bypass.
+
+To enable `GET` safely, do one of the following:
+
+- Set authentication cookies to `SameSite=Strict`, which browsers never send cross-site
+- Use an independent protection, such as the [CSRF Guard Plugin](/docs/plugins/csrf-guard)
+- Allow `GET` only for safe procedures that never modify data, as shown below
+
+Learn more about this attack on [MDN](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/CSRF) and in the [OWASP CSRF Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html).
+:::
+
+Add `GET` to `allowMethods` to enable it for every procedure:
+
+```ts
+import { CSRFGuardHandlerPlugin } from '@orpc/server/plugins'
+import { RPC_DEFAULT_ALLOW_METHODS } from '@orpc/server/standard'
+
+const handler = new RPCHandler(router, {
+  allowMethods: ['GET', ...RPC_DEFAULT_ALLOW_METHODS],
+  plugins: [
+    new CSRFGuardHandlerPlugin(), // reject requests triggered by navigations, forms, etc.
+  ],
+})
+```
+
+Or pass a function to decide per request. For example, only allow `GET` for procedures that declare it via [OpenAPI metadata](/docs/openapi/routing):
+
+```ts
+import { getOpenAPIMeta, openapi } from '@orpc/openapi'
+import { RPC_DEFAULT_ALLOW_METHODS } from '@orpc/server/standard'
+
+const listPlanets = os
+  .meta(openapi({ method: 'GET', path: '/planets' }))
+  .handler(() => ['Earth', 'Mars'])
+
+const handler = new RPCHandler({ listPlanets }, {
+  allowMethods: (method, procedure, path) => {
+    if (method === 'GET' && getOpenAPIMeta(procedure)?.method === 'GET') {
+      return true
+    }
+
+    return RPC_DEFAULT_ALLOW_METHODS.includes(method)
+  },
+})
+```
+
 ## Interceptors
 
 Interceptors let you observe or change different stages of an RPC request. Common use cases include logging, error handling, and metrics.
@@ -161,19 +224,6 @@ const handler = new RPCHandler(router, {
   ],
 })
 ```
-
-::: info
-HTTP-based `RPCHandler` implementations enable the [CSRF Guard Plugin](/docs/plugins/csrf-guard) by default to protect RPC requests from CSRF attacks. Disable it with `csrfGuardHandlerPlugin.enabled`.
-
-```ts
-const handler = new RPCHandler(router, {
-  csrfGuardHandlerPlugin: {
-    enabled: false,
-  },
-})
-```
-
-:::
 
 ## Custom Serializer
 

--- a/apps/content/docs/rpc/link.md
+++ b/apps/content/docs/rpc/link.md
@@ -249,6 +249,10 @@ const link = new RPCLink({
 
 `RPCLink` sends requests with `POST` by default. Use `method` to choose the method per call.
 
+::: warning
+By default, [RPC handlers](/docs/rpc/handler#supported-http-methods) only accept `POST`, `PUT`, `PATCH`, and `DELETE` requests. Before sending `GET` or `QUERY` requests, allow them in the handler first, and understand [the risks of enabling `GET`](/docs/rpc/handler#enabling-the-get-method).
+:::
+
 ```ts
 type ClientContext = {
   cache?: RequestCache

--- a/apps/content/docs/rpc/protocol.md
+++ b/apps/content/docs/rpc/protocol.md
@@ -28,7 +28,7 @@ const router = {
 
 ## Sending Input
 
-You can use any HTTP method. Send input in the query string or request body, depending on the method.
+Requests can use the `POST`, `PUT`, `PATCH`, or `DELETE` method, or other methods like `GET` and `QUERY` when the server [allows them](/docs/rpc/handler#supported-http-methods). Send input in the query string (`GET`) or request body (other methods).
 
 ::: info
 Request payloads depend on the serializer and are not plain JSON. Learn more in [RPC Serializer Format](/docs/rpc/serializer#serialization-format).

--- a/packages/openapi/src/meta.ts
+++ b/packages/openapi/src/meta.ts
@@ -436,6 +436,11 @@ openapi.prefix = prefix => ({
   name: '~openapi/prefix',
 })
 
+/**
+ * Retrieves the OpenAPI metadata attached to a procedure or router, or `undefined` if not set.
+ *
+ * @see {@link https://orpc.dev/docs/rpc/handler#enabling-the-get-method | RPC Handler - Enabling the GET Method}
+ */
 export function getOpenAPIMeta(procedureOrLazy: AnyProcedureContract | Lazy<any>): OpenAPIMeta | undefined {
   return procedureOrLazy['~orpc'].meta['~openapi'] as OpenAPIMeta | undefined
 }

--- a/packages/ratelimit/src/handler-plugin.test.ts
+++ b/packages/ratelimit/src/handler-plugin.test.ts
@@ -6,6 +6,7 @@ describe('ratelimitHandlerPlugin', () => {
   const handlerFn = vi.fn()
   const procedure = os.handler(handlerFn)
   const handler = new RPCHandler(procedure, {
+    allowMethods: ['GET'], // tests below send GET requests
     plugins: [
       new RateLimitHandlerPlugin(),
     ],

--- a/packages/server/src/adapters/aws-lambda/rpc-handler.test.ts
+++ b/packages/server/src/adapters/aws-lambda/rpc-handler.test.ts
@@ -111,46 +111,36 @@ describe('rpcHandler', () => {
     expect(responseStream.text).toBe('intercepted')
   })
 
-  it('enables csrfGuardPlugin by default', async () => {
+  it('treats GET requests as unmatched by default', async () => {
     const handler = new RPCHandler({
       ping: os.handler(() => 'pong'),
     })
 
     const responseStream = new TestResponseStream()
     const result = await handler.handle(createEvent({
-      headers: {
-        'host': 'example.com',
-        'content-type': 'application/json',
-        'cookie': 'session=abc',
-        'sec-fetch-mode': 'navigate',
-      },
+      requestContext: { http: { method: 'GET' } },
+      rawQueryString: `data=${encodeURIComponent(JSON.stringify({ json: null }))}`,
+      body: undefined,
     }), responseStream)
 
-    expect(result.matched).toBe(true)
-    expect(responseStream.metadata?.statusCode).toBe(403)
-    expect(responseStream.text).toContain('Request blocked by CSRF protection')
+    expect(result.matched).toBe(false)
   })
 
-  it('disables csrfGuardPlugin when configured', async () => {
+  it('allows GET requests when allowMethods includes GET', async () => {
     const handler = new RPCHandler(
       {
         ping: os.handler(() => 'pong'),
       },
       {
-        csrfGuardPlugin: {
-          enabled: false,
-        },
+        allowMethods: ['GET'],
       },
     )
 
     const responseStream = new TestResponseStream()
     const result = await handler.handle(createEvent({
-      headers: {
-        'host': 'example.com',
-        'content-type': 'application/json',
-        'cookie': 'session=abc',
-        'sec-fetch-mode': 'navigate',
-      },
+      requestContext: { http: { method: 'GET' } },
+      rawQueryString: `data=${encodeURIComponent(JSON.stringify({ json: null }))}`,
+      body: undefined,
     }), responseStream)
 
     expect(result.matched).toBe(true)

--- a/packages/server/src/adapters/aws-lambda/rpc-handler.ts
+++ b/packages/server/src/adapters/aws-lambda/rpc-handler.ts
@@ -2,26 +2,11 @@ import type { Context } from '../../context'
 import type { Router } from '../../router'
 import type { RPCHandlerCodecOptions, StandardHandlerOptions } from '../standard'
 import type { AwsLambdaHandlerOptions } from './handler'
-import { toArray } from '@orpc/shared'
-import { CSRFGuardHandlerPlugin } from '../../plugins'
 import { RPCHandlerCodec, StandardHandler } from '../standard'
 import { AwsLambdaHandler } from './handler'
 
 export interface RPCHandlerOptions<T extends Context>
-  extends AwsLambdaHandlerOptions<T>, Omit<StandardHandlerOptions<T>, 'plugins'>, RPCHandlerCodecOptions<T> {
-
-  /**
-   * Configuration for {@link CSRFGuardHandlerPlugin}, which is enabled by default for `RPCHandler` over HTTP.
-   */
-  csrfGuardPlugin?: {
-    /**
-     * If `false`, this plugin is disabled.
-     *
-     * @default true
-     */
-    enabled?: boolean
-  }
-}
+  extends AwsLambdaHandlerOptions<T>, Omit<StandardHandlerOptions<T>, 'plugins'>, RPCHandlerCodecOptions<T> {}
 
 /**
  * Serves an oRPC router over the RPC protocol on AWS Lambda,
@@ -37,13 +22,6 @@ export class RPCHandler<T extends Context> extends AwsLambdaHandler<T> {
     router: Router<T>,
     options: NoInfer<RPCHandlerOptions<T>> = {},
   ) {
-    if (options.csrfGuardPlugin?.enabled !== false) {
-      options = {
-        ...options,
-        plugins: [...toArray(options.plugins), new CSRFGuardHandlerPlugin()],
-      }
-    }
-
     const codec = new RPCHandlerCodec(router, options)
     const handler = new StandardHandler(codec, options)
     super(handler, options)

--- a/packages/server/src/adapters/fastify/rpc-handler.test.ts
+++ b/packages/server/src/adapters/fastify/rpc-handler.test.ts
@@ -82,7 +82,7 @@ describe('rpcHandler', () => {
     expect(res.text).toBe('intercepted')
   })
 
-  it('enables csrfGuardPlugin by default', async () => {
+  it('treats GET requests as unmatched by default', async () => {
     const handler = new RPCHandler({
       ping: os.handler(() => 'pong'),
     })
@@ -100,25 +100,19 @@ describe('rpcHandler', () => {
     await app.ready()
 
     const res = await request(app.server)
-      .post('/ping')
-      .set('content-type', 'application/json')
-      .set('cookie', 'session=abc')
-      .set('sec-fetch-mode', 'navigate')
-      .send({ json: null })
+      .get(`/ping?data=${encodeURIComponent(JSON.stringify({ json: null }))}`)
 
-    expect(res.status).toBe(403)
-    expect(res.text).toContain('Request blocked by CSRF protection')
+    expect(res.status).toBe(404)
+    expect(res.text).toBe('not matched')
   })
 
-  it('disables csrfGuardPlugin when configured', async () => {
+  it('allows GET requests when allowMethods includes GET', async () => {
     const handler = new RPCHandler(
       {
         ping: os.handler(() => 'pong'),
       },
       {
-        csrfGuardPlugin: {
-          enabled: false,
-        },
+        allowMethods: ['GET'],
       },
     )
 
@@ -130,11 +124,7 @@ describe('rpcHandler', () => {
     await app.ready()
 
     const res = await request(app.server)
-      .post('/ping')
-      .set('content-type', 'application/json')
-      .set('cookie', 'session=abc')
-      .set('sec-fetch-mode', 'navigate')
-      .send({ json: null })
+      .get(`/ping?data=${encodeURIComponent(JSON.stringify({ json: null }))}`)
 
     expect(res.status).toBe(200)
     expect(res.text).toContain('pong')

--- a/packages/server/src/adapters/fastify/rpc-handler.ts
+++ b/packages/server/src/adapters/fastify/rpc-handler.ts
@@ -2,26 +2,11 @@ import type { Context } from '../../context'
 import type { Router } from '../../router'
 import type { RPCHandlerCodecOptions, StandardHandlerOptions } from '../standard'
 import type { FastifyHandlerOptions } from './handler'
-import { toArray } from '@orpc/shared'
-import { CSRFGuardHandlerPlugin } from '../../plugins'
 import { RPCHandlerCodec, StandardHandler } from '../standard'
 import { FastifyHandler } from './handler'
 
 export interface RPCHandlerOptions<T extends Context>
-  extends FastifyHandlerOptions<T>, Omit<StandardHandlerOptions<T>, 'plugins'>, RPCHandlerCodecOptions<T> {
-
-  /**
-   * Configuration for {@link CSRFGuardHandlerPlugin}, which is enabled by default for `RPCHandler` over HTTP.
-   */
-  csrfGuardPlugin?: {
-    /**
-     * If `false`, this plugin is disabled.
-     *
-     * @default true
-     */
-    enabled?: boolean
-  }
-}
+  extends FastifyHandlerOptions<T>, Omit<StandardHandlerOptions<T>, 'plugins'>, RPCHandlerCodecOptions<T> {}
 
 /**
  * Serves an oRPC router over the RPC protocol inside a Fastify server.
@@ -33,13 +18,6 @@ export class RPCHandler<T extends Context> extends FastifyHandler<T> {
     router: Router<T>,
     options: NoInfer<RPCHandlerOptions<T>> = {},
   ) {
-    if (options.csrfGuardPlugin?.enabled !== false) {
-      options = {
-        ...options,
-        plugins: [...toArray(options.plugins), new CSRFGuardHandlerPlugin()],
-      }
-    }
-
     const codec = new RPCHandlerCodec(router, options)
     const handler = new StandardHandler(codec, options)
     super(handler, options)

--- a/packages/server/src/adapters/fetch/rpc-handler.test.ts
+++ b/packages/server/src/adapters/fetch/rpc-handler.test.ts
@@ -69,54 +69,82 @@ describe('rpcHandler', () => {
     return expect(response!.text()).resolves.toBe('intercepted')
   })
 
-  it('enables csrfGuardHandlerPlugin by default', async () => {
+  it('treats GET requests as unmatched by default', async () => {
     const handler = new RPCHandler({
       ping: os.handler(() => 'pong'),
     })
 
     const result = await handler.handle(
-      new Request('https://example.com/ping', {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          'cookie': 'session=abc',
-          'sec-fetch-mode': 'navigate',
-        },
-        body: JSON.stringify({ json: null }),
-      }),
+      new Request(`https://example.com/ping?data=${encodeURIComponent(JSON.stringify({ json: null }))}`),
     )
 
-    expect(result.response?.status).toBe(403)
-    expect(await result.response?.text()).toContain('Request blocked by CSRF protection')
+    expect(result.matched).toBe(false)
+    expect(result.response).toBeUndefined()
   })
 
-  it('disables csrfGuardHandlerPlugin when configured', async () => {
+  it('treats unsupported methods like OPTIONS as unmatched', async () => {
     const handler = new RPCHandler(
       {
         ping: os.handler(() => 'pong'),
       },
       {
-        csrfGuardHandlerPlugin: {
-          enabled: false,
-        },
+        allowMethods: ['GET'],
       },
     )
 
     const result = await handler.handle(
-      new Request('https://example.com/ping', {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/json',
-          'cookie': 'session=abc',
-          'sec-fetch-mode': 'navigate',
-        },
-        body: JSON.stringify({ json: null }),
-      }),
+      new Request('https://example.com/ping', { method: 'OPTIONS' }),
+    )
+
+    expect(result.matched).toBe(false)
+    expect(result.response).toBeUndefined()
+  })
+
+  it('allows GET requests when allowMethods includes GET', async () => {
+    const handler = new RPCHandler(
+      {
+        ping: os.handler(() => 'pong'),
+      },
+      {
+        allowMethods: ['GET'],
+      },
+    )
+
+    const result = await handler.handle(
+      new Request(`https://example.com/ping?data=${encodeURIComponent(JSON.stringify({ json: null }))}`),
     )
 
     expect(result.matched).toBe(true)
-    expect(result.response).toBeInstanceOf(Response)
     expect(result.response!.status).toBe(200)
     await expect(result.response!.text()).resolves.toContain('pong')
+  })
+
+  it('supports deciding allowMethods per procedure', async () => {
+    const allowMethods = vi.fn((method: string, _procedure: unknown, path: string[]) => method === 'GET' && path[0] === 'public')
+
+    const handler = new RPCHandler(
+      {
+        public: os.handler(() => 'public'),
+        private: os.handler(() => 'private'),
+      },
+      {
+        allowMethods,
+      },
+    )
+
+    const allowed = await handler.handle(
+      new Request(`https://example.com/public?data=${encodeURIComponent(JSON.stringify({ json: null }))}`),
+    )
+
+    expect(allowed.matched).toBe(true)
+    expect(allowed.response!.status).toBe(200)
+    await expect(allowed.response!.text()).resolves.toContain('public')
+
+    const blocked = await handler.handle(
+      new Request(`https://example.com/private?data=${encodeURIComponent(JSON.stringify({ json: null }))}`),
+    )
+
+    expect(blocked.matched).toBe(false)
+    expect(allowMethods).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/server/src/adapters/fetch/rpc-handler.ts
+++ b/packages/server/src/adapters/fetch/rpc-handler.ts
@@ -2,25 +2,11 @@ import type { Context } from '../../context'
 import type { Router } from '../../router'
 import type { RPCHandlerCodecOptions, StandardHandlerOptions } from '../standard'
 import type { FetchHandlerOptions } from './handler'
-import { toArray } from '@orpc/shared'
-import { CSRFGuardHandlerPlugin } from '../../plugins'
 import { RPCHandlerCodec, StandardHandler } from '../standard'
 import { FetchHandler } from './handler'
 
 export interface RPCHandlerOptions<T extends Context>
-  extends FetchHandlerOptions<T>, Omit<StandardHandlerOptions<T>, 'plugins'>, RPCHandlerCodecOptions<T> {
-  /**
-   * Configuration for {@link CSRFGuardHandlerPlugin}, which is enabled by default for `RPCHandler` over HTTP.
-   */
-  csrfGuardHandlerPlugin?: {
-    /**
-     * If `false`, this plugin is disabled.
-     *
-     * @default true
-     */
-    enabled?: boolean
-  }
-}
+  extends FetchHandlerOptions<T>, Omit<StandardHandlerOptions<T>, 'plugins'>, RPCHandlerCodecOptions<T> {}
 
 /**
  * Serves an oRPC router over the RPC protocol using the Fetch API
@@ -34,13 +20,6 @@ export class RPCHandler<T extends Context> extends FetchHandler<T> {
     router: Router<T>,
     options: NoInfer<RPCHandlerOptions<T>> = {},
   ) {
-    if (options.csrfGuardHandlerPlugin?.enabled !== false) {
-      options = {
-        ...options,
-        plugins: [...toArray(options.plugins), new CSRFGuardHandlerPlugin()],
-      }
-    }
-
     const codec = new RPCHandlerCodec(router, options)
     const handler = new StandardHandler(codec, options)
     super(handler, options)

--- a/packages/server/src/adapters/node/rpc-handler.test.ts
+++ b/packages/server/src/adapters/node/rpc-handler.test.ts
@@ -70,51 +70,39 @@ describe('rpcHandler', () => {
     expect(res.text).toBe('intercepted')
   })
 
-  it('enables csrfGuardPlugin by default', async () => {
+  it('treats GET requests as unmatched by default', async () => {
     const handler = new RPCHandler({
       ping: os.handler(() => 'pong'),
     })
 
-    let result: Awaited<ReturnType<typeof handler.handle>> | undefined
-
     const res = await request(async (req: IncomingMessage, response: ServerResponse) => {
-      result = await handler.handle(req as any, response as any)
+      const result = await handler.handle(req as any, response as any)
 
       if (!result.matched) {
         response.statusCode = 404
         response.end('not matched')
       }
     })
-      .post('/ping')
-      .set('content-type', 'application/json')
-      .set('cookie', 'session=abc')
-      .set('sec-fetch-mode', 'navigate')
-      .send({ json: null })
+      .get(`/ping?data=${encodeURIComponent(JSON.stringify({ json: null }))}`)
 
-    expect(res.status).toBe(403)
-    expect(res.text).toContain('Request blocked by CSRF protection')
+    expect(res.status).toBe(404)
+    expect(res.text).toBe('not matched')
   })
 
-  it('disables csrfGuardPlugin when configured', async () => {
+  it('allows GET requests when allowMethods includes GET', async () => {
     const handler = new RPCHandler(
       {
         ping: os.handler(() => 'pong'),
       },
       {
-        csrfGuardPlugin: {
-          enabled: false,
-        },
+        allowMethods: ['GET'],
       },
     )
 
     const res = await request(async (req: IncomingMessage, response: ServerResponse) => {
       await handler.handle(req as any, response as any)
     })
-      .post('/ping')
-      .set('content-type', 'application/json')
-      .set('cookie', 'session=abc')
-      .set('sec-fetch-mode', 'navigate')
-      .send({ json: null })
+      .get(`/ping?data=${encodeURIComponent(JSON.stringify({ json: null }))}`)
 
     expect(res.status).toBe(200)
     expect(res.text).toContain('pong')

--- a/packages/server/src/adapters/node/rpc-handler.ts
+++ b/packages/server/src/adapters/node/rpc-handler.ts
@@ -2,26 +2,11 @@ import type { Context } from '../../context'
 import type { Router } from '../../router'
 import type { RPCHandlerCodecOptions, StandardHandlerOptions } from '../standard'
 import type { NodeHttpHandlerOptions } from './handler'
-import { toArray } from '@orpc/shared'
-import { CSRFGuardHandlerPlugin } from '../../plugins'
 import { RPCHandlerCodec, StandardHandler } from '../standard'
 import { NodeHttpHandler } from './handler'
 
 export interface RPCHandlerOptions<T extends Context>
-  extends NodeHttpHandlerOptions<T>, Omit<StandardHandlerOptions<T>, 'plugins'>, RPCHandlerCodecOptions<T> {
-
-  /**
-   * Configuration for {@link CSRFGuardHandlerPlugin}, which is enabled by default for `RPCHandler` over HTTP.
-   */
-  csrfGuardPlugin?: {
-    /**
-     * If `false`, this plugin is disabled.
-     *
-     * @default true
-     */
-    enabled?: boolean
-  }
-}
+  extends NodeHttpHandlerOptions<T>, Omit<StandardHandlerOptions<T>, 'plugins'>, RPCHandlerCodecOptions<T> {}
 
 /**
  * Serves an oRPC router over the RPC protocol using Node.js built-in
@@ -34,13 +19,6 @@ export class RPCHandler<T extends Context> extends NodeHttpHandler<T> {
     router: Router<T>,
     options: NoInfer<RPCHandlerOptions<T>> = {},
   ) {
-    if (options.csrfGuardPlugin?.enabled !== false) {
-      options = {
-        ...options,
-        plugins: [...toArray(options.plugins), new CSRFGuardHandlerPlugin()],
-      }
-    }
-
     const codec = new RPCHandlerCodec(router, options)
     const handler = new StandardHandler(codec, options)
     super(handler, options)

--- a/packages/server/src/adapters/standard/rpc-handler-codec.test.ts
+++ b/packages/server/src/adapters/standard/rpc-handler-codec.test.ts
@@ -22,7 +22,7 @@ describe('rpcHandlerCodec', () => {
       const codec = new RPCHandlerCodec(router)
 
       const result = await codec.resolveProcedure({
-        method: 'GET',
+        method: 'POST',
         url: '/missing?data=%7B%7D',
         resolveBody: vi.fn(),
         headers: {},
@@ -38,7 +38,7 @@ describe('rpcHandlerCodec', () => {
         deserialize: vi.fn().mockReturnValueOnce('__deserialized__'),
       } as any
 
-      const codec = new RPCHandlerCodec(router, { serializer })
+      const codec = new RPCHandlerCodec(router, { serializer, allowMethods: ['GET'] })
 
       const result = await codec.resolveProcedure({
         method: 'GET',
@@ -85,6 +85,31 @@ describe('rpcHandlerCodec', () => {
       expect(resolveBody).toHaveBeenCalledOnce()
       expect(serializer.deserialize).toHaveBeenCalledOnce()
       expect(serializer.deserialize).toHaveBeenCalledWith({ json: { deep: true } })
+    })
+
+    it('resolves QUERY requests when allowMethods includes QUERY and decodes input from the body', async () => {
+      const serializer = {
+        serialize: vi.fn(),
+        deserialize: vi.fn().mockReturnValueOnce('__deserialized__'),
+      } as any
+
+      const resolveBody = vi.fn().mockResolvedValueOnce({ json: null })
+      const codec = new RPCHandlerCodec(router, { serializer, allowMethods: ['QUERY'] })
+
+      const result = await codec.resolveProcedure({
+        method: 'QUERY',
+        url: '/ping',
+        resolveBody,
+        headers: {},
+        signal: undefined,
+      } as any, options as any)
+
+      expect(result).toBeDefined()
+
+      const input = await result!.decodeInput()
+
+      expect(input).toBe('__deserialized__')
+      expect(resolveBody).toHaveBeenCalledOnce()
     })
   })
 
@@ -278,7 +303,7 @@ describe('rpcHandlerCodec', () => {
       })
 
       const result = await codec.resolveProcedure({
-        method: 'GET',
+        method: 'POST',
         url: '/missing?data=%7B%7D',
         resolveBody: vi.fn(),
         headers: {},

--- a/packages/server/src/adapters/standard/rpc-matcher.test.ts
+++ b/packages/server/src/adapters/standard/rpc-matcher.test.ts
@@ -254,15 +254,37 @@ describe('rpcMatcher', () => {
     })
 
     it('decides per request with the method, matched procedure, and path', async () => {
-      const allowMethods = vi.fn(async (method: string, _procedure: unknown, path: string[]) => method === 'GET' && path[0] === 'ping')
+      const allowMethods = vi.fn((method: string, _procedure: unknown, path: string[]) => method === 'GET' && path[0] === 'ping')
       const matcher = new RPCMatcher(router, { allowMethods })
 
-      await expect(matcher.match('GET', '/ping', undefined)).resolves.toBeDefined()
+      const matched = await matcher.match('GET', '/ping', undefined)
+      expect(matched).toBeDefined()
+      expect(matched!.path).toEqual(['ping'])
+      expect(matched!.procedure).toBe(procedure1)
       expect(allowMethods).toHaveBeenCalledWith('GET', procedure1, ['ping'])
 
       await expect(matcher.match('GET', '/nested/echo', undefined)).resolves.toBeUndefined()
+      expect(allowMethods).toHaveBeenCalledWith('GET', procedure2, ['nested', 'echo'])
+
+      // the function replaces the default allowlist entirely
       await expect(matcher.match('POST', '/ping', undefined)).resolves.toBeUndefined()
+      expect(allowMethods).toHaveBeenCalledWith('POST', procedure1, ['ping'])
+
       expect(allowMethods).toHaveBeenCalledTimes(3)
+    })
+
+    it('consults the function with lazily resolved procedures', async () => {
+      const allowMethods = vi.fn(() => false)
+      const matcher = new RPCMatcher(router, { allowMethods })
+
+      await expect(matcher.match('POST', '/lazy/info', undefined)).resolves.toBeUndefined()
+      expect(allowMethods).toHaveBeenCalledOnce()
+      expect(allowMethods).toHaveBeenCalledWith('POST', procedure3, ['lazy', 'info'])
+
+      allowMethods.mockReturnValueOnce(true)
+      const matched = await matcher.match('POST', '/lazy/info', undefined)
+      expect(matched).toBeDefined()
+      expect(matched!.procedure).toBe(procedure3)
     })
 
     it('does not consult the function for unmatched paths', async () => {

--- a/packages/server/src/adapters/standard/rpc-matcher.test.ts
+++ b/packages/server/src/adapters/standard/rpc-matcher.test.ts
@@ -221,6 +221,59 @@ describe('rpcMatcher', () => {
     await expect(matcher.match('POST', '/nested/echo', undefined)).resolves.toBeDefined()
   })
 
+  describe('allowMethods', () => {
+    it.each([
+      'POST',
+      'PUT',
+      'PATCH',
+      'DELETE',
+    ] as const)('matches %s requests by default', async (method) => {
+      const matcher = new RPCMatcher(router)
+
+      await expect(matcher.match(method, '/ping', undefined)).resolves.toBeDefined()
+    })
+
+    it.each([
+      'GET',
+      'HEAD',
+      'OPTIONS',
+      'QUERY',
+      'TRACE',
+    ] as const)('treats %s requests as unmatched by default', async (method) => {
+      const matcher = new RPCMatcher(router)
+
+      await expect(matcher.match(method, '/ping', undefined)).resolves.toBeUndefined()
+    })
+
+    it('replaces the default allowlist entirely when a list is provided', async () => {
+      const matcher = new RPCMatcher(router, { allowMethods: ['GET', 'QUERY'] })
+
+      await expect(matcher.match('GET', '/ping', undefined)).resolves.toBeDefined()
+      await expect(matcher.match('QUERY', '/ping', undefined)).resolves.toBeDefined()
+      await expect(matcher.match('POST', '/ping', undefined)).resolves.toBeUndefined()
+    })
+
+    it('decides per request with the method, matched procedure, and path', async () => {
+      const allowMethods = vi.fn(async (method: string, _procedure: unknown, path: string[]) => method === 'GET' && path[0] === 'ping')
+      const matcher = new RPCMatcher(router, { allowMethods })
+
+      await expect(matcher.match('GET', '/ping', undefined)).resolves.toBeDefined()
+      expect(allowMethods).toHaveBeenCalledWith('GET', procedure1, ['ping'])
+
+      await expect(matcher.match('GET', '/nested/echo', undefined)).resolves.toBeUndefined()
+      await expect(matcher.match('POST', '/ping', undefined)).resolves.toBeUndefined()
+      expect(allowMethods).toHaveBeenCalledTimes(3)
+    })
+
+    it('does not consult the function for unmatched paths', async () => {
+      const allowMethods = vi.fn(() => true)
+      const matcher = new RPCMatcher(router, { allowMethods })
+
+      await expect(matcher.match('POST', '/missing', undefined)).resolves.toBeUndefined()
+      expect(allowMethods).not.toHaveBeenCalled()
+    })
+  })
+
   describe('prefix', () => {
     it('handles prefix stripping', async () => {
       const matcher = new RPCMatcher(router)

--- a/packages/server/src/adapters/standard/rpc-matcher.ts
+++ b/packages/server/src/adapters/standard/rpc-matcher.ts
@@ -54,17 +54,24 @@ interface PendingLazyRouter extends WalkProcedureContractsLazyResult {
 
 export class RPCMatcher {
   private readonly filter: Exclude<RPCMatcherOptions['filter'], undefined>
-  /** list-form `allowMethods` is normalized to a Set for O(1) lookups on every request */
-  private readonly allowMethods: ReadonlySet<StandardMethod> | ((method: StandardMethod, procedure: AnyProcedure, path: string[]) => boolean)
+  private readonly allowMethodsFn: (method: StandardMethod, procedure: AnyProcedure, path: string[]) => boolean
   private readonly rootRouter: AnyRouter
 
   private readonly tree: Map<`/${string}`, TreeEntry> = new Map()
   private readonly pendingLazyRouters: Map<string, PendingLazyRouter> = new Map()
 
   constructor(router: AnyRouter, options: RPCMatcherOptions = {}) {
-    const allowMethods = options.allowMethods ?? RPC_DEFAULT_ALLOW_METHODS
     this.filter = options.filter ?? true
-    this.allowMethods = typeof allowMethods === 'function' ? allowMethods : new Set(allowMethods)
+
+    const allowMethods = options.allowMethods ?? RPC_DEFAULT_ALLOW_METHODS
+    if (typeof allowMethods !== 'function') {
+      const set = new Set(allowMethods)
+      this.allowMethodsFn = (method: StandardMethod) => set.has(method)
+    }
+    else {
+      this.allowMethodsFn = allowMethods
+    }
+
     this.rootRouter = router
     this.index(router)
   }
@@ -89,10 +96,6 @@ export class RPCMatcher {
   }
 
   async match(method: StandardMethod, pathname: `/${string}`, prefix: `/${string}` | undefined): Promise<{ path: string[], procedure: AnyProcedure } | undefined> {
-    if (typeof this.allowMethods !== 'function' && !this.allowMethods.has(method)) {
-      return undefined
-    }
-
     if (pathname.length > 1 && pathname.endsWith('/')) {
       // Remove trailing slash for matching
       pathname = pathname.slice(0, -1) as `/${string}`
@@ -148,7 +151,7 @@ export class RPCMatcher {
 
     const procedure = entry.procedure ?? await this.resolveProcedure(entry)
 
-    if (typeof this.allowMethods === 'function' && !this.allowMethods(method, procedure, entry.path)) {
+    if (!this.allowMethodsFn(method, procedure, entry.path)) {
       return undefined
     }
 

--- a/packages/server/src/adapters/standard/rpc-matcher.ts
+++ b/packages/server/src/adapters/standard/rpc-matcher.ts
@@ -1,5 +1,5 @@
 import type { AnyProcedureContract } from '@orpc/contract'
-import type { Value } from '@orpc/shared'
+import type { Promisable, Value } from '@orpc/shared'
 import type { StandardMethod } from '@standardserver/core'
 import type { AnyProcedure } from '../../procedure'
 import type { AnyRouter } from '../../router'
@@ -10,6 +10,17 @@ import { Procedure } from '../../procedure'
 import { createContractProcedure } from '../../procedure-utils'
 import { getRouter, walkProcedureContractsSync } from '../../router-utils'
 
+/**
+ * Methods that can invoke procedures by default. Browsers cannot trigger them
+ * cross-site without a CORS preflight or an HTML form, unlike `GET`, which a plain
+ * `<a>` click or redirect can trigger with `SameSite=Lax` cookies attached. Other
+ * methods (`HEAD`, `OPTIONS`, `QUERY`, ...) have safe semantics that should not
+ * invoke a procedure that can modify data.
+ *
+ * @see {@link https://orpc.dev/docs/rpc/handler#supported-http-methods | RPC Handler - Supported HTTP Methods}
+ */
+export const RPC_DEFAULT_ALLOW_METHODS: readonly StandardMethod[] = ['POST', 'PUT', 'PATCH', 'DELETE']
+
 export interface RPCMatcherOptions {
   /**
    * Filter which procedures are exposed for matching. Return `false` to exclude.
@@ -17,6 +28,17 @@ export interface RPCMatcherOptions {
    * @default true
    */
   filter?: Value<boolean, [procedure: AnyProcedureContract | AnyProcedure, path: string[]]>
+
+  /**
+   * Restricts which HTTP methods can invoke procedures, either with a list of allowed
+   * methods or decided per request via a function. Requests using a disallowed method
+   * are treated as unmatched. `GET` is excluded by default because it is exposed to
+   * Cross-Site Request Forgery (CSRF) attacks.
+   *
+   * @default RPC_DEFAULT_ALLOW_METHODS (['POST', 'PUT', 'PATCH', 'DELETE'])
+   * @see {@link https://orpc.dev/docs/rpc/handler#supported-http-methods | RPC Handler - Supported HTTP Methods}
+   */
+  allowMethods?: readonly StandardMethod[] | ((method: StandardMethod, procedure: AnyProcedure, path: string[]) => Promisable<boolean>)
 }
 
 interface TreeEntry {
@@ -32,13 +54,17 @@ interface PendingLazyRouter extends WalkProcedureContractsLazyResult {
 
 export class RPCMatcher {
   private readonly filter: Exclude<RPCMatcherOptions['filter'], undefined>
+  /** list-form `allowMethods` is normalized to a Set for O(1) lookups on every request */
+  private readonly allowMethods: ReadonlySet<StandardMethod> | ((method: StandardMethod, procedure: AnyProcedure, path: string[]) => Promisable<boolean>)
   private readonly rootRouter: AnyRouter
 
   private readonly tree: Map<`/${string}`, TreeEntry> = new Map()
   private readonly pendingLazyRouters: Map<string, PendingLazyRouter> = new Map()
 
   constructor(router: AnyRouter, options: RPCMatcherOptions = {}) {
+    const allowMethods = options.allowMethods ?? RPC_DEFAULT_ALLOW_METHODS
     this.filter = options.filter ?? true
+    this.allowMethods = typeof allowMethods === 'function' ? allowMethods : new Set(allowMethods)
     this.rootRouter = router
     this.index(router)
   }
@@ -62,7 +88,11 @@ export class RPCMatcher {
     }
   }
 
-  async match(_method: StandardMethod, pathname: `/${string}`, prefix: `/${string}` | undefined): Promise<{ path: string[], procedure: AnyProcedure } | undefined> {
+  async match(method: StandardMethod, pathname: `/${string}`, prefix: `/${string}` | undefined): Promise<{ path: string[], procedure: AnyProcedure } | undefined> {
+    if (typeof this.allowMethods !== 'function' && !this.allowMethods.has(method)) {
+      return undefined
+    }
+
     if (pathname.length > 1 && pathname.endsWith('/')) {
       // Remove trailing slash for matching
       pathname = pathname.slice(0, -1) as `/${string}`
@@ -116,9 +146,15 @@ export class RPCMatcher {
       return undefined
     }
 
+    const procedure = entry.procedure ?? await this.resolveProcedure(entry)
+
+    if (typeof this.allowMethods === 'function' && !(await this.allowMethods(method, procedure, entry.path))) {
+      return undefined
+    }
+
     return {
       path: entry.path,
-      procedure: entry.procedure ?? await this.resolveProcedure(entry),
+      procedure,
     }
   }
 

--- a/packages/server/src/adapters/standard/rpc-matcher.ts
+++ b/packages/server/src/adapters/standard/rpc-matcher.ts
@@ -54,7 +54,8 @@ interface PendingLazyRouter extends WalkProcedureContractsLazyResult {
 
 export class RPCMatcher {
   private readonly filter: Exclude<RPCMatcherOptions['filter'], undefined>
-  private readonly allowMethodsFn: (method: StandardMethod, procedure: AnyProcedure, path: string[]) => boolean
+  private readonly allowMethodsSet: undefined | ReadonlySet<StandardMethod>
+  private readonly allowMethodsFn: undefined | ((method: StandardMethod, procedure: AnyProcedure, path: string[]) => boolean)
   private readonly rootRouter: AnyRouter
 
   private readonly tree: Map<`/${string}`, TreeEntry> = new Map()
@@ -65,8 +66,7 @@ export class RPCMatcher {
 
     const allowMethods = options.allowMethods ?? RPC_DEFAULT_ALLOW_METHODS
     if (typeof allowMethods !== 'function') {
-      const set = new Set(allowMethods)
-      this.allowMethodsFn = (method: StandardMethod) => set.has(method)
+      this.allowMethodsSet = new Set(allowMethods)
     }
     else {
       this.allowMethodsFn = allowMethods
@@ -96,6 +96,10 @@ export class RPCMatcher {
   }
 
   async match(method: StandardMethod, pathname: `/${string}`, prefix: `/${string}` | undefined): Promise<{ path: string[], procedure: AnyProcedure } | undefined> {
+    if (this.allowMethodsSet && !this.allowMethodsSet.has(method)) {
+      return undefined
+    }
+
     if (pathname.length > 1 && pathname.endsWith('/')) {
       // Remove trailing slash for matching
       pathname = pathname.slice(0, -1) as `/${string}`
@@ -151,7 +155,7 @@ export class RPCMatcher {
 
     const procedure = entry.procedure ?? await this.resolveProcedure(entry)
 
-    if (!this.allowMethodsFn(method, procedure, entry.path)) {
+    if (this.allowMethodsFn && !this.allowMethodsFn(method, procedure, entry.path)) {
       return undefined
     }
 

--- a/packages/server/src/adapters/standard/rpc-matcher.ts
+++ b/packages/server/src/adapters/standard/rpc-matcher.ts
@@ -1,5 +1,5 @@
 import type { AnyProcedureContract } from '@orpc/contract'
-import type { Promisable, Value } from '@orpc/shared'
+import type { Value } from '@orpc/shared'
 import type { StandardMethod } from '@standardserver/core'
 import type { AnyProcedure } from '../../procedure'
 import type { AnyRouter } from '../../router'
@@ -38,7 +38,7 @@ export interface RPCMatcherOptions {
    * @default RPC_DEFAULT_ALLOW_METHODS (['POST', 'PUT', 'PATCH', 'DELETE'])
    * @see {@link https://orpc.dev/docs/rpc/handler#supported-http-methods | RPC Handler - Supported HTTP Methods}
    */
-  allowMethods?: readonly StandardMethod[] | ((method: StandardMethod, procedure: AnyProcedure, path: string[]) => Promisable<boolean>)
+  allowMethods?: readonly StandardMethod[] | ((method: StandardMethod, procedure: AnyProcedure, path: string[]) => boolean)
 }
 
 interface TreeEntry {
@@ -55,7 +55,7 @@ interface PendingLazyRouter extends WalkProcedureContractsLazyResult {
 export class RPCMatcher {
   private readonly filter: Exclude<RPCMatcherOptions['filter'], undefined>
   /** list-form `allowMethods` is normalized to a Set for O(1) lookups on every request */
-  private readonly allowMethods: ReadonlySet<StandardMethod> | ((method: StandardMethod, procedure: AnyProcedure, path: string[]) => Promisable<boolean>)
+  private readonly allowMethods: ReadonlySet<StandardMethod> | ((method: StandardMethod, procedure: AnyProcedure, path: string[]) => boolean)
   private readonly rootRouter: AnyRouter
 
   private readonly tree: Map<`/${string}`, TreeEntry> = new Map()
@@ -148,7 +148,7 @@ export class RPCMatcher {
 
     const procedure = entry.procedure ?? await this.resolveProcedure(entry)
 
-    if (typeof this.allowMethods === 'function' && !(await this.allowMethods(method, procedure, entry.path))) {
+    if (typeof this.allowMethods === 'function' && !this.allowMethods(method, procedure, entry.path)) {
       return undefined
     }
 

--- a/packages/server/src/plugins/csrf-guard.ts
+++ b/packages/server/src/plugins/csrf-guard.ts
@@ -10,7 +10,9 @@ import { flattenStandardHeader } from '@standardserver/core'
  * (for example, fetch/XHR) rather than from standard HTML forms or direct browser navigation.
  *
  * @remarks
- * **Note**: This plugin is enabled by default for `RPCHandler` over HTTP.
+ * Unlike `SameSite` cookies, this protection also covers cross-site requests that
+ * still carry cookies, so it is the recommended safeguard when you enable the `GET`
+ * method on RPC handlers or rely on cookie-based authentication.
  *
  * @see {@link https://orpc.dev/docs/plugins/csrf-guard | CSRF Guard Plugin}
  */

--- a/packages/server/src/plugins/request-limit.test.ts
+++ b/packages/server/src/plugins/request-limit.test.ts
@@ -21,6 +21,7 @@ describe('requestLimitHandlerPlugin', () => {
         ping: procedure,
       },
       {
+        allowMethods: ['GET'], // this test sends a GET request
         plugins: [new RequestLimitHandlerPlugin({ maxBodySize: 22 })],
       },
     )

--- a/packages/server/src/plugins/rethrow.test.ts
+++ b/packages/server/src/plugins/rethrow.test.ts
@@ -15,6 +15,7 @@ describe('rethrowHandlerPlugin', () => {
   const filter = vi.fn(() => false)
   const interceptor = vi.fn(({ next }) => next())
   const handler = new RPCHandler(procedure, {
+    allowMethods: ['GET'], // tests below send GET requests
     interceptors: [interceptor],
     plugins: [
       new RethrowHandlerPlugin({
@@ -72,6 +73,7 @@ describe('rethrowHandlerPlugin', () => {
   it('throws when another interceptor corrupts the plugin context', async () => {
     const interceptor = vi.fn(({ next, ...options }) => next({ ...options, context: {} }))
     const handler = new RPCHandler(procedure, {
+      allowMethods: ['GET'],
       interceptors: [interceptor],
       plugins: [
         new RethrowHandlerPlugin({

--- a/tests/batch/__shared__/client-server.hono-fetch.ts
+++ b/tests/batch/__shared__/client-server.hono-fetch.ts
@@ -18,6 +18,7 @@ export const createHonoFetchBatchClientServerTest: CreateBatchClientServerTest =
 ) => {
   const handler = new RPCHandler(router, {
     serializer,
+    allowMethods: ['GET', 'POST'], // the client below sends GET requests (POST as fallback)
     plugins: [new BatchHandlerPlugin()],
   })
 

--- a/tests/rpc/__shared__/client-server.compression-node-http.ts
+++ b/tests/rpc/__shared__/client-server.compression-node-http.ts
@@ -14,6 +14,7 @@ export const createCompressionNodeHttpClientServerTest: CreateClientServerTest =
 ) => {
   const handler = new RPCHandler(router, {
     serializer,
+    allowMethods: ['GET', 'POST'], // the client below sends GET requests (POST as fallback)
     plugins: [
       new RequestCompressionHandlerPlugin(),
       new ResponseCompressionHandlerPlugin({

--- a/tests/rpc/__shared__/client-server.node-http.ts
+++ b/tests/rpc/__shared__/client-server.node-http.ts
@@ -12,6 +12,7 @@ export const createNodeHttpClientServerTest: CreateClientServerTest = (
 ) => {
   const handler = new RPCHandler(router, {
     serializer,
+    allowMethods: ['GET', 'POST'], // the client below sends GET requests (POST as fallback)
   })
 
   const server = http.createServer(async (req, res) => {


### PR DESCRIPTION
RPC handlers no longer accept every HTTP method. `RPCMatcher` now enforces an allowlist: `POST`, `PUT`, `PATCH`, and `DELETE` match by default, and any other method (`GET`, `HEAD`, `OPTIONS`, `QUERY`, ...) is treated as unmatched. This replaces enabling `CSRFGuardHandlerPlugin` by default on HTTP RPC handlers: with `GET` blocked, `SameSite=Lax` cookies can no longer be ridden through a cross-site link click, and safe-method requests can no longer invoke procedures that modify data.

## Security

- Cross-site `GET` navigations (the `SameSite=Lax` CSRF vector) and safe methods like `HEAD` or `OPTIONS` no longer reach procedures; disallowed methods fall through as unmatched, so nothing about the route is disclosed and co-mounted handlers keep working.
- `CSRFGuardHandlerPlugin` is no longer enabled by default and the `csrfGuardHandlerPlugin`/`csrfGuardPlugin` handler options are removed (breaking). The plugin remains available as an opt-in defense-in-depth layer.

## API

- New `allowMethods` option on `RPCMatcherOptions`, available on every RPC handler: either a method list that replaces the default allowlist (also allows tightening to `POST` only or accepting `QUERY`), or a `(method, procedure, path)` predicate for per-procedure decisions, e.g. based on OpenAPI metadata. List form is normalized to a `Set` once, so the per-request check is O(1).
- `RPC_DEFAULT_ALLOW_METHODS` is exported from `@orpc/server/standard` for composing predicates.

## Docs

- New "Supported HTTP Methods" section in the RPC handler docs covers the default, `QUERY`, and how to enable `GET` safely (`SameSite=Strict` cookies, the CSRF Guard Plugin, or `GET` only for read-only procedures), with MDN and OWASP references. The RPC link, protocol, and CSRF guard pages are updated to match.

## Testing

- Matcher, codec, and all four HTTP adapter tests cover default blocking, allowlist replacement, `QUERY` body decoding, and per-request predicates; e2e setups that exercise `GET` opt in via `allowMethods`. Full root suite (2871 tests), bun tests, type check, lint, and the docs-JSDoc sync check all pass.
