### PR TITLE
chore(content): rule off sidebar icon quick links from plain pages

### DIFF
--- a/apps/content/components/blume/NavTree.astro
+++ b/apps/content/components/blume/NavTree.astro
@@ -182,8 +182,14 @@ const initialId =
       {items.map((item, index) => {
         if (item.kind === "page") {
           const isActive = item.route === currentRoute;
+          // Icon rows form a quick-links block at the top of a section; rule
+          // off the first plain page after them so the two read as separate
+          // lists.
+          const prev = items[index - 1];
+          const afterIconRows =
+            !item.icon && prev?.kind === "page" && Boolean(prev.icon);
           return (
-            <li>
+            <li class:list={[afterIconRows && "mt-3 border-border border-t pt-3"]}>
               <a
                 aria-current={isActive ? "page" : undefined}
                 class:list={[


### PR DESCRIPTION
The docs sidebar's icon quick links (Getting Started, Comparison, Ecosystem, Playgrounds) and the plain page links below them ran together as one list. The first plain page after the icon block now draws a top border, so the two blocks read as separate lists.

## Behavior

- The divider keys off the frontmatter `sidebar.icon` boundary in the owned NavTree component, not a hardcoded page, so it follows icon additions or removals automatically.
- Applies in both the desktop sidebar and the mobile drawer, which share the component.

## Testing

- Verified on the dev server: the first icon-less row computes a 1px top border in the theme's border color (checked in dark mode), with no console errors.