### PR TITLE
feat(server)!: default CORS origin to `*`

### DIFF
--- a/apps/content/docs/plugins/cors.md
+++ b/apps/content/docs/plugins/cors.md
@@ -13,9 +13,28 @@ import { CORSHandlerPlugin } from '@orpc/server/plugins'
 const handler = new RPCHandler(router, {
   plugins: [
     new CORSHandlerPlugin({
-      origin: (origin, options) => origin,
+      origin: '*',
       allowMethods: ['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH'],
       // ...
+    }),
+  ],
+})
+```
+
+## Origin
+
+`origin` defaults to `*`, which allows any origin but forbids credentials. To send credentials, restrict `origin` to an allowlist or reflect the request origin, and enable `credentials`. A `Vary: Origin` header is added automatically whenever the allowed origin depends on the request.
+
+```ts twoslash
+import { RPCHandler } from '@orpc/server/fetch'
+import { router } from './shared/planet'
+import { CORSHandlerPlugin } from '@orpc/server/plugins'
+// ---cut---
+const handler = new RPCHandler(router, {
+  plugins: [
+    new CORSHandlerPlugin({
+      origin: ['https://example.com', 'https://app.example.com'],
+      credentials: true,
     }),
   ],
 })

--- a/packages/server/src/plugins/cors.test.ts
+++ b/packages/server/src/plugins/cors.test.ts
@@ -26,8 +26,8 @@ describe('corsHandlerPlugin', () => {
 
     expect(handlerFn).toHaveBeenCalledTimes(0)
     expect(response!.status).toBe(204)
-    expect(response!.headers.get('access-control-allow-origin')).toBe('https://example.com')
-    expect(response!.headers.get('vary')).toBe('Origin')
+    expect(response!.headers.get('access-control-allow-origin')).toBe('*')
+    expect(response!.headers.get('vary')).toBeNull()
     expect(response!.headers.get('access-control-allow-methods')).toBe('GET, HEAD, PUT, POST, DELETE, PATCH')
     expect(response!.headers.get('access-control-max-age')).toBeNull()
   })
@@ -217,9 +217,9 @@ describe('corsHandlerPlugin', () => {
     expect(response!.headers.get('access-control-allow-headers')).toBe('X-Requested-With, Content-Type')
   })
 
-  it('does not set access-control-allow-origin when request has no origin header', async () => {
+  it('does not set access-control-allow-origin when request has no origin header and origin reflects the request', async () => {
     const handler = new RPCHandler(router, {
-      plugins: [new CORSHandlerPlugin()],
+      plugins: [new CORSHandlerPlugin({ origin: origin => origin })],
     })
 
     const { response } = await handler.handle(new Request('https://example.com/ping', {
@@ -230,7 +230,7 @@ describe('corsHandlerPlugin', () => {
       body: JSON.stringify({ json: null }),
     }))
 
-    // default origin function `origin => origin` returns '' for empty origin,
+    // origin function `origin => origin` returns '' for empty origin,
     // which is not included in the response as a valid origin
     expect(response!.headers.get('access-control-allow-origin')).toBe('')
     expect(response!.headers.get('vary')).toBe('Origin')
@@ -238,7 +238,7 @@ describe('corsHandlerPlugin', () => {
 
   it('does not copy Vary from the request', async () => {
     const handler = new RPCHandler(router, {
-      plugins: [new CORSHandlerPlugin()],
+      plugins: [new CORSHandlerPlugin({ origin: origin => origin })],
     })
 
     const { response } = await handler.handle(new Request('https://example.com', {
@@ -283,7 +283,7 @@ describe('corsHandlerPlugin', () => {
             }
           },
         },
-        new CORSHandlerPlugin(),
+        new CORSHandlerPlugin({ origin: origin => origin }),
       ],
     })
 
@@ -329,7 +329,7 @@ describe('corsHandlerPlugin', () => {
             }
           },
         },
-        new CORSHandlerPlugin(),
+        new CORSHandlerPlugin({ origin: origin => origin }),
       ],
     })
 

--- a/packages/server/src/plugins/cors.ts
+++ b/packages/server/src/plugins/cors.ts
@@ -10,7 +10,7 @@ export interface CORSHandlerPluginOptions<T extends Context> {
    * Configures the `Access-Control-Allow-Origin` header.
    * Can be a string, an array of allowed origins, or a function that returns the allowed origin(s).
    *
-   * @default (origin) => origin
+   * @default '*'
    */
   origin?: Value<Promisable<string | readonly string[] | null | undefined>, [origin: string, options: StandardHandlerRoutingInterceptorOptions<T>]>
 
@@ -79,7 +79,7 @@ export class CORSHandlerPlugin<T extends Context> implements StandardHandlerPlug
 
   constructor(options: CORSHandlerPluginOptions<T> = {}) {
     const defaults: CORSHandlerPluginOptions<T> = {
-      origin: origin => origin,
+      origin: '*',
       allowMethods: ['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH'],
     }
 


### PR DESCRIPTION
The CORS plugin's `origin` option now defaults to `*` instead of reflecting the request `Origin` header back. A default-configured plugin sends a literal `Access-Control-Allow-Origin: *` for every request, and no longer emits `Vary: Origin`, so responses stay cacheable as a single entry instead of fragmenting per origin.

## Breaking

Setups using `credentials: true` must now set `origin` explicitly (an allowlist, or `origin => origin` to keep reflecting). Browsers reject `*` together with `Access-Control-Allow-Credentials`, so leaving `origin` unset silently breaks credentialed cross-origin requests.

Requests arriving without an `Origin` header now receive `*` rather than an empty header value.

## Docs

The CORS plugin page shows `origin: '*'` in the basic example and gains a short Origin section covering the `*`-versus-credentials tradeoff and the allowlist form.

## Testing

`pnpm vitest run packages/server/src/plugins/cors.test.ts` — 15/15 pass. The default-behavior test asserts `*` with no `Vary`; the four tests covering origin reflection and `Vary` merging now pass `origin` explicitly so that path stays covered.