### PR TITLE
fix(shared): prevent clone() from re-parenting the cloned object

### DIFF
--- a/packages/shared/src/object.test.ts
+++ b/packages/shared/src/object.test.ts
@@ -318,6 +318,28 @@ describe('clone', () => {
     expect(cloned[sym]).not.toBe(obj[sym])
     expect(cloned[sym][nestedSym]).toBe(3)
   })
+
+  it('clone with __proto__ property', () => {
+    const obj = JSON.parse('{ "a": 1, "__proto__": { "polluted": true } }')
+    const cloned = clone(obj)
+
+    expect(Object.getPrototypeOf(cloned)).toBe(Object.prototype)
+    expect(({} as any).polluted).toBeUndefined()
+    expect(cloned.a).toBe(1)
+    // eslint-disable-next-line no-restricted-properties, no-proto
+    expect(cloned.__proto__).toEqual({ polluted: true })
+    // eslint-disable-next-line no-restricted-properties, no-proto
+    expect(cloned.__proto__).not.toBe(obj.__proto__)
+
+    const nullProto = new NullProtoObj<any>()
+    // eslint-disable-next-line no-restricted-properties, no-proto
+    nullProto.__proto__ = 2
+    const clonedNullProto = clone(nullProto)
+
+    expect(Object.getPrototypeOf(clonedNullProto)).toBe(Object.prototype)
+    // eslint-disable-next-line no-restricted-properties, no-proto
+    expect(clonedNullProto.__proto__).toBe(2)
+  })
 })
 
 describe('bindMethods', () => {

--- a/packages/shared/src/object.ts
+++ b/packages/shared/src/object.ts
@@ -140,12 +140,13 @@ export function clone<T>(value: T): T {
   if (isPlainObject(value)) {
     const result: Record<PropertyKey, unknown> = {}
 
+    // Use defineOwnProperty so special keys like __proto__ don't re-parent the result.
     for (const key in value) {
-      result[key] = clone(value[key])
+      defineOwnProperty(result, key, clone(value[key]))
     }
 
     for (const sym of Object.getOwnPropertySymbols(value)) {
-      result[sym] = clone(value[sym])
+      defineOwnProperty(result, sym, clone(value[sym]))
     }
 
     return result as any


### PR DESCRIPTION
`clone()` copied properties with plain assignment, so a source object carrying an own `__proto__` key went through `Object.prototype`'s `__proto__` setter instead of getting a property. The clone came back re-parented onto the source's payload, or silently lost the key when its value was not an object. Copying through `Object.defineProperty` makes every key a real own property.

This is reachable with ordinary input: `JSON.parse` and `NullProtoObj` both produce own `__proto__` keys, and `isPlainObject` treats both as plain objects.

## Fixes

- Cloning an object with an own `__proto__` key now yields a clone whose prototype is still `Object.prototype`, with `__proto__` present as a normal own property.
- Non-object `__proto__` values (e.g. `2`) are preserved instead of being dropped by the setter.
- Scope note: `Object.prototype` itself was never mutated, so this was clone corruption rather than global prototype pollution.

## Testing

New `clone with __proto__ property` case covers both the `JSON.parse` and `NullProtoObj` sources and fails on the previous code (the clone's prototype had become the payload). Full `packages/shared` suite passes at 302 tests, lint clean.