### PR TITLE
chore(content): make 404 page button text legible in dark mode

### DIFF
--- a/apps/content/theme.css
+++ b/apps/content/theme.css
@@ -28,6 +28,10 @@
      blume.config.ts `theme`). Surfaces sit above the page, code blocks
      recess below it like Zed's editor pane. */
   --blume-foreground: #dce0e5;
+  /* Blume assumes a saturated accent and forces white accent text in dark
+     mode; our accent is near-white there, so flip the text dark to match
+     the light mode's inverse (white-on-black) treatment. */
+  --blume-accent-foreground: oklch(0.145 0 0);
   --blume-muted: #2f343e;
   --blume-muted-foreground: #a9afbc;
   --blume-border: #363c46;


### PR DESCRIPTION
The docs 404 page's "Back to home" button rendered white text on a white pill in dark mode, making it unreadable. The button now shows dark text on the white pill, mirroring light mode's inverse (white-on-black) treatment.

## Cause

Blume hardcodes the dark-mode accent foreground to white whenever a theme accent is configured, assuming a saturated accent color. Our monochrome brand sets the dark accent to near-white, so text and background collided.

## Fix

A `--blume-accent-foreground` override in theme.css's dark palette block, which loads after Blume's generated tokens. The token is shared with the skip-to-content link and Step/Prompt components, so those become legible in dark mode too.

## Testing

Verified in the dev server: the button computes to `oklch(0.145 0 0)` text on `oklch(0.985 0 0)` background in dark mode; light mode unchanged (white on black).