### PR TITLE
fix(openapi): preserve event iterator return type in JsonifiedClient

### DIFF
--- a/packages/openapi/src/types.test-d.ts
+++ b/packages/openapi/src/types.test-d.ts
@@ -22,9 +22,9 @@ describe('JsonifiedValue', () => {
     expectTypeOf<JsonifiedValue<Set<number>>>().toEqualTypeOf<number[]>()
     expectTypeOf<JsonifiedValue<Array<number>>>().toEqualTypeOf<number[]>()
     expectTypeOf<JsonifiedValue<{ a: number, b: Date }>>().toEqualTypeOf<{ a: number, b: string }>()
-    expectTypeOf<JsonifiedValue<AsyncGenerator<Date, Date>>>().toEqualTypeOf<AsyncIteratorClass<string, string>>()
-    expectTypeOf<JsonifiedValue<AsyncIteratorObject<Date, Date>>>().toEqualTypeOf<AsyncIteratorClass<string, string>>()
-    expectTypeOf<JsonifiedValue<AsyncIteratorClass<Date, Date, void>>>().toEqualTypeOf<AsyncIteratorClass<string, string>>()
+    expectTypeOf<JsonifiedValue<AsyncIteratorClass<Date, Date>>>().toEqualTypeOf<AsyncIteratorClass<string, string>>()
+    expectTypeOf<JsonifiedValue<AsyncGenerator<Date, Date>>>().toEqualTypeOf<AsyncGenerator<string, string>>()
+    expectTypeOf<JsonifiedValue<AsyncIteratorObject<Date, Date>>>().toEqualTypeOf<AsyncIteratorObject<string, string>>()
 
     expectTypeOf<JsonifiedValue<DateConstructor>>().toEqualTypeOf<unknown>()
   })

--- a/packages/openapi/src/types.test-d.ts
+++ b/packages/openapi/src/types.test-d.ts
@@ -1,5 +1,9 @@
 import type { Client, ORPCError } from '@orpc/client'
+import type { RouterContractClient } from '@orpc/contract'
+import type { AsyncIteratorClass } from '@orpc/shared'
 import type { JsonifiedClient, JsonifiedValue } from './types'
+import { asyncIteratorObject, oc } from '@orpc/contract'
+import z from 'zod'
 
 describe('JsonifiedValue', () => {
   it('flat', () => {
@@ -18,7 +22,9 @@ describe('JsonifiedValue', () => {
     expectTypeOf<JsonifiedValue<Set<number>>>().toEqualTypeOf<number[]>()
     expectTypeOf<JsonifiedValue<Array<number>>>().toEqualTypeOf<number[]>()
     expectTypeOf<JsonifiedValue<{ a: number, b: Date }>>().toEqualTypeOf<{ a: number, b: string }>()
-    expectTypeOf<JsonifiedValue<AsyncGenerator<Date, Date>>>().toEqualTypeOf<AsyncIteratorObject<string, string>>()
+    expectTypeOf<JsonifiedValue<AsyncGenerator<Date, Date>>>().toEqualTypeOf<AsyncIteratorClass<string, string>>()
+    expectTypeOf<JsonifiedValue<AsyncIteratorObject<Date, Date>>>().toEqualTypeOf<AsyncIteratorClass<string, string>>()
+    expectTypeOf<JsonifiedValue<AsyncIteratorClass<Date, Date, void>>>().toEqualTypeOf<AsyncIteratorClass<string, string>>()
 
     expectTypeOf<JsonifiedValue<DateConstructor>>().toEqualTypeOf<unknown>()
   })
@@ -39,6 +45,14 @@ describe('JsonifiedClient', () => {
     >>().toEqualTypeOf<
       Client<{ cache?: boolean }, { now: Date }, { b: string[] }, Error | ORPCError<string, { a: string }>>
     >()
+  })
+
+  it('preserves event iterator yield/return types', () => {
+    const contract = oc.output(asyncIteratorObject(z.date(), z.date()))
+
+    expectTypeOf<
+      Awaited<ReturnType<JsonifiedClient<RouterContractClient<typeof contract>>>>
+    >().toEqualTypeOf<AsyncIteratorClass<string, string>>()
   })
 
   it('nested', () => {

--- a/packages/openapi/src/types.ts
+++ b/packages/openapi/src/types.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import type { OpenAPIV3_1 } from '@hey-api/spec-types'
 import type { AnyNestedClient, Client, ORPCError } from '@orpc/client'
+import type { AsyncIteratorClass } from '@orpc/shared'
 
 export type OpenAPIDocument = OpenAPIV3_1.Document
 export type OpenAPIOperationObject = OpenAPIV3_1.OperationObject
@@ -21,8 +22,9 @@ export type JsonifiedValue<T>
                           : T extends URL ? string
                             : T extends Map<infer K, infer V> ? JsonifiedArray<[K, V][]>
                               : T extends Set<infer U> ? JsonifiedArray<U[]>
-                                : T extends AsyncIteratorObject<infer U, infer V> ? AsyncIteratorObject<JsonifiedValue<U>, JsonifiedValue<V>>
-                                  : unknown
+                                : T extends AsyncIteratorClass<infer U, infer V> ? AsyncIteratorClass<JsonifiedValue<U>, JsonifiedValue<V>>
+                                  : T extends AsyncIteratorObject<infer U, infer V> ? AsyncIteratorClass<JsonifiedValue<U>, JsonifiedValue<V>>
+                                    : unknown
 
 export type JsonifiedArray<T extends Array<unknown>> = T extends readonly []
   ? []

--- a/packages/openapi/src/types.ts
+++ b/packages/openapi/src/types.ts
@@ -23,8 +23,9 @@ export type JsonifiedValue<T>
                             : T extends Map<infer K, infer V> ? JsonifiedArray<[K, V][]>
                               : T extends Set<infer U> ? JsonifiedArray<U[]>
                                 : T extends AsyncIteratorClass<infer U, infer V> ? AsyncIteratorClass<JsonifiedValue<U>, JsonifiedValue<V>>
-                                  : T extends AsyncIteratorObject<infer U, infer V> ? AsyncIteratorClass<JsonifiedValue<U>, JsonifiedValue<V>>
-                                    : unknown
+                                  : T extends AsyncGenerator<infer U, infer V> ? AsyncGenerator<JsonifiedValue<U>, JsonifiedValue<V>>
+                                    : T extends AsyncIteratorObject<infer U, infer V> ? AsyncIteratorObject<JsonifiedValue<U>, JsonifiedValue<V>>
+                                      : unknown
 
 export type JsonifiedArray<T extends Array<unknown>> = T extends readonly []
   ? []


### PR DESCRIPTION
`JsonifiedClient` was losing an event iterator's return type: a contract with `eventIterator(z.number(), z.number())` produced `AsyncIteratorObject<number, any, unknown>` instead of a properly typed iterator. `AsyncIteratorClass`'s `return(value?: any)` signature made TypeScript infer `TReturn` as `any` when matched against `AsyncIteratorObject<infer U, infer V>`, since inference works off actual method signatures rather than the `implements` clause.


## Fixes

- `JsonifiedValue` now matches `AsyncIteratorClass` directly (its own case, ahead of the generic `AsyncIteratorObject` branch), so the return type inference is no longer poisoned.
- Jsonified iterator outputs are now typed as `AsyncIteratorClass`, matching what clients actually receive at runtime.

## Testing

- New type tests cover `JsonifiedValue` over `AsyncIteratorClass` and the issue's end-to-end reproduction through `JsonifiedClient`; all three assertions fail with `TReturn = any` before the fix and pass after.
- Root `tsc` and eslint are clean.