### PR TITLE
feat(content): VitePress-style docs theme with unified blog layout

### DIFF
--- a/apps/content/blume.config.ts
+++ b/apps/content/blume.config.ts
@@ -35,6 +35,8 @@ export default defineConfig({
   theme: {
     // Monochrome accent to match the oRPC brand: black in light, white in dark.
     accent: { light: 'oklch(0.145 0 0)', dark: 'oklch(0.985 0 0)' },
+    // VitePress dark page background; the rest of the palette lives in theme.css.
+    background: { dark: '#161618' },
     fonts: {
       display: 'inter',
       body: 'inter',

--- a/apps/content/blume.config.ts
+++ b/apps/content/blume.config.ts
@@ -33,8 +33,8 @@ export default defineConfig({
     dir: 'apps/content',
   },
   theme: {
-    // VitePress-style blue accent (Tailwind blue-600 / blue-400 in dark).
-    accent: { light: 'oklch(0.546 0.245 262.881)', dark: 'oklch(0.707 0.165 254.624)' },
+    // Monochrome accent to match the oRPC brand: black in light, white in dark.
+    accent: { light: 'oklch(0.145 0 0)', dark: 'oklch(0.985 0 0)' },
     fonts: {
       display: 'inter',
       body: 'inter',
@@ -43,18 +43,20 @@ export default defineConfig({
   lastModified: true,
   navigation: {
     tabs: [
-      { label: 'Docs', path: '/docs' },
+      { label: 'Documentation', path: '/docs' },
       { label: 'Blog', path: '/blog', href: '/blog' },
-      { label: 'Learn & Contribute', path: '/learn-and-contribute' },
       { label: 'Changelog', path: '/changelog', href: '/changelog' },
-    ],
-    selectors: [
+      { label: 'Comparison', path: '/docs', href: '/docs/comparison' },
+      { label: 'Contribute', path: '/learn-and-contribute' },
       {
-        kind: 'version',
-        label: 'Version',
+        label: 'More',
+        path: '',
         items: [
-          { label: 'v2 (latest)', path: '/', icon: 'rocket' },
-          { label: 'v1', path: 'https://v1.orpc.dev' },
+          { label: 'V1 Documentation', path: 'https://v1.orpc.dev' },
+          { label: 'Discussions', path: 'https://github.com/middleapi/orpc/discussions' },
+          { label: 'Sponsors', path: 'https://github.com/sponsors/dinwwwh' },
+          { label: 'LLM Context', path: 'https://orpc.dev/llms.txt' },
+          { label: 'LLM Context (Full)', path: 'https://orpc.dev/llms-full.txt' },
         ],
       },
     ],
@@ -70,6 +72,25 @@ export default defineConfig({
   },
   export: true,
   integrations: [
+    {
+      // Blume's PageLayout (used by the custom blog pages) imports the built-in
+      // Header directly and has no layout-slot support, so the owned header in
+      // components/blume/ is swapped in with a Vite alias that both RootLayout
+      // and PageLayout resolve. It carries the "More" dropdown tab support.
+      name: 'header-override',
+      hooks: {
+        'astro:config:setup': ({ updateConfig }) => {
+          const headerPath = fileURLToPath(new URL('./components/blume/Header.astro', import.meta.url))
+          updateConfig({
+            vite: {
+              resolve: {
+                alias: [{ find: /^\.\/Header\.astro$/u, replacement: headerPath }],
+              },
+            },
+          })
+        },
+      },
+    },
     {
       name: 'sponsors',
       hooks: {

--- a/apps/content/blume.config.ts
+++ b/apps/content/blume.config.ts
@@ -32,11 +32,16 @@ export default defineConfig({
     repo: 'orpc',
     dir: 'apps/content',
   },
+  theme: {
+    // VitePress-style blue accent (Tailwind blue-600 / blue-400 in dark).
+    accent: { light: 'oklch(0.546 0.245 262.881)', dark: 'oklch(0.707 0.165 254.624)' },
+    fonts: {
+      display: 'inter',
+      body: 'inter',
+    },
+  },
   lastModified: true,
   navigation: {
-    sidebar: {
-      display: 'group',
-    },
     tabs: [
       { label: 'Docs', path: '/docs' },
       { label: 'Blog', path: '/blog', href: '/blog' },

--- a/apps/content/blume.config.ts
+++ b/apps/content/blume.config.ts
@@ -94,6 +94,17 @@ export default defineConfig({
       },
     },
     {
+      // Keeps mobile twoslash popups inside the viewport (theme.css anchors
+      // them below the hovered token; this nudges bottom-of-screen ones up).
+      name: 'twoslash-mobile',
+      hooks: {
+        'astro:config:setup': ({ injectScript }) => {
+          const clientPath = fileURLToPath(new URL('./components/blume/twoslash-mobile.ts', import.meta.url))
+          injectScript('page', `import '${clientPath.replaceAll('\\', '\\\\').replaceAll('\'', '\\\'')}'`)
+        },
+      },
+    },
+    {
       name: 'sponsors',
       hooks: {
         'astro:config:setup': ({ injectScript, updateConfig }) => {

--- a/apps/content/components.ts
+++ b/apps/content/components.ts
@@ -5,4 +5,8 @@ export default defineComponents({
   mdx: {
     SponsorSlot: './sponsors/SponsorSlot.astro',
   },
+  layout: {
+    Sidebar: './components/blume/NavTree.astro',
+    TableOfContents: './components/blume/TableOfContents.astro',
+  },
 })

--- a/apps/content/components.ts
+++ b/apps/content/components.ts
@@ -7,6 +7,7 @@ export default defineComponents({
   },
   layout: {
     Sidebar: './components/blume/NavTree.astro',
+    MobileNav: './components/blume/MobileNav.astro',
     TableOfContents: './components/blume/TableOfContents.astro',
   },
 })

--- a/apps/content/components.ts
+++ b/apps/content/components.ts
@@ -8,6 +8,7 @@ export default defineComponents({
   layout: {
     Sidebar: './components/blume/NavTree.astro',
     MobileNav: './components/blume/MobileNav.astro',
+    Pagination: './components/blume/Pagination.astro',
     TableOfContents: './components/blume/TableOfContents.astro',
   },
 })

--- a/apps/content/components/blume/Header.astro
+++ b/apps/content/components/blume/Header.astro
@@ -14,6 +14,7 @@ import { activeTabForRoute } from "blume/components/layout/nav-utils.ts";
 import NavSelector from "blume/components/layout/NavSelector.astro";
 import { resolveSlot } from "blume/components/layout/overrides.ts";
 import Search from "blume/components/layout/Search.astro";
+import SectionsNav from "./SectionsNav.astro";
 
 interface Props {
   site: { title: string };
@@ -257,4 +258,21 @@ const clickScript = `(()=>{const dr=()=>{const h=document.querySelector("[data-b
     {askEnabled && <Ask strings={askStrings} />}
   </div>
 </header>
+{
+  // Chrome-only pages (blog, custom landings via PageLayout) have no sidebar
+  // drawer, and PageLayout's built-in tabs drawer can't render dropdown-tab
+  // items (the "More" menu) — it's hidden in theme.css and this drawer, using
+  // the same nav-toggle machinery, takes its place. `data-orpc-drawer` keeps
+  // it exempt from that hiding rule.
+  hasDrawer && !hasSidebar && navigation.tabs.length > 0 && (
+    <aside
+      aria-label={n.navigation}
+      class="fixed top-[var(--blume-drawer-top,4rem)] start-0 z-[35] h-[calc(100dvh-var(--blume-drawer-top,4rem))] w-64 max-w-[80vw] -translate-x-[105%] overflow-y-auto border-border border-e bg-background px-5 pt-4 pb-6 transition-transform rtl:translate-x-[105%] [:where([data-blume-nav-open])_&]:translate-x-0! lg:hidden"
+      data-blume-nav-drawer
+      data-orpc-drawer
+    >
+      <SectionsNav currentRoute={route} />
+    </aside>
+  )
+}
 <script is:inline set:html={clickScript} />

--- a/apps/content/components/blume/Header.astro
+++ b/apps/content/components/blume/Header.astro
@@ -1,0 +1,260 @@
+---
+import Ask from "blume:ask";
+import data from "blume:data";
+import { withBase } from "blume/components/islands/base-path.ts";
+import type { ComponentOverride } from "blume/core/define-components.ts";
+import { EN_UI } from "blume/core/i18n-ui.ts";
+import type { UIStrings } from "blume/core/i18n-ui.ts";
+import type { LocaleSwitchOption, Navigation } from "blume/core/types.ts";
+import { GITHUB_MARK } from "blume/components/github-mark.ts";
+import Icon from "blume/components/Icon.astro";
+import LanguageSwitcher from "blume/components/layout/LanguageSwitcher.astro";
+import Logo from "blume/components/layout/Logo.astro";
+import { activeTabForRoute } from "blume/components/layout/nav-utils.ts";
+import NavSelector from "blume/components/layout/NavSelector.astro";
+import { resolveSlot } from "blume/components/layout/overrides.ts";
+import Search from "blume/components/layout/Search.astro";
+
+interface Props {
+  site: { title: string };
+  logo?: {
+    svg?: string;
+    light?: string;
+    dark?: string;
+    alt: string;
+    href: string;
+    text?: string;
+  } | null;
+  navigation: Navigation;
+  route: string;
+  searchEnabled: boolean;
+  /**
+   * Whether the search modal offers an "Ask AI" hand-off. Defaults to whether
+   * Ask AI is configured, so no page has to pass it; a layout can still opt a
+   * shell out explicitly.
+   */
+  askEnabled?: boolean;
+  /** Localized Ask AI strings for the active locale. */
+  askStrings?: UIStrings["ask"];
+  // The mobile menu button toggles the docs sidebar drawer; custom pages
+  // without a sidebar (e.g. a landing page) pass `false` to hide it.
+  hasSidebar?: boolean;
+  /**
+   * Whether the layout renders a drawer for the nav toggle to open. A shell
+   * with no drawer at all (the Scalar reference layout) passes `false`, else
+   * the hamburger would lock page scroll with nothing appearing.
+   */
+  hasDrawer?: boolean;
+  searchStrings?: UIStrings["search"];
+  switcherStrings?: UIStrings["languageSwitcher"];
+  /** Localized chrome labels (nav toggle, sections, GitHub, theme toggle). */
+  navStrings?: UIStrings["nav"];
+  localeSwitch?: LocaleSwitchOption[];
+  /** Active locale for per-language search filtering. */
+  searchLocale?: string;
+  /**
+   * Layout-slot overrides forwarded from the root layout. The header honors
+   * `Logo` and `Search` here so those pieces can be replaced without swapping
+   * the whole header.
+   */
+  layout?: Record<string, ComponentOverride>;
+}
+
+const {
+  site,
+  logo,
+  navigation,
+  route,
+  searchEnabled,
+  // `config.ask` is null whenever Ask AI is off, so the header is the one place
+  // that has to know — the Ask trigger below and the search modal's hand-off to
+  // it both switch on this, and every page gets both for free.
+  askEnabled = Boolean(data.config.ask),
+  askStrings,
+  hasSidebar = true,
+  hasDrawer = true,
+  searchStrings,
+  switcherStrings,
+  navStrings,
+  localeSwitch,
+  searchLocale,
+  layout = {},
+} = Astro.props;
+
+// Merge over the English defaults so a label missing from a translation (or
+// from a not-yet-regenerated snapshot) still renders instead of coming out
+// blank — the PageActions pattern.
+const n = { ...EN_UI.nav, ...navStrings };
+
+const LogoSlot = resolveSlot(layout.Logo, Logo);
+const SearchSlot = resolveSlot(layout.Search, Search);
+
+// The mobile nav-toggle opens a drawer of navigation. On docs pages that drawer
+// is the sidebar tree (`hasSidebar`); on chrome-only pages (a landing page via
+// PageLayout) it's a tabs-only drawer the layout renders — so the button is also
+// needed whenever there are tabs to reveal.
+const showNavToggle = hasDrawer && (hasSidebar || navigation.tabs.length > 0);
+const activeTab = activeTabForRoute(navigation.tabs, route);
+// Where the header's inline tab bar appears. With a sidebar it shares the `md`
+// breakpoint with the docs drawer; without one, the tabs-only drawer is the sole
+// mobile nav below `lg`, so the inline tabs wait until `lg` to avoid duplicating
+// the drawer's links between `md` and `lg`.
+const tabsNavClass = hasSidebar
+  ? "hidden gap-1 md:flex"
+  : "hidden gap-1 lg:flex";
+
+const iconButton =
+  "inline-flex size-9 cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground";
+
+// Delegated handlers for the theme toggle, mobile nav drawer, and banner
+// dismiss. Living with the header means every page that renders it — docs pages
+// and custom pages alike — gets identical behavior from one source.
+//
+// Toggling the theme flips colors; without suppressing transitions the animated
+// styles fade while the non-animated ones snap, so we disable all transitions
+// for the swap (next-themes' disableTransitionOnChange trick), force a
+// synchronous style flush, then restore them on the next tick.
+//
+// The mobile drawer sits below the sticky header, but the banner above the
+// header has no fixed height (its text wraps), so the drawer's top offset can't
+// be static: on open we measure the header's on-screen bottom edge into
+// `--blume-drawer-top` (read by the drawer's `top`/`height`), lock page scroll
+// so the offset can't drift while open, and re-measure when a banner dismiss or
+// a resize/rotation moves the header. Crossing into the desktop breakpoint
+// (64rem, Tailwind `lg`) closes the drawer so the scroll lock can't outlive it.
+const clickScript = `(()=>{const dr=()=>{const h=document.querySelector("[data-blume-header]");if(h){document.documentElement.style.setProperty("--blume-drawer-top",h.getBoundingClientRect().bottom+"px");}};document.addEventListener("click",(e)=>{const t=e.target.closest("[data-blume-theme-toggle]");if(t){const d=document.documentElement;const next=d.dataset.theme==="dark"?"light":"dark";const s=document.createElement("style");s.appendChild(document.createTextNode("*,*::before,*::after{transition:none!important}"));document.head.appendChild(s);d.dataset.theme=next;localStorage.setItem("blume-theme",next);window.getComputedStyle(d).opacity;setTimeout(()=>document.head.removeChild(s),1);}const n=e.target.closest("[data-blume-nav-toggle]");if(n){const d=document.documentElement;const open=d.toggleAttribute("data-blume-nav-open");if(open){dr();}d.style.overflow=open?"hidden":"";}const b=e.target.closest("[data-blume-banner-dismiss]");if(b){const bar=b.closest("[data-blume-banner]");const k=bar&&bar.getAttribute("data-banner-key");if(k){localStorage.setItem("blume-banner:"+k,"1");}document.documentElement.setAttribute("data-blume-banner-hidden","");requestAnimationFrame(dr);}});addEventListener("resize",()=>{const d=document.documentElement;if(!d.hasAttribute("data-blume-nav-open")){return;}if(matchMedia("(min-width:64rem)").matches){d.removeAttribute("data-blume-nav-open");d.style.overflow="";}else{dr();}});})();`;
+---
+
+<header
+  class="sticky top-0 z-40 flex h-16 items-center gap-3 bg-background/90 px-4 backdrop-blur md:px-6"
+  data-blume-header
+>
+  {
+    showNavToggle && (
+      <button
+        aria-label={n.toggleNavigation}
+        class={`${iconButton} lg:hidden`}
+        data-blume-nav-toggle
+        type="button"
+      >
+        <Icon name="menu" size={20} />
+      </button>
+    )
+  }
+  <LogoSlot logo={logo} site={site} />
+  {
+    navigation.selectors.length > 0 && (
+      <div class="flex items-center gap-1.5">
+        {navigation.selectors.map((selector) => (
+          <NavSelector route={route} selector={selector} />
+        ))}
+      </div>
+    )
+  }
+  {
+    navigation.tabs.length > 0 && (
+      <nav aria-label={n.sections} class={tabsNavClass}>
+        {navigation.tabs.map((tab) =>
+          tab.items && tab.items.length > 0 ? (
+            <details class="group/tab relative flex h-full items-center">
+              <summary class="flex h-full cursor-pointer list-none items-center gap-1 font-medium text-muted-foreground text-sm transition-colors hover:text-accent [&::-webkit-details-marker]:hidden">
+                {tab.label}
+                <Icon
+                  class="transition-transform group-open/tab:rotate-180"
+                  name="chevron-down"
+                  size={13}
+                />
+              </summary>
+              <div class="absolute end-0 top-full z-50 mt-1 w-max min-w-44 rounded-blume border border-border bg-background p-1 shadow-xl">
+                {tab.items.map((item) => {
+                  const external = /^https?:\/\//u.test(item.path);
+                  return (
+                    <a
+                      class="flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-muted-foreground text-sm transition-colors hover:bg-muted hover:text-foreground"
+                      href={withBase(item.path)}
+                      rel={external ? "noreferrer" : undefined}
+                      target={external ? "_blank" : undefined}
+                    >
+                      {item.icon && <Icon name={item.icon} size={15} />}
+                      <span class="flex-1">{item.label}</span>
+                      {external && (
+                        <Icon
+                          class="opacity-60"
+                          name="arrow-up-right"
+                          size={13}
+                        />
+                      )}
+                    </a>
+                  );
+                })}
+              </div>
+            </details>
+          ) : (
+            <a
+              aria-current={tab === activeTab ? "page" : undefined}
+              class="rounded-full px-3 py-1.5 font-medium text-muted-foreground text-sm transition-colors hover:bg-muted hover:text-foreground aria-[current=page]:text-foreground"
+              href={withBase(tab.href ?? tab.path)}
+            >
+              {tab.label}
+            </a>
+          )
+        )}
+      </nav>
+    )
+  }
+  <div class="flex-1"></div>
+  {
+    localeSwitch && localeSwitch.length > 1 && (
+      <LanguageSwitcher
+        label={switcherStrings?.label ?? "Language"}
+        options={localeSwitch}
+        untranslatedLabel={switcherStrings?.untranslated ?? "Not translated"}
+      />
+    )
+  }
+  {
+    searchEnabled && (
+      <SearchSlot
+        askEnabled={askEnabled}
+        locale={searchLocale}
+        navigation={navigation}
+        popularPages={data.config.search.popular}
+        strings={searchStrings}
+      />
+    )
+  }
+  <div class="flex items-center gap-2">
+    {
+      navigation.repoUrl && (
+        <a
+          aria-label={n.githubRepository}
+          class={iconButton}
+          href={navigation.repoUrl}
+          rel="noreferrer"
+          target="_blank"
+        >
+          <svg
+            aria-hidden="true"
+            fill="currentColor"
+            height="18"
+            set:html={GITHUB_MARK}
+            viewBox="0 0 16 16"
+            width="18"
+            xmlns="http://www.w3.org/2000/svg"
+          />
+        </a>
+      )
+    }
+    <button
+      aria-label={n.toggleTheme}
+      class={iconButton}
+      data-blume-theme-toggle
+      type="button"
+    >
+      <span class="inline-flex dark:hidden"><Icon name="sun" size={18} /></span>
+      <span class="hidden dark:inline-flex"><Icon name="moon" size={18} /></span>
+    </button>
+    {askEnabled && <Ask strings={askStrings} />}
+  </div>
+</header>
+<script is:inline set:html={clickScript} />

--- a/apps/content/components/blume/Header.astro
+++ b/apps/content/components/blume/Header.astro
@@ -101,8 +101,13 @@ const activeTab = activeTabForRoute(navigation.tabs, route);
 // mobile nav below `lg`, so the inline tabs wait until `lg` to avoid duplicating
 // the drawer's links between `md` and `lg`.
 const tabsNavClass = hasSidebar
-  ? "hidden gap-1 md:flex"
-  : "hidden gap-1 lg:flex";
+  ? "hidden items-center gap-4 self-stretch ms-1 md:flex lg:ms-3 lg:gap-6"
+  : "hidden items-center gap-6 self-stretch ms-3 lg:flex";
+
+// VitePress-style tab link: full-height, with a 2px accent underline
+// reserved via `after` so the active state doesn't shift the layout.
+const tabLinkClass =
+  "relative flex h-full items-center whitespace-nowrap font-medium text-muted-foreground text-sm transition-colors after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:bg-transparent after:content-[''] hover:text-accent aria-[current=page]:text-accent aria-[current=page]:after:bg-accent";
 
 const iconButton =
   "inline-flex size-9 cursor-pointer items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground";
@@ -127,8 +132,11 @@ const clickScript = `(()=>{const dr=()=>{const h=document.querySelector("[data-b
 ---
 
 <header
-  class="sticky top-0 z-40 flex h-16 items-center gap-3 bg-background/90 px-4 backdrop-blur md:px-6"
+  class="sticky top-0 z-40 border-border border-b bg-background/85 backdrop-blur"
   data-blume-header
+>
+<div
+  class="mx-auto flex h-14 w-[min(100%,var(--docs-frame-width))] items-center gap-3 px-5"
 >
   {
     showNavToggle && (
@@ -143,15 +151,6 @@ const clickScript = `(()=>{const dr=()=>{const h=document.querySelector("[data-b
     )
   }
   <LogoSlot logo={logo} site={site} />
-  {
-    navigation.selectors.length > 0 && (
-      <div class="flex items-center gap-1.5">
-        {navigation.selectors.map((selector) => (
-          <NavSelector route={route} selector={selector} />
-        ))}
-      </div>
-    )
-  }
   {
     navigation.tabs.length > 0 && (
       <nav aria-label={n.sections} class={tabsNavClass}>
@@ -193,7 +192,7 @@ const clickScript = `(()=>{const dr=()=>{const h=document.querySelector("[data-b
           ) : (
             <a
               aria-current={tab === activeTab ? "page" : undefined}
-              class="rounded-full px-3 py-1.5 font-medium text-muted-foreground text-sm transition-colors hover:bg-muted hover:text-foreground aria-[current=page]:text-foreground"
+              class={tabLinkClass}
               href={withBase(tab.href ?? tab.path)}
             >
               {tab.label}
@@ -204,6 +203,15 @@ const clickScript = `(()=>{const dr=()=>{const h=document.querySelector("[data-b
     )
   }
   <div class="flex-1"></div>
+  {
+    navigation.selectors.length > 0 && (
+      <div class="flex items-center gap-1.5">
+        {navigation.selectors.map((selector) => (
+          <NavSelector route={route} selector={selector} />
+        ))}
+      </div>
+    )
+  }
   {
     localeSwitch && localeSwitch.length > 1 && (
       <LanguageSwitcher
@@ -257,6 +265,7 @@ const clickScript = `(()=>{const dr=()=>{const h=document.querySelector("[data-b
     </button>
     {askEnabled && <Ask strings={askStrings} />}
   </div>
+</div>
 </header>
 {
   // Chrome-only pages (blog, custom landings via PageLayout) have no sidebar

--- a/apps/content/components/blume/MobileNav.astro
+++ b/apps/content/components/blume/MobileNav.astro
@@ -1,16 +1,13 @@
 ---
-import data from "blume:data";
 import type { UIStrings } from "blume/core/i18n-ui.ts";
 import type { NavNode } from "blume/core/types.ts";
-import Icon from "blume/components/Icon.astro";
-import { withBase } from "blume/components/islands/base-path.ts";
-import { activeTabForRoute } from "blume/components/layout/nav-utils.ts";
 import NavTree from "./NavTree.astro";
+import SectionsNav from "./SectionsNav.astro";
 
-// The nav shown inside the mobile drawer. RootLayout's own drawer tab list
-// renders dropdown tabs (`items`) as dead links, so it is hidden in theme.css
-// and this component lists the sections itself — expanding a dropdown tab
-// (the "More" menu) into a labeled group of links — above the page tree.
+// The nav shown inside the docs mobile drawer. RootLayout's own drawer tab
+// list renders dropdown tabs (`items`) as dead links, so it is hidden in
+// theme.css and this component lists the sections itself — expanding a
+// dropdown tab (the "More" menu) into a labeled group — above the page tree.
 interface Props {
   items: NavNode[];
   currentRoute: string;
@@ -18,69 +15,12 @@ interface Props {
 }
 
 const { items, currentRoute, strings } = Astro.props;
-
-const tabs = data.navigation.tabs;
-const activeTab = activeTabForRoute(tabs, currentRoute);
-const isExternal = (path: string): boolean => /^https?:\/\//u.test(path);
-
-const rowClass =
-  "block py-1.5 font-medium text-muted-foreground text-sm transition-colors hover:text-foreground aria-[current=page]:text-accent";
 ---
 
-{
-  tabs.length > 0 && (
-    <nav
-      aria-label="Sections"
-      class:list={[
-        "mb-4 border-border border-b pb-4",
-        // From `md` the header's inline tab bar takes over; keep the drawer
-        // list only when there is no page tree to show (e.g. the changelog).
-        items.length > 0 && "md:hidden",
-      ]}
-    >
-      <ul class="m-0 list-none p-0">
-        {tabs.map((tab) =>
-          tab.items && tab.items.length > 0 ? (
-            <li class="mt-2">
-              <p class="mb-1 py-1.5 font-medium text-muted-foreground text-sm">
-                {tab.label}
-              </p>
-              <ul class="m-0 list-none border-border border-s p-0 ps-3">
-                {tab.items.map((item) => (
-                  <li>
-                    <a
-                      class="flex items-center gap-2 py-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground"
-                      href={withBase(item.path)}
-                      rel={isExternal(item.path) ? "noreferrer" : undefined}
-                      target={isExternal(item.path) ? "_blank" : undefined}
-                    >
-                      <span class="flex-1 truncate">{item.label}</span>
-                      {isExternal(item.path) && (
-                        <Icon
-                          class="shrink-0 opacity-60"
-                          name="arrow-up-right"
-                          size={12}
-                        />
-                      )}
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </li>
-          ) : (
-            <li>
-              <a
-                aria-current={tab === activeTab ? "page" : undefined}
-                class={rowClass}
-                href={withBase(tab.href ?? tab.path)}
-              >
-                {tab.label}
-              </a>
-            </li>
-          )
-        )}
-      </ul>
-    </nav>
-  )
-}
+{/* From `md` the header's inline tab bar takes over; keep the drawer
+    list only when there is no page tree to show (e.g. the changelog). */}
+<SectionsNav
+  class={`mb-4 border-border border-b pb-4${items.length > 0 ? " md:hidden" : ""}`}
+  currentRoute={currentRoute}
+/>
 <NavTree currentRoute={currentRoute} items={items} strings={strings} />

--- a/apps/content/components/blume/MobileNav.astro
+++ b/apps/content/components/blume/MobileNav.astro
@@ -1,0 +1,86 @@
+---
+import data from "blume:data";
+import type { UIStrings } from "blume/core/i18n-ui.ts";
+import type { NavNode } from "blume/core/types.ts";
+import Icon from "blume/components/Icon.astro";
+import { withBase } from "blume/components/islands/base-path.ts";
+import { activeTabForRoute } from "blume/components/layout/nav-utils.ts";
+import NavTree from "./NavTree.astro";
+
+// The nav shown inside the mobile drawer. RootLayout's own drawer tab list
+// renders dropdown tabs (`items`) as dead links, so it is hidden in theme.css
+// and this component lists the sections itself — expanding a dropdown tab
+// (the "More" menu) into a labeled group of links — above the page tree.
+interface Props {
+  items: NavNode[];
+  currentRoute: string;
+  strings?: UIStrings["nav"];
+}
+
+const { items, currentRoute, strings } = Astro.props;
+
+const tabs = data.navigation.tabs;
+const activeTab = activeTabForRoute(tabs, currentRoute);
+const isExternal = (path: string): boolean => /^https?:\/\//u.test(path);
+
+const rowClass =
+  "block py-1.5 font-medium text-muted-foreground text-sm transition-colors hover:text-foreground aria-[current=page]:text-accent";
+---
+
+{
+  tabs.length > 0 && (
+    <nav
+      aria-label="Sections"
+      class:list={[
+        "mb-4 border-border border-b pb-4",
+        // From `md` the header's inline tab bar takes over; keep the drawer
+        // list only when there is no page tree to show (e.g. the changelog).
+        items.length > 0 && "md:hidden",
+      ]}
+    >
+      <ul class="m-0 list-none p-0">
+        {tabs.map((tab) =>
+          tab.items && tab.items.length > 0 ? (
+            <li class="mt-2">
+              <p class="mb-1 py-1.5 font-medium text-muted-foreground text-sm">
+                {tab.label}
+              </p>
+              <ul class="m-0 list-none border-border border-s p-0 ps-3">
+                {tab.items.map((item) => (
+                  <li>
+                    <a
+                      class="flex items-center gap-2 py-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground"
+                      href={withBase(item.path)}
+                      rel={isExternal(item.path) ? "noreferrer" : undefined}
+                      target={isExternal(item.path) ? "_blank" : undefined}
+                    >
+                      <span class="flex-1 truncate">{item.label}</span>
+                      {isExternal(item.path) && (
+                        <Icon
+                          class="shrink-0 opacity-60"
+                          name="arrow-up-right"
+                          size={12}
+                        />
+                      )}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ) : (
+            <li>
+              <a
+                aria-current={tab === activeTab ? "page" : undefined}
+                class={rowClass}
+                href={withBase(tab.href ?? tab.path)}
+              >
+                {tab.label}
+              </a>
+            </li>
+          )
+        )}
+      </ul>
+    </nav>
+  )
+}
+<NavTree currentRoute={currentRoute} items={items} strings={strings} />

--- a/apps/content/components/blume/NavTree.astro
+++ b/apps/content/components/blume/NavTree.astro
@@ -1,0 +1,513 @@
+---
+import { EN_UI } from "blume/core/i18n-ui.ts";
+import type { UIStrings } from "blume/core/i18n-ui.ts";
+import type { NavNode } from "blume/core/types.ts";
+import Icon from "blume/components/Icon.astro";
+import { withBase } from "blume/components/islands/base-path.ts";
+import Self from "./NavTree.astro";
+
+interface PagePanel {
+  id: string;
+  parentId: string;
+  label: string;
+  route?: string;
+  icon?: string;
+  children: NavNode[];
+  active: boolean;
+}
+
+interface Props {
+  items: NavNode[];
+  currentRoute: string;
+  depth?: number;
+  /** Id prefix used to address `page`-mode panels (`${prefix}.${index}`). */
+  idPrefix?: string;
+  /** True only for the top-level call; renders the `<blume-nav>` panel stack. */
+  root?: boolean;
+  /** Localized labels ("Back", the deprecated badge); English when omitted. */
+  strings?: UIStrings["nav"];
+}
+
+const {
+  items,
+  currentRoute,
+  depth = 0,
+  idPrefix = "n",
+  root = depth === 0,
+  strings,
+} = Astro.props;
+
+// Merge over the English defaults so a label missing from a translation (or
+// from a not-yet-regenerated snapshot) still renders instead of coming out
+// blank — the PageActions pattern.
+const n = { ...EN_UI.nav, ...strings };
+
+const badgeBase =
+  "shrink-0 rounded-full px-1.5 py-0.5 font-medium text-[0.65rem] leading-none";
+const badgeClass = `${badgeBase} bg-muted text-muted-foreground`;
+// HTTP-method badges (from an OpenAPI reference's sidebar) are color-coded;
+// every other badge keeps the neutral style.
+const METHOD_BADGE: Record<string, string> = {
+  DELETE: "bg-red-500/15 text-red-700 dark:text-red-300",
+  GET: "bg-green-500/15 text-green-700 dark:text-green-300",
+  HEAD: "bg-muted text-muted-foreground",
+  OPTIONS: "bg-muted text-muted-foreground",
+  PATCH: "bg-yellow-500/20 text-yellow-800 dark:text-yellow-300",
+  POST: "bg-blue-500/15 text-blue-700 dark:text-blue-300",
+  PUT: "bg-orange-500/15 text-orange-700 dark:text-orange-300",
+};
+const badgeClassFor = (badge: string): string => {
+  const method = METHOD_BADGE[badge.toUpperCase()];
+  return method ? `${badgeBase} ${method}` : badgeClass;
+};
+const deprecatedClass =
+  "shrink-0 rounded-full bg-amber-500/10 px-1.5 py-0.5 font-medium text-[0.65rem] text-amber-700 leading-none dark:text-amber-300";
+
+const hasActivePage = (item: NavNode): boolean =>
+  item.kind === "page"
+    ? item.route === currentRoute
+    : item.route === currentRoute || item.children.some(hasActivePage);
+
+// Collect every `page`-mode group in the tree as a panel that is hoisted to the
+// top of the `<blume-nav>` stack. Panel ids match the `${prefix}.${index}`
+// scheme the row renderer uses for `data-nav-to`, so a drill-in trigger and its
+// panel always agree. `flat`/`group` ancestors keep their children in the same
+// visual panel (parentId unchanged); a `page` group opens a new panel.
+const collectPanels = (
+  nodes: NavNode[],
+  prefix: string,
+  parentId: string
+): PagePanel[] => {
+  const out: PagePanel[] = [];
+  nodes.forEach((node, index) => {
+    if (node.kind !== "group") {
+      return;
+    }
+    const id = `${prefix}.${index}`;
+    if ((node.display ?? "flat") === "page") {
+      out.push({
+        active: hasActivePage(node),
+        children: node.children,
+        icon: node.icon,
+        id,
+        label: node.label,
+        parentId,
+        route: node.route,
+      });
+      out.push(...collectPanels(node.children, id, id));
+    } else {
+      out.push(...collectPanels(node.children, id, parentId));
+    }
+  });
+  return out;
+};
+
+const panels = root ? collectPanels(items, idPrefix, "root") : [];
+// Open the deepest panel that contains the current page, so a real page load
+// lands on the right sub-panel (and degrades gracefully without JS).
+const activePanels = panels.filter((panel) => panel.active);
+const initialId =
+  activePanels.length > 0
+    ? activePanels.reduce((a, b) =>
+        b.id.split(".").length > a.id.split(".").length ? b : a
+      ).id
+    : "root";
+---
+
+{
+  root && panels.length > 0 ? (
+    <blume-nav class="block" data-initial={initialId}>
+      <div data-nav-panel="root" hidden={initialId !== "root"}>
+        <Self
+          currentRoute={currentRoute}
+          depth={0}
+          idPrefix={idPrefix}
+          items={items}
+          root={false}
+          strings={n}
+        />
+      </div>
+      {panels.map((panel) => (
+        <div data-nav-panel={panel.id} hidden={panel.id !== initialId}>
+          {/* The title is the only sidebar link to the section's own page, so
+              a routed panel keeps it as a link; without a route the whole row
+              becomes the back button. Either way every part of the row is
+              interactive. */}
+          {panel.route ? (
+            <div class="mb-3 flex items-center gap-0.5">
+              <button
+                aria-label={n.back}
+                class="-ml-1 flex shrink-0 items-center justify-center self-stretch rounded-[0.65rem] px-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                data-nav-back={panel.parentId}
+                type="button"
+              >
+                <Icon class="rtl:-scale-x-100" name="arrow-left" size={16} />
+              </button>
+              <a
+                aria-current={panel.route === currentRoute ? "page" : undefined}
+                class="flex-1 truncate rounded-[0.65rem] px-1 py-1 font-semibold text-foreground text-sm transition-colors hover:bg-muted"
+                href={withBase(panel.route)}
+              >
+                {panel.label}
+              </a>
+            </div>
+          ) : (
+            <button
+              aria-label={`${n.back}: ${panel.label}`}
+              class="-ml-1 mb-3 flex w-full items-center gap-1.5 rounded-[0.65rem] p-1 text-left font-semibold text-foreground text-sm transition-colors hover:bg-muted"
+              data-nav-back={panel.parentId}
+              type="button"
+            >
+              <Icon
+                class="shrink-0 text-muted-foreground rtl:-scale-x-100"
+                name="arrow-left"
+                size={16}
+              />
+              <span class="flex-1 truncate">{panel.label}</span>
+            </button>
+          )}
+          <Self
+            currentRoute={currentRoute}
+            depth={1}
+            idPrefix={panel.id}
+            items={panel.children}
+            root={false}
+            strings={n}
+          />
+        </div>
+      ))}
+    </blume-nav>
+  ) : (
+    <ul class="m-0 list-none space-y-px p-0">
+      {items.map((item, index) => {
+        if (item.kind === "page") {
+          return (
+            <li>
+              <a
+                aria-current={item.route === currentRoute ? "page" : undefined}
+                class="block py-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground aria-[current=page]:text-accent"
+                href={withBase(item.route)}
+              >
+                <span class="flex items-center gap-2">
+                  {item.icon && (
+                    <Icon
+                      class="shrink-0 text-muted-foreground"
+                      name={item.icon}
+                      size={14}
+                    />
+                  )}
+                  <span class="flex-1 truncate">{item.label}</span>
+                  {item.badge && <span class={badgeClassFor(item.badge)}>{item.badge}</span>}
+                  {item.deprecated && (
+                    <span class={deprecatedClass}>{n.deprecated}</span>
+                  )}
+                </span>
+              </a>
+            </li>
+          );
+        }
+
+        const display = item.display ?? "flat";
+        const id = `${idPrefix}.${index}`;
+        // Flat groups are section headers and want breathing room; collapsible
+        // `group`/`page` rows are single rows and should stack tightly.
+        const spacing =
+          index === 0 ? "mt-0" : display === "flat" ? "mt-7" : "mt-0.5";
+
+        // `page`: a single row that drills into this group's panel.
+        if (display === "page") {
+          return (
+            <li class={spacing}>
+              <button
+                class="flex w-full cursor-pointer items-center gap-2 py-1.5 text-left font-medium text-foreground text-sm transition-colors hover:text-accent"
+                data-nav-to={id}
+                type="button"
+              >
+                {item.icon && (
+                  <Icon
+                    class="shrink-0 text-muted-foreground"
+                    name={item.icon}
+                    size={14}
+                  />
+                )}
+                <span class="flex-1 truncate">{item.label}</span>
+                {item.badge && <span class={badgeClassFor(item.badge)}>{item.badge}</span>}
+                <Icon
+                  class="shrink-0 text-muted-foreground rtl:-scale-x-100"
+                  name="chevron-right"
+                  size={14}
+                />
+              </button>
+            </li>
+          );
+        }
+
+        // `group`: a collapsible `<details>` disclosure.
+        if (display === "group") {
+          const active = hasActivePage(item);
+          // Default every group closed; open only those on the active path (so
+          // the current page's ancestors stay expanded) or forced open via meta.
+          const open = active || item.collapsed === false;
+          return (
+            <li class={spacing}>
+              <details open={open}>
+                <summary class="flex cursor-pointer list-none items-center gap-1.5 py-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground [&::-webkit-details-marker]:hidden">
+                  {item.route ? (
+                    <a
+                      aria-current={
+                        item.route === currentRoute ? "page" : undefined
+                      }
+                      class="-my-1 flex flex-1 items-center gap-1.5 py-1 transition-colors aria-[current=page]:text-accent"
+                      href={withBase(item.route)}
+                    >
+                      {item.icon && (
+                        <Icon
+                          class="shrink-0 text-muted-foreground"
+                          name={item.icon}
+                          size={14}
+                        />
+                      )}
+                      <span class="flex-1 truncate">{item.label}</span>
+                      {item.badge && (
+                        <span class={badgeClassFor(item.badge)}>{item.badge}</span>
+                      )}
+                    </a>
+                  ) : (
+                    <>
+                      {item.icon && (
+                        <Icon
+                          class="shrink-0 text-muted-foreground"
+                          name={item.icon}
+                          size={14}
+                        />
+                      )}
+                      <span class="flex-1 truncate">{item.label}</span>
+                      {item.badge && (
+                        <span class={badgeClassFor(item.badge)}>{item.badge}</span>
+                      )}
+                    </>
+                  )}
+                  {/* Scope the rotation to this group's own `details` — the
+                      `group-open` variant matches any open ancestor `.group`,
+                      so nested chevrons rotated while their own group stayed
+                      closed. */}
+                  <span class="shrink-0 text-muted-foreground transition-transform [details[open]>summary_&]:rotate-90">
+                    <Icon name="chevron-right" size={13} />
+                  </span>
+                </summary>
+                <div class="space-y-0.5 border-border border-l pl-3">
+                  <Self
+                    currentRoute={currentRoute}
+                    depth={depth + 1}
+                    idPrefix={id}
+                    items={item.children}
+                    root={false}
+                    strings={n}
+                  />
+                </div>
+              </details>
+            </li>
+          );
+        }
+
+        // `flat` (default): a non-collapsible header with its items beneath.
+        return (
+          <li class={spacing}>
+            <p class="mb-2 flex items-center gap-1.5 font-semibold text-foreground text-sm">
+              {item.route ? (
+                <a
+                  aria-current={item.route === currentRoute ? "page" : undefined}
+                  class="flex flex-1 items-center gap-1.5 text-foreground transition-colors hover:text-accent aria-[current=page]:text-accent"
+                  href={withBase(item.route)}
+                >
+                  {item.icon && (
+                    <Icon
+                      class="shrink-0 text-muted-foreground"
+                      name={item.icon}
+                      size={14}
+                    />
+                  )}
+                  <span class="truncate">{item.label}</span>
+                  {item.badge && (
+                    <span class={`ml-auto ${badgeClassFor(item.badge)}`}>{item.badge}</span>
+                  )}
+                </a>
+              ) : (
+                <>
+                  {item.icon && (
+                    <Icon
+                      class="shrink-0 text-muted-foreground"
+                      name={item.icon}
+                      size={14}
+                    />
+                  )}
+                  <span class="truncate">{item.label}</span>
+                  {item.badge && (
+                    <span class={`ml-auto ${badgeClassFor(item.badge)}`}>{item.badge}</span>
+                  )}
+                </>
+              )}
+            </p>
+            <div class="space-y-0.5">
+              <Self
+                currentRoute={currentRoute}
+                depth={depth + 1}
+                idPrefix={id}
+                items={item.children}
+                root={false}
+                strings={n}
+              />
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  )
+}
+
+<script>
+  const DURATION = 260;
+  const EASING = "cubic-bezier(0.33, 1, 0.68, 1)";
+
+  class BlumeNav extends HTMLElement {
+    connectedCallback() {
+      if (this.dataset.ready) {
+        return;
+      }
+      this.dataset.ready = "1";
+      this.addEventListener("click", (event) => {
+        const target = event.target;
+        if (!(target instanceof Element)) {
+          return;
+        }
+        const drill = target.closest("[data-nav-to]");
+        if (drill && this.contains(drill)) {
+          const id = drill.getAttribute("data-nav-to");
+          if (id && this.panel(id)) {
+            event.preventDefault();
+            this.show(id, true);
+          }
+          return;
+        }
+        const back = target.closest("[data-nav-back]");
+        if (back && this.contains(back)) {
+          event.preventDefault();
+          this.show(back.getAttribute("data-nav-back") || "root", true);
+        }
+      });
+      // Initial panel is route-driven, so it snaps into place without a slide.
+      this.show(this.dataset.initial || "root", false);
+    }
+
+    panel(id) {
+      return this.querySelector(`[data-nav-panel="${id}"]`);
+    }
+
+    depth(id) {
+      return id === "root" ? 0 : id.split(".").length;
+    }
+
+    reduced() {
+      return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    }
+
+    show(id, animate) {
+      const next = this.panel(id) || this.panel("root");
+      if (!next) {
+        return;
+      }
+      const resolved = next.getAttribute("data-nav-panel");
+      const prev = this.active;
+      if (prev === next) {
+        return;
+      }
+      // Settle any in-flight slide before starting the next one.
+      if (this.finishSlide) {
+        this.finishSlide();
+      }
+      this.active = next;
+      this.dataset.active = resolved;
+
+      if (!(animate && prev) || this.reduced()) {
+        for (const panel of this.querySelectorAll("[data-nav-panel]")) {
+          panel.hidden = panel !== next;
+        }
+        return;
+      }
+
+      const forward =
+        this.depth(resolved) > this.depth(prev.getAttribute("data-nav-panel"));
+      this.slide(prev, next, forward);
+    }
+
+    slide(out, into, forward) {
+      const rtl = getComputedStyle(this).direction === "rtl" ? -1 : 1;
+      const sign = (forward ? -1 : 1) * rtl;
+
+      const fromHeight = out.offsetHeight;
+      this.style.position = "relative";
+      this.style.overflow = "hidden";
+      this.style.height = `${fromHeight}px`;
+      into.hidden = false;
+      for (const panel of [out, into]) {
+        panel.style.position = "absolute";
+        panel.style.top = "0";
+        panel.style.insetInlineStart = "0";
+        panel.style.width = "100%";
+      }
+      const toHeight = into.offsetHeight;
+      this.style.height = `${toHeight}px`;
+
+      const options = { duration: DURATION, easing: EASING };
+      const animations = [
+        out.animate(
+          [
+            { transform: "translateX(0)" },
+            { transform: `translateX(${sign * 100}%)` },
+          ],
+          options
+        ),
+        into.animate(
+          [
+            { transform: `translateX(${-sign * 100}%)` },
+            { transform: "translateX(0)" },
+          ],
+          options
+        ),
+        this.animate(
+          [{ height: `${fromHeight}px` }, { height: `${toHeight}px` }],
+          options
+        ),
+      ];
+
+      let done = false;
+      const finish = () => {
+        if (done) {
+          return;
+        }
+        done = true;
+        for (const animation of animations) {
+          animation.cancel();
+        }
+        out.hidden = true;
+        for (const panel of [out, into]) {
+          panel.style.position = "";
+          panel.style.top = "";
+          panel.style.insetInlineStart = "";
+          panel.style.width = "";
+          panel.style.transform = "";
+        }
+        this.style.position = "";
+        this.style.overflow = "";
+        this.style.height = "";
+        this.finishSlide = null;
+      };
+      this.finishSlide = finish;
+      animations[0].finished.then(finish, finish);
+    }
+  }
+
+  if (!customElements.get("blume-nav")) {
+    customElements.define("blume-nav", BlumeNav);
+  }
+</script>

--- a/apps/content/components/blume/NavTree.astro
+++ b/apps/content/components/blume/NavTree.astro
@@ -181,20 +181,31 @@ const initialId =
     <ul class="m-0 list-none space-y-px p-0">
       {items.map((item, index) => {
         if (item.kind === "page") {
+          const isActive = item.route === currentRoute;
           return (
             <li>
               <a
-                aria-current={item.route === currentRoute ? "page" : undefined}
-                class="block py-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground aria-[current=page]:text-accent"
+                aria-current={isActive ? "page" : undefined}
+                class:list={[
+                  "block text-muted-foreground text-sm transition-colors hover:text-foreground aria-[current=page]:text-accent",
+                  // Icon rows are section entry points: a bordered icon chip
+                  // sets them apart from the plain page links below them.
+                  item.icon ? "py-1" : "py-1.5",
+                ]}
                 href={withBase(item.route)}
               >
-                <span class="flex items-center gap-2">
+                <span class="flex items-center gap-2.5">
                   {item.icon && (
-                    <Icon
-                      class="shrink-0 text-muted-foreground"
-                      name={item.icon}
-                      size={14}
-                    />
+                    <span
+                      class:list={[
+                        "flex size-6 shrink-0 items-center justify-center rounded-md border bg-background shadow-xs transition-colors",
+                        isActive
+                          ? "border-accent/40 text-accent"
+                          : "border-border text-muted-foreground",
+                      ]}
+                    >
+                      <Icon name={item.icon} size={14} />
+                    </span>
                   )}
                   <span class="flex-1 truncate">{item.label}</span>
                   {item.badge && <span class={badgeClassFor(item.badge)}>{item.badge}</span>}

--- a/apps/content/components/blume/Pagination.astro
+++ b/apps/content/components/blume/Pagination.astro
@@ -1,0 +1,63 @@
+---
+import { withBase } from "blume/components/islands/base-path.ts";
+import { EN_UI } from "blume/core/i18n-ui.ts";
+import type { UIStrings } from "blume/core/i18n-ui.ts";
+import type { FlatPage } from "blume/components/layout/nav-utils.ts";
+import Icon from "blume/components/Icon.astro";
+
+interface Props {
+  /** Previous page in reading order, or `null` at the start. */
+  prev: FlatPage | null;
+  /** Next page in reading order, or `null` at the end. */
+  next: FlatPage | null;
+  /** Localized page-level strings (`previous`, `next`, the landmark label). */
+  strings: UIStrings["page"];
+}
+
+const { prev, next, strings } = Astro.props;
+
+// Merge over the English defaults so a label missing from a translation (or
+// from a not-yet-regenerated snapshot) still renders instead of coming out
+// blank — the PageActions pattern.
+const s = { ...EN_UI.page, ...strings };
+---
+
+{
+  (prev || next) && (
+    <nav
+      aria-label={s.pagination}
+      class="mx-auto mt-12 flex max-w-content justify-between gap-4 border-border border-t pt-6 max-md:flex-col"
+    >
+      {prev ? (
+        <a
+          class="flex max-w-[48%] flex-1 items-center gap-2 rounded-blume border border-border px-4 py-3 text-foreground transition-colors hover:border-foreground max-md:max-w-full"
+          href={withBase(prev.route)}
+        >
+          <Icon class="rtl:-scale-x-100" name="arrow-left" size={16} />
+          <span class="min-w-0">
+            <span class="block text-muted-foreground text-xs max-md:hidden">
+              {s.previous}
+            </span>
+            <span class="block truncate font-medium">{prev.label}</span>
+          </span>
+        </a>
+      ) : (
+        <span />
+      )}
+      {next && (
+        <a
+          class="ms-auto flex max-w-[48%] flex-1 items-center justify-end gap-2 rounded-blume border border-border px-4 py-3 text-end text-foreground transition-colors hover:border-foreground max-md:ms-0 max-md:max-w-full"
+          href={withBase(next.route)}
+        >
+          <span class="min-w-0">
+            <span class="block text-muted-foreground text-xs max-md:hidden">
+              {s.next}
+            </span>
+            <span class="block truncate font-medium">{next.label}</span>
+          </span>
+          <Icon class="rtl:-scale-x-100" name="arrow-right" size={16} />
+        </a>
+      )}
+    </nav>
+  )
+}

--- a/apps/content/components/blume/SectionsNav.astro
+++ b/apps/content/components/blume/SectionsNav.astro
@@ -1,0 +1,72 @@
+---
+import data from "blume:data";
+import Icon from "blume/components/Icon.astro";
+import { withBase } from "blume/components/islands/base-path.ts";
+import { activeTabForRoute } from "blume/components/layout/nav-utils.ts";
+
+// The drawer's section list: header tabs as rows, with a dropdown tab (the
+// "More" menu) expanded into a labeled group of links. Shared between the
+// docs drawer (MobileNav) and the tabs-only drawer on chrome pages (Header).
+interface Props {
+  currentRoute: string;
+  class?: string;
+}
+
+const { currentRoute, class: className } = Astro.props;
+
+const tabs = data.navigation.tabs;
+const activeTab = activeTabForRoute(tabs, currentRoute);
+const isExternal = (path: string): boolean => /^https?:\/\//u.test(path);
+
+const rowClass =
+  "block py-1.5 font-medium text-muted-foreground text-sm transition-colors hover:text-foreground aria-[current=page]:text-accent";
+---
+
+{
+  tabs.length > 0 && (
+    <nav aria-label="Sections" class:list={[className]}>
+      <ul class="m-0 list-none p-0">
+        {tabs.map((tab) =>
+          tab.items && tab.items.length > 0 ? (
+            <li class="mt-2">
+              <p class="mb-1 py-1.5 font-medium text-muted-foreground text-sm">
+                {tab.label}
+              </p>
+              <ul class="m-0 list-none border-border border-s p-0 ps-3">
+                {tab.items.map((item) => (
+                  <li>
+                    <a
+                      class="flex items-center gap-2 py-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground"
+                      href={withBase(item.path)}
+                      rel={isExternal(item.path) ? "noreferrer" : undefined}
+                      target={isExternal(item.path) ? "_blank" : undefined}
+                    >
+                      <span class="flex-1 truncate">{item.label}</span>
+                      {isExternal(item.path) && (
+                        <Icon
+                          class="shrink-0 opacity-60"
+                          name="arrow-up-right"
+                          size={12}
+                        />
+                      )}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ) : (
+            <li>
+              <a
+                aria-current={tab === activeTab ? "page" : undefined}
+                class={rowClass}
+                href={withBase(tab.href ?? tab.path)}
+              >
+                {tab.label}
+              </a>
+            </li>
+          )
+        )}
+      </ul>
+    </nav>
+  )
+}

--- a/apps/content/components/blume/TableOfContents.astro
+++ b/apps/content/components/blume/TableOfContents.astro
@@ -1,0 +1,70 @@
+---
+import type { Heading } from "blume/core/types.ts";
+import Icon from "blume/components/Icon.astro";
+
+interface Props {
+  /** Headings to list (already filtered to the depths shown in the TOC). */
+  headings: Heading[];
+  /** Localized "On this page" heading. */
+  title: string;
+  /**
+   * `mobile` renders the collapsible `<details>` shown above content on narrow
+   * viewports; `desktop` renders the sticky aside list shown on wide ones.
+   */
+  variant: "mobile" | "desktop";
+}
+
+const { headings, title, variant } = Astro.props;
+---
+
+{
+  headings.length > 0 && variant === "mobile" && (
+    <details class="group mx-auto mb-6 max-w-content rounded-blume border border-border xl:hidden">
+      <summary class="flex cursor-pointer list-none items-center justify-between gap-2 px-4 py-3 font-medium text-foreground text-sm [&::-webkit-details-marker]:hidden">
+        <span>{title}</span>
+        <Icon
+          class="text-muted-foreground transition-transform group-open:rotate-180"
+          name="chevron-down"
+          size={16}
+        />
+      </summary>
+      <blume-toc class="block">
+        <ul class="m-0 list-none border-border border-t p-2">
+          {headings.map((heading) => (
+            <li style={`padding-inline-start:${(heading.depth - 2) * 0.75}rem`}>
+              <a
+                class="block rounded-md px-2 py-1.5 text-muted-foreground text-sm transition-colors hover:text-foreground aria-[current=location]:font-medium aria-[current=location]:text-foreground"
+                href={`#${heading.slug}`}
+              >
+                {heading.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </blume-toc>
+    </details>
+  )
+}
+{
+  headings.length > 0 && variant === "desktop" && (
+    <>
+      <p class="mb-3 font-semibold text-muted-foreground text-xs uppercase tracking-[0.05em]">
+        {title}
+      </p>
+      <blume-toc class="block">
+        <ul class="m-0 list-none p-0">
+          {headings.map((heading) => (
+            <li style={`padding-inline-start:${(heading.depth - 2) * 0.875}rem`}>
+              <a
+                class="block py-1 text-muted-foreground transition-colors hover:text-foreground aria-[current=location]:text-accent"
+                href={`#${heading.slug}`}
+              >
+                {heading.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </blume-toc>
+    </>
+  )
+}

--- a/apps/content/components/blume/twoslash-mobile.ts
+++ b/apps/content/components/blume/twoslash-mobile.ts
@@ -1,0 +1,68 @@
+// Mobile twoslash popups: theme.css makes them fixed, readable-width, and
+// horizontally centered; this anchors each one just below its hovered or
+// tapped token (or above it when the token sits near the bottom of the
+// screen). The popup's own height is never measured — the available space
+// becomes its max-height and longer signatures scroll internally — so late
+// reflows of the nested code signature can't push it offscreen.
+//
+// Placement is only ever written, never proactively cleared: a popup is
+// re-placed (or reset, on desktop widths) at the moment it is revealed, so
+// stale styles on a hidden popup are harmless. Clearing eagerly — on outside
+// tap or on touch pointerout, which fires the moment a tap ends — made the
+// still-visible popup flash at its fallback position.
+const MOBILE = '(max-width: 48rem)'
+const EDGE = 8
+const GAP = 6
+const MIN_SPACE = 160
+
+function popupFor(target: EventTarget | null): { hover: Element, popup: HTMLElement } | null {
+  const element = target instanceof Element ? target : null
+  const hover = element?.closest('.twoslash-hover')
+  const popup = hover?.querySelector<HTMLElement>('.twoslash-popup-container')
+  return hover && popup ? { hover, popup } : null
+}
+
+function place(hover: Element, popup: HTMLElement): void {
+  const rect = hover.getBoundingClientRect()
+  const spaceBelow = window.innerHeight - rect.bottom - GAP - EDGE
+  const spaceAbove = rect.top - GAP - EDGE
+  if (spaceBelow >= MIN_SPACE || spaceBelow >= spaceAbove) {
+    popup.style.top = `${rect.bottom + GAP}px`
+    popup.style.bottom = 'auto'
+    popup.style.maxHeight = `${Math.max(spaceBelow, 80)}px`
+  }
+  else {
+    popup.style.top = 'auto'
+    popup.style.bottom = `${window.innerHeight - rect.top + GAP}px`
+    popup.style.maxHeight = `${Math.max(spaceAbove, 80)}px`
+  }
+  popup.style.marginTop = '0'
+}
+
+function reset(popup: HTMLElement): void {
+  popup.style.top = ''
+  popup.style.bottom = ''
+  popup.style.maxHeight = ''
+  popup.style.marginTop = ''
+}
+
+function reveal(target: EventTarget | null): void {
+  const found = popupFor(target)
+  if (!found) {
+    return
+  }
+  if (window.matchMedia(MOBILE).matches) {
+    place(found.hover, found.popup)
+  }
+  else {
+    // Desktop reveal: drop any placement left over from a mobile-width
+    // session, so the absolute-positioned popup anchors normally.
+    reset(found.popup)
+  }
+}
+
+// Hover shows the popup via CSS :hover; touch taps show it via sticky
+// :hover but with unreliable pointerover/pointerout sequencing, so the tap
+// itself also places.
+document.addEventListener('pointerover', event => reveal(event.target))
+document.addEventListener('pointerdown', event => reveal(event.target))

--- a/apps/content/pages/blog/[...slug].astro
+++ b/apps/content/pages/blog/[...slug].astro
@@ -129,15 +129,16 @@ const postJsonLd = {
             {dateFormat.format(date)}
           </time>
         )}
+        <span class="text-muted-foreground">
+          {' / '}
+          {minutes} min read
+        </span>
       </p>
-      <h1 class="font-display mt-4 text-4xl font-semibold tracking-tight text-balance sm:text-5xl">
+      <h1 class="font-display mt-4 text-3xl font-bold tracking-tight text-balance sm:text-4xl">
         {entry.data.title}
       </h1>
-      <p class="mt-4 font-mono text-xs tracking-widest text-muted-foreground uppercase">
-        {minutes} minute{minutes === 1 ? '' : 's'} read
-      </p>
       {authors.length > 0 && (
-        <div class="mt-8 flex flex-wrap items-center gap-6">
+        <div class="mt-6 flex flex-wrap items-center gap-6">
           {authors.map(author => (
             <span class="flex items-center gap-3">
               {author.avatar && (
@@ -170,7 +171,7 @@ const postJsonLd = {
       )}
     </header>
 
-    <hr class="my-10 border-border" />
+    <hr class="my-8 border-border" />
 
     <div class="prose max-w-none">
       <BlumePage id={route.entryId} components={{ SponsorSlot }} />

--- a/apps/content/pages/blog/index.astro
+++ b/apps/content/pages/blog/index.astro
@@ -47,8 +47,6 @@ const posts = (await getCollection('docs'))
       tags: entry.data.search?.tags as string[] | undefined ?? [],
       authors: normalizeAuthors(entry.data.authors),
       minutes: readMinutes(entry.body),
-      // Prefer an explicit share image; fall back to the generated OG card.
-      cover: entry.data.seo?.image ?? (href ? `/og${href}.png` : undefined),
     }
   })
   .filter(post => post.href)
@@ -63,9 +61,6 @@ for (const post of posts) {
 }
 const tags = [...tagCounts.keys()]
   .sort((a, b) => (tagCounts.get(b)! - tagCounts.get(a)!) || a.localeCompare(b))
-
-// The featured card is always the latest post; filters only affect the grid.
-const featured = posts[0]
 
 const feed = data.feeds.find(f => f.href.startsWith('/blog'))
 
@@ -107,63 +102,13 @@ const blogJsonLd = {
     type="application/ld+json"
     set:html={JSON.stringify(blogJsonLd).replaceAll('<', '\\u003c')}
   />
-  <section class="mx-auto w-full max-w-6xl px-6 py-12">
-    {
-      featured && (
-        <a
-          href={featured.href}
-          class="group mb-10 grid overflow-hidden rounded-blume border border-border bg-muted/30 md:grid-cols-[2fr_3fr]"
-        >
-          <div class="flex flex-col gap-3 p-8">
-            <p class="text-sm text-muted-foreground">
-              {featured.date && (
-                <time datetime={featured.date.toISOString()}>
-                  {dateFormat.format(featured.date)}
-                </time>
-              )}
-              {' · '}
-              {featured.minutes} min read
-            </p>
-            <h2 class="font-display text-2xl font-semibold tracking-tight transition-colors group-hover:text-muted-foreground">
-              {featured.title}
-            </h2>
-            {featured.authors.length > 0 && (
-              <div class="mt-auto flex items-center gap-3 pt-8">
-                {featured.authors[0]!.avatar && (
-                  <img
-                    src={featured.authors[0]!.avatar}
-                    alt=""
-                    width="40"
-                    height="40"
-                    class="size-10 rounded-blume"
-                    data-no-zoom
-                  />
-                )}
-                <span class="text-sm">
-                  <span class="block font-medium">{featured.authors[0]!.name}</span>
-                  {featured.authors[0]!.role && (
-                    <span class="text-muted-foreground">
-                      {featured.authors[0]!.role}
-                    </span>
-                  )}
-                </span>
-              </div>
-            )}
-          </div>
-          {featured.cover && (
-            <img
-              src={featured.cover}
-              alt=""
-              loading="eager"
-              class="h-full max-h-105 w-full object-cover"
-              data-no-zoom
-            />
-          )}
-        </a>
-      )
-    }
+  <section class="mx-auto w-full max-w-3xl px-6 py-12">
+    <h1 class="font-display text-3xl font-bold tracking-tight">Blog</h1>
+    <p class="mt-2 text-muted-foreground">
+      News, announcements, and writing from the oRPC team.
+    </p>
 
-    <div class="mb-10 flex items-center justify-between gap-4 border-b border-border">
+    <div class="mt-10 mb-2 flex items-center justify-between gap-4 border-b border-border">
       <nav
         class="flex gap-6 overflow-x-auto overflow-y-hidden text-sm [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
         aria-label="Blog tags"
@@ -214,47 +159,50 @@ const blogJsonLd = {
       }
     </div>
 
-    <div class="grid gap-x-8 gap-y-12 sm:grid-cols-2 lg:grid-cols-3">
+    <div class="divide-y divide-border">
       {
         posts.map(post => (
           <a
             href={post.href}
             data-blog-card
             data-tags={post.tags.join('|')}
-            data-slug={post.href}
-            style={post.href === featured?.href ? 'display: none' : undefined}
-            class="group block"
+            class="group block py-7"
           >
-            {post.cover && (
-              <img
-                src={post.cover}
-                alt=""
-                loading="lazy"
-                class="aspect-[1200/630] w-full rounded-blume border border-border object-cover"
-                data-no-zoom
-              />
-            )}
-            <div class="mt-4 flex items-center gap-3 text-sm">
+            <p class="flex items-center gap-3 text-sm text-muted-foreground">
+              {post.date && (
+                <time datetime={post.date.toISOString()}>
+                  {dateFormat.format(post.date)}
+                </time>
+              )}
+              <span>·</span>
+              <span>{post.minutes} min read</span>
               {post.tags.map(tag => (
                 <span class="rounded-blume border border-border px-2 py-0.5 text-xs font-medium whitespace-nowrap">
                   {tag}
                 </span>
               ))}
-              {post.date && (
-                <time
-                  datetime={post.date.toISOString()}
-                  class="text-muted-foreground"
-                >
-                  {dateFormat.format(post.date)}
-                </time>
-              )}
-            </div>
-            <h3 class="font-display mt-2 line-clamp-2 text-lg font-semibold tracking-tight transition-colors group-hover:text-muted-foreground">
+            </p>
+            <h2 class="font-display mt-2 text-xl font-semibold tracking-tight transition-colors group-hover:text-accent">
               {post.title}
-            </h3>
+            </h2>
             {post.description && (
-              <p class="mt-1 line-clamp-2 text-sm text-muted-foreground">
+              <p class="mt-1.5 line-clamp-2 text-sm text-muted-foreground">
                 {post.description}
+              </p>
+            )}
+            {post.authors.length > 0 && (
+              <p class="mt-3 flex items-center gap-2 text-sm text-muted-foreground">
+                {post.authors[0]!.avatar && (
+                  <img
+                    src={post.authors[0]!.avatar}
+                    alt=""
+                    width="20"
+                    height="20"
+                    class="size-5 rounded-full"
+                    data-no-zoom
+                  />
+                )}
+                {post.authors.map(author => author.name).join(', ')}
               </p>
             )}
           </a>
@@ -267,7 +215,6 @@ const blogJsonLd = {
 <script>
   const buttons = document.querySelectorAll<HTMLButtonElement>('[data-blog-filter]')
   const cards = document.querySelectorAll<HTMLElement>('[data-blog-card]')
-  const featuredSlug = document.querySelector<HTMLAnchorElement>('section > a.group')?.getAttribute('href')
 
   for (const button of buttons) {
     button.addEventListener('click', () => {
@@ -282,13 +229,9 @@ const blogJsonLd = {
         other.classList.toggle('text-muted-foreground', !isActive)
       }
 
-      // The featured card always stays; a tag filter lists all of its posts
-      // in the grid, while "All articles" skips the featured duplicate.
       for (const card of cards) {
         const cardTags = (card.dataset.tags ?? '').split('|')
-        const visible = active
-          ? cardTags.includes(active)
-          : card.dataset.slug !== featuredSlug
+        const visible = !active || cardTags.includes(active)
         card.style.display = visible ? '' : 'none'
       }
     })

--- a/apps/content/theme.css
+++ b/apps/content/theme.css
@@ -116,15 +116,64 @@
   background: var(--blume-code-background) !important;
 }
 
-/* Twoslash hover popups are rendered at opacity 0 with no clipping
-   ancestor, so wide ones stretch the page sideways on narrow viewports.
-   Clip the content column instead of letting the page scroll. */
+/* Twoslash hover popups are rendered at opacity 0 but still occupy
+   layout, stretching the page sideways and adding thousands of pixels
+   of phantom height below the content on narrow viewports. Keep them
+   out of layout entirely until their trigger is hovered. */
+.prose .twoslash-hover:not(:hover) .twoslash-popup-container {
+  display: none;
+}
+
 main#blume-content {
   overflow-x: clip;
 }
 
 .prose .twoslash-popup-container {
   max-width: min(85vw, 34rem);
+}
+
+/* On narrow screens the popup is anchored to a tiny inline token and
+   squeezes into an unreadable sliver over the code. Keep it by the
+   hovered token vertically (its natural static position), but fix it,
+   size it readably, and center it horizontally in the viewport —
+   fixed positioning escapes the code scroller below. */
+@media (max-width: 48rem) {
+  .prose .twoslash-popup-container {
+    position: fixed;
+    inset: auto auto auto 50%;
+    /* Twoslash offsets the popup with transform: translateY(1.1em); the
+       margin below replaces it so the fixed math stays exact. */
+    transform: none;
+    translate: -50% 0;
+    z-index: 60;
+    margin: 0.375rem 0 0;
+    width: max-content;
+    max-width: calc(100vw - 1.5rem);
+    max-height: 45dvh;
+    overflow-y: auto;
+    border-radius: 0.5rem;
+    box-shadow: 0 8px 30px rgb(0 0 0 / 0.25);
+  }
+
+  /* Blume wraps twoslash lines on mobile because its anchored popups
+     can't escape a scroll container — the fixed bottom sheet above can,
+     so twoslash code scrolls horizontally like every other block
+     (scrolling the inner code keeps the header bar and copy button
+     static, matching Blume's own pattern). */
+  .prose pre.twoslash {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .prose pre.twoslash > code {
+    display: block;
+    overflow-x: auto;
+    white-space: pre;
+    overflow-wrap: normal;
+    padding: 0 1.25rem 0.375rem;
+    scrollbar-color: var(--blume-border) transparent;
+    scrollbar-width: thin;
+  }
 }
 
 /* ---------------------------------------------------------------- */

--- a/apps/content/theme.css
+++ b/apps/content/theme.css
@@ -57,7 +57,9 @@
     padding: 2rem 1.5rem 2.5rem 1.25rem;
   }
 
-  main#blume-content {
+  /* Docs content column only — PageLayout pages (blog, custom landings)
+     manage their own padding. */
+  [data-blume-doc-grid] > main#blume-content {
     padding: 3rem 3rem 3.5rem;
   }
 }
@@ -137,15 +139,44 @@ main#blume-content {
   padding-inline: max(1.25rem, calc((100% - var(--docs-frame-width)) / 2 + 1.25rem));
 }
 
+/* Header row order: logo, tabs, spacer, then selectors/search/icons on
+   the right (the version dropdown reads better beside search than
+   wedged between the logo and the tabs). */
+[data-blume-header] > button[data-blume-nav-toggle] {
+  order: -40;
+}
+
+[data-blume-header] > a {
+  order: -30;
+}
+
+[data-blume-header] > nav {
+  order: -20;
+}
+
+[data-blume-header] > .flex-1 {
+  order: -10;
+}
+
 /* Section tabs: full-height text links with an accent underline for
-   the active tab, replacing the default pill treatment. */
+   the active tab, replacing the default pill treatment. Direct children
+   only — dropdown-tab menus inside the nav keep their own styling. */
 [data-blume-header] > nav {
   align-self: stretch;
   align-items: center;
   gap: 1.5rem;
+  /* With the header's own 0.75rem gap this equals the 1.5rem tab gap,
+     so logo → nav spacing matches nav → nav spacing. */
+  margin-inline-start: 0.75rem;
 }
 
-[data-blume-header] > nav a {
+/* The drawer's built-in section list can't render dropdown-tab items
+   (the "More" menu) — the MobileNav override lists the sections instead. */
+[data-blume-nav-drawer] > nav:not([data-blume-nav-tree]) {
+  display: none;
+}
+
+[data-blume-header] > nav > a {
   position: relative;
   display: flex;
   align-items: center;
@@ -153,23 +184,57 @@ main#blume-content {
   padding: 0;
   border-radius: 0;
   background: transparent;
+  white-space: nowrap;
 }
 
-[data-blume-header] > nav a:hover {
+/* Between md and lg the header shows the tab bar, the hamburger, and the
+   full search box at once: tighten gaps and collapse search to its icon
+   so nothing wraps or truncates. */
+@media (min-width: 48rem) and (max-width: 63.9375rem) {
+  [data-blume-header] {
+    gap: 0.5rem;
+  }
+
+  [data-blume-header] > nav {
+    gap: 1rem;
+  }
+
+  [data-blume-search-open] {
+    min-width: 0;
+  }
+
+  [data-blume-search-open] > span,
+  [data-blume-search-open] > kbd {
+    display: none;
+  }
+}
+
+[data-blume-header] > nav > a:hover,
+[data-blume-header] > nav > details > summary:hover {
   color: var(--blume-accent);
 }
 
-[data-blume-header] > nav a[aria-current='page'] {
+[data-blume-header] > nav > a[aria-current='page'] {
   color: var(--blume-accent);
 }
 
-[data-blume-header] > nav a[aria-current='page']::after {
+[data-blume-header] > nav > a[aria-current='page']::after {
   content: '';
   position: absolute;
   inset-inline: 0;
   bottom: -1px;
   height: 2px;
   background: var(--blume-accent);
+}
+
+/* The page-actions popovers (Export, Connect to MCP) are up to 22rem
+   wide but live inside the scrollable TOC rail, which clips anything
+   wider than the rail. Size them to the rail instead. */
+[data-blume-toc] [data-blume-menu] {
+  inset-inline-end: 0;
+  width: 100%;
+  min-width: 0;
+  max-width: none;
 }
 
 /* Search trigger: wide, quiet gray box like the reference header */

--- a/apps/content/theme.css
+++ b/apps/content/theme.css
@@ -1,29 +1,30 @@
 /*
- * VitePress/Flue-style theme (flueframework.com reference).
- * Loaded after Blume's layered styles, so plain selectors here win over
- * the theme defaults and the Tailwind utility classes in layout markup.
+ * VitePress-style theme (flueframework.com reference).
+ * Design-token overrides per https://useblume.dev/docs/configuration/theming,
+ * plus layout/chrome overrides for the pieces Blume renders internally
+ * (RootLayout grid, PageLayout drawer, search trigger, page-actions menus).
+ * Owned components (components/blume/*) style themselves with utilities.
  */
 
 :root {
-  /* Palette — light (VitePress defaults, measured from the reference) */
+  /* Palette — light (VitePress values, accent + background live in
+     blume.config.ts `theme`) */
   --blume-foreground: #1b1b1f;
   --blume-muted: #f6f6f7;
   --blume-muted-foreground: #61636b;
   --blume-border: #e7e7eb;
   --blume-code-background: #f6f8fa;
-  --blume-radius: 0.5rem;
 
   /* Prose column: 700px like the reference article */
   --blume-content-width: 43.75rem;
 
-  /* Layout frame */
+  /* Layout frame shared by the header and the docs grid */
   --docs-frame-width: 81.875rem;
   --docs-header-height: calc(3.5rem + 1px);
 }
 
 :root[data-theme='dark'] {
-  /* Palette — dark (VitePress dark palette) */
-  --blume-background: #161618;
+  /* Palette — dark (VitePress values) */
   --blume-foreground: #dfdfd6;
   --blume-muted: #202127;
   --blume-muted-foreground: #98989f;
@@ -32,8 +33,8 @@
 }
 
 /* ---------------------------------------------------------------- */
-/* Centered layout frame: sidebar | content | toc, like the docs at */
-/* the reference site (254px / minmax(0,820px) / 16.5rem).          */
+/* Docs layout frame (RootLayout isn't overridable): sidebar |      */
+/* content | toc, centered on the frame width.                      */
 /* ---------------------------------------------------------------- */
 
 [data-blume-doc-grid] {
@@ -109,6 +110,12 @@
   letter-spacing: -0.0125em;
 }
 
+/* Filled code blocks like the reference (not Blume's outline style) */
+.prose pre,
+.prose pre.astro-code {
+  background: var(--blume-code-background) !important;
+}
+
 /* Twoslash hover popups are rendered at opacity 0 with no clipping
    ancestor, so wide ones stretch the page sideways on narrow viewports.
    Clip the content column instead of letting the page scroll. */
@@ -120,54 +127,43 @@ main#blume-content {
   max-width: min(85vw, 34rem);
 }
 
-/* Filled code blocks like the reference (not Blume's outline style) */
-.prose pre,
-.prose pre.astro-code {
-  background: var(--blume-code-background) !important;
-}
-
 /* ---------------------------------------------------------------- */
-/* Header chrome (styled here, not via a component override, so the */
-/* custom pages that render the built-in header match the docs)     */
+/* Non-owned chrome                                                 */
 /* ---------------------------------------------------------------- */
 
-[data-blume-header] {
-  height: var(--docs-header-height);
-  border-bottom: 1px solid var(--blume-border);
-  background: color-mix(in srgb, var(--blume-background) 85%, transparent);
-  /* Center the chrome on the same frame as the content grid */
-  padding-inline: max(1.25rem, calc((100% - var(--docs-frame-width)) / 2 + 1.25rem));
+/* Search trigger: wide, quiet gray box like the reference header */
+[data-blume-search-open] {
+  height: 2.375rem;
+  border-color: transparent;
+  border-radius: 0.5rem;
+  background: var(--blume-muted);
 }
 
-/* Header row order: logo, tabs, spacer, then selectors/search/icons on
-   the right (the version dropdown reads better beside search than
-   wedged between the logo and the tabs). */
-[data-blume-header] > button[data-blume-nav-toggle] {
-  order: -40;
+[data-blume-search-open]:hover {
+  border-color: var(--blume-border);
 }
 
-[data-blume-header] > a {
-  order: -30;
+/* Between md and lg the header shows the tab bar, the hamburger, and
+   the search box at once: collapse search to its icon so nothing wraps. */
+@media (min-width: 48rem) and (max-width: 63.9375rem) {
+  [data-blume-search-open] {
+    min-width: 0;
+  }
+
+  [data-blume-search-open] > span,
+  [data-blume-search-open] > kbd {
+    display: none;
+  }
 }
 
-[data-blume-header] > nav {
-  order: -20;
-}
-
-[data-blume-header] > .flex-1 {
-  order: -10;
-}
-
-/* Section tabs: full-height text links with an accent underline for
-   the active tab, replacing the default pill treatment. Direct children
-   only — dropdown-tab menus inside the nav keep their own styling. */
-[data-blume-header] > nav {
-  align-self: stretch;
-  align-items: center;
-  gap: 1.5rem;
-  /* With the header's own 0.75rem gap this equals the 1.5rem tab gap,
-     so logo → nav spacing matches nav → nav spacing. */
-  margin-inline-start: 0.75rem;
+/* The page-actions popovers (Export, Connect to MCP) are up to 22rem
+   wide but live inside the scrollable TOC rail, which clips anything
+   wider than the rail. Size them to the rail instead. */
+[data-blume-toc] [data-blume-menu] {
+  inset-inline-end: 0;
+  width: 100%;
+  min-width: 0;
+  max-width: none;
 }
 
 /* The built-in drawer section lists can't render dropdown-tab items
@@ -181,77 +177,4 @@ main#blume-content {
 
 body > aside[data-blume-nav-drawer]:not([data-orpc-drawer]) {
   display: none;
-}
-
-[data-blume-header] > nav > a {
-  position: relative;
-  display: flex;
-  align-items: center;
-  height: 100%;
-  padding: 0;
-  border-radius: 0;
-  background: transparent;
-  white-space: nowrap;
-}
-
-/* Between md and lg the header shows the tab bar, the hamburger, and the
-   full search box at once: tighten gaps and collapse search to its icon
-   so nothing wraps or truncates. */
-@media (min-width: 48rem) and (max-width: 63.9375rem) {
-  [data-blume-header] {
-    gap: 0.5rem;
-  }
-
-  [data-blume-header] > nav {
-    gap: 1rem;
-  }
-
-  [data-blume-search-open] {
-    min-width: 0;
-  }
-
-  [data-blume-search-open] > span,
-  [data-blume-search-open] > kbd {
-    display: none;
-  }
-}
-
-[data-blume-header] > nav > a:hover,
-[data-blume-header] > nav > details > summary:hover {
-  color: var(--blume-accent);
-}
-
-[data-blume-header] > nav > a[aria-current='page'] {
-  color: var(--blume-accent);
-}
-
-[data-blume-header] > nav > a[aria-current='page']::after {
-  content: '';
-  position: absolute;
-  inset-inline: 0;
-  bottom: -1px;
-  height: 2px;
-  background: var(--blume-accent);
-}
-
-/* The page-actions popovers (Export, Connect to MCP) are up to 22rem
-   wide but live inside the scrollable TOC rail, which clips anything
-   wider than the rail. Size them to the rail instead. */
-[data-blume-toc] [data-blume-menu] {
-  inset-inline-end: 0;
-  width: 100%;
-  min-width: 0;
-  max-width: none;
-}
-
-/* Search trigger: wide, quiet gray box like the reference header */
-[data-blume-search-open] {
-  height: 2.375rem;
-  border-color: transparent;
-  border-radius: 0.5rem;
-  background: var(--blume-muted);
-}
-
-[data-blume-search-open]:hover {
-  border-color: var(--blume-border);
 }

--- a/apps/content/theme.css
+++ b/apps/content/theme.css
@@ -1,0 +1,185 @@
+/*
+ * VitePress/Flue-style theme (flueframework.com reference).
+ * Loaded after Blume's layered styles, so plain selectors here win over
+ * the theme defaults and the Tailwind utility classes in layout markup.
+ */
+
+:root {
+  /* Palette — light (VitePress defaults, measured from the reference) */
+  --blume-foreground: #1b1b1f;
+  --blume-muted: #f6f6f7;
+  --blume-muted-foreground: #61636b;
+  --blume-border: #e7e7eb;
+  --blume-code-background: #f6f8fa;
+  --blume-radius: 0.5rem;
+
+  /* Prose column: 700px like the reference article */
+  --blume-content-width: 43.75rem;
+
+  /* Layout frame */
+  --docs-frame-width: 81.875rem;
+  --docs-header-height: calc(3.5rem + 1px);
+}
+
+:root[data-theme='dark'] {
+  /* Palette — dark (VitePress dark palette) */
+  --blume-background: #161618;
+  --blume-foreground: #dfdfd6;
+  --blume-muted: #202127;
+  --blume-muted-foreground: #98989f;
+  --blume-border: #2e2e32;
+  --blume-code-background: #202127;
+}
+
+/* ---------------------------------------------------------------- */
+/* Centered layout frame: sidebar | content | toc, like the docs at */
+/* the reference site (254px / minmax(0,820px) / 16.5rem).          */
+/* ---------------------------------------------------------------- */
+
+[data-blume-doc-grid] {
+  width: min(100%, var(--docs-frame-width));
+  min-height: calc(100vh - var(--docs-header-height));
+}
+
+@media (min-width: 64rem) {
+  /* Scoped to grids that carry Blume's own responsive column classes:
+     "bare" pages (the changelog index) render a single centered column
+     and must keep grid-cols-1. */
+  [data-blume-doc-grid][class*='lg:grid-cols-'] {
+    grid-template-columns: 14.5rem minmax(0, 1fr);
+  }
+
+  /* Sidebar rail: sits under the shorter header, gets a right border */
+  [data-blume-nav-drawer] {
+    top: var(--docs-header-height);
+    height: calc(100dvh - var(--docs-header-height));
+    border-inline-end: 1px solid var(--blume-border);
+    padding: 2rem 1.5rem 2.5rem 1.25rem;
+  }
+
+  main#blume-content {
+    padding: 3rem 3rem 3.5rem;
+  }
+}
+
+/* TOC appears only when the full three-column frame fits (like the
+   reference's max-2xl collapse). */
+[data-blume-toc] {
+  display: none;
+}
+
+@media (min-width: 96rem) {
+  [data-blume-doc-grid][class*='xl:grid-cols-'] {
+    grid-template-columns: 15.875rem minmax(0, 51.25rem) 16.5rem;
+  }
+
+  [data-blume-toc] {
+    display: block;
+    top: var(--docs-header-height);
+    height: calc(100dvh - var(--docs-header-height));
+    padding-top: 3rem;
+  }
+}
+
+/* ---------------------------------------------------------------- */
+/* Typography — Inter with tight, bold headings                     */
+/* ---------------------------------------------------------------- */
+
+.prose {
+  font-size: 0.9375rem;
+  line-height: 1.65;
+}
+
+.prose :where(h1) {
+  font-weight: 700;
+  letter-spacing: -0.05em;
+}
+
+.prose :where(h2) {
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+  margin-top: 2.75rem;
+}
+
+.prose :where(h3) {
+  font-weight: 600;
+  letter-spacing: -0.0125em;
+}
+
+/* Twoslash hover popups are rendered at opacity 0 with no clipping
+   ancestor, so wide ones stretch the page sideways on narrow viewports.
+   Clip the content column instead of letting the page scroll. */
+main#blume-content {
+  overflow-x: clip;
+}
+
+.prose .twoslash-popup-container {
+  max-width: min(85vw, 34rem);
+}
+
+/* Filled code blocks like the reference (not Blume's outline style) */
+.prose pre,
+.prose pre.astro-code {
+  background: var(--blume-code-background) !important;
+}
+
+/* ---------------------------------------------------------------- */
+/* Header chrome (styled here, not via a component override, so the */
+/* custom pages that render the built-in header match the docs)     */
+/* ---------------------------------------------------------------- */
+
+[data-blume-header] {
+  height: var(--docs-header-height);
+  border-bottom: 1px solid var(--blume-border);
+  background: color-mix(in srgb, var(--blume-background) 85%, transparent);
+  /* Center the chrome on the same frame as the content grid */
+  padding-inline: max(1.25rem, calc((100% - var(--docs-frame-width)) / 2 + 1.25rem));
+}
+
+/* Section tabs: full-height text links with an accent underline for
+   the active tab, replacing the default pill treatment. */
+[data-blume-header] > nav {
+  align-self: stretch;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+[data-blume-header] > nav a {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+[data-blume-header] > nav a:hover {
+  color: var(--blume-accent);
+}
+
+[data-blume-header] > nav a[aria-current='page'] {
+  color: var(--blume-accent);
+}
+
+[data-blume-header] > nav a[aria-current='page']::after {
+  content: '';
+  position: absolute;
+  inset-inline: 0;
+  bottom: -1px;
+  height: 2px;
+  background: var(--blume-accent);
+}
+
+/* Search trigger: wide, quiet gray box like the reference header */
+[data-blume-search-open] {
+  height: 2.375rem;
+  border-color: transparent;
+  border-radius: 0.5rem;
+  background: var(--blume-muted);
+}
+
+[data-blume-search-open]:hover {
+  border-color: var(--blume-border);
+}

--- a/apps/content/theme.css
+++ b/apps/content/theme.css
@@ -170,9 +170,16 @@ main#blume-content {
   margin-inline-start: 0.75rem;
 }
 
-/* The drawer's built-in section list can't render dropdown-tab items
-   (the "More" menu) — the MobileNav override lists the sections instead. */
-[data-blume-nav-drawer] > nav:not([data-blume-nav-tree]) {
+/* The built-in drawer section lists can't render dropdown-tab items
+   (the "More" menu), so the overrides supply their own: MobileNav inside
+   the docs drawer, and the header's own drawer (data-orpc-drawer) on
+   chrome-only PageLayout pages, whose built-in drawer sits directly
+   under <body> and is hidden wholesale here. */
+[data-blume-nav-drawer]:not([data-orpc-drawer]) > nav:not([data-blume-nav-tree]) {
+  display: none;
+}
+
+body > aside[data-blume-nav-drawer]:not([data-orpc-drawer]) {
   display: none;
 }
 


### PR DESCRIPTION
Restyles the Blume docs site with a VitePress-style layout: a centered 1310px frame with bordered header, flat sidebar sections with icon chips, an uppercase "On this page" rail, and a monochrome black/white accent matching the oRPC brand. The blog moves to a single 768px reading column shared by the index and posts.

## Layout and theme

- Header is 56px+border with full-height tabs and an accent underline on the active tab; the version selector sits on the right beside search. A "More" tab renders a dropdown of external links (v1 docs, discussions, sponsors, LLM context), which Blume's built-in header does not support.
- Sidebar entry points with icons get bordered icon chips; active links use the accent color instead of pill backgrounds. The TOC appears only when the full three-column frame fits, matching the reference design.
- Light/dark palettes follow VitePress values; code blocks are filled instead of outlined.

## Implementation notes for review

- Styling follows Blume's layering: config tokens in `blume.config.ts`, `--blume-*` token overrides in `theme.css`, and owned components (`components/blume/*`) styled with Tailwind utilities. `theme.css` also carries the few overrides for chrome Blume renders internally (RootLayout grid, search trigger, page-actions menus).
- Blume's PageLayout hardcodes its header import with no slot support, so a small Vite alias in `blume.config.ts` swaps in the owned Header for custom pages too - docs and blog stay consistent.
- The built-in drawer section lists render dropdown tabs as dead links, so MobileNav/SectionsNav overrides supply the drawer content, including the expanded "More" group.

## Fixes along the way

- Invisible twoslash hover popups no longer stretch the page sideways on narrow viewports.
- "Connect to MCP" / Export popovers no longer clip inside the TOC rail.
- The header no longer wraps or truncates between 768px and 1024px.

## Testing

Verified in the browser at 375/768/894/1280/1600px in both color modes across docs, blog index, blog post, changelog, and home: no horizontal overflow, drawers and dropdowns work on every page type, and head tags (canonical, og:*, twitter:*, JSON-LD, RSS discovery) render correctly. `blume doctor` reports no problems.
