### PR TITLE
chore(content): make twoslash popups reachable by pointer and touch-friendly

### DIFF
--- a/apps/content/components/blume/twoslash-mobile.ts
+++ b/apps/content/components/blume/twoslash-mobile.ts
@@ -1,19 +1,43 @@
-// Mobile twoslash popups: theme.css makes them fixed, readable-width, and
-// horizontally centered; this anchors each one just below its hovered or
-// tapped token (or above it when the token sits near the bottom of the
-// screen). The popup's own height is never measured — the available space
-// becomes its max-height and longer signatures scroll internally — so late
-// reflows of the nested code signature can't push it offscreen.
+// Twoslash popups need three behaviors CSS :hover can't provide alone:
 //
-// Placement is only ever written, never proactively cleared: a popup is
-// re-placed (or reset, on desktop widths) at the moment it is revealed, so
-// stale styles on a hidden popup are harmless. Clearing eagerly — on outside
-// tap or on touch pointerout, which fires the moment a tap ends — made the
-// still-visible popup flash at its fallback position.
+// 1. Mobile placement — theme.css makes popups fixed and readable-width;
+//    this anchors each one just below its hovered or tapped token (or above
+//    it when the token sits near the bottom of the screen), left-aligned
+//    with the token as far as the viewport allows. The popup's own height
+//    is never measured — the available space becomes its max-height and
+//    longer signatures scroll internally — so late reflows of the nested
+//    code signature can't push it offscreen. Fixed popups don't follow the
+//    page, so the visible one is re-anchored on scroll. Placement is only
+//    written on reveal or scroll, never proactively cleared: clearing
+//    eagerly (outside tap, touch pointerout) made the still-visible popup
+//    flash at its fallback position.
+//
+// 2. Hover bridge — the popup sits GAP px away from the token, and :hover
+//    alone closes it the instant the pointer enters that gap. The popup
+//    scrolls internally, so it can't span the gap itself (anything hanging
+//    outside its box is clipped); instead a transparent fixed strip inside
+//    the hover span covers exactly the gap band at the popup's width. As a
+//    descendant of the token it keeps :hover alive while the pointer
+//    crosses, at any speed — no timers. It must never reach into the
+//    token's own line nor stretch wider than the popup, or it traps
+//    sideways movement between neighboring tokens, holding the old popup
+//    open instead of switching. Desktop widths bridge with a CSS ::before
+//    on the popup instead (theme.css).
+//
+// 3. Tap pin — touch has no hover, and sticky :hover emulation on tap is
+//    unreliable across mobile browsers. A tap pins the popup open via
+//    OPEN_CLASS (mirrored to the :hover reveal in theme.css); tapping
+//    anywhere else unpins it. Pins react to click, not pointerdown: a
+//    scroll gesture that starts on a token fires pointerdown too, but
+//    only a completed tap produces a click — so dragging across code
+//    doesn't spawn popups. Mouse clicks are left alone so selecting code
+//    text doesn't pin popups.
 const MOBILE = '(max-width: 48rem)'
 const EDGE = 8
 const GAP = 6
 const MIN_SPACE = 160
+const OPEN_CLASS = 'twoslash-open'
+const BRIDGE_CLASS = 'twoslash-mobile-bridge'
 
 function popupFor(target: EventTarget | null): { hover: Element, popup: HTMLElement } | null {
   const element = target instanceof Element ? target : null
@@ -22,28 +46,52 @@ function popupFor(target: EventTarget | null): { hover: Element, popup: HTMLElem
   return hover && popup ? { hover, popup } : null
 }
 
+function bridgeFor(hover: Element): HTMLElement {
+  let bridge = hover.querySelector<HTMLElement>(`:scope > .${BRIDGE_CLASS}`)
+  if (!bridge) {
+    bridge = document.createElement('span')
+    bridge.className = BRIDGE_CLASS
+    bridge.style.position = 'fixed'
+    bridge.style.zIndex = '60'
+    hover.append(bridge)
+  }
+  return bridge
+}
+
+let placed: { hover: Element, popup: HTMLElement } | null = null
+
 function place(hover: Element, popup: HTMLElement): void {
+  // Width is only measurable while the popup is displayed. Reveals always
+  // precede placement (mouse pointerover implies :hover; taps pin before
+  // placing), so an unmeasurable popup is a transient pre-reveal event —
+  // skip it, the next event re-places.
+  const width = popup.getBoundingClientRect().width
+  if (!width) {
+    return
+  }
+
   const rect = hover.getBoundingClientRect()
   const spaceBelow = window.innerHeight - rect.bottom - GAP - EDGE
   const spaceAbove = rect.top - GAP - EDGE
-  if (spaceBelow >= MIN_SPACE || spaceBelow >= spaceAbove) {
-    popup.style.top = `${rect.bottom + GAP}px`
-    popup.style.bottom = 'auto'
-    popup.style.maxHeight = `${Math.max(spaceBelow, 80)}px`
-  }
-  else {
-    popup.style.top = 'auto'
-    popup.style.bottom = `${window.innerHeight - rect.top + GAP}px`
-    popup.style.maxHeight = `${Math.max(spaceAbove, 80)}px`
-  }
-  popup.style.marginTop = '0'
-}
+  const below = spaceBelow >= MIN_SPACE || spaceBelow >= spaceAbove
+  const left = Math.max(Math.min(rect.left, window.innerWidth - width - EDGE), EDGE)
 
-function reset(popup: HTMLElement): void {
-  popup.style.top = ''
-  popup.style.bottom = ''
-  popup.style.maxHeight = ''
-  popup.style.marginTop = ''
+  popup.style.top = below ? `${rect.bottom + GAP}px` : 'auto'
+  popup.style.bottom = below ? 'auto' : `${window.innerHeight - rect.top + GAP}px`
+  popup.style.maxHeight = `${Math.max(below ? spaceBelow : spaceAbove, 80)}px`
+  popup.style.left = `${left}px`
+  popup.style.translate = 'none'
+  popup.style.marginTop = '0'
+
+  // Flush at the token's text edge, 1px into the popup, at the popup's
+  // exact span — see the header on why the bounds are strict.
+  const bridge = bridgeFor(hover)
+  bridge.style.top = below ? `${rect.bottom}px` : `${rect.top - GAP - 1}px`
+  bridge.style.left = `${left}px`
+  bridge.style.width = `${width}px`
+  bridge.style.height = `${GAP + 1}px`
+
+  placed = { hover, popup }
 }
 
 function reveal(target: EventTarget | null): void {
@@ -54,15 +102,54 @@ function reveal(target: EventTarget | null): void {
   if (window.matchMedia(MOBILE).matches) {
     place(found.hover, found.popup)
   }
-  else {
-    // Desktop reveal: drop any placement left over from a mobile-width
-    // session, so the absolute-positioned popup anchors normally.
-    reset(found.popup)
+  else if (found.popup.style.top) {
+    // Drop placement left over from a mobile-width session so the
+    // absolute-positioned popup anchors normally; desktop bridges with a
+    // CSS ::before, so the strip goes too.
+    for (const prop of ['top', 'bottom', 'maxHeight', 'marginTop', 'left', 'translate'] as const) {
+      found.popup.style[prop] = ''
+    }
+    found.hover.querySelector(`:scope > .${BRIDGE_CLASS}`)?.remove()
   }
 }
 
-// Hover shows the popup via CSS :hover; touch taps show it via sticky
-// :hover but with unreliable pointerover/pointerout sequencing, so the tap
-// itself also places.
+let openHover: Element | null = null
+
+function setOpen(hover: Element | null): void {
+  if (openHover === hover) {
+    return
+  }
+  openHover?.classList.remove(OPEN_CLASS)
+  openHover = hover
+  hover?.classList.add(OPEN_CLASS)
+}
+
+// Hover shows the popup via CSS :hover (the bridge keeps the chain alive
+// on the way in); completed taps pin it via OPEN_CLASS — see the header on
+// why click, not pointerdown. Pinning happens before placing so place()
+// can measure the freshly displayed popup. click carries no pointerType in
+// every browser, so the preceding pointerdown's type stands in for it.
+let lastPointerType = 'mouse'
 document.addEventListener('pointerover', event => reveal(event.target))
-document.addEventListener('pointerdown', event => reveal(event.target))
+document.addEventListener('pointerdown', (event) => {
+  lastPointerType = event.pointerType
+})
+document.addEventListener('click', (event) => {
+  const found = popupFor(event.target)
+  if (!found) {
+    setOpen(null)
+  }
+  else if (lastPointerType !== 'mouse') {
+    setOpen(found.hover)
+    reveal(event.target)
+  }
+})
+
+// Fixed popups don't follow the page: re-anchor the last-placed one while
+// its token scrolls (capture catches every scroller, including the code
+// block's own). place() no-ops while the popup is hidden.
+document.addEventListener('scroll', () => {
+  if (placed && window.matchMedia(MOBILE).matches) {
+    place(placed.hover, placed.popup)
+  }
+}, { capture: true, passive: true })

--- a/apps/content/components/blume/twoslash-mobile.ts
+++ b/apps/content/components/blume/twoslash-mobile.ts
@@ -80,7 +80,7 @@ function place(hover: Element, popup: HTMLElement): void {
   popup.style.bottom = below ? 'auto' : `${window.innerHeight - rect.top + GAP}px`
   popup.style.maxHeight = `${Math.max(below ? spaceBelow : spaceAbove, 80)}px`
   popup.style.left = `${left}px`
-  popup.style.translate = 'none'
+  popup.style.transform = 'none'
   popup.style.marginTop = '0'
 
   // Flush at the token's text edge, 1px into the popup, at the popup's
@@ -106,7 +106,7 @@ function reveal(target: EventTarget | null): void {
     // Drop placement left over from a mobile-width session so the
     // absolute-positioned popup anchors normally; desktop bridges with a
     // CSS ::before, so the strip goes too.
-    for (const prop of ['top', 'bottom', 'maxHeight', 'marginTop', 'left', 'translate'] as const) {
+    for (const prop of ['top', 'bottom', 'maxHeight', 'marginTop', 'left', 'transform'] as const) {
       found.popup.style[prop] = ''
     }
     found.hover.querySelector(`:scope > .${BRIDGE_CLASS}`)?.remove()

--- a/apps/content/components/blume/twoslash-mobile.ts
+++ b/apps/content/components/blume/twoslash-mobile.ts
@@ -147,9 +147,17 @@ document.addEventListener('click', (event) => {
 
 // Fixed popups don't follow the page: re-anchor the last-placed one while
 // its token scrolls (capture catches every scroller, including the code
-// block's own). place() no-ops while the popup is hidden.
+// block's own), throttled to one place() per frame so scrolling never
+// forces extra layout flushes. place() no-ops while the popup is hidden.
+let reanchorQueued = false
 document.addEventListener('scroll', () => {
-  if (placed && window.matchMedia(MOBILE).matches) {
-    place(placed.hover, placed.popup)
+  if (!reanchorQueued && placed && window.matchMedia(MOBILE).matches) {
+    reanchorQueued = true
+    requestAnimationFrame(() => {
+      reanchorQueued = false
+      if (placed) {
+        place(placed.hover, placed.popup)
+      }
+    })
   }
 }, { capture: true, passive: true })

--- a/apps/content/theme.css
+++ b/apps/content/theme.css
@@ -191,10 +191,13 @@ main#blume-content {
   .prose .twoslash-popup-container {
     position: fixed;
     inset: auto auto auto 50%;
-    /* Twoslash offsets the popup with transform: translateY(1.1em); the
-       margin below replaces it so the fixed math stays exact. */
-    transform: none;
-    translate: -50% 0;
+    /* Replaces twoslash's transform: translateY(1.1em) — the margin below
+       keeps the fixed math exact — and centers horizontally. Centering
+       must live on transform, not the translate property: the production
+       build lowers translate into transform, which would survive the
+       script's inline override and drag the placed popup half a width
+       off-screen. */
+    transform: translateX(-50%);
     z-index: 60;
     margin: 0.375rem 0 0;
     max-width: calc(100vw - 1.5rem);

--- a/apps/content/theme.css
+++ b/apps/content/theme.css
@@ -120,8 +120,17 @@
    layout, stretching the page sideways and adding thousands of pixels
    of phantom height below the content on narrow viewports. Keep them
    out of layout entirely until their trigger is hovered. */
-.prose .twoslash-hover:not(:hover) .twoslash-popup-container {
+.prose .twoslash-hover:not(:hover):not(.twoslash-open) :is(.twoslash-popup-container, .twoslash-mobile-bridge) {
   display: none;
+}
+
+/* Touch has no hover: twoslash-mobile.ts pins .twoslash-open on the
+   tapped token (cleared by tapping elsewhere). Mirror the :hover reveal
+   the shiki stylesheet keys on (opacity 0 / pointer-events none
+   otherwise). */
+.prose .twoslash-hover.twoslash-open .twoslash-popup-container {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 main#blume-content {
@@ -129,14 +138,55 @@ main#blume-content {
 }
 
 .prose .twoslash-popup-container {
+  /* max-content, not shrink-to-fit: sized against the tiny token span,
+     shrink-to-fit collapses a wrappable popup to its narrowest content.
+     With the cap as max-width, only signatures that genuinely exceed it
+     wrap, at the full cap width. */
+  width: max-content;
   max-width: min(85vw, 34rem);
 }
 
+/* Wrap popup code: signatures emitted as one long line would otherwise
+   keep pre whitespace and blow the popup past its max-width. */
+.prose .twoslash-popup-container :is(pre, code) {
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+
+/* Desktop: push the popup down from twoslash's translateY(1.1em) (nearly
+   on top of the token) and bridge the resulting hover gap with a ::before
+   strip, so the pointer can reach the popup without leaving the :hover
+   target — leaving it hides the popup instantly via the display:none rule
+   above. Scoped to .twoslash-hover so persisted-query popups keep their
+   own offset; on mobile widths twoslash-mobile.ts bridges with a real
+   element instead (the popup scrolls internally there, which would clip a
+   ::before hanging outside its box). */
+@media (width > 48rem) {
+  .prose .twoslash-hover .twoslash-popup-container {
+    transform: translateY(2em);
+  }
+
+  .prose .twoslash-hover .twoslash-popup-container::before {
+    content: '';
+    position: absolute;
+    /* Exactly the dead gap (~0.54em: the 2em shift minus the code line
+       under the popup's static position) plus 1px into the line's lower
+       half-leading so rounding can't reopen a seam. Any taller and it
+       overlaps the code line, trapping sideways movement between
+       neighboring hover tokens. */
+    top: calc(-0.55em - 1px);
+    left: 0;
+    right: 0;
+    height: calc(0.55em + 1px);
+  }
+}
+
 /* On narrow screens the popup is anchored to a tiny inline token and
-   squeezes into an unreadable sliver over the code. Keep it by the
-   hovered token vertically (its natural static position), but fix it,
-   size it readably, and center it horizontally in the viewport —
-   fixed positioning escapes the code scroller below. */
+   squeezes into an unreadable sliver over the code. Fix it and size it
+   readably instead — fixed positioning escapes the code scroller below.
+   twoslash-mobile.ts anchors it next to the token on reveal; the
+   viewport centering here is only the first-frame fallback until the
+   script can measure the popup's width. */
 @media (max-width: 48rem) {
   .prose .twoslash-popup-container {
     position: fixed;
@@ -147,7 +197,6 @@ main#blume-content {
     translate: -50% 0;
     z-index: 60;
     margin: 0.375rem 0 0;
-    width: max-content;
     max-width: calc(100vw - 1.5rem);
     max-height: 45dvh;
     overflow-y: auto;


### PR DESCRIPTION
Twoslash hover popups in the docs were effectively unusable: the popup sat almost on top of its token yet closed the instant the pointer left the token, single-line type signatures overflowed off the page, and on touch devices popups either never opened or spawned while scrolling. This makes them behave like editor tooltips on every input method.

## Pointer

- The popup sits a small gap below the token (or above it when space runs out on narrow screens) and an invisible bridge spans the gap, so the pointer can travel into the popup at any speed — including a mid-gap pause — without it closing. Desktop bridges with a `::before` on the popup; narrow widths use a real element because the popup scrolls internally there and would clip a pseudo-element.
- The bridge covers exactly the gap at the popup's width, so sliding sideways along a code line still switches between neighboring tokens' popups instead of trapping the first one open.

## Sizing

- Long single-line signatures wrap at the popup's width cap instead of running off the page; short ones stay compact (`width: max-content` prevents shrink-to-fit collapsing wrappable popups into slivers).

## Touch

- A completed tap pins the popup open (class-based, no reliance on sticky `:hover` emulation); tapping elsewhere closes it. Pins react to `click`, not `pointerdown`, so scroll gestures that start on a token no longer spawn popups.
- Popups are anchored next to their token, clamped to the viewport, and re-anchored on scroll (page or the code block's own scroller), so an open popup follows its token instead of sticking to the viewport.
- Mouse clicks never pin, so selecting code text is unaffected.

## Testing

- Verified in the dev server at 600px and 1280px with real pointer input: hover into popup (fast, slow, and paused mid-gap), sideways token-to-token switching, tap pin/unpin, drag-scroll starting on a token, scroll re-anchoring, wrap/cap widths across /docs/procedure and /docs/router.
- `pnpm eslint` clean on both files.