### PR TITLE
fix(client): preserve subclass prototype chain in cloneORPCError

### DIFF
--- a/packages/client/src/error-utils.test.ts
+++ b/packages/client/src/error-utils.test.ts
@@ -234,4 +234,22 @@ describe('cloneORPCError', () => {
     expect(original.data).toBe(1)
     expect(cloned.data).toBe(2)
   })
+
+  it('preserves custom subclass prototype chain', () => {
+    class CustomSubclassError extends ORPCError<'BAD_REQUEST', { customField: string }> {
+      customProp = 'test'
+    }
+
+    const original = new CustomSubclassError('BAD_REQUEST', {
+      message: 'Custom error message',
+      data: { customField: 'value' },
+    })
+
+    const cloned = cloneORPCError(original)
+
+    expect(cloned).toBeInstanceOf(CustomSubclassError)
+    expect(cloned).toBeInstanceOf(ORPCError)
+    expect(cloned.customProp).toBe('test')
+    expect(cloned.message).toBe('Custom error message')
+  })
 })

--- a/packages/client/src/error-utils.ts
+++ b/packages/client/src/error-utils.ts
@@ -54,15 +54,14 @@ export function createORPCErrorFromJson<TCode extends ORPCErrorCode, TData>(
   return error
 }
 
-export function cloneORPCError<T extends ORPCErrorCode, TData>(error: ORPCError<T, TData>): ORPCError<T, TData> {
-  const cloned = new ORPCError(error.code, {
-    ...error,
-    message: error.message,
-    data: error.data,
-    cause: error.cause,
-  })
+export function cloneORPCError<T extends AnyORPCError>(error: T): T {
+  const cloned = Object.create(Object.getPrototypeOf(error))
 
+  Object.assign(cloned, error)
+
+  cloned.message = error.message
   cloned.stack = error.stack
+  cloned.cause = error.cause
   ;(cloned.defined as Writable<typeof cloned.defined>) = error.defined
   ;(cloned.inferable as Writable<typeof cloned.inferable>) = error.inferable
 


### PR DESCRIPTION
# fix(client): preserve subclass prototype chain in `cloneORPCError`

## Problem
`cloneORPCError` instantiates `new ORPCError(error.code, ...)` directly, stripping custom subclass prototypes (e.g. `class CustomError extends ORPCError`). This causes `error instanceof CustomError` checks to fail downstream during procedure error reconciliation.

## Solution
- Use `Object.create(Object.getPrototypeOf(error))` to preserve the subclass prototype chain.
- Explicitly copy `.message`, `.stack`, and `.cause` to preserve non-enumerable error properties.
- Update `cloneORPCError` signature to `<T extends AnyORPCError>(error: T): T`.

## Tests
- Added unit test in `packages/client/src/error-utils.test.ts` verifying subclass prototype preservation and custom property copying. All 23 tests pass.
