### PR TITLE
refactor(client,contract,openapi): drop single-use error subclasses and name ValidationError

### DIFF
--- a/packages/client/src/plugins/batch.ts
+++ b/packages/client/src/plugins/batch.ts
@@ -31,8 +31,6 @@ export interface BatchLinkPluginGroup<T extends ClientContext> {
   path?: Value<string[], [items: [StandardLinkTransportInterceptorOptions<T>, ...StandardLinkTransportInterceptorOptions<T>[]]]>
 }
 
-export class BatchLinkPluginError extends TypeError {}
-
 export interface BatchLinkPluginOptions<T extends ClientContext> {
   groups: [BatchLinkPluginGroup<T>, ...BatchLinkPluginGroup<T>[]]
 
@@ -334,10 +332,10 @@ export class BatchLinkPlugin<T extends ClientContext> implements StandardLinkPlu
               await decodeLengthPrefixedStream(body, peer)
             }
             else {
-              throw new BatchLinkPluginError('Invalid batch response format.')
+              throw new TypeError('Invalid batch response format.')
             }
 
-            await peer.close(new BatchLinkPluginError('Batch response is incomplete.'))
+            await peer.close(new TypeError('Batch response is incomplete.'))
           }
           catch (error) {
             await peer.close(error)
@@ -365,7 +363,7 @@ async function decodeLengthPrefixedBlob(blob: Blob, peer: ClientPeer): Promise<v
 
   while (offset < buffer.length) {
     if (offset + 4 > buffer.length) {
-      throw new BatchLinkPluginError('Invalid batch response: incomplete length header.')
+      throw new TypeError('Invalid batch response: incomplete length header.')
     }
 
     const view = new DataView(buffer.buffer, buffer.byteOffset + offset, 4)
@@ -373,7 +371,7 @@ async function decodeLengthPrefixedBlob(blob: Blob, peer: ClientPeer): Promise<v
     offset += 4
 
     if (offset + length > buffer.length) {
-      throw new BatchLinkPluginError('Invalid batch response: incomplete message.')
+      throw new TypeError('Invalid batch response: incomplete message.')
     }
 
     const messageBytes = buffer.subarray(offset, offset + length)
@@ -381,7 +379,7 @@ async function decodeLengthPrefixedBlob(blob: Blob, peer: ClientPeer): Promise<v
 
     const result = decodePeerMessage(messageBytes)
     if (!result.matched || !isServerPeerSendMessage(result.message)) {
-      throw new BatchLinkPluginError('Invalid batch response: invalid message.')
+      throw new TypeError('Invalid batch response: invalid message.')
     }
 
     await peer.message(result.message)
@@ -423,7 +421,7 @@ async function decodeLengthPrefixedStream(stream: ReadableStream<Uint8Array>, pe
         const result = decodePeerMessage(messageBytes)
 
         if (!result.matched || !isServerPeerSendMessage(result.message)) {
-          throw new BatchLinkPluginError('Invalid batch response: invalid message.')
+          throw new TypeError('Invalid batch response: invalid message.')
         }
 
         await peer.message(result.message)

--- a/packages/contract/src/error.ts
+++ b/packages/contract/src/error.ts
@@ -46,6 +46,8 @@ export interface ValidationErrorOptions extends ErrorOptions {
  * @see {@link https://orpc.dev/docs/advanced/validation-customization | Validation Customization}
  */
 export class ValidationError extends Error {
+  override name: string = 'ValidationError'
+
   /**
    * This array is readonly because the upstream Standard Schema returns readonly issues.
    */

--- a/packages/openapi/src/adapters/standard/openapi-link-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-link-codec.ts
@@ -20,8 +20,6 @@ import { OpenAPISerializer } from '../../openapi-serializer'
 import { getDynamicPathParams, isBodylessMethod } from '../../utils'
 import { serializeHeaders } from './utils'
 
-export class OpenAPILinkCodecError extends TypeError {}
-
 export interface OpenAPILinkCodecOptions<T extends ClientContext> {
   /**
    * Base URL for all requests, without origin. Should match the OpenAPI handler mount path.
@@ -94,7 +92,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
 
       if (dynamicParams?.length) {
         if (!isTypescriptObject(input)) {
-          throw new OpenAPILinkCodecError(
+          throw new TypeError(
             `Input must be an object with "compact" input structure when the path has dynamic params (${dynamicParams.map(p => p.parameterName).join(', ')}) in call to procedure (${path.join('.')}).`,
           )
         }
@@ -139,7 +137,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
     }
 
     if (!isValidDetailedInput(input)) {
-      throw new OpenAPILinkCodecError(`
+      throw new TypeError(`
         Invalid "detailed" input structure in call to procedure (${path.join('.')}):
         • Expected an object or undefined with optional properties:
           - params (object, required when the path has dynamic params)
@@ -154,7 +152,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
 
     if (dynamicParams?.length) {
       if (!input?.params) {
-        throw new OpenAPILinkCodecError(
+        throw new TypeError(
           `The "params" property is required for "detailed" input when the path has dynamic params (${dynamicParams.map(p => p.parameterName).join(', ')}) in call to procedure (${path.join('.')}).`,
         )
       }
@@ -231,7 +229,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
     }
 
     if (!encoded) {
-      throw new OpenAPILinkCodecError(`Path param "${param.parameterName}" cannot be empty in call to procedure (${path.join('.')}).`)
+      throw new TypeError(`Path param "${param.parameterName}" cannot be empty in call to procedure (${path.join('.')}).`)
     }
 
     return encoded
@@ -434,7 +432,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
     const { default: maybeProcedure } = await unlazy(getRouterContract(this.router, path))
 
     if (!(maybeProcedure instanceof ProcedureContract)) {
-      throw new OpenAPILinkCodecError(`Expected a procedure or contract at path (${path.join('.')})`)
+      throw new TypeError(`Expected a procedure or contract at path (${path.join('.')})`)
     }
 
     return maybeProcedure


### PR DESCRIPTION
Removes the single-use \`BatchLinkPluginError\` and \`OpenAPILinkCodecError\` subclasses in favor of plain \`TypeError\`, and gives \`ValidationError\` its own \`name\` so it no longer reports as a generic \`Error\`.

## Changes

- \`ValidationError\` instances now report \`name: 'ValidationError'\` instead of the default \`Error\`, matching how \`ORPCError\` already identifies itself.
- \`BatchLinkPluginError\` and \`OpenAPILinkCodecError\` added no behavior over \`TypeError\` and are removed from the public surface; the same errors are now thrown as plain \`TypeError\` with unchanged messages. Meaningful error classes (\`ORPCError\`, \`ValidationError\`, \`OpenAPIGeneratorError\`) are unaffected.

## Breaking

- \`BatchLinkPluginError\` (\`@orpc/client\`) and \`OpenAPILinkCodecError\` (\`@orpc/openapi\`) are no longer exported. Code catching them via \`instanceof\` should match \`TypeError\` instead.

## Testing

- All tests covering the changed files pass, and \`pnpm type:check\` is clean across the monorepo; no remaining references to the removed classes exist in packages, docs, tests, or playgrounds.