### PR TITLE
docs: fill in the ecosystem page with orpc-mcp

### DIFF
--- a/apps/content/docs/ecosystem.mdx
+++ b/apps/content/docs/ecosystem.mdx
@@ -5,4 +5,10 @@ sidebar:
   icon: network
 ---
 
-// TODO
+:::info
+Built something on top of oRPC? [Open a pull request](https://github.com/middleapi/orpc/edit/main/apps/content/docs/ecosystem.mdx) to add it here. These packages are maintained by their authors, not by the oRPC core team, so report issues in their own repositories.
+:::
+
+## AI
+
+<GithubInfo owner="mi3lix9" repo="orpc-mcp" />


### PR DESCRIPTION
The ecosystem page was an empty `// TODO` stub while already being linked from the docs sidebar and the home footer. It now has content: an invitation to submit community packages and a first entry, [orpc-mcp](https://github.com/mi3lix9/orpc-mcp), which serves an oRPC router as an MCP server.

Entries are grouped by category (`## AI` for now) and rendered with Blume's `GithubInfo` component, so each card carries the repository's own description plus live star and fork counts fetched at build time. No hand-written per-package blurbs to keep in sync.

## Notes

- The intro callout links to the GitHub edit URL so authors can add their own package in one click.
- Ownership is stated up front: these packages are maintained by their authors, not the oRPC core team.