### PR TITLE
chore(content): adopt Zed One Dark palette for dark mode

### DIFF
--- a/apps/content/blume.config.ts
+++ b/apps/content/blume.config.ts
@@ -35,8 +35,8 @@ export default defineConfig({
   theme: {
     // Monochrome accent to match the oRPC brand: black in light, white in dark.
     accent: { light: 'oklch(0.145 0 0)', dark: 'oklch(0.985 0 0)' },
-    // VitePress dark page background; the rest of the palette lives in theme.css.
-    background: { dark: '#161618' },
+    // Zed One Dark editor background; the rest of the palette lives in theme.css.
+    background: { dark: '#282c33' },
     fonts: {
       display: 'inter',
       body: 'inter',

--- a/apps/content/theme.css
+++ b/apps/content/theme.css
@@ -24,12 +24,14 @@
 }
 
 :root[data-theme='dark'] {
-  /* Palette — dark (VitePress values) */
-  --blume-foreground: #dfdfd6;
-  --blume-muted: #202127;
-  --blume-muted-foreground: #98989f;
-  --blume-border: #2e2e32;
-  --blume-code-background: #202127;
+  /* Palette — dark (Zed One Dark values; page background lives in
+     blume.config.ts `theme`). Surfaces sit above the page, code blocks
+     recess below it like Zed's editor pane. */
+  --blume-foreground: #dce0e5;
+  --blume-muted: #2f343e;
+  --blume-muted-foreground: #a9afbc;
+  --blume-border: #363c46;
+  --blume-code-background: #21252b;
 }
 
 /* ---------------------------------------------------------------- */


### PR DESCRIPTION
Dark mode on the docs site now uses Zed editor's default dark theme (One Dark) instead of the VitePress grays: a blue-gray page background with surfaces that sit above it and code blocks that recess below it like an editor pane.

## Changes
- Page background is Zed's editor background `#282c33` (was `#161618`).
- Foreground, muted surface, muted text, and border tokens take Zed's `text`, `surface.background`, `text.muted`, and `border.variant` values, so callouts, table headers, and the search box now read as raised surfaces.
- Code blocks use `#21252b`, a shade darker than the page; the existing GitHub Dark syntax colors read naturally on it (their native background is `#24292e`).
- The monochrome brand accent is unchanged.

## Testing
- Verified in the dev server on `/docs/procedure` in dark mode: tokens resolve to the new values, all code blocks pick up the recessed background, and there are no console or server errors.