### PR TITLE
fix(client): forward error batch responses instead of parsing them

### DIFF
--- a/packages/client/src/plugins/batch.test.ts
+++ b/packages/client/src/plugins/batch.test.ts
@@ -844,6 +844,76 @@ describe('batchLinkPlugin', () => {
     })
   })
 
+  describe('error batch responses', () => {
+    it.each(['buffered', 'streaming'] as const)('forwards %s batch responses with status >= 400 to every subrequest', async (mode) => {
+      const codec = makeCodec()
+      const transport = makeTransport()
+
+      vi.mocked(transport.send).mockImplementation(async () => {
+        return {
+          status: 502,
+          headers: { 'x-error': 'gateway' },
+          resolveBody: async () => 'Bad Gateway',
+        }
+      })
+
+      const link = new StandardLink(codec, transport, {
+        plugins: [new BatchLinkPlugin({ groups: [defaultGroup], mode })],
+      })
+
+      await Promise.all([
+        expect(link.call(['a'], {}, { context: {} })).resolves.toBe('Bad Gateway'),
+        expect(link.call(['b'], {}, { context: {} })).resolves.toBe('Bad Gateway'),
+      ])
+
+      expect(codec.decodeResponse).toHaveBeenCalledTimes(2)
+      expect(vi.mocked(codec.decodeResponse).mock.calls[0]![0]).toMatchObject({
+        status: 502,
+        headers: { 'x-error': 'gateway' },
+      })
+      expect(vi.mocked(codec.decodeResponse).mock.calls[1]![0]).toMatchObject({
+        status: 502,
+        headers: { 'x-error': 'gateway' },
+      })
+    })
+
+    it('resolves the error response body only once for all subrequests', async () => {
+      const codec = makeCodec()
+      const transport = makeTransport()
+      const resolveBody = vi.fn(async () => 'Bad Gateway')
+
+      vi.mocked(transport.send).mockImplementation(async () => {
+        return { status: 502, headers: {}, resolveBody }
+      })
+
+      const link = new StandardLink(codec, transport, {
+        plugins: [new BatchLinkPlugin({ groups: [defaultGroup], mode: 'buffered' })],
+      })
+
+      await Promise.all([
+        expect(link.call(['a'], {}, { context: {} })).resolves.toBe('Bad Gateway'),
+        expect(link.call(['b'], {}, { context: {} })).resolves.toBe('Bad Gateway'),
+      ])
+
+      expect(transport.send).toHaveBeenCalledTimes(1)
+      expect(resolveBody).toHaveBeenCalledTimes(1)
+    })
+
+    it('still parses batch responses with status < 400', async () => {
+      const codec = makeCodec()
+      const transport = makeTransport()
+
+      const link = new StandardLink(codec, transport, {
+        plugins: [new BatchLinkPlugin({ groups: [defaultGroup], mode: 'buffered' })],
+      })
+
+      await Promise.all([
+        expect(link.call(['a'], {}, { context: {} })).resolves.toBe('result-0'),
+        expect(link.call(['b'], {}, { context: {} })).resolves.toBe('result-1'),
+      ])
+    })
+  })
+
   describe('method GET batch URL handling', () => {
     it('splits GET batches when URL exceeds maxUrlLength', async () => {
       const codec = makeCodec()

--- a/packages/client/src/plugins/batch.ts
+++ b/packages/client/src/plugins/batch.ts
@@ -3,7 +3,7 @@ import type { StandardHeaders, StandardLazyResponse, StandardRequest, StandardUr
 import type { ClientPeerSendMessage } from '@standardserver/peer'
 import type { StandardLinkOptions, StandardLinkPlugin, StandardLinkTransportInterceptor, StandardLinkTransportInterceptorOptions } from '../adapters/standard'
 import type { ClientContext } from '../types'
-import { defer, isAsyncIteratorObject, loadBytes, splitInHalf, stringifyJSON, toArray, value } from '@orpc/shared'
+import { defer, isAsyncIteratorObject, loadBytes, once, splitInHalf, stringifyJSON, toArray, value } from '@orpc/shared'
 import { parseStandardUrl } from '@standardserver/core'
 import { ClientPeer, decodePeerMessage, isServerPeerSendMessage } from '@standardserver/peer'
 
@@ -317,6 +317,25 @@ export class BatchLinkPlugin<T extends ClientContext> implements StandardLinkPlu
               request,
               signal: controller.signal,
             })
+
+            /**
+             * An error response is not a batch response, so forward it as-is to every subrequest
+             * instead of failing to parse it.
+             */
+            if (batchResponse.status >= 400) {
+              suppressErrorFromCurrentBatch = true
+
+              const resolveBody = once(() => batchResponse.resolveBody())
+              const errorResponse: StandardLazyResponse = { ...batchResponse, resolveBody }
+
+              groupItems.forEach(([subOptions, resolve]) => {
+                resolve(this.mapSubresponse(errorResponse, batchResponse, subOptions))
+              })
+
+              await peer.close()
+
+              return
+            }
 
             const body = await batchResponse.resolveBody()
 


### PR DESCRIPTION
The batch link plugin tried to decode every batch response as a batch payload, including ones that clearly are not. A 404 on the batch endpoint, a 502 from a proxy, or an auth rejection all surfaced to every call in the batch as `Invalid batch response format.`, hiding the real status, headers, and body.

Batch responses with status >= 400 are now forwarded to each subrequest as-is, so the codec turns them into a proper `ORPCError` carrying the original status and body.

## Fixes

- Callers of a batched request now see the real error instead of `Invalid batch response format.`
- The error body is resolved once and shared across subresponses, so one-shot stream and blob bodies are not consumed twice.
- Responses with status < 400 decode as before.

## Testing

Forwarding is covered in both buffered and streaming modes, along with single body resolution and a regression check that successful batches still parse. `pnpm vitest run packages/client/src/plugins/batch.test.ts` passes (31 tests), as do `pnpm type:check` and lint.