### PR TITLE
chore(content): dismiss twoslash popups on scroll and fit them to the viewport

### DIFF
--- a/apps/content/components/blume/twoslash-mobile.ts
+++ b/apps/content/components/blume/twoslash-mobile.ts
@@ -1,4 +1,4 @@
-// Twoslash popups need three behaviors CSS :hover can't provide alone:
+// Twoslash popups need four behaviors CSS :hover can't provide alone:
 //
 // 1. Mobile placement — theme.css makes popups fixed and readable-width;
 //    this anchors each one just below its hovered or tapped token (or above
@@ -7,10 +7,12 @@
 //    is never measured — the available space becomes its max-height and
 //    longer signatures scroll internally — so late reflows of the nested
 //    code signature can't push it offscreen. Fixed popups don't follow the
-//    page, so the visible one is re-anchored on scroll. Placement is only
-//    written on reveal or scroll, never proactively cleared: clearing
-//    eagerly (outside tap, touch pointerout) made the still-visible popup
-//    flash at its fallback position.
+//    page, so the visible one is dismissed as soon as scrolling starts —
+//    composited touch scrolling moves the page before scroll events reach
+//    the main thread, so JS re-anchoring always trails the finger visibly.
+//    Placement is only written on reveal, never proactively cleared:
+//    clearing eagerly (outside tap, touch pointerout) made the
+//    still-visible popup flash at its fallback position.
 //
 // 2. Hover bridge — the popup sits GAP px away from the token, and :hover
 //    alone closes it the instant the pointer enters that gap. The popup
@@ -24,7 +26,13 @@
 //    open instead of switching. Desktop widths bridge with a CSS ::before
 //    on the popup instead (theme.css).
 //
-// 3. Tap pin — touch has no hover, and sticky :hover emulation on tap is
+// 3. Desktop flip — desktop popups drop below the token via CSS alone,
+//    so one near the viewport bottom runs offscreen. CSS can't see the
+//    viewport, so reveal() measures and toggles FLIP_CLASS; theme.css
+//    mirrors the below-placement geometry above the token (popup and
+//    bridge both).
+//
+// 4. Tap pin — touch has no hover, and sticky :hover emulation on tap is
 //    unreliable across mobile browsers. A tap pins the popup open via
 //    OPEN_CLASS (mirrored to the :hover reveal in theme.css); tapping
 //    anywhere else unpins it. Pins react to click, not pointerdown: a
@@ -32,12 +40,18 @@
 //    only a completed tap produces a click — so dragging across code
 //    doesn't spawn popups. Mouse clicks are left alone so selecting code
 //    text doesn't pin popups.
-const MOBILE = '(max-width: 48rem)'
+const MOBILE = window.matchMedia('(max-width: 48rem)')
 const EDGE = 8
 const GAP = 6
 const MIN_SPACE = 160
 const OPEN_CLASS = 'twoslash-open'
 const BRIDGE_CLASS = 'twoslash-mobile-bridge'
+const DISMISSED_CLASS = 'twoslash-dismissed'
+const FLIP_CLASS = 'twoslash-flip'
+// Desktop gap between token and popup (--twoslash-gap in theme.css) plus
+// breathing room, so a popup that would only just graze the viewport
+// bottom still flips.
+const FLIP_GAP = 16
 
 function popupFor(target: EventTarget | null): { hover: Element, popup: HTMLElement } | null {
   const element = target instanceof Element ? target : null
@@ -61,6 +75,10 @@ function bridgeFor(hover: Element): HTMLElement {
 let placed: { hover: Element, popup: HTMLElement } | null = null
 
 function place(hover: Element, popup: HTMLElement): void {
+  // Un-dismiss first: the dismissal rule display:nones the popup, which
+  // would zero the width below.
+  hover.classList.remove(DISMISSED_CLASS)
+
   // Width is only measurable while the popup is displayed. Reveals always
   // precede placement (mouse pointerover implies :hover; taps pin before
   // placing), so an unmeasurable popup is a transient pre-reveal event —
@@ -94,15 +112,22 @@ function place(hover: Element, popup: HTMLElement): void {
   placed = { hover, popup }
 }
 
+// The desktop flip side is decided once per open, not on every pointerover
+// — pointer movement inside an open popup re-fires pointerover constantly,
+// and geometry can't change while the pointer holds the popup open.
+let flipDecidedFor: Element | null = null
+
 function reveal(target: EventTarget | null): void {
   const found = popupFor(target)
   if (!found) {
+    flipDecidedFor = null
     return
   }
-  if (window.matchMedia(MOBILE).matches) {
+  if (MOBILE.matches) {
     place(found.hover, found.popup)
+    return
   }
-  else if (found.popup.style.top) {
+  if (found.popup.style.top) {
     // Drop placement left over from a mobile-width session so the
     // absolute-positioned popup anchors normally; desktop bridges with a
     // CSS ::before, so the strip goes too.
@@ -110,6 +135,25 @@ function reveal(target: EventTarget | null): void {
       found.popup.style[prop] = ''
     }
     found.hover.querySelector(`:scope > .${BRIDGE_CLASS}`)?.remove()
+    placed = null
+  }
+  if (found.hover === flipDecidedFor) {
+    return
+  }
+
+  // Flip above a token too close to the viewport bottom for the popup to
+  // fit under it, when above actually fits more. Height is only
+  // measurable while the popup is displayed (same transient pre-reveal
+  // case as place()); keep the previous side rather than guessing.
+  const height = found.popup.getBoundingClientRect().height
+  if (height) {
+    const rect = found.hover.getBoundingClientRect()
+    const spaceBelow = window.innerHeight - rect.bottom - EDGE
+    found.hover.classList.toggle(
+      FLIP_CLASS,
+      spaceBelow < height + FLIP_GAP && rect.top - EDGE > spaceBelow,
+    )
+    flipDecidedFor = found.hover
   }
 }
 
@@ -145,19 +189,20 @@ document.addEventListener('click', (event) => {
   }
 })
 
-// Fixed popups don't follow the page: re-anchor the last-placed one while
-// its token scrolls (capture catches every scroller, including the code
-// block's own), throttled to one place() per frame so scrolling never
-// forces extra layout flushes. place() no-ops while the popup is hidden.
-let reanchorQueued = false
-document.addEventListener('scroll', () => {
-  if (!reanchorQueued && placed && window.matchMedia(MOBILE).matches) {
-    reanchorQueued = true
-    requestAnimationFrame(() => {
-      reanchorQueued = false
-      if (placed) {
-        place(placed.hover, placed.popup)
-      }
-    })
+// Dismiss the placed popup on the first scroll (capture catches every
+// scroller, including the code block's own) — see the header on why it
+// can't follow instead. DISMISSED_CLASS hides the popup and bridge even
+// where a sticky tap-:hover would keep the CSS reveal alive; the next
+// place() lifts it. Scrolling inside the popup itself is the one scroller
+// reading depends on, so it never dismisses.
+document.addEventListener('scroll', (event) => {
+  if (!placed || !MOBILE.matches) {
+    return
   }
+  if (event.target instanceof Node && placed.popup.contains(event.target)) {
+    return
+  }
+  setOpen(null)
+  placed.hover.classList.add(DISMISSED_CLASS)
+  placed = null
 }, { capture: true, passive: true })

--- a/apps/content/theme.css
+++ b/apps/content/theme.css
@@ -165,21 +165,55 @@ main#blume-content {
    ::before hanging outside its box). */
 @media (width > 48rem) {
   .prose .twoslash-hover .twoslash-popup-container {
+    /* The dead gap the 2em shift leaves between the code line and the
+       popup (~0.54em); the bridge and flip rules below must all agree on
+       it, or the hover seam reopens. */
+    --twoslash-gap: 0.55em;
+
     transform: translateY(2em);
+    /* Cap oversized popups; the internal scrolling lives on the children
+       below. */
+    max-height: min(45vh, 28rem);
   }
 
   .prose .twoslash-hover .twoslash-popup-container::before {
     content: '';
     position: absolute;
-    /* Exactly the dead gap (~0.54em: the 2em shift minus the code line
-       under the popup's static position) plus 1px into the line's lower
-       half-leading so rounding can't reopen a seam. Any taller and it
-       overlaps the code line, trapping sideways movement between
-       neighboring hover tokens. */
-    top: calc(-0.55em - 1px);
+    /* The gap plus 1px into the line's lower half-leading so rounding
+       can't reopen a seam. Any taller and it overlaps the code line,
+       trapping sideways movement between neighboring hover tokens. */
+    top: calc(-1px - var(--twoslash-gap));
     left: 0;
     right: 0;
-    height: calc(0.55em + 1px);
+    height: calc(var(--twoslash-gap) + 1px);
+  }
+
+  /* Flip: twoslash-mobile.ts sets .twoslash-flip on the hover when the
+     popup can't fit under a token near the viewport bottom. Anchor the
+     popup the same gap above the token (the hover span is position:
+     relative) and hang the bridge off its bottom edge instead, 1px into
+     the line's upper half-leading — same seam logic as below. */
+  .prose .twoslash-hover.twoslash-flip .twoslash-popup-container {
+    top: auto;
+    bottom: calc(100% + var(--twoslash-gap));
+    transform: none;
+  }
+
+  .prose .twoslash-hover.twoslash-flip .twoslash-popup-container::before {
+    top: auto;
+    bottom: calc(-1px - var(--twoslash-gap));
+  }
+
+  /* The internal scrolling for the max-height cap above. It must live on
+     the flex children, not the container: the container anchors two
+     elements hanging outside its box — the ::before hover bridge and the
+     popup arrow — and container-level overflow would clip both, closing
+     the popup the moment the pointer crosses the gap. */
+  .prose .twoslash-hover .twoslash-popup-container > * {
+    min-height: 0;
+    overflow-y: auto;
+    scrollbar-color: var(--blume-border) transparent;
+    scrollbar-width: thin;
   }
 }
 
@@ -190,6 +224,15 @@ main#blume-content {
    viewport centering here is only the first-frame fallback until the
    script can measure the popup's width. */
 @media (max-width: 48rem) {
+  /* Scrolling dismisses the placed popup (twoslash-mobile.ts sets
+     .twoslash-dismissed, the next placement lifts it). display, not
+     opacity: the popup must also disappear in browsers whose sticky
+     tap-:hover would otherwise keep the reveal alive, and the bridge
+     must go with it so the stale fixed strip can't swallow a tap. */
+  .prose .twoslash-hover.twoslash-dismissed :is(.twoslash-popup-container, .twoslash-mobile-bridge) {
+    display: none;
+  }
+
   .prose .twoslash-popup-container {
     position: fixed;
     inset: auto auto auto 50%;


### PR DESCRIPTION
Twoslash popups on mobile trailed the finger during scroll: the fixed-position popup was re-anchored from a scroll handler, but composited touch scrolling moves the page before scroll events reach the main thread, so JS following always lags visibly. Scrolling now dismisses the popup instead (a tap re-opens it), and desktop popups gained the mobile niceties: oversized ones cap and scroll internally, and ones near the viewport bottom open above their token.

## Mobile

- Scrolling anywhere (page or the code block's own scroller) closes an open popup instantly instead of dragging it behind the content; scrolling inside the popup still works. Dismissal is class-based, so browsers whose sticky tap-hover keeps the reveal alive hide it too, and the hover bridge goes with it so its stale strip can't swallow a later tap.

## Desktop

- Popups cap at min(45vh, 28rem); longer signatures scroll inside the popup. The overflow lives on the popup's flex children because container-level overflow would clip the hover bridge and close the popup as the pointer crosses the gap.
- A popup that can't fit under a token near the viewport bottom opens above it, with the hover bridge mirrored to its bottom edge, so it stays fully readable on screen.

## Cleanup

- The token-to-popup gap is a single `--twoslash-gap` custom property instead of five hardcoded `0.55em` calcs, the flip side is decided once per open rather than on every pointerover, and both event paths share one `MediaQueryList`.

## Testing

- Verified in the dev server at 375px and 1280px: tap pin/place, dismissal on page and code-block scroll, popup-internal scroll exemption, re-tap restore, mobile above-placement near the viewport bottom; desktop height cap with internal scroll, hover-gap bridge hit-testing in both orientations, flip near the viewport bottom (fully onscreen) and un-flip on return.
- `pnpm eslint` clean on both files; no console errors.