### PR TITLE
fix(client): preserve subclass prototype chain in cloneORPCError

### DIFF
--- a/packages/client/src/error-utils.test.ts
+++ b/packages/client/src/error-utils.test.ts
@@ -262,8 +262,6 @@ describe('cloneORPCError', () => {
 
     expect(Object.prototype.toString.call(cloned)).toBe('[object Error]')
     expect(Object.keys(cloned)).toEqual(Object.keys(original))
-    // `message`, `stack`, and `cause` must stay non-enumerable so spreading
-    // or iterating a cloned error does not expose them
     expect({ ...cloned }).toEqual({ ...original })
   })
 })

--- a/packages/client/src/error-utils.test.ts
+++ b/packages/client/src/error-utils.test.ts
@@ -234,4 +234,36 @@ describe('cloneORPCError', () => {
     expect(original.data).toBe(1)
     expect(cloned.data).toBe(2)
   })
+
+  it('preserves custom subclass prototype chain', () => {
+    class CustomSubclassError extends ORPCError<'BAD_REQUEST', { customField: string }> {
+      customProp = 'test'
+    }
+
+    const original = new CustomSubclassError('BAD_REQUEST', {
+      message: 'Custom error message',
+      data: { customField: 'value' },
+      cause: new Error('why'),
+    })
+
+    const cloned = cloneORPCError(original)
+
+    expect(cloned).toBeInstanceOf(CustomSubclassError)
+    expect(cloned).toBeInstanceOf(ORPCError)
+    expect(cloned.customProp).toBe('test')
+    expect(cloned.message).toBe('Custom error message')
+    expect(cloned.stack).toBe(original.stack)
+    expect(cloned.cause).toBe(original.cause)
+  })
+
+  it('clone keeps native error semantics and property shape', () => {
+    const original = new ORPCError('BAD_REQUEST', { message: 'msg', data: 1, cause: 'why' })
+    const cloned = cloneORPCError(original)
+
+    expect(Object.prototype.toString.call(cloned)).toBe('[object Error]')
+    expect(Object.keys(cloned)).toEqual(Object.keys(original))
+    // `message`, `stack`, and `cause` must stay non-enumerable so spreading
+    // or iterating a cloned error does not expose them
+    expect({ ...cloned }).toEqual({ ...original })
+  })
 })

--- a/packages/client/src/error-utils.test.ts
+++ b/packages/client/src/error-utils.test.ts
@@ -256,22 +256,6 @@ describe('cloneORPCError', () => {
     expect(cloned.cause).toBe(original.cause)
   })
 
-  it('does not carry over subclass private fields', () => {
-    class PrivateFieldError extends ORPCError<'BAD_REQUEST', undefined> {
-      #secret = 'secret'
-
-      get secret(): string {
-        return this.#secret
-      }
-    }
-
-    const original = new PrivateFieldError('BAD_REQUEST')
-    const cloned = cloneORPCError(original)
-
-    expect(original.secret).toBe('secret')
-    expect(() => cloned.secret).toThrow(TypeError)
-  })
-
   it('clone keeps native error semantics and property shape', () => {
     const original = new ORPCError('BAD_REQUEST', { message: 'msg', data: 1, cause: 'why' })
     const cloned = cloneORPCError(original)

--- a/packages/client/src/error-utils.test.ts
+++ b/packages/client/src/error-utils.test.ts
@@ -256,6 +256,22 @@ describe('cloneORPCError', () => {
     expect(cloned.cause).toBe(original.cause)
   })
 
+  it('does not carry over subclass private fields', () => {
+    class PrivateFieldError extends ORPCError<'BAD_REQUEST', undefined> {
+      #secret = 'secret'
+
+      get secret(): string {
+        return this.#secret
+      }
+    }
+
+    const original = new PrivateFieldError('BAD_REQUEST')
+    const cloned = cloneORPCError(original)
+
+    expect(original.secret).toBe('secret')
+    expect(() => cloned.secret).toThrow(TypeError)
+  })
+
   it('clone keeps native error semantics and property shape', () => {
     const original = new ORPCError('BAD_REQUEST', { message: 'msg', data: 1, cause: 'why' })
     const cloned = cloneORPCError(original)

--- a/packages/client/src/error-utils.ts
+++ b/packages/client/src/error-utils.ts
@@ -54,17 +54,23 @@ export function createORPCErrorFromJson<TCode extends ORPCErrorCode, TData>(
   return error
 }
 
-export function cloneORPCError<T extends ORPCErrorCode, TData>(error: ORPCError<T, TData>): ORPCError<T, TData> {
+/**
+ * Clones an `ORPCError` while preserving its prototype chain, so instances of
+ * `ORPCError` subclasses remain `instanceof` their class. Subclass constructors
+ * are not re-run, so private fields (`#field`) are not carried over.
+ */
+export function cloneORPCError<T extends AnyORPCError>(error: T): T {
   const cloned = new ORPCError(error.code, {
-    ...error,
     message: error.message,
     data: error.data,
     cause: error.cause,
   })
 
+  Object.setPrototypeOf(cloned, Object.getPrototypeOf(error))
+  Object.defineProperties(cloned, Object.getOwnPropertyDescriptors(error))
+  // `stack` is not an own property in every engine (e.g. an accessor on
+  // `Error.prototype` in SpiderMonkey), so copy it explicitly as well.
   cloned.stack = error.stack
-  ;(cloned.defined as Writable<typeof cloned.defined>) = error.defined
-  ;(cloned.inferable as Writable<typeof cloned.inferable>) = error.inferable
 
-  return cloned
+  return cloned as T
 }

--- a/packages/client/src/error-utils.ts
+++ b/packages/client/src/error-utils.ts
@@ -54,6 +54,14 @@ export function createORPCErrorFromJson<TCode extends ORPCErrorCode, TData>(
   return error
 }
 
+/**
+ * Clones an `ORPCError` while preserving its prototype chain, so instances of
+ * `ORPCError` subclasses remain `instanceof` their class.
+ *
+ * Limitation: subclass constructors are not re-run, so private fields
+ * (`#field`) are not carried over and subclass members that read them
+ * will throw on the clone.
+ */
 export function cloneORPCError<T extends AnyORPCError>(error: T): T {
   const cloned = new ORPCError(error.code, {
     message: error.message,

--- a/packages/client/src/error-utils.ts
+++ b/packages/client/src/error-utils.ts
@@ -54,11 +54,6 @@ export function createORPCErrorFromJson<TCode extends ORPCErrorCode, TData>(
   return error
 }
 
-/**
- * Clones an `ORPCError` while preserving its prototype chain, so instances of
- * `ORPCError` subclasses remain `instanceof` their class. Subclass constructors
- * are not re-run, so private fields (`#field`) are not carried over.
- */
 export function cloneORPCError<T extends AnyORPCError>(error: T): T {
   const cloned = new ORPCError(error.code, {
     message: error.message,
@@ -68,8 +63,6 @@ export function cloneORPCError<T extends AnyORPCError>(error: T): T {
 
   Object.setPrototypeOf(cloned, Object.getPrototypeOf(error))
   Object.defineProperties(cloned, Object.getOwnPropertyDescriptors(error))
-  // `stack` is not an own property in every engine (e.g. an accessor on
-  // `Error.prototype` in SpiderMonkey), so copy it explicitly as well.
   cloned.stack = error.stack
 
   return cloned as T


### PR DESCRIPTION
`cloneORPCError` rebuilt errors with `new ORPCError(...)`, which stripped custom subclass prototypes, so `error instanceof CustomError` failed after error reconciliation. The clone is now constructed as a real `ORPCError` whose prototype is swapped to the original's, so subclass instances stay `instanceof` their class while the clone remains a native `Error`.

Supersedes #1799, thanks @Wadiou for the report and the initial approach.

## Fixes

- Cloned errors are `instanceof` their subclass, and custom properties are copied with their exact descriptors.
- Unlike the `Object.create` approach in #1799, the clone keeps native `Error` semantics: `message` / `stack` / `cause` stay non-enumerable, so `{ ...error }` and key iteration do not expose stack traces, and `structuredClone` / `postMessage` still round-trip.
- Signature widened to `<T extends AnyORPCError>(error: T): T`, backward compatible.

## Testing

- New tests cover subclass prototype preservation and clone shape / native-error semantics; the shape test fails under the #1799 approach.
- All client, contract, server, and json-schema tests pass (1157), `tsc` clean.
