### PR TITLE
docs(error-handling): update ORPCErrorCode registry augmentation exam…

### DIFF
--- a/apps/content/docs/error-handling.mdx
+++ b/apps/content/docs/error-handling.mdx
@@ -185,14 +185,19 @@ if (err instanceof RateLimitedError) {
 By default, oRPC allows any string as an error code and suggests common HTTP codes like `NOT_FOUND` and `UNAUTHORIZED`. You can override this with your own set of allowed error codes for better type safety and consistency.
 
 ```ts
+import type { COMMON_ERROR_STATUS_MAP } from '@orpc/server'
+
 declare module '@orpc/server' { // or '@orpc/client'
   interface Registry {
-    ORPCErrorCode: 'NOT_FOUND' | 'UNAUTHORIZED' | 'RATE_LIMITED' | 'MY_CUSTOM_ERROR' | (string & {})
+    ORPCErrorCode:
+      | keyof typeof COMMON_ERROR_STATUS_MAP
+      | 'MY_CUSTOM_ERROR'
+      | 'VALIDATION_FAILED'
   }
 }
 ```
 
-With this configuration, only `NOT_FOUND`, `UNAUTHORIZED`, `RATE_LIMITED`, and `MY_CUSTOM_ERROR` will be suggested as error codes. The `(string & {})` fallback ensures you can still use any string value when needed.
+With this configuration, the built-in HTTP error codes along with `MY_CUSTOM_ERROR` and `VALIDATION_FAILED` will be suggested as error codes.
 
 ## Using Custom Error Classes
 

--- a/apps/content/docs/migrations/from-v1.mdx
+++ b/apps/content/docs/migrations/from-v1.mdx
@@ -426,6 +426,23 @@ if (error && isDefined) {
 v2 also introduces `error` factories for defining reusable typed errors outside `.errors`. See [Error Handling](/docs/error-handling).
 :::
 
+### Custom Error Code Registry Augmentation
+
+In v2, custom error codes and autocomplete are configured via TypeScript module augmentation on `Registry.ORPCErrorCode`. You can combine `keyof typeof COMMON_ERROR_STATUS_MAP` with custom error codes:
+
+```ts
+import type { COMMON_ERROR_STATUS_MAP } from '@orpc/server'
+
+declare module '@orpc/server' { // or '@orpc/client'
+  interface Registry {
+    ORPCErrorCode:
+      | keyof typeof COMMON_ERROR_STATUS_MAP
+      | 'MY_CUSTOM_ERROR'
+      | 'VALIDATION_FAILED'
+  }
+}
+```
+
 ## AsyncIteratorObject (Event Iterator)
 
 The "Event Iterator" concept was renamed to [AsyncIteratorObject](/docs/async-iterator-object) (see also [AsyncIteratorObject in Client](/docs/client/async-iterator-object)). All old names still work as deprecated aliases:


### PR DESCRIPTION
# docs(error-handling): update `Registry.ORPCErrorCode` augmentation examples

## Summary
- Updated **`apps/content/docs/error-handling.mdx`** under `## ORPC Error Codes` to show how to combine `keyof typeof COMMON_ERROR_STATUS_MAP` with custom application error codes.
- Added a new subsection **Custom Error Code Registry Augmentation** in **`apps/content/docs/migrations/from-v1.mdx`** under **Error Handling**.

This provides developers with a clear reference on preserving default HTTP status error codes while extending oRPC's type system with custom error codes.
