### PR TITLE
chore(content): stop the landing page zooming out on mobile

### DIFF
--- a/apps/content/theme.css
+++ b/apps/content/theme.css
@@ -744,6 +744,14 @@ body > aside[data-blume-nav-drawer]:not([data-orpc-drawer]) {
    browser default is a chunky arrow-ended bar that reads as a page-level
    overflow rather than a region you can swipe. */
 .orpc-scroller {
+  /* Also the containing block for anything absolutely positioned inside.
+     Overflow never clips an abs-pos descendant whose containing block sits
+     outside the scroller, so the comparison table's `.sr-only` cells (Tailwind
+     makes them position: absolute) escaped it at the far right of the table and
+     stretched the document ~130px past the viewport. Mobile browsers shrink the
+     page to fit that width, which zoomed the whole landing page out and left a
+     blank band down the right edge. */
+  position: relative;
   scrollbar-color: var(--blume-border) transparent;
   scrollbar-width: thin;
 }


### PR DESCRIPTION
The landing page rendered zoomed out on phones, with a blank band down the right edge. Its document measured 503px wide on a 375px viewport, so mobile browsers shrank the whole page to ~0.75 to fit content that was never visible.

The cause is the comparison table's `.sr-only` cells. Tailwind makes them `position: absolute`, and an overflow container never clips an absolutely positioned descendant whose containing block sits outside it. With no positioned ancestor they resolved against `<body>` and parked at the far right of the 506px-wide table, past the viewport. Making the scroll wrapper their containing block clips them with the rest of the table.

## Fixes

- The landing page fills the viewport at its normal scale on mobile again; no horizontal page scroll and no blank band.
- The comparison table still scrolls horizontally inside its own region, and the screen-reader labels for the ✅/🟡/🛑 markers are unchanged.

## Testing

Measured on the local dev server at 375x812 and 320x700: `documentElement.scrollWidth` equals `clientWidth` and the visual viewport scale is 1.0. Reverting the wrapper to `position: static` in the same page reproduces 503px, confirming the cause. Swiping the table to its right end leaves the page itself unmoved. `/docs/comparison` at mobile is unaffected, and there are no console errors.