### PR TITLE
docs(openapi): update Scalar guide to v2 OpenAPIGenerator API

### DIFF
--- a/apps/content/docs/openapi/scalar.md
+++ b/apps/content/docs/openapi/scalar.md
@@ -24,7 +24,7 @@ const openAPIHandler = new OpenAPIHandler(router, {
 })
 
 const openAPIGenerator = new OpenAPIGenerator({
-  schemaConverters: [
+  converters: [
     new ZodToJsonSchemaConverter(),
   ],
 })
@@ -40,19 +40,21 @@ const server = createServer(async (req, res) => {
 
   if (req.url === '/spec.json') {
     const spec = await openAPIGenerator.generate(router, {
-      info: {
-        title: 'My Playground',
-        version: '1.0.0',
-      },
-      servers: [
-        { url: '/api' }, /** Use an absolute URL in production. */
-      ],
-      security: [{ bearerAuth: [] }],
-      components: {
-        securitySchemes: {
-          bearerAuth: {
-            type: 'http',
-            scheme: 'bearer',
+      base: {
+        info: {
+          title: 'My Playground',
+          version: '1.0.0',
+        },
+        servers: [
+          { url: '/api' }, /** Use an absolute URL in production. */
+        ],
+        security: [{ bearerAuth: [] }],
+        components: {
+          securitySchemes: {
+            bearerAuth: {
+              type: 'http',
+              scheme: 'bearer',
+            },
           },
         },
       },


### PR DESCRIPTION
The Scalar guide still showed the v1 `OpenAPIGenerator` API. Its snippet now matches the current v2 API, so copying it no longer produces code that fails to compile.

## Fixes

- `schemaConverters` renamed to `converters` in the `OpenAPIGenerator` constructor.
- `generate()` document fields (`info`, `servers`, `security`, `components`) are now nested under the `base` option, matching `OpenAPIGeneratorGenerateOptions` and the Specification page.

## Testing

- Verified against `packages/openapi/src/openapi-generator.ts`; the rest of the page (`OpenAPIHandler` from `@orpc/openapi/node`, `CORSHandlerPlugin`, `handle` signature) is already current.
- Eslint passes on the file.