### PR TITLE
docs: add doc-linked JSDoc to server and contract builders

### DIFF
--- a/packages/contract/src/builder-variants.ts
+++ b/packages/contract/src/builder-variants.ts
@@ -5,65 +5,144 @@ import type { MetaPlugin } from './meta'
 import type { ProcedureContract } from './procedure'
 import type { AnySchema, MergedSchema } from './schema'
 
+/**
+ * The contract builder variant returned after `.input` is called.
+ * It is already a complete procedure contract that can still be refined.
+ *
+ * @see {@link https://orpc.dev/docs/contract/procedure | Procedure Contract}
+ */
 export interface ProcedureContractBuilderWithInput<
   TInputSchema extends AnySchema,
   TErrorMap extends ErrorMap,
 >extends ProcedureContract<TInputSchema, InitialOutputSchema, TErrorMap> {
+  /**
+   * Applies metadata plugins to contracts built from this builder.
+   *
+   * @see {@link https://orpc.dev/docs/contract/procedure#metadata | Procedure Contract - Metadata}
+   */
   meta(
     ...plugins: MetaPlugin<TInputSchema, InitialOutputSchema, TErrorMap>[]
   ): ProcedureContractBuilderWithInput<TInputSchema, TErrorMap>
 
+  /**
+   * Defines typesafe errors that implementations of this contract can throw.
+   *
+   * @see {@link https://orpc.dev/docs/contract/procedure#typesafe-errors | Procedure Contract - Typesafe Errors}
+   */
   errors<T extends ErrorMap>(
     errors: T,
   ): ProcedureContractBuilderWithInput<TInputSchema, MergedErrorMap<TErrorMap, T>>
 
+  /**
+   * Adds an additional input schema, merged with the previously defined one.
+   *
+   * @see {@link https://orpc.dev/docs/contract/procedure#multiple-schemas | Procedure Contract - Multiple Schemas}
+   */
   input<T extends AnySchema>(
     schema: T,
   ): ProcedureContractBuilderWithInput<MergedSchema<T, TInputSchema>, TErrorMap>
 
+  /**
+   * Defines the output schema used to validate and type the procedure output.
+   *
+   * @see {@link https://orpc.dev/docs/contract/procedure#inputoutput-validation | Procedure Contract - Input/Output Validation}
+   */
   output<T extends AnySchema>(
     schema: T,
   ): ProcedureContractBuilderWithInputOutput<TInputSchema, T, TErrorMap>
 }
 
+/**
+ * The contract builder variant returned after `.output` is called.
+ * It is already a complete procedure contract that can still be refined.
+ *
+ * @see {@link https://orpc.dev/docs/contract/procedure | Procedure Contract}
+ */
 export interface ProcedureContractBuilderWithOutput<
   TOutputSchema extends AnySchema,
   TErrorMap extends ErrorMap,
 >extends ProcedureContract<InitialInputSchema, TOutputSchema, TErrorMap> {
+  /**
+   * Applies metadata plugins to contracts built from this builder.
+   *
+   * @see {@link https://orpc.dev/docs/contract/procedure#metadata | Procedure Contract - Metadata}
+   */
   meta(
     ...plugins: MetaPlugin<InitialInputSchema, TOutputSchema, TErrorMap>[]
   ): ProcedureContractBuilderWithOutput<TOutputSchema, TErrorMap>
 
+  /**
+   * Defines typesafe errors that implementations of this contract can throw.
+   *
+   * @see {@link https://orpc.dev/docs/contract/procedure#typesafe-errors | Procedure Contract - Typesafe Errors}
+   */
   errors<T extends ErrorMap>(
     errors: T,
   ): ProcedureContractBuilderWithOutput<TOutputSchema, MergedErrorMap<TErrorMap, T>>
 
+  /**
+   * Defines the input schema used to validate and type the procedure input.
+   *
+   * @see {@link https://orpc.dev/docs/contract/procedure#inputoutput-validation | Procedure Contract - Input/Output Validation}
+   */
   input<T extends AnySchema>(
     schema: T,
   ): ProcedureContractBuilderWithInputOutput<T, TOutputSchema, TErrorMap>
 
+  /**
+   * Adds an additional output schema, merged with the previously defined one.
+   *
+   * @see {@link https://orpc.dev/docs/contract/procedure#multiple-schemas | Procedure Contract - Multiple Schemas}
+   */
   output<T extends AnySchema>(
     schema: T,
   ): ProcedureContractBuilderWithOutput<MergedSchema<T, TOutputSchema>, TErrorMap>
 }
 
+/**
+ * The contract builder variant returned after both `.input` and `.output`
+ * are called. It is already a complete procedure contract that can still be
+ * refined.
+ *
+ * @see {@link https://orpc.dev/docs/contract/procedure | Procedure Contract}
+ */
 export interface ProcedureContractBuilderWithInputOutput<
   TInputSchema extends AnySchema,
   TOutputSchema extends AnySchema,
   TErrorMap extends ErrorMap,
 >extends ProcedureContract<TInputSchema, TOutputSchema, TErrorMap> {
+  /**
+   * Applies metadata plugins to contracts built from this builder.
+   *
+   * @see {@link https://orpc.dev/docs/contract/procedure#metadata | Procedure Contract - Metadata}
+   */
   meta(
     ...plugins: MetaPlugin<TInputSchema, TOutputSchema, TErrorMap>[]
   ): ProcedureContractBuilderWithInputOutput<TInputSchema, TOutputSchema, TErrorMap>
 
+  /**
+   * Defines typesafe errors that implementations of this contract can throw.
+   *
+   * @see {@link https://orpc.dev/docs/contract/procedure#typesafe-errors | Procedure Contract - Typesafe Errors}
+   */
   errors<T extends ErrorMap>(
     errors: T,
   ): ProcedureContractBuilderWithInputOutput<TInputSchema, TOutputSchema, MergedErrorMap<TErrorMap, T>>
 
+  /**
+   * Adds an additional input schema, merged with the previously defined one.
+   *
+   * @see {@link https://orpc.dev/docs/contract/procedure#multiple-schemas | Procedure Contract - Multiple Schemas}
+   */
   input<T extends AnySchema>(
     schema: T,
   ): ProcedureContractBuilderWithInputOutput<MergedSchema<T, TInputSchema>, TOutputSchema, TErrorMap>
 
+  /**
+   * Adds an additional output schema, merged with the previously defined one.
+   *
+   * @see {@link https://orpc.dev/docs/contract/procedure#multiple-schemas | Procedure Contract - Multiple Schemas}
+   */
   output<T extends AnySchema>(
     schema: T,
   ): ProcedureContractBuilderWithInputOutput<TInputSchema, MergedSchema<T, TOutputSchema>, TErrorMap>

--- a/packages/contract/src/builder.ts
+++ b/packages/contract/src/builder.ts
@@ -13,9 +13,25 @@ import { resolveMetaPlugins } from './meta-utils'
 import { ProcedureContract } from './procedure'
 import { augmentContractRouter } from './router-utils'
 
+/**
+ * The input schema type used before `.input` is called.
+ * Input is `void` for better compatibility with third-party libraries,
+ * such as TanStack Query, which allow calling mutations without input.
+ */
 export type InitialInputSchema = Schema<void, unknown>
+
+/**
+ * The output schema type used before `.output` is called.
+ */
 export type InitialOutputSchema = Schema<unknown>
 
+/**
+ * The contract builder behind `oc`. Chain its methods to define procedure
+ * contracts — metadata, errors, and input/output schemas — without any
+ * business logic.
+ *
+ * @see {@link https://orpc.dev/docs/contract/procedure | Procedure Contract}
+ */
 export class ContractBuilder<
   TErrorMap extends ErrorMap,
 > extends ProcedureContract<InitialInputSchema, InitialOutputSchema, TErrorMap> {
@@ -27,15 +43,24 @@ export class ContractBuilder<
     super(definition)
   }
 
+  /**
+   * Creates a fresh contract builder with an empty definition.
+   * Prefer the exported `oc` instance over calling this directly.
+   *
+   * @see {@link https://orpc.dev/docs/contract/procedure | Procedure Contract}
+   */
   static create(): ContractBuilder<object> {
-    // The initial input schema is void for better compatibility with third-party libraries like TanStack Query,
-    // for example, which allow calling mutations without input, ...
     return new ContractBuilder({
       errorMap: {},
       meta: {},
     })
   }
 
+  /**
+   * Applies metadata plugins to contracts built from this builder.
+   *
+   * @see {@link https://orpc.dev/docs/contract/procedure#metadata | Procedure Contract - Metadata}
+   */
   meta(
     ...plugins: MetaPlugin<InitialInputSchema, InitialOutputSchema, TErrorMap>[]
   ): ContractBuilder<TErrorMap> {
@@ -52,6 +77,11 @@ export class ContractBuilder<
     }) as any
   }
 
+  /**
+   * Defines typesafe errors that implementations of this contract can throw.
+   *
+   * @see {@link https://orpc.dev/docs/contract/procedure#typesafe-errors | Procedure Contract - Typesafe Errors}
+   */
   errors<T extends ErrorMap>(
     errors: T,
   ): ContractBuilder<MergedErrorMap<TErrorMap, T>> {
@@ -68,6 +98,11 @@ export class ContractBuilder<
     return result as any
   }
 
+  /**
+   * Defines the input schema used to validate and type the procedure input.
+   *
+   * @see {@link https://orpc.dev/docs/contract/procedure#inputoutput-validation | Procedure Contract - Input/Output Validation}
+   */
   input<T extends AnySchema>(
     schema: T,
   ): ProcedureContractBuilderWithInput<T, TErrorMap> {
@@ -84,6 +119,11 @@ export class ContractBuilder<
     return result as any
   }
 
+  /**
+   * Defines the output schema used to validate and type the procedure output.
+   *
+   * @see {@link https://orpc.dev/docs/contract/procedure#inputoutput-validation | Procedure Contract - Input/Output Validation}
+   */
   output<T extends AnySchema>(
     schema: T,
   ): ProcedureContractBuilderWithOutput<T, TErrorMap> {
@@ -100,6 +140,12 @@ export class ContractBuilder<
     return result as any
   }
 
+  /**
+   * Applies the builder's errors and metadata to every procedure contract in
+   * the given router contract.
+   *
+   * @see {@link https://orpc.dev/docs/contract/router#extending-router | Router Contract - Extending Router}
+   */
   router<T extends RouterContract>(
     router: T,
   ): AugmentedContractRouter<T, TErrorMap> {
@@ -108,8 +154,9 @@ export class ContractBuilder<
 }
 
 /**
- * The contract builder — the entry point for defining procedure and router contracts
- * (input/output schemas, errors, and metadata) without any business logic.
+ * The oRPC contract builder. Chain methods like `.input`, `.errors`, and
+ * `.output` to define procedure contracts, then compose them into router
+ * contracts.
  *
  * @see {@link https://orpc.dev/docs/contract/procedure | Procedure Contract}
  */

--- a/packages/server/src/builder-variants.ts
+++ b/packages/server/src/builder-variants.ts
@@ -11,6 +11,12 @@ import type { DecoratedProcedure } from './procedure-decorated'
 import type { Router } from './router'
 import type { AugmentedRouterWithMiddlewares } from './router-utils'
 
+/**
+ * The builder variant returned after `.use` is called.
+ * `.$context` and `.$config` are no longer available once middleware is applied.
+ *
+ * @see {@link https://orpc.dev/docs/procedure | Procedure}
+ */
 export interface BuilderWithMiddlewares<
   TInitialContext extends Context,
   TInjectedContext extends Context,
@@ -18,14 +24,31 @@ export interface BuilderWithMiddlewares<
 > {
   '~orpc': BuilderDefinition<InitialInputSchema, InitialOutputSchema, TErrorMap>
 
+  /**
+   * Applies metadata plugins to procedures built from this builder.
+   *
+   * @see {@link https://orpc.dev/docs/metadata | Metadata}
+   */
   'meta'(
     ...plugins: MetaPlugin<InitialInputSchema, InitialOutputSchema, TErrorMap>[]
   ): BuilderWithMiddlewares<TInitialContext, TInjectedContext, TErrorMap>
 
+  /**
+   * Defines typesafe errors that procedures built from this builder can throw
+   * via the `errors` utility in handlers and middleware.
+   *
+   * @see {@link https://orpc.dev/docs/error-handling#typesafe-errors | Error Handling - Typesafe Errors}
+   */
   'errors'<T extends ErrorMap>(
     errors: T,
   ): BuilderWithMiddlewares<TInitialContext, TInjectedContext, MergedErrorMap<TErrorMap, T>>
 
+  /**
+   * Applies a middleware that runs before the handler of every procedure
+   * built from this builder.
+   *
+   * @see {@link https://orpc.dev/docs/middleware | Middleware}
+   */
   'use'<
     $OutContext extends IntersectPick<MergedContext<TInitialContext, TInjectedContext>, $OutContext>,
     $InContext extends Context = MergedContext<TInitialContext, TInjectedContext>,
@@ -44,6 +67,12 @@ export interface BuilderWithMiddlewares<
     MergedErrorMap<$ErrorMap, TErrorMap>
   >
 
+  /**
+   * Creates a standalone middleware that can be composed and applied to any
+   * compatible builder or procedure with `.use`.
+   *
+   * @see {@link https://orpc.dev/docs/middleware | Middleware}
+   */
   'middleware'<
     $OutContext extends IntersectPick<MergedContext<TInitialContext, TInjectedContext>, $OutContext>,
     $Input,
@@ -65,14 +94,30 @@ export interface BuilderWithMiddlewares<
     TErrorMap
   >
 
+  /**
+   * Defines the input schema used to validate and type the procedure input.
+   *
+   * @see {@link https://orpc.dev/docs/procedure#inputoutput-validation | Procedure - Input/Output Validation}
+   */
   'input'<T extends AnySchema>(
     schema: T
   ): BuilderWithInput<TInitialContext, TInjectedContext, T, TErrorMap>
 
+  /**
+   * Defines the output schema used to validate and type the procedure output.
+   *
+   * @see {@link https://orpc.dev/docs/procedure#inputoutput-validation | Procedure - Input/Output Validation}
+   */
   'output'<T extends AnySchema>(
     schema: T
   ): BuilderWithOutput<TInitialContext, TInjectedContext, T, TErrorMap>
 
+  /**
+   * Defines the function that implements the procedure and completes the
+   * chain, returning a callable procedure.
+   *
+   * @see {@link https://orpc.dev/docs/procedure | Procedure}
+   */
   'handler'<T>(
     handler: ProcedureHandler<MergedContext<TInitialContext, TInjectedContext>, InferSchemaOutput<InitialInputSchema>, T, ORPCErrorConstructorMap<TErrorMap>>,
   ): DecoratedProcedure<
@@ -84,15 +129,33 @@ export interface BuilderWithMiddlewares<
     Extract<T, AnyORPCError>
   >
 
+  /**
+   * Applies the builder's middleware, errors, and metadata to every procedure
+   * in the given router.
+   *
+   * @see {@link https://orpc.dev/docs/router#extending-router | Router - Extending Router}
+   */
   'router'<T extends Router<MergedContext<TInitialContext, TInjectedContext>>>(
     router: T,
   ): AugmentedRouterWithMiddlewares<T, TInitialContext, TInjectedContext, TErrorMap>
 
+  /**
+   * Like `.router`, but loads the router lazily on first access, which helps
+   * reduce startup time for large applications.
+   *
+   * @see {@link https://orpc.dev/docs/router#lazy-router | Router - Lazy Router}
+   */
   'lazy'<T extends Router<MergedContext<TInitialContext, TInjectedContext>>>(
     loader: () => Promise<{ default: T }>,
   ): Lazy<AugmentedRouterWithMiddlewares<T, TInitialContext, TInjectedContext, TErrorMap>>
 }
 
+/**
+ * The builder variant returned after `.input` is called.
+ * Only procedure-level methods remain available once an input schema is defined.
+ *
+ * @see {@link https://orpc.dev/docs/procedure | Procedure}
+ */
 export interface BuilderWithInput<
   TInitialContext extends Context,
   TInjectedContext extends Context,
@@ -101,14 +164,31 @@ export interface BuilderWithInput<
 > {
   '~orpc': BuilderDefinition<TInputSchema, InitialOutputSchema, TErrorMap>
 
+  /**
+   * Applies metadata plugins to procedures built from this builder.
+   *
+   * @see {@link https://orpc.dev/docs/metadata | Metadata}
+   */
   'meta'(
     ...plugins: MetaPlugin<TInputSchema, InitialOutputSchema, TErrorMap>[]
   ): BuilderWithInput<TInitialContext, TInjectedContext, TInputSchema, TErrorMap>
 
+  /**
+   * Defines typesafe errors that procedures built from this builder can throw
+   * via the `errors` utility in handlers and middleware.
+   *
+   * @see {@link https://orpc.dev/docs/error-handling#typesafe-errors | Error Handling - Typesafe Errors}
+   */
   'errors'<T extends ErrorMap>(
     errors: T,
   ): BuilderWithInput<TInitialContext, TInjectedContext, TInputSchema, MergedErrorMap<TErrorMap, T>>
 
+  /**
+   * Applies a middleware that runs before the handler and can access the
+   * validated input.
+   *
+   * @see {@link https://orpc.dev/docs/middleware | Middleware}
+   */
   'use'<
     $OutContext extends IntersectPick<MergedContext<TInitialContext, TInjectedContext>, $OutContext>,
     $InContext extends Context = MergedContext<TInitialContext, TInjectedContext>,
@@ -128,14 +208,30 @@ export interface BuilderWithInput<
     MergedErrorMap<$ErrorMap, TErrorMap>
   >
 
+  /**
+   * Adds an additional input schema, merged with the previously defined one.
+   *
+   * @see {@link https://orpc.dev/docs/procedure#multiple-schemas | Procedure - Multiple Schemas}
+   */
   'input'<T extends AnySchema>(
     schema: T
   ): BuilderWithInput<TInitialContext, TInjectedContext, MergedSchema<T, TInputSchema>, TErrorMap>
 
+  /**
+   * Defines the output schema used to validate and type the procedure output.
+   *
+   * @see {@link https://orpc.dev/docs/procedure#inputoutput-validation | Procedure - Input/Output Validation}
+   */
   'output'<T extends AnySchema>(
     schema: T
   ): BuilderWithInputOutput<TInitialContext, TInjectedContext, TInputSchema, T, TErrorMap>
 
+  /**
+   * Defines the function that implements the procedure and completes the
+   * chain, returning a callable procedure.
+   *
+   * @see {@link https://orpc.dev/docs/procedure | Procedure}
+   */
   'handler'<T>(
     handler: ProcedureHandler<MergedContext<TInitialContext, TInjectedContext>, InferSchemaOutput<TInputSchema>, T, ORPCErrorConstructorMap<TErrorMap>>,
   ): DecoratedProcedure<
@@ -148,6 +244,12 @@ export interface BuilderWithInput<
   >
 }
 
+/**
+ * The builder variant returned after `.output` is called.
+ * Only procedure-level methods remain available once an output schema is defined.
+ *
+ * @see {@link https://orpc.dev/docs/procedure | Procedure}
+ */
 export interface BuilderWithOutput<
   TInitialContext extends Context,
   TInjectedContext extends Context,
@@ -156,14 +258,31 @@ export interface BuilderWithOutput<
 > {
   '~orpc': BuilderDefinition<InitialInputSchema, TOutputSchema, TErrorMap>
 
+  /**
+   * Applies metadata plugins to procedures built from this builder.
+   *
+   * @see {@link https://orpc.dev/docs/metadata | Metadata}
+   */
   'meta'(
     ...plugins: MetaPlugin<InitialInputSchema, TOutputSchema, TErrorMap>[]
   ): BuilderWithOutput<TInitialContext, TInjectedContext, TOutputSchema, TErrorMap>
 
+  /**
+   * Defines typesafe errors that procedures built from this builder can throw
+   * via the `errors` utility in handlers and middleware.
+   *
+   * @see {@link https://orpc.dev/docs/error-handling#typesafe-errors | Error Handling - Typesafe Errors}
+   */
   'errors'<T extends ErrorMap>(
     errors: T,
   ): BuilderWithOutput<TInitialContext, TInjectedContext, TOutputSchema, MergedErrorMap<TErrorMap, T>>
 
+  /**
+   * Applies a middleware that runs before the handler and can access the
+   * typed output.
+   *
+   * @see {@link https://orpc.dev/docs/middleware | Middleware}
+   */
   'use'<
     $OutContext extends IntersectPick<MergedContext<TInitialContext, TInjectedContext>, $OutContext>,
     $InContext extends Context = MergedContext<TInitialContext, TInjectedContext>,
@@ -183,19 +302,41 @@ export interface BuilderWithOutput<
     MergedErrorMap<$ErrorMap, TErrorMap>
   >
 
+  /**
+   * Defines the input schema used to validate and type the procedure input.
+   *
+   * @see {@link https://orpc.dev/docs/procedure#inputoutput-validation | Procedure - Input/Output Validation}
+   */
   'input'<T extends AnySchema>(
     schema: T
   ): BuilderWithInputOutput<TInitialContext, TInjectedContext, T, TOutputSchema, TErrorMap>
 
+  /**
+   * Adds an additional output schema, merged with the previously defined one.
+   *
+   * @see {@link https://orpc.dev/docs/procedure#multiple-schemas | Procedure - Multiple Schemas}
+   */
   'output'<T extends AnySchema>(
     schema: T
   ): BuilderWithOutput<TInitialContext, TInjectedContext, MergedSchema<T, TOutputSchema>, TErrorMap>
 
+  /**
+   * Defines the function that implements the procedure and completes the
+   * chain, returning a callable procedure.
+   *
+   * @see {@link https://orpc.dev/docs/procedure | Procedure}
+   */
   'handler'<T extends InferSchemaInput<TOutputSchema> | AnyORPCError>(
     handler: ProcedureHandler<MergedContext<TInitialContext, TInjectedContext>, InferSchemaOutput<InitialInputSchema>, T, ORPCErrorConstructorMap<TErrorMap>>,
   ): DecoratedProcedure<TInitialContext, TInjectedContext, InitialInputSchema, TOutputSchema, TErrorMap, Extract<T, AnyORPCError>>
 }
 
+/**
+ * The builder variant returned after both `.input` and `.output` are called.
+ * Only procedure-level methods remain available.
+ *
+ * @see {@link https://orpc.dev/docs/procedure | Procedure}
+ */
 export interface BuilderWithInputOutput<
   TInitialContext extends Context,
   TInjectedContext extends Context,
@@ -205,14 +346,31 @@ export interface BuilderWithInputOutput<
 > {
   '~orpc': BuilderDefinition<TInputSchema, TOutputSchema, TErrorMap>
 
+  /**
+   * Applies metadata plugins to procedures built from this builder.
+   *
+   * @see {@link https://orpc.dev/docs/metadata | Metadata}
+   */
   'meta'(
     ...plugins: MetaPlugin<TInputSchema, TOutputSchema, TErrorMap>[]
   ): BuilderWithInputOutput<TInitialContext, TInjectedContext, TInputSchema, TOutputSchema, TErrorMap>
 
+  /**
+   * Defines typesafe errors that procedures built from this builder can throw
+   * via the `errors` utility in handlers and middleware.
+   *
+   * @see {@link https://orpc.dev/docs/error-handling#typesafe-errors | Error Handling - Typesafe Errors}
+   */
   'errors'<T extends ErrorMap>(
     errors: T,
   ): BuilderWithInputOutput<TInitialContext, TInjectedContext, TInputSchema, TOutputSchema, MergedErrorMap<TErrorMap, T>>
 
+  /**
+   * Applies a middleware that runs before the handler and can access the
+   * validated input and typed output.
+   *
+   * @see {@link https://orpc.dev/docs/middleware | Middleware}
+   */
   'use'<
     $OutContext extends IntersectPick<MergedContext<TInitialContext, TInjectedContext>, $OutContext>,
     $InContext extends Context = MergedContext<TInitialContext, TInjectedContext>,
@@ -233,14 +391,30 @@ export interface BuilderWithInputOutput<
     MergedErrorMap<$ErrorMap, TErrorMap>
   >
 
+  /**
+   * Adds an additional input schema, merged with the previously defined one.
+   *
+   * @see {@link https://orpc.dev/docs/procedure#multiple-schemas | Procedure - Multiple Schemas}
+   */
   'input'<T extends AnySchema>(
     schema: T
   ): BuilderWithInputOutput<TInitialContext, TInjectedContext, MergedSchema<T, TInputSchema>, TOutputSchema, TErrorMap>
 
+  /**
+   * Adds an additional output schema, merged with the previously defined one.
+   *
+   * @see {@link https://orpc.dev/docs/procedure#multiple-schemas | Procedure - Multiple Schemas}
+   */
   'output'<T extends AnySchema>(
     schema: T
   ): BuilderWithInputOutput<TInitialContext, TInjectedContext, TInputSchema, MergedSchema<T, TOutputSchema>, TErrorMap>
 
+  /**
+   * Defines the function that implements the procedure and completes the
+   * chain, returning a callable procedure.
+   *
+   * @see {@link https://orpc.dev/docs/procedure | Procedure}
+   */
   'handler'<T extends InferSchemaInput<TOutputSchema> | AnyORPCError>(
     handler: ProcedureHandler<MergedContext<TInitialContext, TInjectedContext>, InferSchemaOutput<TInputSchema>, T, ORPCErrorConstructorMap<TErrorMap>>,
   ): DecoratedProcedure<TInitialContext, TInjectedContext, TInputSchema, TOutputSchema, TErrorMap, Extract<T, AnyORPCError>>

--- a/packages/server/src/builder.ts
+++ b/packages/server/src/builder.ts
@@ -15,6 +15,13 @@ import { decorateMiddleware } from './middleware-decorated'
 import { DecoratedProcedure } from './procedure-decorated'
 import { augmentRouter } from './router-utils'
 
+/**
+ * The initial context type used when `.$context` is not called.
+ * Augment this interface with `declare module '@orpc/server'` to define
+ * a default initial context type globally.
+ *
+ * @see {@link https://orpc.dev/docs/context#default-initial-context | Context - Default Initial Context}
+ */
 export interface DefaultInitialContext {
 }
 
@@ -26,16 +33,32 @@ export interface BuilderDefinition<
   orderedMiddlewares: OrderedMiddleware[]
 }
 
+/**
+ * The procedure builder behind `os`. Chain its methods to gradually define
+ * context, middleware, errors, schemas, and finally a handler or router.
+ *
+ * @see {@link https://orpc.dev/docs/procedure | Procedure}
+ */
 export class Builder<
   TInitialContext extends Context,
   TErrorMap extends ErrorMap,
 > {
   '~orpc': BuilderDefinition<InitialInputSchema, InitialOutputSchema, TErrorMap>
 
+  /**
+   * Private constructor to prevent direct instantiation.
+   * Use the static `create` method to initialize a new instance with a safe initial definition.
+   */
   private constructor(definition: BuilderDefinition<InitialInputSchema, InitialOutputSchema, TErrorMap>) {
     this['~orpc'] = definition
   }
 
+  /**
+   * Creates a fresh builder with an empty definition.
+   * Prefer the exported `os` instance over calling this directly.
+   *
+   * @see {@link https://orpc.dev/docs/procedure | Procedure}
+   */
   static create<T extends Context = DefaultInitialContext>(): Builder<T & object, Record<never, never>> {
     // Using `& object` avoids "has no properties in common with type" errors
     // when combining procedures or routers with compatible but non-overlapping contexts.
@@ -47,6 +70,12 @@ export class Builder<
     })
   }
 
+  /**
+   * Declares the initial context type that must be provided when executing
+   * procedures built from this builder.
+   *
+   * @see {@link https://orpc.dev/docs/context#initial-context | Context - Initial Context}
+   */
   $context<T extends Context = DefaultInitialContext>(): Builder<T & object, TErrorMap> {
     // Using `& object` avoids "has no properties in common with type" errors
     // when combining procedures or routers with compatible but non-overlapping contexts.
@@ -55,6 +84,12 @@ export class Builder<
     return this as any
   }
 
+  /**
+   * Overrides the procedure configuration, such as disabling runtime
+   * input/output validation.
+   *
+   * @see {@link https://orpc.dev/docs/advanced/validation-customization | Validation Customization}
+   */
   $config(config: ProcedureConfig): Builder<TInitialContext, TErrorMap> {
     return new Builder({
       ...this['~orpc'],
@@ -62,6 +97,11 @@ export class Builder<
     })
   }
 
+  /**
+   * Applies metadata plugins to procedures built from this builder.
+   *
+   * @see {@link https://orpc.dev/docs/metadata | Metadata}
+   */
   meta(
     ...plugins: MetaPlugin<InitialInputSchema, InitialOutputSchema, TErrorMap>[]
   ): Builder<TInitialContext, TErrorMap> {
@@ -78,6 +118,12 @@ export class Builder<
     })
   }
 
+  /**
+   * Defines typesafe errors that procedures built from this builder can throw
+   * via the `errors` utility in handlers and middleware.
+   *
+   * @see {@link https://orpc.dev/docs/error-handling#typesafe-errors | Error Handling - Typesafe Errors}
+   */
   errors<U extends ErrorMap>(
     errors: U,
   ): Builder<TInitialContext, MergedErrorMap<TErrorMap, U>> {
@@ -94,6 +140,12 @@ export class Builder<
     return builder as any
   }
 
+  /**
+   * Applies a middleware that runs before the handler of every procedure
+   * built from this builder.
+   *
+   * @see {@link https://orpc.dev/docs/middleware | Middleware}
+   */
   use<
     $OutContext extends IntersectPick<TInitialContext, $OutContext>,
     $InContext extends Context = TInitialContext,
@@ -128,6 +180,12 @@ export class Builder<
     return builder as any
   }
 
+  /**
+   * Creates a standalone middleware that can be composed and applied to any
+   * compatible builder or procedure with `.use`.
+   *
+   * @see {@link https://orpc.dev/docs/middleware | Middleware}
+   */
   middleware<
     $OutContext extends IntersectPick<TInitialContext, $OutContext>,
     $Input,
@@ -158,6 +216,11 @@ export class Builder<
     return current
   }
 
+  /**
+   * Defines the input schema used to validate and type the procedure input.
+   *
+   * @see {@link https://orpc.dev/docs/procedure#inputoutput-validation | Procedure - Input/Output Validation}
+   */
   input<$ extends AnySchema>(schema: $): BuilderWithInput<TInitialContext, object, $, TErrorMap> {
     let builder = new Builder({
       ...this['~orpc'],
@@ -172,6 +235,11 @@ export class Builder<
     return builder as any
   }
 
+  /**
+   * Defines the output schema used to validate and type the procedure output.
+   *
+   * @see {@link https://orpc.dev/docs/procedure#inputoutput-validation | Procedure - Input/Output Validation}
+   */
   output<$ extends AnySchema>(schema: $): BuilderWithOutput<TInitialContext, object, $, TErrorMap> {
     let builder = new Builder({
       ...this['~orpc'],
@@ -186,6 +254,12 @@ export class Builder<
     return builder as any
   }
 
+  /**
+   * Defines the function that implements the procedure and completes the
+   * chain, returning a callable procedure.
+   *
+   * @see {@link https://orpc.dev/docs/procedure | Procedure}
+   */
   handler<T>(
     handler: ProcedureHandler<TInitialContext, InferSchemaOutput<InitialInputSchema>, T, ORPCErrorConstructorMap<TErrorMap>>,
   ): DecoratedProcedure<
@@ -209,6 +283,12 @@ export class Builder<
     return procedure as any
   }
 
+  /**
+   * Applies the builder's middleware, errors, and metadata to every procedure
+   * in the given router.
+   *
+   * @see {@link https://orpc.dev/docs/router#extending-router | Router - Extending Router}
+   */
   router<T extends AnyRouter>(
     router: T,
   ): AugmentedRouter<T, TErrorMap> {
@@ -218,6 +298,12 @@ export class Builder<
     }) as any
   }
 
+  /**
+   * Like `.router`, but loads the router lazily on first access, which helps
+   * reduce startup time for large applications.
+   *
+   * @see {@link https://orpc.dev/docs/router#lazy-router | Router - Lazy Router}
+   */
   lazy<T extends AnyRouter>(
     loader: () => Promise<{ default: T }>,
   ): Lazy<AugmentedRouter<T, TErrorMap>> {


### PR DESCRIPTION
Adds JSDoc to `Builder`, `ContractBuilder`, and all their builder variant interfaces in `@orpc/server` and `@orpc/contract`. Hovering any chainable method (`.use`, `.input`, `.errors`, `.meta`, `.handler`, `.router`, ...) now shows a short description plus an `@see` backlink to the matching orpc.dev docs page and anchor.

## Notes

- Descriptions reflect variant-specific semantics: repeated `.input`/`.output` calls are documented as schema merges (Multiple Schemas), and `.use` variants mention access to validated input / typed output.
- The rationale for the `void` initial input schema moved from an inline comment in `ContractBuilder.create` to the `InitialInputSchema` type doc, where editors can surface it.
- No `@example` blocks, matching the JSDoc convention; examples stay on the linked docs pages.

## Testing

- `node scripts/verify-docs-jsdoc.ts` passes for both packages (all links and anchor titles resolve).
- `pnpm vitest run` on the builder tests of both packages passes; eslint clean.