### PR TITLE
docs(openapi): document OpenAPI path parameter syntax requirement ({i…

### DIFF
--- a/apps/content/docs/migrations/from-v1.mdx
+++ b/apps/content/docs/migrations/from-v1.mdx
@@ -105,6 +105,28 @@ const router = {
 
 </CodeGroup>
 
+### Path parameter syntax (`/{id}` vs `/:id`)
+
+In v2, OpenAPI path parameters strictly require curly brace syntax (`/{id}`). Express-style colon parameters (`/:id`) are no longer converted automatically and are treated as literal static paths, causing path parameter parsing and input validation to fail.
+
+<CodeGroup>
+
+```ts v2
+import { openapi } from '@orpc/openapi'
+
+const getPlanet = os
+  .meta(openapi({ method: 'GET', path: '/planets/{id}' }))
+  .input(z.object({ id: z.string() }))
+```
+
+```ts v1
+const getPlanet = os
+  .route({ method: 'GET', path: '/planets/:id' })
+  .input(z.object({ id: z.string() }))
+```
+
+</CodeGroup>
+
 ## Procedure Builder
 
 ### `.callable` is no longer built in

--- a/apps/content/docs/openapi/routing.mdx
+++ b/apps/content/docs/openapi/routing.mdx
@@ -45,6 +45,10 @@ const getFile = os
   .input(z.object({ path: z.string() }))
 ```
 
+:::warning
+Path parameters strictly require OpenAPI curly brace syntax (`/{name}`). Express-style colon parameters (`/:name`) are treated as literal static paths and will not extract path parameters into procedure input.
+:::
+
 :::info
 To customize path parameter encoding and decoding, see [Path Parameter Styles](/docs/openapi/input-and-output-mapping#path-parameter-styles).
 :::


### PR DESCRIPTION
# docs(openapi): document OpenAPI path parameter syntax requirement (`/{id}` vs `/:id`)

## Summary
- Added `### Path parameter syntax ({id} vs :id)` section in **`apps/content/docs/migrations/from-v1.mdx`** with side-by-side `v2` vs `v1` `<CodeGroup>` comparisons.
- Added a warning callout in **`apps/content/docs/openapi/routing.mdx`** under `## Path Parameters`.

These updates clarify that oRPC v2 strictly requires OpenAPI curly brace syntax (`/{id}`). Express-style colon parameters (`/:id`) are treated as literal static paths and do not extract path parameters into procedure input (`422 INPUT_VALIDATION_FAILED`).
