### PR TITLE
docs: remove duplicate Next.js playground row

### DIFF
--- a/apps/content/docs/playgrounds.mdx
+++ b/apps/content/docs/playgrounds.mdx
@@ -13,7 +13,6 @@ sidebar:
 | Cloudflare Playground | [Open in StackBlitz](https://stackblitz.com/github/middleapi/orpc/tree/main/playgrounds/cloudflare) | [View Source](https://github.com/middleapi/orpc/tree/main/playgrounds/cloudflare) |
 | NestJS Playground     | [Open in StackBlitz](https://stackblitz.com/github/middleapi/orpc/tree/main/playgrounds/nest)       | [View Source](https://github.com/middleapi/orpc/tree/main/playgrounds/nest)       |
 | Next.js Playground    | [Open in StackBlitz](https://stackblitz.com/github/middleapi/orpc/tree/main/playgrounds/next)       | [View Source](https://github.com/middleapi/orpc/tree/main/playgrounds/next)       |
-| Next.js Playground    | [Open in StackBlitz](https://stackblitz.com/github/middleapi/orpc/tree/main/playgrounds/next)       | [View Source](https://github.com/middleapi/orpc/tree/main/playgrounds/next)       |
 | Expo Playground       | [Open in StackBlitz](https://stackblitz.com/github/middleapi/orpc-expo-playground)                  | [View Source](https://github.com/middleapi/orpc-expo-playground)                  |
 
 :::warning


### PR DESCRIPTION
The playgrounds table listed the Next.js playground twice with identical links. Readers now see each playground exactly once.

## Fixes

- Deleted the repeated Next.js row from the Available Playgrounds table in `apps/content/docs/playgrounds.mdx`.

The table now lists Bun, Cloudflare, NestJS, Next.js, and Expo once each, matching the `playgrounds/` directory plus the external Expo repo. The `giget` command list below the table was already correct and is unchanged.