### PR TITLE
chore(content): add the docs page rail to blog posts

### DIFF
--- a/apps/content/pages/blog/[...slug].astro
+++ b/apps/content/pages/blog/[...slug].astro
@@ -1,8 +1,11 @@
 ---
-import { getCollection } from 'astro:content'
+import { getCollection, render } from 'astro:content'
 import BlumePage from 'blume/components/BlumePage.astro'
+import { withBase } from 'blume/components/islands/base-path.ts'
+import PageActions from 'blume/components/layout/PageActions.astro'
 import PageLayout from 'blume/components/layout/PageLayout.astro'
 import data from 'blume:data'
+import TableOfContents from '../../components/blume/TableOfContents.astro'
 import SponsorSlot from '../../sponsors/SponsorSlot.astro'
 
 export const prerender = true
@@ -46,7 +49,18 @@ export async function getStaticPaths() {
 }
 
 const { entry, route } = Astro.props
-const { config } = data
+const { config, ui } = data
+
+// Headings for the "On this page" rail. The compiled module is import-cached,
+// so BlumePage rendering the same entry below costs nothing extra.
+const { headings } = await render(entry)
+const tocHeadings = config.toc.enabled
+  ? headings.filter(h => h.depth >= config.toc.minLevel && h.depth <= config.toc.maxLevel)
+  : []
+// The install menu needs an absolute URL, so it only shows with a site set.
+const mcpUrl = config.mcp && config.site
+  ? new URL(withBase(config.mcp.route), config.site).href
+  : null
 
 const authors = normalizeAuthors(entry.data.authors)
 const tags = entry.data.search?.tags ?? []
@@ -99,82 +113,125 @@ const postJsonLd = {
     type="application/ld+json"
     set:html={JSON.stringify(postJsonLd).replaceAll('<', '\\u003c')}
   />
-  <article class="mx-auto w-full max-w-3xl px-6 py-12">
-    <a
-      href="/blog"
-      class="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
-    >
-      <svg
-        width="14"
-        height="14"
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
+  {/*
+    The docs frame: theme.css centers `[data-blume-doc-grid]` on the header
+    width and, from 96rem, sizes any grid whose class carries `xl:grid-cols-`.
+    The nav column stays empty here, which keeps the article centered opposite
+    the table of contents.
+  */}
+  <div
+    class="mx-auto grid grid-cols-1 items-start xl:grid-cols-[17.5rem_minmax(0,1fr)_17.5rem]"
+    data-blume-doc-grid
+  >
+    <article class="mx-auto w-full max-w-3xl px-6 py-12 xl:col-start-2">
+      <a
+        href="/blog"
+        class="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
       >
-        <path d="m12 19-7-7 7-7" />
-        <path d="M19 12H5" />
-      </svg>
-      All articles
-    </a>
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="m12 19-7-7 7-7" />
+          <path d="M19 12H5" />
+        </svg>
+        All articles
+      </a>
 
-    <header class="mt-10">
-      <p class="font-mono text-xs tracking-widest uppercase">
-        {tags.length > 0 && <span class="text-accent">{tags.join(', ')}</span>}
-        {tags.length > 0 && date && <span class="text-muted-foreground">{' / '}</span>}
-        {date && (
-          <time datetime={date.toISOString()} class="text-muted-foreground">
-            {dateFormat.format(date)}
-          </time>
-        )}
-        <span class="text-muted-foreground">
-          {' / '}
-          {minutes} min read
-        </span>
-      </p>
-      <h1 class="font-display mt-4 text-3xl font-bold tracking-tight text-balance sm:text-4xl">
-        {entry.data.title}
-      </h1>
-      {authors.length > 0 && (
-        <div class="mt-6 flex flex-wrap items-center gap-6">
-          {authors.map(author => (
-            <span class="flex items-center gap-3">
-              {author.avatar && (
-                <img
-                  src={author.avatar}
-                  alt=""
-                  width="40"
-                  height="40"
-                  class="size-10 rounded-blume"
-                  data-no-zoom
-                />
-              )}
-              <span class="text-sm">
-                {author.url
-                  ? (
-                      <a href={author.url} class="block font-medium hover:underline">
-                        {author.name}
-                      </a>
-                    )
-                  : (
-                      <span class="block font-medium">{author.name}</span>
-                    )}
-                {author.role && (
-                  <span class="text-muted-foreground">{author.role}</span>
+      <header class="mt-10">
+        <p class="font-mono text-xs tracking-widest uppercase">
+          {tags.length > 0 && <span class="text-accent">{tags.join(', ')}</span>}
+          {tags.length > 0 && date && <span class="text-muted-foreground">{' / '}</span>}
+          {date && (
+            <time datetime={date.toISOString()} class="text-muted-foreground">
+              {dateFormat.format(date)}
+            </time>
+          )}
+          <span class="text-muted-foreground">
+            {' / '}
+            {minutes} min read
+          </span>
+        </p>
+        <h1 class="font-display mt-4 text-3xl font-bold tracking-tight text-balance sm:text-4xl">
+          {entry.data.title}
+        </h1>
+        {authors.length > 0 && (
+          <div class="mt-6 flex flex-wrap items-center gap-6">
+            {authors.map(author => (
+              <span class="flex items-center gap-3">
+                {author.avatar && (
+                  <img
+                    src={author.avatar}
+                    alt=""
+                    width="40"
+                    height="40"
+                    class="size-10 rounded-blume"
+                    data-no-zoom
+                  />
                 )}
+                <span class="text-sm">
+                  {author.url
+                    ? (
+                        <a href={author.url} class="block font-medium hover:underline">
+                          {author.name}
+                        </a>
+                      )
+                    : (
+                        <span class="block font-medium">{author.name}</span>
+                      )}
+                  {author.role && (
+                    <span class="text-muted-foreground">{author.role}</span>
+                  )}
+                </span>
               </span>
-            </span>
-          ))}
-        </div>
-      )}
-    </header>
+            ))}
+          </div>
+        )}
+      </header>
 
-    <hr class="my-8 border-border" />
+      <hr class="my-8 border-border" />
 
-    <div class="prose max-w-none">
-      <BlumePage id={route.entryId} components={{ SponsorSlot }} />
-    </div>
-  </article>
+      {/* The collapsible is sized for the docs prose column; widen it to this
+          article's own measure. */}
+      <div class="[&>details]:max-w-none">
+        <TableOfContents headings={tocHeadings} title={ui.toc.title} variant="mobile" />
+      </div>
+
+      <div class="prose max-w-none">
+        <BlumePage id={route.entryId} components={{ SponsorSlot }} />
+      </div>
+    </article>
+
+    {/* theme.css owns the rail's visibility and vertical metrics (it only
+        appears once the three-column frame fits); the rest is styling. */}
+    <aside
+      aria-label={ui.toc.title}
+      class="sticky overflow-y-auto scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent px-4 pb-10 text-sm xl:col-start-3"
+      data-blume-toc
+    >
+      <TableOfContents headings={tocHeadings} title={ui.toc.title} variant="desktop" />
+      {/* `export` isn't part of `blume:data`, so the PDF/EPUB actions mirror
+          the `export: true` in blume.config.ts by hand. */}
+      <PageActions
+        editUrl={route.editUrl}
+        exportEpub
+        exportPdf
+        mcpName={config.mcp?.name}
+        mcpUrl={mcpUrl}
+        route={route.path}
+        strings={ui.actions}
+      />
+    </aside>
+  </div>
+  <script>
+    // Scrollspy for the <blume-toc> lists; RootLayout registers it for docs
+    // pages, but PageLayout ships no page scripts of its own.
+    import 'blume/components/layout/toc-element.ts'
+  </script>
 </PageLayout>


### PR DESCRIPTION
Blog detail pages were the only content pages without the "On this page" rail, so a long post like the v1 announcement gave readers no way to jump between sections. They now render the same rail the docs pages do: the table of contents on wide viewports, the collapsible variant above the content on narrow ones, and the page actions below it (Edit on GitHub, Scroll to top, Copy as Markdown, Export, Open in chat, Connect to MCP).

The blog page is a custom page on Blume's `PageLayout`, which ships chrome only and resolves no layout slots, so the rail is assembled in the page itself, matching what `RootLayout` renders for docs. The article keeps its own measure and stays centred, with the nav column of the docs grid left empty.

## Fixes

- Headings, scrollspy, and every page action work on blog posts exactly as they do on docs pages; the raw-markdown and MCP links resolve to the post.
- The collapsible table of contents matches the article's width instead of the narrower docs prose column.

## Testing

Verified against the dev server at 1920px (rail renders with all seven headings and all six actions, article centred, scrollspy tracks the section in view, the Export/chat/MCP popovers open inside the rail), at 1000px (collapsible aligns with the prose), and at 390px (collapsible spans the article, expands, no horizontal overflow).
