### PR TITLE
fix(client): respect user-provided mapSubresponse in BatchLinkPlugin

### DIFF
--- a/packages/client/src/plugins/batch.test.ts
+++ b/packages/client/src/plugins/batch.test.ts
@@ -408,6 +408,49 @@ describe('batchLinkPlugin', () => {
       expect(subResponse2.headers['x-index']).toEqual('1')
     })
 
+    it('uses custom mapSubresponse and forwards its response to the caller', async () => {
+      const codec = makeCodec()
+      const transport = makeTransport()
+
+      vi.mocked(transport.send).mockImplementation(async (request) => {
+        const response = makeBufferedBatchResponseFromRequest(request)
+        return {
+          ...response,
+          headers: { ...response.headers, 'x-from-batch-response': 'true' },
+        }
+      })
+
+      const mapSubresponse = vi.fn((subResponse: StandardLazyResponse, batchResponse: StandardLazyResponse): StandardLazyResponse => ({
+        ...subResponse,
+        headers: {
+          ...subResponse.headers,
+          'x-mapped': 'true',
+          'x-batch-status': `${batchResponse.status}`,
+        },
+        resolveBody: async () => `mapped-${await subResponse.resolveBody()}`,
+      }))
+
+      const link = new StandardLink(codec, transport, {
+        plugins: [new BatchLinkPlugin({
+          groups: [defaultGroup],
+          mapSubresponse,
+        })],
+      })
+
+      await Promise.all([
+        expect(link.call(['a'], {}, { context: {} })).resolves.toBe('mapped-result-0'),
+        expect(link.call(['b'], {}, { context: {} })).resolves.toBe('mapped-result-1'),
+      ])
+
+      expect(mapSubresponse).toHaveBeenCalledTimes(2)
+
+      const subResponse1 = vi.mocked(codec.decodeResponse).mock.calls[0]![0]
+      expect(subResponse1.headers['x-mapped']).toEqual('true')
+      expect(subResponse1.headers['x-batch-status']).toEqual('207')
+      // the default merge of batch response headers is not applied anymore
+      expect(subResponse1.headers['x-from-batch-response']).toBeUndefined()
+    })
+
     it('separates GET and POST requests into distinct batches', async () => {
       const codec = makeCodec()
       const transport = makeTransport()

--- a/packages/client/src/plugins/batch.ts
+++ b/packages/client/src/plugins/batch.ts
@@ -161,7 +161,7 @@ export class BatchLinkPlugin<T extends ClientContext> implements StandardLinkPlu
         headers: subHeaders,
       }
     })
-    this.mapSubresponse = (subResponse, batchResponse) => {
+    this.mapSubresponse = options.mapSubresponse ?? ((subResponse, batchResponse) => {
       return {
         ...subResponse,
         headers: {
@@ -169,7 +169,7 @@ export class BatchLinkPlugin<T extends ClientContext> implements StandardLinkPlu
           ...subResponse.headers,
         },
       }
-    }
+    })
   }
 
   init(options: StandardLinkOptions<T>): StandardLinkOptions<T> {


### PR DESCRIPTION
A custom `mapSubresponse` passed to `BatchLinkPlugin` was silently ignored: the constructor assigned the built-in implementation unconditionally instead of using the `options.mapSubresponse ?? ...` fallback that every other option uses. Users who supplied the hook to rewrite sub-responses got the default header merge instead, with no error or warning.

## Fixes

A user-provided `mapSubresponse` now runs for every sub-request, and the response it returns (headers and body alike) is what reaches the caller. Behavior is unchanged when the option is omitted.

## Testing

New test in `packages/client/src/plugins/batch.test.ts` supplies a custom `mapSubresponse` that tags headers and rewrites the body, then asserts it is called once per sub-request, that its headers reach the codec, and that its body is what `link.call` resolves to. The batch response carries its own header so the test also confirms the default merge is replaced rather than layered on. The test fails on the unpatched plugin and passes with the fix.
