### PR TITLE
docs: call out v1/v2 wire format incompatibility in migration guide

### DIFF
--- a/apps/content/docs/migrations/from-v1.mdx
+++ b/apps/content/docs/migrations/from-v1.mdx
@@ -48,7 +48,7 @@ The Hey API and Durable Iterator integrations no longer exist in v2. In place of
 Two formats changed on the wire:
 
 - The [RPC serializer](/docs/rpc/serializer) format, described in the [RPC Protocol](/docs/rpc/protocol).
-- The error response body, which no longer contains a `status` field since [`status` was removed from errors](#status-removed-from-errors).
+- The error response body, which adds an `inferable` field and no longer contains a `status` field, since [`status` was removed from errors](#status-removed-from-errors).
 
 Because of these changes, a v1 [RPC Link](/docs/rpc/link) or [OpenAPI Link](/docs/openapi/link) cannot talk to a v2 server (and vice versa). Deploy the upgraded server and clients together.
 

--- a/apps/content/docs/migrations/from-v1.mdx
+++ b/apps/content/docs/migrations/from-v1.mdx
@@ -9,7 +9,7 @@ Most of your code keeps working: many v1 names still compile through deprecated 
 
 :::warning[Read these first]
 
-- The [RPC Protocol](/docs/rpc/protocol) changed, so a v1 client cannot talk to a v2 server. Deploy the upgraded server and client together.
+- The RPC serializer format and the error response format changed, so v1 [RPC Link](/docs/rpc/link) and [OpenAPI Link](/docs/openapi/link) clients cannot talk to a v2 server. Deploy the upgraded server and client together. See [Wire Format Changes](#wire-format-changes).
 - Automatic middleware deduplication was removed. Middleware applied at both router and procedure level now runs twice. See [Middleware](#middleware).
 - The Batch Plugin replaced `exclude` with `filter`, which has the opposite meaning. In most cases you can simply remove `exclude`. See [Batch Plugin](#batch-plugin).
 
@@ -42,6 +42,28 @@ Some packages were renamed, merged, or promoted from experimental status:
 :::warning
 The Hey API and Durable Iterator integrations no longer exist in v2. In place of Durable Iterator, use [Hibernation](/docs/integrations/hibernation) or [DurablePublisher](/docs/helpers/publisher#adapters).
 :::
+
+## Wire Format Changes
+
+Two formats changed on the wire:
+
+- The [RPC serializer](/docs/rpc/serializer) format, described in the [RPC Protocol](/docs/rpc/protocol).
+- The error response body, which no longer contains a `status` field since [`status` was removed from errors](#status-removed-from-errors).
+
+Because of these changes, a v1 [RPC Link](/docs/rpc/link) or [OpenAPI Link](/docs/openapi/link) cannot talk to a v2 server (and vice versa). Deploy the upgraded server and clients together.
+
+If your [OpenAPI Handler](/docs/openapi/handler) endpoints have external consumers that expect the v1 error format, add the `status` field back with a [custom error response](/docs/openapi/handler#custom-error-response):
+
+```ts
+import { COMMON_ERROR_STATUS_MAP } from '@orpc/openapi'
+
+const handler = new OpenAPIHandler(router, {
+  customErrorResponseBodyEncoder: error => ({
+    ...error.toJSON(),
+    status: COMMON_ERROR_STATUS_MAP[error.code] ?? 500,
+  }),
+})
+```
 
 ## Routing Moved to OpenAPI Metadata
 
@@ -360,7 +382,7 @@ The `dedupeLeadingMiddlewares` config option was removed together with this beha
 
 ### `status` removed from errors
 
-`ORPCError` and `.errors` definitions no longer accept a `status`. HTTP status codes are now a handler concern, configured with `errorStatusMap`. See [Error Handling](/docs/error-handling) and [RPC Handler](/docs/rpc/handler).
+`ORPCError` and `.errors` definitions no longer accept a `status`. HTTP status codes are now a handler concern, configured with `errorStatusMap`. Error response bodies no longer contain the field either, see [Wire Format Changes](#wire-format-changes). See [Error Handling](/docs/error-handling) and [RPC Handler](/docs/rpc/handler).
 
 <CodeGroup>
 


### PR DESCRIPTION
The v1 migration guide now states explicitly that the RPC serializer format and the error response format changed in v2, so v1 RPC Link and OpenAPI Link clients cannot talk to a v2 server. It also documents how to keep OpenAPI endpoints backward compatible for external consumers by restoring the `status` field in error bodies.

## Changes

- The top warning names both changed formats and links to a new **Wire Format Changes** section instead of a generic "RPC Protocol changed" note.
- The new section lists the two wire changes and shows a `customErrorResponseBodyEncoder` snippet that adds `status` back using `COMMON_ERROR_STATUS_MAP`, matching the [custom error response](https://v2.orpc.dev/docs/openapi/handler#custom-error-response) docs.
- The "`status` removed from errors" section cross-references the wire change.

## Testing

- The code snippet type-checks against `@orpc/openapi/fetch` (verified with a scratch `test-d` file, since removed).