### PR TITLE
chore(content): add frontmatter descriptions to all MDX pages

### DIFF
--- a/apps/content/docs/adapters/aws-lambda.mdx
+++ b/apps/content/docs/adapters/aws-lambda.mdx
@@ -1,10 +1,9 @@
 ---
 title: "AWS Lambda Adapter"
+description: "Use oRPC on AWS Lambda behind API Gateway (payload formats 1.0 and 2.0) and Lambda Function URLs using response streaming."
 sidebar:
   label: "AWS Lambda"
 ---
-
-oRPC supports [AWS Lambda](https://aws.amazon.com/lambda/) behind [API Gateway](https://aws.amazon.com/api-gateway/) (payload format 1.0 and 2.0) and [Lambda Function URLs](https://docs.aws.amazon.com/lambda/latest/dg/urls-invocation.html).
 
 :::warning
 This adapter requires the Lambda Node.js runtime with [response streaming](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html) enabled, so handlers must be wrapped with `awslambda.streamifyResponse`.

--- a/apps/content/docs/adapters/fastify.mdx
+++ b/apps/content/docs/adapters/fastify.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Fastify Adapter"
+description: "Use oRPC with Fastify servers via RPCHandler or OpenAPIHandler, with content type parser tips and event stream options."
 sidebar:
   label: "Fastify"
 ---
-
-oRPC supports [Fastify](https://fastify.dev/) servers out of the box.
 
 ## Server Usage
 

--- a/apps/content/docs/adapters/fetch-api.mdx
+++ b/apps/content/docs/adapters/fetch-api.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Fetch API Adapter"
+description: "Use oRPC with the Fetch API on both servers and clients, in runtimes such as Bun, Deno, and Cloudflare Workers."
 sidebar:
   label: "Fetch API"
 ---
-
-oRPC supports the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) for both servers and clients.
 
 ## Server Usage
 

--- a/apps/content/docs/adapters/message-port.mdx
+++ b/apps/content/docs/adapters/message-port.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Message Port Adapter"
+description: "Use oRPC over the Message Port API to communicate between contexts such as iframes, web workers, and service workers."
 sidebar:
   label: "Message Port"
 ---
-
-oRPC supports the [Message Port](https://developer.mozilla.org/en-US/docs/Web/API/MessagePort) for communicating between different contexts, such as iframes, web workers, and service workers.
 
 ## Basic Usage
 

--- a/apps/content/docs/adapters/node-http.mdx
+++ b/apps/content/docs/adapters/node-http.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Node HTTP Adapter"
+description: "Use oRPC with Node HTTP, HTTPS, and HTTP2 servers via RPCHandler or OpenAPIHandler, with CORS and event stream options."
 sidebar:
   label: "Node HTTP"
 ---
-
-oRPC supports [Node HTTP](https://nodejs.org/api/http.html), [Node HTTPS](https://nodejs.org/api/https.html), and [Node HTTP2](https://nodejs.org/api/http2.html) for servers.
 
 ## Server Usage
 

--- a/apps/content/docs/adapters/react-native.mdx
+++ b/apps/content/docs/adapters/react-native.mdx
@@ -1,10 +1,9 @@
 ---
 title: "React Native Adapter"
+description: "Learn how to use oRPC with React Native over fetch or WebSocket, including supported features and current platform limitations."
 sidebar:
   label: "React Native"
 ---
-
-This guide explains how to use oRPC with React Native, including the platform's supported features and current limitations.
 
 ## Fetch Link
 

--- a/apps/content/docs/adapters/websocket.mdx
+++ b/apps/content/docs/adapters/websocket.mdx
@@ -1,10 +1,9 @@
 ---
 title: "WebSocket Adapters"
+description: "Use oRPC over WebSocket for low-latency, full-duplex communication, with adapters for ws, crossws, Bun, Deno, Cloudflare, and uWebSockets."
 sidebar:
   label: "WebSocket"
 ---
-
-oRPC supports WebSockets for low-latency, full-duplex communication between clients and servers.
 
 ## Server Adapters
 

--- a/apps/content/docs/advanced/exceeds-the-maximum-length-problem.mdx
+++ b/apps/content/docs/advanced/exceeds-the-maximum-length-problem.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Exceeds the Maximum Length Problem"
+description: "Fix the TypeScript error where an inferred router type exceeds the maximum length the compiler will serialize."
 sidebar:
   label: "Exceeds the maximum length ..."
 ---

--- a/apps/content/docs/advanced/expanding-type-support-for-openapi-link.mdx
+++ b/apps/content/docs/advanced/expanding-type-support-for-openapi-link.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Expanding Type Support for OpenAPI Link"
+description: "Restore native types like Date and bigint on OpenAPI Link clients using the Response Validation or Smart Coercion plugins."
 ---
 
 Because of [OpenAPI Serializer limitations](/docs/openapi/serializer#limitations), values like `Date` and `bigint` are received by the client in JSON-friendly form. You can convert them back to native types on the client with either [Response Validation Plugin](/docs/plugins/response-validation) or [Smart Coercion Plugin](/docs/plugins/smart-coercion), but only under the conditions described below.

--- a/apps/content/docs/advanced/publish-client-to-npm.mdx
+++ b/apps/content/docs/advanced/publish-client-to-npm.mdx
@@ -1,8 +1,7 @@
 ---
 title: "Publish Client to NPM"
+description: "Learn how to build and publish your oRPC client to NPM so users can consume your APIs as a fully typed SDK."
 ---
-
-Publishing your oRPC client to NPM allows users to easily consume your APIs as a software development kit (SDK).
 
 :::info
 Before you start, we recommend watching some [publish typescript library to npm tutorials](https://www.youtube.com/results?search_query=publish+typescript+library+to+npm) to get familiar with the process.

--- a/apps/content/docs/advanced/scaling-large-projects.mdx
+++ b/apps/content/docs/advanced/scaling-large-projects.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Scaling Large Projects"
+description: "Learn how to scale large oRPC codebases by importing individual procedure contracts and creating clients with a contract client factory."
 ---
 
 A single root [client](/docs/client/client-side) is a great way to get started. As your project grows, though, it can lead to type performance issues and tangled dependencies. Splitting the client into smaller service-level clients can help for a while, but very large codebases can still outgrow that approach.
-
-This guide shows an alternative pattern for large projects: import and use individual [procedure contracts](/docs/contract/procedure) directly.
 
 ## Requirements
 

--- a/apps/content/docs/advanced/testing-and-mocking.mdx
+++ b/apps/content/docs/advanced/testing-and-mocking.mdx
@@ -1,8 +1,7 @@
 ---
 title: "Testing and Mocking"
+description: "Learn how to test oRPC procedures directly with server-side clients and create mock implementations with the implementer."
 ---
-
-Testing and mocking are essential for building reliable applications. In this section, we'll explore how to test your procedures and routers effectively, as well as how to create mock implementations for testing purposes.
 
 ## Testing
 

--- a/apps/content/docs/advanced/validation-customization.mdx
+++ b/apps/content/docs/advanced/validation-customization.mdx
@@ -1,8 +1,7 @@
 ---
 title: "Validation Customization"
+description: "Learn how to customize validation in oRPC, including disabling runtime validation and shaping custom validation errors."
 ---
-
-This guide explains how to customize validation in oRPC, including how to disable runtime validation and how to customize validation errors.
 
 ## Disable Validation
 

--- a/apps/content/docs/async-iterator-object.mdx
+++ b/apps/content/docs/async-iterator-object.mdx
@@ -1,8 +1,7 @@
 ---
 title: "AsyncIteratorObject (SSE)"
+description: "Stream realtime typesafe data from oRPC procedures with async generators, event validation, resume support, and cleanup on disconnect."
 ---
-
-AsyncIteratorObject enables **typesafe**, **realtime data streaming**. It is the recommended approach for building features like live notifications, chat messages, progress updates, and data feeds.
 
 ## Overview
 

--- a/apps/content/docs/best-practices/dedupe-middleware.mdx
+++ b/apps/content/docs/best-practices/dedupe-middleware.mdx
@@ -1,8 +1,7 @@
 ---
 title: "Dedupe Middleware"
+description: "Learn how to use context to prevent the same middleware from repeating expensive work when it runs multiple times in a single call."
 ---
-
-Use [context](/docs/context) to prevent the same [middleware](/docs/middleware) from repeating expensive work.
 
 ## Problem
 
@@ -17,7 +16,7 @@ Repeated middleware work can hurt performance, especially for expensive operatio
 
 ## Solution
 
-Store the computed value in `context` and reuse it when the middleware runs again.
+Store the computed value in [`context`](/docs/context) and reuse it when the [middleware](/docs/middleware) runs again.
 
 For example, this middleware loads auth at most once per call:
 

--- a/apps/content/docs/best-practices/monorepo-setup.mdx
+++ b/apps/content/docs/best-practices/monorepo-setup.mdx
@@ -1,10 +1,7 @@
 ---
 title: "Monorepo Setup"
+description: "Set up a monorepo with oRPC using TypeScript project references to keep end-to-end type safety across interconnected apps and packages."
 ---
-
-A monorepo stores multiple related projects in a single repository, a common practice for managing interconnected projects like web applications and their APIs.
-
-This guide shows you how to efficiently set up a monorepo with oRPC while maintaining end-to-end type safety across all projects.
 
 :::info[Playground]
 Explore a sample monorepo setup in our [Multiservice Monorepo Playground](https://github.com/middleapi/orpc-multiservice-monorepo-playground).

--- a/apps/content/docs/best-practices/no-throw-literal.mdx
+++ b/apps/content/docs/best-practices/no-throw-literal.mdx
@@ -1,8 +1,7 @@
 ---
 title: "No Throw Literal"
+description: "Learn why oRPC recommends throwing only Error instances and how to customize this behavior with ThrowableError in the Registry."
 ---
-
-In JavaScript, you can throw any value, but it's best to throw only `Error` instances.
 
 ```ts
 // eslint-disable-next-line no-throw-literal

--- a/apps/content/docs/best-practices/optimizing-ssr.mdx
+++ b/apps/content/docs/best-practices/optimizing-ssr.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Optimizing Server-Side Rendering (SSR) for Fullstack Frameworks"
+description: "Optimize server-side rendering with oRPC in Next.js, Nuxt, and SvelteKit by calling API logic directly and avoiding extra HTTP requests."
 sidebar:
   label: "Optimizing SSR"
 ---
-
-This guide shows how to optimize Server-Side Rendering (SSR) with oRPC in fullstack frameworks such as Next.js, Nuxt, and SvelteKit. The goal is to avoid unnecessary network calls while the server renders a page.
 
 ## The Problem with Standard SSR Data Fetching
 

--- a/apps/content/docs/binary-data.mdx
+++ b/apps/content/docs/binary-data.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Binary Data"
+description: "Learn how oRPC procedures accept and return File, Blob, and binary streams, and how to configure CORS headers for cross-origin binary responses."
 ---
 
 [File](https://developer.mozilla.org/en-US/docs/Web/API/File), [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob), and [`ReadableStream<Uint8Array>`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) are supported by the [RPC Serializer](/docs/rpc/serializer) and [OpenAPI Serializer](/docs/openapi/serializer). Use them to handle binary data in your procedures.

--- a/apps/content/docs/client/async-iterator-object.mdx
+++ b/apps/content/docs/client/async-iterator-object.mdx
@@ -1,12 +1,13 @@
 ---
 title: "AsyncIteratorObject in Client"
+description: "Consume an AsyncIteratorObject from the client like an AsyncGenerator, with stream cancellation, error handling, and event metadata."
 sidebar:
   label: "AsyncIteratorObject (SSE)"
 ---
 
-Consume an [AsyncIteratorObject](/docs/async-iterator-object) like an [AsyncGenerator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator). Await the call, then iterate over events as they arrive.
-
 ## Basic Usage
+
+Await a call to a procedure that returns an [AsyncIteratorObject](/docs/async-iterator-object), then iterate over the events as they arrive, just like an [AsyncGenerator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncGenerator).
 
 ```ts twoslash
 import { asyncIteratorObject, oc, RouterContractClient } from '@orpc/contract'

--- a/apps/content/docs/client/client-side.mdx
+++ b/apps/content/docs/client/client-side.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Client-Side Clients"
+description: "Create oRPC clients that call procedures remotely over a link, with client context, interceptors, and type inference utilities."
 sidebar:
   label: "Client-Side"
 ---
-
-Client-side clients call procedures remotely, in a different process or on a different machine. They are useful in frontend applications, mobile apps, or any setup where the client and server run in different environments.
 
 ## Installation
 

--- a/apps/content/docs/client/dynamic-link.mdx
+++ b/apps/content/docs/client/dynamic-link.mdx
@@ -1,10 +1,9 @@
 ---
 title: "DynamicLink"
+description: "Use DynamicLink to choose a link at runtime and route different oRPC requests through different links based on client context."
 sidebar:
   label: "Dynamic Link"
 ---
-
-`DynamicLink` lets you choose a link at runtime. Use it when different requests should be routed through different links.
 
 ## Example
 

--- a/apps/content/docs/client/error-handling.mdx
+++ b/apps/content/docs/client/error-handling.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Client Error Handling"
+description: "Handle client-side errors in oRPC with try/catch, or use safe and createSafeClient for fully type-inferred typesafe errors."
 sidebar:
   label: "Error Handling"
 ---
-
-oRPC supports several ways to handle client-side errors. In most cases, `try/catch` is enough. If you use [Typesafe Errors](/docs/error-handling#typesafe-errors), `safe` and `createSafeClient` let you handle them with full type inference.
 
 ## Using `try/catch`
 

--- a/apps/content/docs/client/server-side.mdx
+++ b/apps/content/docs/client/server-side.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Server-Side Clients"
+description: "Call oRPC procedures locally in the same process with call, createRouterClient, or the callable extension, ideal for server-side code."
 sidebar:
   label: "Server-Side"
 ---
-
-Server-side clients call procedures locally, within the same process. They are useful in microservices, serverless functions, or any setup where the caller and procedures run in the same environment.
 
 ## One-Off Calls
 

--- a/apps/content/docs/comparison.mdx
+++ b/apps/content/docs/comparison.mdx
@@ -1,5 +1,6 @@
 ---
 title: Comparison
+description: "See how oRPC compares to alternatives like tRPC and ts-rest across type safety, OpenAPI support, and framework integrations."
 sidebar:
   icon: scale
 ---

--- a/apps/content/docs/context.mdx
+++ b/apps/content/docs/context.mdx
@@ -1,8 +1,7 @@
 ---
 title: "Context"
+description: "Use oRPC context for type-safe dependency injection, providing initial context explicitly or injecting values through middleware."
 ---
-
-The context mechanism provides a type-safe dependency injection pattern. It lets you provide required dependencies explicitly or inject them dynamically through middleware.
 
 ## Initial Context
 

--- a/apps/content/docs/contract/implementation.mdx
+++ b/apps/content/docs/contract/implementation.mdx
@@ -1,8 +1,7 @@
 ---
 title: "Contract Implementation"
+description: "Learn how to implement a contract with the implement function, adding type-checked handlers, middleware, and routers to every procedure."
 ---
-
-Implementing a contract means adding business logic to each procedure defined in that contract. It ensures every implementation stays consistent by verifying that each handler matches the procedure's expected shape.
 
 ## Implementer
 

--- a/apps/content/docs/contract/procedure.mdx
+++ b/apps/content/docs/contract/procedure.mdx
@@ -1,8 +1,7 @@
 ---
 title: "Procedure Contract"
+description: "Define procedure contracts that describe input, output, errors, and metadata without business logic, keeping implementations aligned."
 ---
-
-Procedure contracts define the expected shape of a [procedure](/docs/procedure) without including any business logic. They are useful for documentation, testing, and keeping multiple implementations of the same procedure aligned.
 
 ## Overview
 

--- a/apps/content/docs/contract/router.mdx
+++ b/apps/content/docs/contract/router.mdx
@@ -1,8 +1,7 @@
 ---
 title: "Router Contract"
+description: "Define router contracts that describe the shape of a router without business logic, useful for documentation, testing, and aligned implementations."
 ---
-
-Router contracts define the shape of a [router](/docs/router) without including any business logic. Use them for documentation, testing, and keeping multiple implementations of the same router aligned.
 
 :::info
 A standalone [procedure contract](/docs/contract/procedure) is also a router contract, so you can use the same features with individual procedure contracts.

--- a/apps/content/docs/ecosystem.mdx
+++ b/apps/content/docs/ecosystem.mdx
@@ -1,5 +1,6 @@
 ---
 title: Ecosystem
+description: "Discover libraries, integrations, and community projects that extend oRPC across frameworks, runtimes, and tooling."
 sidebar:
   icon: network
 ---

--- a/apps/content/docs/error-handling.mdx
+++ b/apps/content/docs/error-handling.mdx
@@ -1,8 +1,7 @@
 ---
 title: "Error Handling"
+description: "Handle errors in oRPC with the ORPCError class, typesafe error definitions, reusable error factories, and custom error conversion."
 ---
-
-Error handling in oRPC is flexible and consistent. You can use the `ORPCError` class, define typesafe errors, and adapt custom error classes while still returning meaningful feedback to clients.
 
 ## `ORPCError` Class
 

--- a/apps/content/docs/getting-started.mdx
+++ b/apps/content/docs/getting-started.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Getting Started"
+description: "Build your first end-to-end typesafe API with oRPC, from defining procedures to serving and calling them from a client."
 sidebar:
   icon: rocket
 ---

--- a/apps/content/docs/helpers/base64url.mdx
+++ b/apps/content/docs/helpers/base64url.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Base64Url Helpers"
+description: "Encode and decode URL-safe base64url strings with oRPC helpers, useful for web tokens, data serialization, and APIs."
 sidebar:
   label: "Base64Url"
 ---
-
-Base64Url helpers provide functions to encode and decode base64url strings, a URL-safe variant of base64 encoding used in web tokens, data serialization, and APIs.
 
 ## Basic Usage
 

--- a/apps/content/docs/helpers/cookie.mdx
+++ b/apps/content/docs/helpers/cookie.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Cookie Helpers"
+description: "Set, read, and delete HTTP cookies from fetch Headers with oRPC cookie helpers, and secure them with signing or encryption."
 sidebar:
   label: "Cookie"
 ---
-
-Cookie helpers provide utilities for setting and reading HTTP cookies from fetch headers.
 
 ## Basic Usage
 

--- a/apps/content/docs/helpers/encryption.mdx
+++ b/apps/content/docs/helpers/encryption.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Encryption Helpers"
+description: "Encrypt and decrypt sensitive data in oRPC using AES-GCM with PBKDF2 key derivation via the encrypt and decrypt helpers."
 sidebar:
   label: "Encryption"
 ---
-
-Encryption helpers provide functions to encrypt and decrypt sensitive data using AES-GCM with PBKDF2 key derivation.
 
 :::warning
 Encryption secures data content but has performance trade-offs compared to [signing](/docs/helpers/signing). It requires more CPU resources and processing time. For edge runtimes like [Cloudflare Workers](https://developers.cloudflare.com/workers/), ensure you have sufficient CPU time budget (recommend >200ms per request) for encryption operations.

--- a/apps/content/docs/helpers/form-data.mdx
+++ b/apps/content/docs/helpers/form-data.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Form Data Helpers"
+description: "Parse HTML form data and extract validation error messages with bracket notation support for complex nested structures."
 sidebar:
   label: "Form Data"
 ---
-
-Form data helpers provide utilities for parsing HTML form data and extracting validation error messages, with full support for [bracket notation](/docs/openapi/bracket-notation) to handle complex nested structures.
 
 ## `parseFormData`
 

--- a/apps/content/docs/helpers/publisher.mdx
+++ b/apps/content/docs/helpers/publisher.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Publisher Helpers"
+description: "Publish and subscribe to events across storage backends in oRPC, with adapters, dynamic event names, and resume support for missed events."
 sidebar:
   label: "Publisher"
 ---
-
-Publisher helpers provide a unified way to publish and subscribe to events across different storage backends in oRPC applications. They support both static and dynamic event names, along with optional resume support so subscribers can catch up on missed events.
 
 ## Installation
 

--- a/apps/content/docs/helpers/ratelimit.mdx
+++ b/apps/content/docs/helpers/ratelimit.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Rate Limit Helpers"
+description: "Add rate limiting to oRPC with a unified RateLimiter interface, storage adapters, procedure middleware, and a handler plugin for HTTP headers."
 sidebar:
   label: "Ratelimit"
 ---
-
-Rate Limit helpers provide a unified set of adapters, middleware, and handler plugins for adding rate limiting to oRPC applications. They are flexible and composable, so you can use different rate-limiting strategies and storage backends without changing your procedure code.
 
 ## Installation
 

--- a/apps/content/docs/helpers/signing.mdx
+++ b/apps/content/docs/helpers/signing.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Signing Helpers"
+description: "Cryptographically sign and verify data with HMAC-SHA256 using oRPC signing helpers, a faster alternative to encryption."
 sidebar:
   label: "Signing"
 ---
-
-Signing helpers provide functions to cryptographically sign and verify data using HMAC-SHA256.
 
 :::info
 Signing is faster than [encryption](/docs/helpers/encryption) but users can view the original data.

--- a/apps/content/docs/integrations/ai-sdk.mdx
+++ b/apps/content/docs/integrations/ai-sdk.mdx
@@ -1,10 +1,9 @@
 ---
 title: "AI SDK Integration"
+description: "Learn how to use oRPC as a transport for AI SDK streams and turn oRPC procedures and contracts into AI SDK tools."
 sidebar:
   label: "AI SDK"
 ---
-
-[AI SDK](https://ai-sdk.dev/) is a free open-source library for building AI-powered products. You can seamlessly integrate it with oRPC without any extra overhead.
 
 :::warning
 This documentation requires AI SDK v7.0.0 or later. For a refresher, review the [AI SDK documentation](https://ai-sdk.dev/docs).

--- a/apps/content/docs/integrations/arktype.mdx
+++ b/apps/content/docs/integrations/arktype.mdx
@@ -1,10 +1,13 @@
 ---
 title: "ArkType Integration"
+description: "Use ArkType types directly in oRPC via Standard Schema, with a dedicated JSON Schema converter for OpenAPI generation and Smart Coercion."
 sidebar:
   label: "ArkType"
 ---
 
-[ArkType](https://arktype.io/) implements [Standard Schema](/docs/integrations/standard-schema), so you can use it directly in your procedures without any extra setup. On top of that, `@orpc/arktype` provides a dedicated JSON Schema converter.
+:::info
+[ArkType](https://arktype.io/) implements [Standard Schema](/docs/integrations/standard-schema), so procedures accept ArkType types without any converter. The converter below is only needed when generating JSON Schema.
+:::
 
 ## Installation
 

--- a/apps/content/docs/integrations/arktype.mdx
+++ b/apps/content/docs/integrations/arktype.mdx
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::info
-[ArkType](https://arktype.io/) implements [Standard Schema](/docs/integrations/standard-schema), so procedures accept ArkType types without any converter. The converter below is only needed when generating JSON Schema.
+[ArkType](https://arktype.io/) implements [Standard Schema](/docs/integrations/standard-schema), so procedures accept ArkType types without any converter. The converter below is only needed by tools that consume JSON Schema, such as OpenAPI generation and Smart Coercion.
 :::
 
 ## Installation

--- a/apps/content/docs/integrations/effect.mdx
+++ b/apps/content/docs/integrations/effect.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Effect Integration"
+description: "Write effectful oRPC handlers with Effect generators, provide services through context, and use Effect Schema for input and output validation."
 sidebar:
   label: "Effect"
 ---
-
-[Effect](https://effect.website/) integration lets you seamlessly use Effect's powerful features, such as its effect system, concurrency model, and schema library, within oRPC.
 
 :::warning
 This guide assumes familiarity with [Effect](https://effect.website/). Review the official documentation if needed.

--- a/apps/content/docs/integrations/evlog.mdx
+++ b/apps/content/docs/integrations/evlog.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Evlog Integration"
+description: "Add structured logging to oRPC with the Evlog integration to trace requests, monitor errors, and inspect application behavior."
 sidebar:
   label: "Evlog"
 ---
-
-[Evlog](https://evlog.dev/) integration for oRPC adds structured logging so you can trace requests, monitor errors, and inspect application behavior.
 
 :::warning
 This guide assumes familiarity with [Evlog](https://evlog.dev/). Review the official documentation if needed.

--- a/apps/content/docs/integrations/hibernation.mdx
+++ b/apps/content/docs/integrations/hibernation.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Hibernation Integration"
+description: "Learn how oRPC integrates with Hibernation APIs like Cloudflare's WebSocket Hibernation so servers can sleep without dropping connections."
 sidebar:
   label: "Hibernation"
 ---
-
-Hibernation integration lets oRPC leverage Hibernation APIs like [Cloudflare's Hibernation WebSocket](https://developers.cloudflare.com/durable-objects/best-practices/websockets/#durable-objects-hibernation-websocket-api), so your server can sleep between events without dropping active connections.
 
 ## Installation
 

--- a/apps/content/docs/integrations/nest.mdx
+++ b/apps/content/docs/integrations/nest.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Implement oRPC contract with NestJS"
+description: "Learn how to implement oRPC contracts in NestJS with the @orpc/nest package while keeping type safety and OpenAPI compatibility."
 sidebar:
   label: "NestJS"
 ---
-
-oRPC provides built-in support for NestJS applications through the `@orpc/nest` package. It lets you implement [oRPC contracts](/docs/contract/router) in NestJS while maintaining type safety and OpenAPI compatibility.
 
 ## Installation
 
@@ -47,7 +46,7 @@ const contract = populateRouterContractOpenAPIPaths({
 
 ## Implement Your Contract
 
-To implement your contract in NestJS, use the `@Implement` decorator and the `implement` function. The `@Implement` very similar to NestJS built-in HTTP method decorators (e.g., `@Get`, `@Post`) and can be used to implement either a single procedure contract or an router contract or combine with other NestJS decorators.
+To implement your contract in NestJS, use the `@Implement` decorator and the `implement` function. The `@Implement` very similar to NestJS built-in HTTP method decorators (e.g., `@Get`, `@Post`) and can be used to implement either a single procedure contract or an [router contract](/docs/contract/router) or combine with other NestJS decorators.
 
 ```ts
 import { Implement } from '@orpc/nest'

--- a/apps/content/docs/integrations/next.mdx
+++ b/apps/content/docs/integrations/next.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Next.js Integration"
+description: "Use oRPC in Next.js applications with server functions, form actions, and React hooks for optimistic updates and typesafe error handling."
 sidebar:
   label: "Next.js"
 ---
-
-[Next.js](https://nextjs.org/) integration provides utilities for using oRPC in Next.js applications, including support for [server functions](https://nextjs.org/docs/app/api-reference/directives/use-server) and form actions.
 
 ## Installation
 

--- a/apps/content/docs/integrations/opentelemetry.mdx
+++ b/apps/content/docs/integrations/opentelemetry.mdx
@@ -1,10 +1,9 @@
 ---
 title: "OpenTelemetry Integration"
+description: "Add automatic OpenTelemetry instrumentation to oRPC for distributed tracing and performance monitoring across client and server."
 sidebar:
   label: "OpenTelemetry"
 ---
-
-[OpenTelemetry](https://opentelemetry.io/) integration adds automatic instrumentation to oRPC applications, enabling distributed tracing and performance monitoring with minimal setup.
 
 :::warning
 This guide assumes familiarity with [OpenTelemetry](https://opentelemetry.io/). Review the official documentation if needed.

--- a/apps/content/docs/integrations/pinia-colada.mdx
+++ b/apps/content/docs/integrations/pinia-colada.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Pinia Colada Integration"
+description: "Use oRPC clients with Pinia Colada through utilities for building query and mutation options, keys, and typesafe error handling."
 sidebar:
   label: "Pinia Colada"
 ---
-
-[Pinia Colada](https://pinia-colada.esm.dev/) integration provides utilities for using oRPC clients with Pinia Colada. It includes helper methods for building query and mutation options, as well as query and mutation keys.
 
 :::warning
 This guide assumes you are already familiar with [Pinia Colada](https://pinia-colada.esm.dev/). If you need a refresher, review the official Pinia Colada documentation before continuing.

--- a/apps/content/docs/integrations/pino.mdx
+++ b/apps/content/docs/integrations/pino.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Pino Integration"
+description: "Add structured logging to oRPC with the Pino integration to track requests, monitor errors, and gain insight into application behavior."
 sidebar:
   label: "Pino"
 ---
-
-[Pino](https://getpino.io/) integration for oRPC provides structured logging capabilities, allowing you to easily track requests, monitor errors, and gain insights into your application's behavior.
 
 :::warning
 This guide assumes familiarity with [Pino](https://getpino.io/). Review the official documentation if needed.

--- a/apps/content/docs/integrations/standard-schema.mdx
+++ b/apps/content/docs/integrations/standard-schema.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Standard Schema Integration"
+description: "Use Zod, Valibot, ArkType, or any Standard Schema library with oRPC, plus automatic JSON Schema conversion via Standard JSON Schema."
 sidebar:
   label: "Standard Schema"
 ---

--- a/apps/content/docs/integrations/swr.mdx
+++ b/apps/content/docs/integrations/swr.mdx
@@ -1,10 +1,9 @@
 ---
 title: "SWR Integration"
+description: "Use oRPC with SWR through lightweight key, fetcher, subscriber, and mutator helpers for data fetching, subscriptions, and mutations in React."
 sidebar:
   label: "SWR"
 ---
-
-[SWR](https://swr.vercel.app/) is a React Hooks library for data fetching that provides features like caching, revalidation, and more. oRPC SWR integration is very lightweight and straightforward. There is no extra overhead.
 
 :::warning
 This guide assumes you are already familiar with [SWR](https://swr.vercel.app/). If you need a refresher, review the official SWR documentation before continuing.

--- a/apps/content/docs/integrations/tanstack-query.mdx
+++ b/apps/content/docs/integrations/tanstack-query.mdx
@@ -1,10 +1,9 @@
 ---
 title: "TanStack Query Integration"
+description: "Integrate oRPC with TanStack Query using utilities for query and mutation options, keys, infinite and streamed queries, and typesafe errors."
 sidebar:
   label: "Tanstack Query"
 ---
-
-[TanStack Query](https://tanstack.com/query/latest) integration provides utilities for using oRPC clients with TanStack Query. It includes helper methods for building query and mutation options, as well as query and mutation keys.
 
 :::warning
 This guide assumes you are already familiar with [TanStack Query](https://tanstack.com/query/latest). If you need a refresher, review the official TanStack Query documentation before continuing.

--- a/apps/content/docs/integrations/trpc.mdx
+++ b/apps/content/docs/integrations/trpc.mdx
@@ -1,10 +1,9 @@
 ---
 title: "tRPC Integration"
+description: "Learn how to integrate tRPC with oRPC by converting tRPC routers into oRPC routers and bridging metadata between the two."
 sidebar:
   label: "tRPC"
 ---
-
-This guide shows how to integrate [tRPC](https://trpc.io/) with oRPC, so you can use oRPC features in your existing tRPC applications.
 
 ## Installation
 

--- a/apps/content/docs/integrations/valibot.mdx
+++ b/apps/content/docs/integrations/valibot.mdx
@@ -6,7 +6,7 @@ sidebar:
 ---
 
 :::info
-[Valibot](https://valibot.dev/) implements [Standard Schema](/docs/integrations/standard-schema), so procedures accept Valibot schemas without any converter. The converter below is only needed when generating JSON Schema.
+[Valibot](https://valibot.dev/) implements [Standard Schema](/docs/integrations/standard-schema), so procedures accept Valibot schemas without any converter. The converter below is only needed by tools that consume JSON Schema, such as OpenAPI generation and Smart Coercion.
 :::
 
 ## Installation

--- a/apps/content/docs/integrations/valibot.mdx
+++ b/apps/content/docs/integrations/valibot.mdx
@@ -1,10 +1,13 @@
 ---
 title: "Valibot Integration"
+description: "Use Valibot schemas directly in oRPC via Standard Schema, with a dedicated JSON Schema converter for OpenAPI generation and Smart Coercion."
 sidebar:
   label: "Valibot"
 ---
 
-[Valibot](https://valibot.dev/) implements [Standard Schema](/docs/integrations/standard-schema), so you can use it directly in your procedures without any extra setup. On top of that, `@orpc/valibot` provides a dedicated JSON Schema converter.
+:::info
+[Valibot](https://valibot.dev/) implements [Standard Schema](/docs/integrations/standard-schema), so procedures accept Valibot schemas without any converter. The converter below is only needed when generating JSON Schema.
+:::
 
 ## Installation
 

--- a/apps/content/docs/integrations/zod.mdx
+++ b/apps/content/docs/integrations/zod.mdx
@@ -1,13 +1,16 @@
 ---
 title: "Zod Integration"
+description: "Use Zod schemas directly in oRPC via Standard Schema, with a dedicated JSON Schema converter and registries for customizing generated schemas."
 sidebar:
   label: "Zod"
 ---
 
-[Zod](https://zod.dev/) implements [Standard Schema](/docs/integrations/standard-schema), so you can use it directly in your procedures without any extra setup. On top of that, `@orpc/zod` provides a dedicated JSON Schema converter and registries for customizing the generated JSON schemas.
-
 :::warning
 `@orpc/zod` requires Zod v4 or later.
+:::
+
+:::info
+[Zod](https://zod.dev/) implements [Standard Schema](/docs/integrations/standard-schema), so procedures accept Zod schemas without any converter. The converter below is only needed when generating JSON Schema.
 :::
 
 ## Installation

--- a/apps/content/docs/integrations/zod.mdx
+++ b/apps/content/docs/integrations/zod.mdx
@@ -10,7 +10,7 @@ sidebar:
 :::
 
 :::info
-[Zod](https://zod.dev/) implements [Standard Schema](/docs/integrations/standard-schema), so procedures accept Zod schemas without any converter. The converter below is only needed when generating JSON Schema.
+[Zod](https://zod.dev/) implements [Standard Schema](/docs/integrations/standard-schema), so procedures accept Zod schemas without any converter. The converter below is only needed by tools that consume JSON Schema, such as OpenAPI generation and Smart Coercion.
 :::
 
 ## Installation

--- a/apps/content/docs/metadata.mdx
+++ b/apps/content/docs/metadata.mdx
@@ -1,8 +1,7 @@
 ---
 title: "Metadata"
+description: "Attach metadata to oRPC procedures with defineMeta or a custom MetaPlugin so middleware, plugins, and tooling can read it to control behavior."
 ---
-
-Metadata lets you attach extra information to procedures. Middleware, plugins, and tooling can read it later to control behavior.
 
 ## Quickly Define Meta
 

--- a/apps/content/docs/middleware.mdx
+++ b/apps/content/docs/middleware.mdx
@@ -1,8 +1,7 @@
 ---
 title: "Middleware"
+description: "Run code before and after oRPC handlers with composable middleware that can inject context, guard access, and modify input or output."
 ---
-
-Middleware is a powerful mechanism in oRPC that allows you to execute code before and after your procedure handlers, enabling features like authentication, logging, caching, and more. It provides a way to modify the context, input, and output of procedures in a flexible and composable manner.
 
 ## Overview
 

--- a/apps/content/docs/migrations/from-trpc.mdx
+++ b/apps/content/docs/migrations/from-trpc.mdx
@@ -1,8 +1,7 @@
 ---
 title: "Migrating from tRPC"
+description: "Migrate an existing tRPC app to oRPC step by step. Most tRPC concepts map directly, so routers, procedures, and middleware feel familiar."
 ---
-
-This guide shows how to migrate an existing tRPC app to oRPC. Because oRPC is heavily inspired by tRPC, most concepts map directly, so the migration should feel familiar.
 
 :::info
 If you want to add oRPC features to an existing tRPC app without a full migration, see [tRPC Integration](/docs/integrations/trpc).

--- a/apps/content/docs/migrations/from-v1.mdx
+++ b/apps/content/docs/migrations/from-v1.mdx
@@ -1,10 +1,11 @@
 ---
 title: "Migrating from oRPC v1"
+description: "Upgrade an oRPC v1 app to v2, with side-by-side v1 and v2 comparisons for every change that needs your attention."
 sidebar:
   label: "Migrating from v1"
 ---
 
-This guide walks you through upgrading an oRPC v1 app to v2. Most of your code keeps working: many v1 names still compile through deprecated aliases, so your editor shows a strike-through hint instead of an error. The sections below focus on the changes that need your attention, each with a v2 and v1 comparison.
+Most of your code keeps working: many v1 names still compile through deprecated aliases, so your editor shows a strike-through hint instead of an error.
 
 :::warning[Read these first]
 

--- a/apps/content/docs/openapi/bracket-notation.mdx
+++ b/apps/content/docs/openapi/bracket-notation.mdx
@@ -1,8 +1,9 @@
 ---
 title: "Bracket Notation"
+description: "Learn how bracket notation encodes structured data like nested objects and arrays in flat key-value formats such as query strings and form data."
 ---
 
-Bracket notation encodes structured data in flat key-value formats such as query strings and form data. [OpenAPI Serializer](/docs/openapi/serializer), [OpenAPI Handler](/docs/openapi/handler), and [OpenAPI Link](/docs/openapi/link) use it whenever nested data must be represented outside plain JSON.
+[OpenAPI Serializer](/docs/openapi/serializer), [OpenAPI Handler](/docs/openapi/handler), and [OpenAPI Link](/docs/openapi/link) use bracket notation whenever nested data must be represented outside plain JSON.
 
 ## Rules
 

--- a/apps/content/docs/openapi/handler.mdx
+++ b/apps/content/docs/openapi/handler.mdx
@@ -1,8 +1,7 @@
 ---
 title: "OpenAPI Handler"
+description: "Use OpenAPIHandler to expose oRPC procedures as HTTP endpoints for OpenAPI Link and other OpenAPI-compliant clients."
 ---
-
-Use `OpenAPIHandler` to expose HTTP endpoints or communicate with [OpenAPI Link](/docs/openapi/link) and other OpenAPI-compliant clients.
 
 ## Overview
 

--- a/apps/content/docs/openapi/input-and-output-mapping.mdx
+++ b/apps/content/docs/openapi/input-and-output-mapping.mdx
@@ -1,10 +1,9 @@
 ---
 title: "OpenAPI Input and Output Mapping"
+description: "Learn how oRPC maps OpenAPI requests and responses to procedure inputs and outputs with compact and detailed structures, parameter styles, and body hints."
 sidebar:
   label: "Input and Output Mapping"
 ---
-
-oRPC lets you map OpenAPI requests and responses to procedure inputs and outputs in a few different ways.
 
 ## Input Mapping
 

--- a/apps/content/docs/openapi/link.mdx
+++ b/apps/content/docs/openapi/link.mdx
@@ -1,8 +1,7 @@
 ---
 title: "OpenAPI Link"
+description: "Use OpenAPILink to call HTTP endpoints served by OpenAPI Handler or any OpenAPI-compliant server through a typesafe oRPC client."
 ---
-
-Use `OpenAPILink` to call HTTP endpoints served by [OpenAPI Handler](/docs/openapi/handler) and other OpenAPI-compliant servers.
 
 ## Overview
 

--- a/apps/content/docs/openapi/routing.mdx
+++ b/apps/content/docs/openapi/routing.mdx
@@ -1,8 +1,7 @@
 ---
 title: "OpenAPI Routing"
+description: "Use openapi metadata to control how procedures are exposed over HTTP, including methods, paths, path parameters, and prefixes."
 ---
-
-Use `openapi` metadata to control how a procedure is exposed over HTTP.
 
 ## Basic Routing
 

--- a/apps/content/docs/openapi/scalar.mdx
+++ b/apps/content/docs/openapi/scalar.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Scalar (Swagger)"
+description: "Use Scalar to serve an interactive API reference UI for your oRPC API generated from its OpenAPI specification."
 sidebar:
   label: "OpenAPI Scalar (Swagger)"
 ---
-
-Use [Scalar](https://github.com/scalar/scalar) to serve an interactive API reference for your oRPC API from an [OpenAPI specification](/docs/openapi/specification).
 
 :::info
 This guide shows a manual setup. If you want a simpler option, use the [OpenAPI Reference Plugin](/docs/plugins/openapi-reference), which serves both the API reference UI and the OpenAPI specification for you.
@@ -12,7 +11,7 @@ This guide shows a manual setup. If you want a simpler option, use the [OpenAPI 
 
 ## Basic Example
 
-This example serves the OpenAPI document at `/spec.json` and renders Scalar at `/`.
+This example serves the [OpenAPI specification](/docs/openapi/specification) document at `/spec.json` and renders Scalar at `/`.
 
 ```ts
 import { createServer } from 'node:http'

--- a/apps/content/docs/openapi/serializer.mdx
+++ b/apps/content/docs/openapi/serializer.mdx
@@ -1,8 +1,7 @@
 ---
 title: "OpenAPI Serializer"
+description: "Learn how OpenAPI Serializer performs one-way serialization of complex types like Date, BigInt, and files into JSON-friendly formats, and how to customize it."
 ---
-
-OpenAPI Serializers handle one-way serialization to JSON-friendly formats. They let you partially support complex data types beyond plain JSON, such as `Date`, `BigInt`, `Set`, and even custom classes.
 
 ## Supported Data Types
 

--- a/apps/content/docs/openapi/specification.mdx
+++ b/apps/content/docs/openapi/specification.mdx
@@ -1,8 +1,7 @@
 ---
 title: "OpenAPI Specification"
+description: "Learn how to configure openapi metadata and generate OpenAPI 3.1 documents from your oRPC contracts and routers with OpenAPIGenerator."
 ---
-
-Learn how to configure metadata and generate OpenAPI documents from your oRPC [contracts](/docs/contract/router) and [routers](/docs/router).
 
 ## Metadata
 

--- a/apps/content/docs/playgrounds.mdx
+++ b/apps/content/docs/playgrounds.mdx
@@ -1,11 +1,9 @@
 ---
 title: "Playgrounds"
+description: "Try oRPC instantly with pre-configured playground examples for Bun, Cloudflare, NestJS, Next.js, and Expo on StackBlitz or locally."
 sidebar:
   icon: joystick
 ---
-
-Explore oRPC implementations through our interactive playgrounds,
-featuring pre-configured examples accessible instantly via StackBlitz or local setup.
 
 ## Available Playgrounds
 

--- a/apps/content/docs/plugins/batch.mdx
+++ b/apps/content/docs/plugins/batch.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Batch Plugin"
+description: "Combine multiple requests into a single batch and receive their responses together, reducing the overhead of separate requests."
 sidebar:
   label: "Batch"
 ---
-
-Use the **Batch Plugin** to combine multiple requests into a single batch and receive their responses together. This reduces the overhead of sending each request separately.
 
 :::warning
 HTTP/2, HTTP/3, and later versions already support multiplexing, which allows multiple requests and responses to share a single connection. Because these protocols are now widely adopted, this plugin is often less useful than it once was.

--- a/apps/content/docs/plugins/cors.mdx
+++ b/apps/content/docs/plugins/cors.mdx
@@ -1,10 +1,9 @@
 ---
 title: "CORS Handler Plugin"
+description: "Configure CORS policy for your oRPC API with CORSHandlerPlugin, including allowed origins, methods, and exposed headers."
 sidebar:
   label: "CORS"
 ---
-
-Use `CORSHandlerPlugin` to configure [CORS Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) for your API.
 
 ## Basic
 

--- a/apps/content/docs/plugins/dedupe.mdx
+++ b/apps/content/docs/plugins/dedupe.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Dedupe Plugin"
+description: "Prevent redundant requests by deduplicating similar in-flight requests, reducing the number of requests sent to the server."
 sidebar:
   label: "Dedupe"
 ---
-
-**Dedupe Plugin** prevents redundant requests by deduplicating similar requests, reducing the number of requests sent to the server.
 
 ## Overview
 

--- a/apps/content/docs/plugins/openapi-reference.mdx
+++ b/apps/content/docs/plugins/openapi-reference.mdx
@@ -1,10 +1,9 @@
 ---
 title: "OpenAPI Reference Plugin (Swagger/Scalar)"
+description: "Serve interactive API reference documentation powered by Scalar or Swagger UI and expose your OpenAPI specification as JSON."
 sidebar:
   label: "OpenAPI Reference"
 ---
-
-This plugin serves API reference documentation powered by [Scalar](https://github.com/scalar/scalar) or [Swagger UI](https://swagger.io/tools/swagger-ui/), and exposes the OpenAPI specification as JSON.
 
 :::info
 This plugin depends on the [OpenAPI Generator](/docs/openapi/specification). Review that guide before setting up the reference plugin.

--- a/apps/content/docs/plugins/request-compression.mdx
+++ b/apps/content/docs/plugins/request-compression.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Request Compression Plugin"
+description: "Compress request bodies on the client and decompress them on the server to reduce bandwidth usage for large payloads."
 sidebar:
   label: "Request Compression"
 ---
-
-Compresses request bodies before sending to the server, reducing bandwidth usage and improving performance for large payloads.
 
 ## Client
 

--- a/apps/content/docs/plugins/request-headers.mdx
+++ b/apps/content/docs/plugins/request-headers.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Request Headers Plugin"
+description: "Expose incoming request headers as context.reqHeaders with RequestHeadersHandlerPlugin for easy access in procedures."
 sidebar:
   label: "Request Headers"
 ---
-
-Use `RequestHeadersHandlerPlugin` to expose incoming request headers as `context.reqHeaders`.
 
 ## Context Access
 

--- a/apps/content/docs/plugins/request-limit.mdx
+++ b/apps/content/docs/plugins/request-limit.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Request Limit Plugin"
+description: "Restrict the size of incoming request bodies with RequestLimitHandlerPlugin to protect your server from oversized payloads."
 sidebar:
   label: "Request Limit"
 ---
-
-Restricts the size of incoming request bodies to protect the server from oversized payloads.
 
 ## Setup
 

--- a/apps/content/docs/plugins/request-validation.mdx
+++ b/apps/content/docs/plugins/request-validation.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Request Validation Plugin"
+description: "Validate requests against your contract on the client before sending them to the server, catching invalid input early."
 sidebar:
   label: "Request Validation"
 ---
-
-**Request Validation Plugin** validates requests against your contract before they are sent to the server. This is useful when your application relies on server-side validation.
 
 ## Setup
 

--- a/apps/content/docs/plugins/response-compression.mdx
+++ b/apps/content/docs/plugins/response-compression.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Response Compression Plugin"
+description: "Compress response bodies on the server and decompress them on the client to reduce bandwidth usage and improve performance."
 sidebar:
   label: "Response Compression"
 ---
-
-Compresses response bodies to reduce bandwidth usage and improve performance for clients that support compression.
 
 ## Server
 

--- a/apps/content/docs/plugins/response-headers.mdx
+++ b/apps/content/docs/plugins/response-headers.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Response Headers Plugin"
+description: "Use ResponseHeadersHandlerPlugin to set response headers and cookies via context.resHeaders and merge them into the final response."
 sidebar:
   label: "Response Headers"
 ---
-
-Use `ResponseHeadersHandlerPlugin` to accumulate response headers in `context.resHeaders` and merge them into the final response.
 
 ## Context Access
 

--- a/apps/content/docs/plugins/response-validation.mdx
+++ b/apps/content/docs/plugins/response-validation.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Response Validation Plugin"
+description: "Validate server responses against your contract on the client, ensuring returned data matches the types your contract defines."
 sidebar:
   label: "Response Validation"
 ---
-
-**Response Validation Plugin** validates server responses against your contract before your application uses them. This helps ensure the data returned by the server matches the types defined in your contract.
 
 ## Setup
 

--- a/apps/content/docs/plugins/rethrow.mdx
+++ b/apps/content/docs/plugins/rethrow.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Rethrow Handler Plugin"
+description: "Bypass oRPC's built-in error handling and rethrow matching errors to your framework, such as NestJS filters or Express error middleware."
 sidebar:
   label: "Rethrow"
 ---
-
-`RethrowHandlerPlugin` can bypass oRPC's built-in error handling and rethrow matching errors directly to your framework's error handling mechanism (e.g., NestJS exception filters, Express error middleware).
 
 ## Usage
 

--- a/apps/content/docs/plugins/retry-after.mdx
+++ b/apps/content/docs/plugins/retry-after.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Retry After Plugin"
+description: "Automatically retry requests based on the Retry-After response header, useful for rate limits and temporary server unavailability."
 sidebar:
   label: "Retry After"
 ---
-
-**Retry After Plugin** automatically retries requests according to the `Retry-After` response header. This is especially useful for handling rate limits and temporary server unavailability.
 
 ## Usage
 

--- a/apps/content/docs/plugins/retry.mdx
+++ b/apps/content/docs/plugins/retry.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Retry Plugin"
+description: "Automatically retry failed oRPC requests with customizable strategies controlled through client context options."
 sidebar:
   label: "Retry"
 ---
-
-**Retry Plugin** automatically retries failed requests based on customizable retry strategies, improving the resilience of your application.
 
 :::warning
 Before using this plugin, make sure you understand [client context](/docs/client/client-side#client-context), as retry behavior is managed through context.

--- a/apps/content/docs/plugins/simple-csrf-protection.mdx
+++ b/apps/content/docs/plugins/simple-csrf-protection.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Simple CSRF Protection Plugin"
+description: "Use SimpleCsrfProtectionHandlerPlugin to block requests with unsafe fetch modes as a first line of defense against CSRF attacks."
 sidebar:
   label: "Simple CSRF Protection"
 ---
-
-Use `SimpleCsrfProtectionHandlerPlugin` to add a first line of defense against [Cross-Site Request Forgery (CSRF) attacks](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/CSRF) by rejecting requests with unsafe fetch modes.
 
 ## How It Works
 

--- a/apps/content/docs/plugins/smart-coercion.mdx
+++ b/apps/content/docs/plugins/smart-coercion.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Smart Coercion Plugin"
+description: "Automatically coerce request and response values to match your schema types without writing manual coercion logic."
 sidebar:
   label: "Smart Coercion"
 ---
-
-Automatically converts values to match your schema types without requiring manual coercion logic.
 
 :::warning
 This plugin improves developer experience, but it adds runtime overhead. For performance sensitive applications or complex schemas, manual coercion in your validation layer is usually more efficient.

--- a/apps/content/docs/plugins/timeout.mdx
+++ b/apps/content/docs/plugins/timeout.mdx
@@ -1,10 +1,9 @@
 ---
 title: "Timeout Plugin"
+description: "Automatically abort requests that exceed a timeout with an AbortError, using a static value or a per-request dynamic timeout."
 sidebar:
   label: "Timeout"
 ---
-
-**Timeout Plugin** automatically aborts requests that exceed a given timeout with an `AbortError`.
 
 ## Usage
 

--- a/apps/content/docs/procedure.mdx
+++ b/apps/content/docs/procedure.mdx
@@ -1,8 +1,7 @@
 ---
 title: "Procedure"
+description: "Learn how oRPC procedures combine input and output validation, middleware, metadata, and typesafe errors through a composable builder."
 ---
-
-Procedures are the core building blocks of oRPC. They define the logic for handling specific operations, including input validation, output validation, and middleware application. Each procedure is created using a builder pattern that allows for flexible composition and reuse.
 
 ## Overview
 

--- a/apps/content/docs/router.mdx
+++ b/apps/content/docs/router.mdx
@@ -1,8 +1,7 @@
 ---
 title: "Router"
+description: "Organize oRPC procedures into nestable routers, extend them with shared middleware, lazy-load routes, and infer their types."
 ---
-
-A router is a plain, nestable object made up of procedures. Routers can also modify those procedures, which makes it easy to organize and extend your API.
 
 :::info
 A standalone [procedure](/docs/procedure) is also a router, so you can use all router features on individual procedures too.

--- a/apps/content/docs/rpc/handler.mdx
+++ b/apps/content/docs/rpc/handler.mdx
@@ -1,10 +1,11 @@
 ---
 title: "RPC Handler"
+description: "Use RPCHandler to serve procedures over the RPC protocol, with HTTP method control, interceptors, plugins, custom serializers, and error responses."
 ---
 
-Use `RPCHandler` to communicate with [RPC Link](/docs/rpc/link) and other clients that implement the [RPC protocol](/docs/rpc/protocol).
-
 ## Overview
+
+`RPCHandler` serves [RPC Link](/docs/rpc/link) clients, or any client that implements the [RPC protocol](/docs/rpc/protocol):
 
 ```ts
 const handler = new RPCHandler(router, {

--- a/apps/content/docs/rpc/link.mdx
+++ b/apps/content/docs/rpc/link.mdx
@@ -1,10 +1,11 @@
 ---
 title: "RPC Link"
+description: "Use RPCLink to call RPC Handler servers or any server implementing the RPC protocol, with headers, interceptors, plugins, and custom serializers."
 ---
 
-Use `RPCLink` to communicate with [RPC Handler](/docs/rpc/handler) and other servers that implement the [RPC protocol](/docs/rpc/protocol).
-
 ## Overview
+
+`RPCLink` can call any server that implements the [RPC protocol](/docs/rpc/protocol):
 
 ```ts
 const link = new RPCLink({

--- a/apps/content/docs/rpc/protocol.mdx
+++ b/apps/content/docs/rpc/protocol.mdx
@@ -1,8 +1,9 @@
 ---
 title: "RPC Protocol"
+description: "Learn how the RPC protocol routes procedure calls, encodes input and output beyond plain JSON, and formats success and error responses."
 ---
 
-The RPC protocol is a lightweight protocol for remote procedure calls. It supports more native types than plain JSON and is used by [RPC Handler](/docs/rpc/handler) and [RPC Link](/docs/rpc/link).
+The RPC protocol is a lightweight protocol for remote procedure calls, used by [RPC Handler](/docs/rpc/handler) and [RPC Link](/docs/rpc/link).
 
 ## Serializer
 

--- a/apps/content/docs/rpc/serializer.mdx
+++ b/apps/content/docs/rpc/serializer.mdx
@@ -1,8 +1,7 @@
 ---
 title: "RPC Serializer"
+description: "Learn how RPC Serializers encode data between client and server, supporting types beyond plain JSON such as Date, BigInt, Set, Map, and custom classes."
 ---
-
-RPC Serializers handle the serialization and deserialization of data sent between the client and server. They allow you to support complex data types beyond plain JSON, such as `Date`, `BigInt`, `Set`, and even custom classes.
 
 ## Supported Data Types
 


### PR DESCRIPTION
Adds a frontmatter `description` to the 91 docs pages that were missing one, so every page now ships proper SEO meta tags and a consistent visible lead paragraph (Blume renders the description as both). Redundant opening paragraphs were removed so pages no longer show the same sentence twice.

## Content

- Descriptions are plain text, 100-160 characters, grounded in each page's actual content.
- ~80 opening paragraphs that merely restated the new description were deleted; additive ones were kept and trimmed of duplication.
- Internal cross-links that lived only in deleted paragraphs were re-anchored in the remaining body text (RPC Handler/Link overviews, Scalar, NestJS, dedupe-middleware, client AsyncIteratorObject, and the Zod/Valibot/ArkType pages, which gained an info callout clarifying that the converter is only needed for JSON Schema generation).

## Verification

- `pnpm docs:validate` passes: 0 JSDoc backlink errors, no broken links under `blume validate --strict`.
- Served the site and confirmed all 91 pages emit correct `<meta name="description">` and `og:description` tags, with the description rendering as the lead paragraph and no duplicated text below it.