### PR TITLE
fix(server): reject non-GET sub-requests in GET batch requests

### DIFF
--- a/packages/server/src/plugins/batch.test.ts
+++ b/packages/server/src/plugins/batch.test.ts
@@ -307,6 +307,41 @@ describe('batchHandlerPlugin', () => {
       expect(response!.status).toBe(400)
       expect(await response!.text()).toContain('Invalid batch request data parameter')
     })
+
+    it('returns 400 when a GET batch contains a non-GET sub-request', async () => {
+      const handler = createHandler()
+      const data = encodeURIComponent(JSON.stringify([
+        makePeerRequestMessage(0, '/ping', 'GET'),
+        makePeerRequestMessage(1, '/ping', 'POST'),
+      ]))
+
+      const { response } = await handler.handle(createBatchRequest({
+        mode: 'buffered',
+        method: 'GET',
+        data,
+      }))
+
+      expect(response!.status).toBe(400)
+      expect(await response!.text()).toContain('GET batch requests only accept GET sub-requests')
+      expect(handlerFn).toHaveBeenCalledTimes(0)
+    })
+
+    it('returns 400 when a GET batch sub-request omits the method (defaults to POST)', async () => {
+      const handler = createHandler()
+      const data = encodeURIComponent(JSON.stringify([
+        { kind: 'request', id: 0, json: { url: '/ping', headers: {} } },
+      ]))
+
+      const { response } = await handler.handle(createBatchRequest({
+        mode: 'buffered',
+        method: 'GET',
+        data,
+      }))
+
+      expect(response!.status).toBe(400)
+      expect(await response!.text()).toContain('GET batch requests only accept GET sub-requests')
+      expect(handlerFn).toHaveBeenCalledTimes(0)
+    })
   })
 
   describe('configuration options', () => {

--- a/packages/server/src/plugins/batch.ts
+++ b/packages/server/src/plugins/batch.ts
@@ -148,6 +148,18 @@ export class BatchHandlerPlugin<T extends Context> implements StandardHandlerPlu
             }
           }
 
+          /**
+           * A GET batch must not execute non-GET sub-requests, otherwise defenses
+           * that treat GET as safe (CSRF protections, caches, method-based rules)
+           * can be bypassed. An absent method defaults to POST, so require an explicit GET.
+           */
+          if (mightBeMessages.some(m => m.kind === 'request' && m.json.method !== 'GET')) {
+            return {
+              matched: true,
+              response: { status: 400, headers: {}, body: 'GET batch requests only accept GET sub-requests' },
+            }
+          }
+
           messages = mightBeMessages
         }
         else {


### PR DESCRIPTION
GET batch requests now execute only sub-requests that explicitly use the GET method. A hand-crafted `data` query parameter could previously smuggle POST sub-requests through a plain GET request, executing mutations past defenses that treat GET as safe (CSRF protections, caches, method-based rules).

## Fixes

- `BatchHandlerPlugin` rejects a GET batch with `400 GET batch requests only accept GET sub-requests` before any sub-request executes if any request message carries a non-GET method.
- A sub-request with the method omitted defaults to POST at execution time, so it is rejected too; only an explicit `GET` passes.
- Legitimate clients are unaffected: `BatchLinkPlugin` only places GET calls into GET batches and always serializes their method explicitly.

## Testing

- New tests cover a POST sub-request and an omitted-method sub-request inside a GET batch; both return 400 and the handler never runs.
- All batch plugin, client, and e2e batch tests pass; lint and type checks are clean.