### PR TITLE
 feat(server): introduce @orpc/server/testing suite for procedure callers

### DIFF
--- a/apps/content/docs/advanced/testing-and-mocking.mdx
+++ b/apps/content/docs/advanced/testing-and-mocking.mdx
@@ -78,7 +78,7 @@ it('overrides context for a single call', async () => {
 })
 ```
 
-```ts Global
+```ts title="Global Context"
 import { configureTestCaller, createTestCaller } from '@orpc/server/testing'
 
 // Set global test context in test setup file (e.g., vitest.setup.ts)
@@ -87,6 +87,9 @@ configureTestCaller({
     db: testDatabaseInstance,
   }),
 })
+
+// Reset global test context defaults between tests if needed:
+// configureTestCaller({ context: undefined })
 
 it('inherits suite-wide context automatically', async () => {
   const listPlanets = createTestCaller(router.planet.list)

--- a/apps/content/docs/advanced/testing-and-mocking.mdx
+++ b/apps/content/docs/advanced/testing-and-mocking.mdx
@@ -1,11 +1,15 @@
 ---
 title: "Testing and Mocking"
-description: "Learn how to test oRPC procedures directly with server-side clients and create mock implementations with the implementer."
+description: "Learn how to test oRPC procedures directly with server-side clients, test callers, and create mock implementations with the implementer."
 ---
 
 ## Testing
 
-For fast, focused tests, use [Server-Side Clients](/docs/client/server-side) or call your procedures directly with `call`. This lets you verify validation, middleware, and handler logic without going through HTTP.
+For fast, focused tests, call your procedures directly with `call` or use `createTestCaller` from `@orpc/server/testing`. This lets you verify validation, middleware, and handler logic without going through HTTP.
+
+### One-Off Procedure Calls
+
+Use `call` to invoke a procedure directly with optional context:
 
 ```ts
 import { call } from '@orpc/server'
@@ -19,6 +23,78 @@ it('lists planets', async () => {
   ])
 })
 ```
+
+### Test Callers (`createTestCaller`)
+
+When procedures require initial context (e.g. database connections or session state), `createTestCaller` binds context once for your test suite without repeating boilerplate on every call.
+
+<CodeGroup>
+
+```ts title="Static Context"
+import { createTestCaller } from '@orpc/server/testing'
+
+const listPlanets = createTestCaller(router.planet.list, {
+  context: {
+    db: mockDatabase,
+  },
+})
+
+it('lists planets with static context', async () => {
+  const planets = await listPlanets({ page: 1, size: 10 })
+  expect(planets).toHaveLength(2)
+})
+```
+
+```ts title="Dynamic Context"
+import { createTestCaller } from '@orpc/server/testing'
+
+const createPlanet = createTestCaller(router.planet.create, {
+  context: () => ({
+    requestId: crypto.randomUUID(), // Dynamic fresh UUID per call!
+    db: mockDatabase,
+  }),
+})
+
+it('creates planets with dynamic request IDs', async () => {
+  await createPlanet({ name: 'Earth' })
+  await createPlanet({ name: 'Mars' })
+})
+```
+
+```ts title="Per-Call Override"
+const getPlanet = createTestCaller(router.planet.find, {
+  context: { db: defaultMockDb },
+})
+
+it('overrides context for a single call', async () => {
+  // Uses default mock DB
+  await getPlanet({ id: 'earth' })
+
+  // Override context ONLY for this call
+  await getPlanet(
+    { id: 'mars' },
+    { context: { db: readOnlyMockDb } }
+  )
+})
+```
+
+```ts Global
+import { configureTestCaller, createTestCaller } from '@orpc/server/testing'
+
+// Set global test context in test setup file (e.g., vitest.setup.ts)
+configureTestCaller({
+  context: () => ({
+    db: testDatabaseInstance,
+  }),
+})
+
+it('inherits suite-wide context automatically', async () => {
+  const listPlanets = createTestCaller(router.planet.list)
+  await listPlanets({ page: 1 })
+})
+```
+
+</CodeGroup>
 
 :::info
 For a production-like test setup, create [fetch-based internal clients](/docs/best-practices/optimizing-ssr#implementation).

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -83,6 +83,11 @@
         "types": "./dist/extensions/callable.d.mts",
         "import": "./dist/extensions/callable.mjs",
         "default": "./dist/extensions/callable.mjs"
+      },
+      "./testing": {
+        "types": "./dist/testing/index.d.mts",
+        "import": "./dist/testing/index.mjs",
+        "default": "./dist/testing/index.mjs"
       }
     }
   },
@@ -100,7 +105,8 @@
     "./websocket": "./src/adapters/websocket/index.ts",
     "./message-port": "./src/adapters/message-port/index.ts",
     "./crossws": "./src/adapters/crossws/index.ts",
-    "./extensions/callable": "./src/extensions/callable.ts"
+    "./extensions/callable": "./src/extensions/callable.ts",
+    "./testing": "./src/testing/index.ts"
   },
   "files": [
     "dist"

--- a/packages/server/src/testing/index.ts
+++ b/packages/server/src/testing/index.ts
@@ -1,0 +1,1 @@
+export * from './test-caller'

--- a/packages/server/src/testing/test-caller.test.ts
+++ b/packages/server/src/testing/test-caller.test.ts
@@ -1,0 +1,91 @@
+import * as z from 'zod'
+import { os } from '../builder'
+import { configureTestCaller, createTestCaller } from './test-caller'
+
+interface PingContext {
+  db?: string
+  globalDb?: string
+}
+
+interface TenantContext {
+  tenantId: string
+  db: string
+}
+
+describe('createTestCaller', () => {
+  const pingBase = os.$context<PingContext>()
+  const pingProcedure = pingBase
+    .input(z.object({ name: z.string() }))
+    .handler(async ({ input, context }) => ({
+      message: `Hello ${input.name}`,
+      context,
+    }))
+
+  const tenantBase = os.$context<TenantContext>()
+  const tenantProcedure = tenantBase
+    .input(z.object({ theme: z.string() }))
+    .handler(async ({ input, context }) => ({
+      activeTenantId: context.tenantId,
+      theme: input.theme,
+      db: context.db,
+    }))
+
+  it('supports static context mode', async () => {
+    const caller = createTestCaller(pingProcedure, {
+      context: { db: 'mock-db' },
+    })
+
+    const result = await caller({ name: 'World' })
+    expect(result.message).toBe('Hello World')
+    expect(result.context).toEqual({ db: 'mock-db' })
+  })
+
+  it('supports dynamic context factory function', async () => {
+    let callCounter = 0
+    const caller = createTestCaller(tenantProcedure, {
+      context: () => {
+        callCounter++
+        return {
+          tenantId: `tenant-${callCounter}`,
+          db: `db-${callCounter}`,
+        }
+      },
+    })
+
+    const res1 = await caller({ theme: 'dark' })
+    expect(res1.activeTenantId).toBe('tenant-1')
+    expect(res1.db).toBe('db-1')
+
+    const res2 = await caller({ theme: 'light' })
+    expect(res2.activeTenantId).toBe('tenant-2')
+    expect(res2.db).toBe('db-2')
+  })
+
+  it('supports per-call context overrides', async () => {
+    const caller = createTestCaller(pingProcedure, {
+      context: { db: 'default-db' },
+    })
+
+    const res1 = await caller({ name: 'Default' })
+    expect(res1.context).toEqual({ db: 'default-db' })
+
+    const res2 = await caller(
+      { name: 'Overridden' },
+      { context: { db: 'custom-db' } },
+    )
+    expect(res2.context).toEqual({ db: 'custom-db' })
+  })
+
+  it('supports suite-wide global test context', async () => {
+    configureTestCaller({
+      context: () => ({
+        globalDb: 'postgres-test',
+      }),
+    })
+
+    const caller = createTestCaller(pingProcedure)
+    const result = await caller({ name: 'Suite' })
+
+    expect(result.context.globalDb).toBe('postgres-test')
+  })
+})

--- a/packages/server/src/testing/test-caller.test.ts
+++ b/packages/server/src/testing/test-caller.test.ts
@@ -30,6 +30,10 @@ describe('createTestCaller', () => {
       db: context.db,
     }))
 
+  afterEach(() => {
+    configureTestCaller({ context: undefined })
+  })
+
   it('supports static context mode', async () => {
     const caller = createTestCaller(pingProcedure, {
       context: { db: 'mock-db' },

--- a/packages/server/src/testing/test-caller.test.ts
+++ b/packages/server/src/testing/test-caller.test.ts
@@ -88,4 +88,18 @@ describe('createTestCaller', () => {
 
     expect(result.context.globalDb).toBe('postgres-test')
   })
+
+  it('supports partial context overrides', async () => {
+    const caller = createTestCaller(tenantProcedure, {
+      context: { tenantId: 'tenant-partial' },
+    })
+
+    const res = await caller(
+      { theme: 'dark' },
+      { context: { db: 'db-partial' } },
+    )
+
+    expect(res.activeTenantId).toBe('tenant-partial')
+    expect(res.db).toBe('db-partial')
+  })
 })

--- a/packages/server/src/testing/test-caller.ts
+++ b/packages/server/src/testing/test-caller.ts
@@ -1,0 +1,62 @@
+import type { AnyORPCError } from '@orpc/client'
+import type { AnySchema, ErrorMap, InferSchemaInput, InferSchemaOutput } from '@orpc/contract'
+import type { Promisable, Value } from '@orpc/shared'
+import type { Context } from '../context'
+import type { Lazyable } from '../lazy'
+import type { Procedure } from '../procedure'
+import { value } from '@orpc/shared'
+import { createProcedureClient } from '../procedure-client'
+
+export type TestContextOption<TInitialContext extends Context> = Value<Promisable<TInitialContext>>
+
+export interface TestCallerOptions<TInitialContext extends Context> {
+  context?: TestContextOption<TInitialContext>
+}
+
+export interface TestInvocationOptions<TInitialContext extends Context> {
+  context?: Partial<TInitialContext>
+}
+
+let globalTestContext: TestContextOption<Context> | undefined
+
+/**
+ * Configure global/suite-wide test context defaults.
+ */
+export function configureTestCaller(options: { context?: TestContextOption<Context> }): void {
+  globalTestContext = options.context
+}
+
+/**
+ * Create a typed test procedure caller supporting static context, dynamic context factories,
+ * per-call context overrides, and suite-wide context defaults.
+ */
+export function createTestCaller<
+  TInitialContext extends Context,
+  TInputSchema extends AnySchema,
+  TOutputSchema extends AnySchema,
+  TErrorMap extends ErrorMap,
+  TReturnedError extends AnyORPCError,
+>(
+  procedure: Lazyable<Procedure<TInitialContext, any, TInputSchema, TOutputSchema, TErrorMap, TReturnedError>>,
+  callerOptions?: TestCallerOptions<TInitialContext>,
+) {
+  return async (
+    input: InferSchemaInput<TInputSchema>,
+    invocationOptions?: TestInvocationOptions<TInitialContext>,
+  ): Promise<InferSchemaOutput<TOutputSchema>> => {
+    const globalCtx = globalTestContext ? await value(globalTestContext) : undefined
+    const callerCtx = callerOptions?.context ? await value(callerOptions.context) : undefined
+
+    const finalContext = {
+      ...globalCtx,
+      ...callerCtx,
+      ...invocationOptions?.context,
+    } as TInitialContext
+
+    const client = createProcedureClient(procedure, {
+      context: finalContext,
+    })
+
+    return await client(input)
+  }
+}

--- a/packages/server/src/testing/test-caller.ts
+++ b/packages/server/src/testing/test-caller.ts
@@ -21,14 +21,19 @@ let globalTestContext: TestContextOption<Context> | undefined
 
 /**
  * Configure global/suite-wide test context defaults.
+ * Pass `{ context: undefined }` or call without arguments to reset global test context defaults.
+ *
+ * @see {@link https://orpc.dev/docs/advanced/testing-and-mocking#test-callers-createtestcaller | Testing and Mocking - Test Callers (createTestCaller)}
  */
-export function configureTestCaller(options: { context?: TestContextOption<Context> }): void {
-  globalTestContext = options.context
+export function configureTestCaller(options?: { context?: TestContextOption<Context> }): void {
+  globalTestContext = options?.context
 }
 
 /**
  * Create a typed test procedure caller supporting static context, dynamic context factories,
  * per-call context overrides, and suite-wide context defaults.
+ *
+ * @see {@link https://orpc.dev/docs/advanced/testing-and-mocking#test-callers-createtestcaller | Testing and Mocking - Test Callers (createTestCaller)}
  */
 export function createTestCaller<
   TInitialContext extends Context,

--- a/packages/server/src/testing/test-caller.ts
+++ b/packages/server/src/testing/test-caller.ts
@@ -7,7 +7,7 @@ import type { Procedure } from '../procedure'
 import { value } from '@orpc/shared'
 import { createProcedureClient } from '../procedure-client'
 
-export type TestContextOption<TInitialContext extends Context> = Value<Promisable<TInitialContext>>
+export type TestContextOption<TInitialContext extends Context = Context> = Value<Promisable<Partial<TInitialContext>>>
 
 export interface TestCallerOptions<TInitialContext extends Context> {
   context?: TestContextOption<TInitialContext>
@@ -47,11 +47,12 @@ export function createTestCaller<
     const globalCtx = globalTestContext ? await value(globalTestContext) : undefined
     const callerCtx = callerOptions?.context ? await value(callerOptions.context) : undefined
 
-    const finalContext = {
-      ...globalCtx,
-      ...callerCtx,
-      ...invocationOptions?.context,
-    } as TInitialContext
+    const finalContext = Object.assign(
+      {},
+      globalCtx,
+      callerCtx,
+      invocationOptions?.context,
+    ) as TInitialContext
 
     const client = createProcedureClient(procedure, {
       context: finalContext,


### PR DESCRIPTION
## Summary

Adds `@orpc/server/testing` exporting `createTestCaller` and `configureTestCaller` to eliminate initial context boilerplate in procedure tests.

- **Static & Dynamic Context**: Supports static objects `{ db }` and dynamic factories `() => Context`.
- **3-Tier Context Merging**: Merges global (`configureTestCaller`) → caller (`createTestCaller`) → per-call (`caller(input, { context })`) partial contexts via `Object.assign`.

## Changes

- `packages/server/src/testing/`: Added `createTestCaller` implementation and Vitest test suite.
- `packages/server/package.json`: Registered `./testing` subpath export.
- `apps/content/docs/advanced/testing-and-mocking.mdx`: Updated testing documentation with `<CodeGroup>` guides.