### PR TITLE
chore: add funding link to published packages

### DIFF
--- a/packages/ai-sdk/package.json
+++ b/packages/ai-sdk/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/arktype/package.json
+++ b/packages/arktype/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/evlog/package.json
+++ b/packages/evlog/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/hibernation/package.json
+++ b/packages/hibernation/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/json-schema/package.json
+++ b/packages/json-schema/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/pinia-colada/package.json
+++ b/packages/pinia-colada/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/pino/package.json
+++ b/packages/pino/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/ratelimit/package.json
+++ b/packages/ratelimit/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/swr/package.json
+++ b/packages/swr/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/tanstack-query/package.json
+++ b/packages/tanstack-query/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/valibot/package.json
+++ b/packages/valibot/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "2.0.0-beta.25",
   "license": "MIT",
+  "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Every published package now carries a `funding` field pointing at the project's GitHub Sponsors page, so `npm fund` and the npm package pages surface a way to support the project.

## Changes

- Added `"funding": "https://github.com/sponsors/dinwwwh"` to all 25 `packages/*/package.json` files, matching the link already used in `.github/FUNDING.yml` and the README's Sponsors section.
- The root `package.json` is private and was left unchanged.

## Testing

Lint passes; the field is placed to satisfy the repo's `jsonc/sort-keys` ordering.