### PR TITLE
feat(server): add MethodOverrideHandlerPlugin

### DIFF
--- a/apps/content/docs/plugins/method-override.mdx
+++ b/apps/content/docs/plugins/method-override.mdx
@@ -1,0 +1,58 @@
+---
+title: "Method Override Plugin"
+description: "Use MethodOverrideHandlerPlugin to override the HTTP method of a POST request with a query parameter, so HTML forms can invoke PUT, PATCH, and DELETE procedures."
+sidebar:
+  label: "Method Override"
+---
+
+## How It Works
+
+HTML forms only support the GET and POST methods. When a POST request carries a `method` query parameter with an allowed value, the plugin routes the request as if it used that method and removes the parameter before input decoding. Values outside the allowed list are ignored and the request is processed as a regular POST.
+
+```html
+<form method="post" action="/api/todos/1?method=DELETE">
+  <button>Delete todo</button>
+</form>
+```
+
+## Setup
+
+```ts
+import { OpenAPIHandler } from '@orpc/openapi/fetch'
+import { MethodOverrideHandlerPlugin } from '@orpc/server/plugins'
+
+const handler = new OpenAPIHandler(router, {
+  plugins: [
+    new MethodOverrideHandlerPlugin({
+      /**
+       * The query parameter carrying the override method.
+       *
+       * @default 'method'
+       */
+      param: 'method',
+
+      /**
+       * The methods a POST request may be overridden to.
+       *
+       * GET and HEAD are excluded by default because they switch input decoding
+       * from the request body to the query string and widen the CSRF surface.
+       *
+       * @default ['PUT', 'PATCH', 'DELETE']
+       */
+      methods: ['PUT', 'PATCH', 'DELETE'],
+    }),
+  ],
+})
+```
+
+:::info
+The `handler` can be any supported oRPC handler, such as [RPCHandler](/docs/rpc/handler), [OpenAPIHandler](/docs/openapi/handler), or a custom one. The plugin is most useful with [OpenAPIHandler](/docs/openapi/handler), where the HTTP method decides which procedure a request matches.
+:::
+
+:::warning
+This plugin is incompatible with the [Simple CSRF Protection Plugin](/docs/plugins/simple-csrf-protection), which blocks the `navigate` fetch mode used by regular HTML form submissions.
+:::
+
+## Learn More
+
+For implementation details, see the [source code](https://github.com/middleapi/orpc/blob/main/packages/server/src/plugins/method-override.ts).

--- a/packages/server/src/plugins/index.test.ts
+++ b/packages/server/src/plugins/index.test.ts
@@ -5,6 +5,7 @@ it('exports plugins', async () => {
     RequestHeadersHandlerPlugin: expect.any(Function),
     ResponseHeadersHandlerPlugin: expect.any(Function),
     SimpleCsrfProtectionHandlerPlugin: expect.any(Function),
+    MethodOverrideHandlerPlugin: expect.any(Function),
     RethrowHandlerPlugin: expect.any(Function),
     RequestCompressionHandlerPlugin: expect.any(Function),
     RequestLimitHandlerPlugin: expect.any(Function),

--- a/packages/server/src/plugins/index.ts
+++ b/packages/server/src/plugins/index.ts
@@ -6,6 +6,7 @@ export {
    */
   CORSHandlerPlugin as CORSPlugin,
 } from './cors'
+export * from './method-override'
 export * from './request-compression'
 export * from './request-headers'
 export {

--- a/packages/server/src/plugins/method-override.test.ts
+++ b/packages/server/src/plugins/method-override.test.ts
@@ -1,0 +1,147 @@
+import { RPCHandler } from '../adapters/fetch'
+import { os } from '../builder'
+import { MethodOverrideHandlerPlugin } from './method-override'
+
+function getInterceptor(options?: ConstructorParameters<typeof MethodOverrideHandlerPlugin>[0]) {
+  const existingInterceptor = vi.fn()
+
+  const handlerOptions = new MethodOverrideHandlerPlugin<any>(options).init({
+    routingInterceptors: [existingInterceptor],
+  } as any)
+
+  return {
+    interceptor: handlerOptions.routingInterceptors![0]!,
+    existingInterceptor,
+    routingInterceptors: handlerOptions.routingInterceptors!,
+  }
+}
+
+async function invokeInterceptor(
+  request: { method: string, url: string },
+  options?: ConstructorParameters<typeof MethodOverrideHandlerPlugin>[0],
+) {
+  const nextResult = { matched: true, response: 'ok' } as any
+  const next = vi.fn().mockResolvedValue(nextResult)
+  const { interceptor } = getInterceptor(options)
+
+  const result = await interceptor({
+    context: {},
+    request,
+    next,
+  } as any)
+
+  return { result, next, nextResult }
+}
+
+describe('methodOverrideHandlerPlugin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('prepends its routing interceptor before existing ones', () => {
+    const { routingInterceptors, existingInterceptor } = getInterceptor()
+
+    expect(routingInterceptors).toHaveLength(2)
+    expect(routingInterceptors[0]).not.toBe(existingInterceptor)
+    expect(routingInterceptors[1]).toBe(existingInterceptor)
+  })
+
+  it('ignores non-POST requests', async () => {
+    const { result, next, nextResult } = await invokeInterceptor({ method: 'GET', url: '/todos/1?method=DELETE' })
+
+    expect(next).toHaveBeenCalledExactlyOnceWith()
+    expect(result).toBe(nextResult)
+  })
+
+  it('ignores POST requests without the override param', async () => {
+    const { result, next, nextResult } = await invokeInterceptor({ method: 'POST', url: '/todos/1?x=1' })
+
+    expect(next).toHaveBeenCalledExactlyOnceWith()
+    expect(result).toBe(nextResult)
+  })
+
+  it('overrides the method and strips the param', async () => {
+    const { result, next, nextResult } = await invokeInterceptor({ method: 'POST', url: '/todos/1?method=DELETE' })
+
+    expect(next).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+      request: expect.objectContaining({ method: 'DELETE', url: '/todos/1' }),
+    }))
+    expect(result).toBe(nextResult)
+  })
+
+  it('matches the override value case-insensitively', async () => {
+    const { next } = await invokeInterceptor({ method: 'POST', url: '/todos/1?method=delete' })
+
+    expect(next).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+      request: expect.objectContaining({ method: 'DELETE', url: '/todos/1' }),
+    }))
+  })
+
+  it('uses the last occurrence when the param is repeated and strips all of them', async () => {
+    const { next } = await invokeInterceptor({ method: 'POST', url: '/todos/1?method=PUT&method=DELETE' })
+
+    expect(next).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+      request: expect.objectContaining({ method: 'DELETE', url: '/todos/1' }),
+    }))
+  })
+
+  it('preserves other query params and the hash', async () => {
+    const { next } = await invokeInterceptor({ method: 'POST', url: '/a?x=1&method=DELETE&y=2#h' })
+
+    expect(next).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+      request: expect.objectContaining({ method: 'DELETE', url: '/a?x=1&y=2#h' }),
+    }))
+  })
+
+  it.each(['FOO', 'GET', 'HEAD', 'POST'])('silently ignores an override value that is not allowed: %s', async (method) => {
+    const { result, next, nextResult } = await invokeInterceptor({ method: 'POST', url: `/todos/1?method=${method}` })
+
+    expect(next).toHaveBeenCalledExactlyOnceWith()
+    expect(result).toBe(nextResult)
+  })
+
+  it('honors a custom param name', async () => {
+    const { next } = await invokeInterceptor({ method: 'POST', url: '/todos/1?_method=DELETE&method=PUT' }, { param: '_method' })
+
+    expect(next).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+      request: expect.objectContaining({ method: 'DELETE', url: '/todos/1?method=PUT' }),
+    }))
+  })
+
+  it('honors custom allowed methods', async () => {
+    const { next } = await invokeInterceptor({ method: 'POST', url: '/todos/1?method=GET' }, { methods: ['get'] })
+
+    expect(next).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
+      request: expect.objectContaining({ method: 'GET', url: '/todos/1' }),
+    }))
+
+    const { next: next2 } = await invokeInterceptor({ method: 'POST', url: '/todos/1?method=DELETE' }, { methods: ['GET'] })
+
+    expect(next2).toHaveBeenCalledExactlyOnceWith()
+  })
+
+  it('works with RPCHandler', async () => {
+    const procedureHandler = vi.fn(() => 'pong')
+    const handler = new RPCHandler(
+      {
+        ping: os.handler(procedureHandler),
+      },
+      {
+        plugins: [new MethodOverrideHandlerPlugin()],
+      },
+    )
+
+    const { matched, response } = await handler.handle(new Request('https://example.com/ping?method=DELETE', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ json: 'input' }),
+    }))
+
+    expect(matched).toBe(true)
+    expect(response!.status).toBe(200)
+    await expect(response!.text()).resolves.toContain('pong')
+    expect(procedureHandler).toHaveBeenCalledWith(expect.any(Object), 'input')
+  })
+})

--- a/packages/server/src/plugins/method-override.ts
+++ b/packages/server/src/plugins/method-override.ts
@@ -1,0 +1,85 @@
+import type { StandardMethod, StandardUrl } from '@standardserver/core'
+import type { StandardHandlerOptions, StandardHandlerPlugin, StandardHandlerRoutingInterceptor } from '../adapters/standard'
+import type { Context } from '../context'
+import { toArray } from '@orpc/shared'
+import { parseStandardUrl } from '@standardserver/core'
+
+export interface MethodOverrideHandlerPluginOptions {
+  /**
+   * The query parameter carrying the override method.
+   *
+   * @default 'method'
+   */
+  param?: string
+
+  /**
+   * The methods a POST request may be overridden to.
+   *
+   * GET and HEAD are excluded by default because they switch input decoding
+   * from the request body to the query string and widen the CSRF surface.
+   *
+   * @default ['PUT', 'PATCH', 'DELETE']
+   */
+  methods?: readonly StandardMethod[]
+}
+
+/**
+ * Overrides the HTTP method of a POST request based on a query parameter,
+ * so HTML forms (which only support GET and POST) can invoke procedures
+ * routed as PUT, PATCH, or DELETE.
+ *
+ * @see {@link https://orpc.dev/docs/plugins/method-override | Method Override Plugin}
+ */
+export class MethodOverrideHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
+  name = '~method-override'
+
+  /**
+   * Should override the original request method, not batch sub-requests.
+   */
+  after = ['~batch']
+
+  private readonly param: string
+  private readonly methods: ReadonlySet<string>
+
+  constructor(options: MethodOverrideHandlerPluginOptions = {}) {
+    this.param = options.param ?? 'method'
+    this.methods = new Set((options.methods ?? ['PUT', 'PATCH', 'DELETE']).map(method => method.toUpperCase()))
+  }
+
+  init(options: StandardHandlerOptions<T>): StandardHandlerOptions<T> {
+    const routingInterceptor: StandardHandlerRoutingInterceptor<T> = async ({ next, ...interceptorOptions }) => {
+      const { request } = interceptorOptions
+
+      if (request.method !== 'POST') {
+        return next()
+      }
+
+      const [pathname, search, hash] = parseStandardUrl(request.url)
+      const params = new URLSearchParams(search)
+      const raw = params.getAll(this.param).at(-1)
+
+      if (raw === undefined) {
+        return next()
+      }
+
+      const method = raw.toUpperCase()
+
+      if (!this.methods.has(method)) {
+        return next()
+      }
+
+      params.delete(this.param)
+      const url = `${pathname}${params.size ? `?${params}` : ''}${hash ?? ''}` as StandardUrl
+
+      return next({
+        ...interceptorOptions,
+        request: { ...request, method, url },
+      })
+    }
+
+    return {
+      ...options,
+      routingInterceptors: [routingInterceptor, ...toArray(options.routingInterceptors)],
+    }
+  }
+}

--- a/packages/server/src/plugins/method-override.ts
+++ b/packages/server/src/plugins/method-override.ts
@@ -34,9 +34,9 @@ export class MethodOverrideHandlerPlugin<T extends Context> implements StandardH
   name = '~method-override'
 
   /**
-   * Should override the original request method, not batch sub-requests.
+   * Should override batch sub-request methods, not the original batch request.
    */
-  after = ['~batch']
+  before = ['~batch']
 
   private readonly param: string
   private readonly methods: ReadonlySet<string>

--- a/tests/openapi/method-override.test.ts
+++ b/tests/openapi/method-override.test.ts
@@ -1,0 +1,92 @@
+import { openapi } from '@orpc/openapi'
+import { OpenAPIHandler } from '@orpc/openapi/fetch'
+import { os } from '@orpc/server'
+import { MethodOverrideHandlerPlugin } from '@orpc/server/plugins'
+import { z } from 'zod'
+
+describe('methodOverrideHandlerPlugin with OpenAPIHandler', () => {
+  const deleteHandler = vi.fn(({ input }) => input)
+  const detailedHandler = vi.fn(({ input }) => ({ body: input }))
+
+  const router = {
+    delete: os
+      .input(z.object({ id: z.string(), reason: z.string() }))
+      .meta(openapi({
+        method: 'DELETE',
+        path: '/todos/{id}',
+      }))
+      .handler(deleteHandler),
+    detailed: os
+      .input(z.any())
+      .meta(openapi({
+        method: 'PUT',
+        path: '/articles/{id}',
+        inputStructure: 'detailed',
+      }))
+      .handler(detailedHandler),
+  }
+
+  const handler = new OpenAPIHandler(router, {
+    plugins: [new MethodOverrideHandlerPlugin()],
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('routes a POST with ?method=DELETE to the DELETE procedure with clean input', async () => {
+    const { matched, response } = await handler.handle(new Request('https://example.com/todos/1?method=DELETE', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({ reason: 'done' }),
+    }))
+
+    expect(matched).toBe(true)
+    expect(response!.status).toBe(200)
+    expect(deleteHandler).toHaveBeenCalledOnce()
+    expect(deleteHandler.mock.calls[0]![0].input).toEqual({ id: '1', reason: 'done' })
+  })
+
+  it('does not match a plain POST to a DELETE-only route', async () => {
+    const { matched } = await handler.handle(new Request('https://example.com/todos/1', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ reason: 'done' }),
+    }))
+
+    expect(matched).toBe(false)
+    expect(deleteHandler).not.toHaveBeenCalled()
+  })
+
+  it('does not leak the override param into detailed query input', async () => {
+    const { matched, response } = await handler.handle(new Request('https://example.com/articles/1?method=PUT&tag=news', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ title: 'hello' }),
+    }))
+
+    expect(matched).toBe(true)
+    expect(response!.status).toBe(200)
+    expect(detailedHandler).toHaveBeenCalledOnce()
+    expect(detailedHandler.mock.calls[0]![0].input).toEqual(expect.objectContaining({
+      params: { id: '1' },
+      query: { tag: 'news' },
+      body: { title: 'hello' },
+    }))
+  })
+
+  it('silently ignores a disallowed override value', async () => {
+    const { matched } = await handler.handle(new Request('https://example.com/todos/1?method=FOO', {
+      method: 'POST',
+    }))
+
+    expect(matched).toBe(false)
+    expect(deleteHandler).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Adds `MethodOverrideHandlerPlugin` to `@orpc/server/plugins`. A POST request carrying a `method` query parameter (e.g. `POST /todos/1?method=DELETE`) is routed and executed as that method, so HTML forms, which only support GET and POST, can invoke procedures routed as PUT, PATCH, or DELETE.

## Behavior

- The override only applies to POST requests; the param name (`method`) and allowed targets (`PUT`, `PATCH`, `DELETE`) are configurable.
- The parameter is stripped from the URL before input decoding, so it never leaks into query-decoded input (including `inputStructure: 'detailed'`).
- Values outside the allowed list are silently ignored and the request proceeds as a regular POST.
- GET and HEAD are excluded by default: they would switch input decoding from body to query and widen the CSRF surface.
- Batch sub-requests are unaffected (`after = ['~batch']`).

## Notes for reviewers

- Works with both `RPCHandler` and `OpenAPIHandler`; it is most useful with the latter, where the method decides route matching.
- Docs page warns the plugin is incompatible with `SimpleCsrfProtectionHandlerPlugin`, which blocks the `navigate` fetch mode real form submissions use.

## Testing

- Unit tests plus an `RPCHandler` integration test in `packages/server`, and `OpenAPIHandler` integration tests in `tests/openapi` (form-encoded POST hits a DELETE route with clean input, plain POST stays unmatched, no param leak into detailed `query`).
- `pnpm type:check`, `pnpm lint`, and `pnpm docs:validate` pass.