### PR TITLE
fix(openapi): preserve event iterator return type in JsonifiedClient

### DIFF
--- a/packages/openapi-client/src/types.test-d.ts
+++ b/packages/openapi-client/src/types.test-d.ts
@@ -1,5 +1,8 @@
 import type { Client, ORPCError } from '@orpc/client'
+import type { ContractRouterClient } from '@orpc/contract'
+import type { AsyncIteratorClass } from '@orpc/shared'
 import type { JsonifiedClient, JsonifiedValue } from './types'
+import { eventIterator, oc, type } from '@orpc/contract'
 
 describe('JsonifiedValue', () => {
   it('flat', () => {
@@ -18,7 +21,9 @@ describe('JsonifiedValue', () => {
     expectTypeOf<JsonifiedValue<Set<number>>>().toEqualTypeOf<number[]>()
     expectTypeOf<JsonifiedValue<Array<number>>>().toEqualTypeOf<number[]>()
     expectTypeOf<JsonifiedValue<{ a: number, b: Date }>>().toEqualTypeOf<{ a: number, b: string }>()
-    expectTypeOf<JsonifiedValue<AsyncGenerator<Date, Date>>>().toEqualTypeOf<AsyncIteratorObject<string, string>>()
+    expectTypeOf<JsonifiedValue<AsyncIteratorClass<Date, Date>>>().toEqualTypeOf<AsyncIteratorClass<string, string>>()
+    expectTypeOf<JsonifiedValue<AsyncGenerator<Date, Date>>>().toEqualTypeOf<AsyncGenerator<string, string>>()
+    expectTypeOf<JsonifiedValue<AsyncIteratorObject<Date, Date>>>().toEqualTypeOf<AsyncIteratorObject<string, string>>()
 
     expectTypeOf<JsonifiedValue<DateConstructor>>().toEqualTypeOf<unknown>()
   })
@@ -39,6 +44,14 @@ describe('JsonifiedClient', () => {
     >>().toEqualTypeOf<
       Client<{ cache?: boolean }, { now: Date }, { b: string[] }, Error | ORPCError<string, { a: string }>>
     >()
+  })
+
+  it('preserves event iterator yield/return types', () => {
+    const contract = oc.output(eventIterator(type<Date>(), type<Date>()))
+
+    expectTypeOf<
+      Awaited<ReturnType<JsonifiedClient<ContractRouterClient<typeof contract>>>>
+    >().toEqualTypeOf<AsyncIteratorClass<string, string>>()
   })
 
   it('nested', () => {

--- a/packages/openapi-client/src/types.ts
+++ b/packages/openapi-client/src/types.ts
@@ -1,4 +1,5 @@
 import type { Client, NestedClient, ORPCError } from '@orpc/client'
+import type { AsyncIteratorClass } from '@orpc/shared'
 
 export type JsonifiedValue<T>
   = T extends string ? T
@@ -16,8 +17,10 @@ export type JsonifiedValue<T>
                           : T extends URL ? string
                             : T extends Map<infer K, infer V> ? JsonifiedArray<[K, V][]>
                               : T extends Set<infer U> ? JsonifiedArray<U[]>
-                                : T extends AsyncIteratorObject<infer U, infer V> ? AsyncIteratorObject<JsonifiedValue<U>, JsonifiedValue<V>>
-                                  : unknown
+                                : T extends AsyncIteratorClass<infer U, infer V> ? AsyncIteratorClass<JsonifiedValue<U>, JsonifiedValue<V>>
+                                  : T extends AsyncGenerator<infer U, infer V> ? AsyncGenerator<JsonifiedValue<U>, JsonifiedValue<V>>
+                                    : T extends AsyncIteratorObject<infer U, infer V> ? AsyncIteratorObject<JsonifiedValue<U>, JsonifiedValue<V>>
+                                      : unknown
 
 export type JsonifiedArray<T extends Array<unknown>> = T extends readonly []
   ? []


### PR DESCRIPTION
v1 port of #1797. `JsonifiedClient` was losing an event iterator's return type: a contract with `eventIterator(z.number(), z.number())` produced an iterator with `TReturn = any` instead of the jsonified return type. `AsyncIteratorClass`'s `return(value?: any)` signature made TypeScript infer `TReturn` as `any` when matched against `AsyncIteratorObject<infer U, infer V>`, since inference works off actual method signatures rather than the `implements` clause.

Fixes #1796

## Fixes

- `JsonifiedValue` now matches `AsyncIteratorClass` directly (its own case, ahead of the generic `AsyncIteratorObject` branch), so the return type inference is no longer poisoned.
- `AsyncGenerator` and plain `AsyncIteratorObject` values now keep their own shape instead of being widened, matching the updated #1797.

## Testing

- New type tests cover `JsonifiedValue` over `AsyncIteratorClass`/`AsyncGenerator`/`AsyncIteratorObject` and the end-to-end reproduction through `JsonifiedClient` (using v1's `eventIterator` + `ContractRouterClient`); three assertions fail before the fix and pass after.
- Root `tsc -b`, `tsc --noEmit`, and eslint are clean.