### PR TITLE
feat(server,contract,ai-sdk): merge stacked object input schemas

### DIFF
--- a/apps/content/docs/contract/procedure.mdx
+++ b/apps/content/docs/contract/procedure.mdx
@@ -42,19 +42,19 @@ Unlike a [procedure](/docs/procedure), a contract has no `.handler` chain. If yo
 
 ### Multiple Schemas
 
-`.input` and `.output` can be called multiple times. Each call adds another schema instead of replacing an earlier one.
+`.input` and `.output` can be called multiple times. Each call adds another schema instead of replacing an earlier one, and the value must satisfy all of them.
 
 ```ts
-const example = oc
-  .input(z.looseObject({ name: z.string() }))
-  .input(z.looseObject({ id: z.number() }))
+const base = oc
+  .input(z.object({ name: z.string() }))
   .output(z.looseObject({ name: z.string() }))
+
+const example = base
+  .input(z.object({ id: z.number() }))
   .output(z.looseObject({ id: z.number() }))
 ```
 
-:::warning
-When you stack schemas, the input or output must satisfy all of them, so the schemas need to be compatible. For example, with Zod, prefer `z.looseObject` over `z.object` to allow unknown properties.
-:::
+Object input schemas compose into a single flat value instead of being piped into each other, so a contract can extend a base contract without repeating its fields. Output schemas are still piped. Learn more in the [Procedure documentation](/docs/procedure#multiple-schemas).
 
 ### `type` Utility
 

--- a/apps/content/docs/migrations/from-v1.mdx
+++ b/apps/content/docs/migrations/from-v1.mdx
@@ -214,13 +214,13 @@ In v1, a procedure had at most one input and one output schema. In v2, each `.in
 
 ```ts
 const example = os
-  .input(z.looseObject({ name: z.string() }))
-  .input(z.looseObject({ id: z.number() })) // adds a second schema
+  .input(z.object({ name: z.string() }))
+  .input(z.object({ id: z.number() })) // adds a second schema
   .handler(async ({ input }) => {}) // input: { name: string } & { id: number }
 ```
 
-:::warning
-Use loose object schemas (like `z.looseObject`) when stacking, so one schema does not strip the keys another schema needs. `.$input` was removed along with this change.
+:::info
+Stacked object input schemas compose into a single flat value, so one schema never strips the keys another schema needs. Output schemas are piped, so use loose object schemas (like `z.looseObject`) when stacking them. `.$input` was removed along with this change.
 :::
 
 ### `.$config` options changed

--- a/apps/content/docs/openapi/routing.mdx
+++ b/apps/content/docs/openapi/routing.mdx
@@ -80,7 +80,7 @@ Prefixes can also include path parameters, but they must be defined as required 
 ```ts
 const base = os
   .meta(openapi({ prefix: '/{workspaceId}' }))
-  .input(z.looseObject({ workspaceId: z.string() }))
+  .input(z.object({ workspaceId: z.string() }))
   .use(({ next }, { workspaceId }) => {
     console.log('Workspace ID:', workspaceId)
     return next()
@@ -88,7 +88,7 @@ const base = os
 
 const procedure = base
   .meta(openapi({ method: 'GET', path: '/planets/{id}' }))
-  .input(z.looseObject({ id: z.string() }))
+  .input(z.object({ id: z.string() }))
   .handler(async ({ input }) => {
     console.log('Workspace ID:', input.workspaceId)
     console.log('Planet ID:', input.id)

--- a/apps/content/docs/procedure.mdx
+++ b/apps/content/docs/procedure.mdx
@@ -74,23 +74,23 @@ Every `.input` object schema validates the original input, then the results are 
 
 ```ts
 const base = os
-  .input(z.object({ name: z.string() }))
+  .input(z.object({ params: z.object({ id: z.string() }) }))
 
 const example = base
-  .input(z.object({ id: z.number() }))
+  .input(z.object({ params: z.object({ slug: z.string() }) }))
   .handler(async ({ input }) => {
-    // input is { name: string, id: number }
-    return { id: 1, name: 'example' }
+    // input is { params: { id: string, slug: string } }
+    return input
   })
 ```
 
 :::warning
-Only plain objects are merged, and only at the top level. Other values, like [`asyncIteratorObject`](/docs/async-iterator-object) or a `z.string()` transform, are piped: each schema validates what the previous one returned. Nested objects are not merged either, the last schema wins, so use `z.looseObject` when two schemas define the same one:
+Only plain objects are merged, and only for the first two levels. Deeper values and anything else, like [`asyncIteratorObject`](/docs/async-iterator-object) or a `z.string()` transform, are piped: each schema validates what the previous one returned. Use `z.looseObject` when two schemas define the same object deeper than that:
 
 ```ts
 const example = os
-  .input(z.object({ user: z.looseObject({ name: z.string() }) }))
-  .input(z.object({ user: z.looseObject({ age: z.number() }) }))
+  .input(z.object({ user: z.object({ address: z.looseObject({ city: z.string() }) }) }))
+  .input(z.object({ user: z.object({ address: z.looseObject({ zip: z.string() }) }) }))
 ```
 
 :::

--- a/apps/content/docs/procedure.mdx
+++ b/apps/content/docs/procedure.mdx
@@ -68,22 +68,45 @@ By specifying `.output` or the handler's return type, TypeScript can infer the o
 
 ### Multiple Schemas
 
-`.input` and `.output` can be called multiple times. Each call adds another schema instead of replacing an earlier one.
+`.input` and `.output` can be called multiple times. Each call adds a schema instead of replacing the previous one, and the value must pass all of them.
+
+Every `.input` object schema validates the original input, then the results are merged. This lets you extend a base procedure without repeating its fields. Fields that no schema defines are dropped. [Middleware](/docs/middleware) sees the fields validated before it, the handler sees them all.
 
 ```ts
-const example = os
-  .input(z.looseObject({ name: z.string() }))
-  .input(z.looseObject({ id: z.number() }))
-  .output(z.looseObject({ name: z.string() }))
-  .output(z.looseObject({ id: z.number() }))
+const base = os
+  .input(z.object({ name: z.string() }))
+
+const example = base
+  .input(z.object({ id: z.number() }))
   .handler(async ({ input }) => {
+    // input is { name: string, id: number }
     return { id: 1, name: 'example' }
   })
 ```
 
 :::warning
-When you stack schemas, the input or output must satisfy all of them, so the schemas need to be compatible. For example, with Zod, prefer `z.looseObject` over `z.object` to allow unknown properties.
+Only plain objects are merged, and only at the top level. Other values, like [`asyncIteratorObject`](/docs/async-iterator-object) or a `z.string()` transform, are piped: each schema validates what the previous one returned. Nested objects are not merged either, the last schema wins, so use `z.looseObject` when two schemas define the same one:
+
+```ts
+const example = os
+  .input(z.object({ user: z.looseObject({ name: z.string() }) }))
+  .input(z.object({ user: z.looseObject({ age: z.number() }) }))
+```
+
 :::
+
+:::warning
+Schemas that reject unknown fields, like `z.strictObject`, cannot be stacked. Each one rejects the fields the others define.
+:::
+
+`.output` schemas are piped, not merged, and run in reverse: the last one validates the handler result, then each earlier one validates what the next returned. Use `z.looseObject` so no schema drops a field another one needs.
+
+```ts
+const example = os
+  .output(z.looseObject({ name: z.string() }))
+  .output(z.looseObject({ id: z.number() }))
+  .handler(async () => ({ id: 1, name: 'example' }))
+```
 
 ### `type` Utility
 

--- a/packages/ai-sdk/src/tool.test.ts
+++ b/packages/ai-sdk/src/tool.test.ts
@@ -75,27 +75,42 @@ describe('implementToolFactory', () => {
       age: z.number().describe('Age of the person'),
     })
 
-    it('combines input schemas by piping validation in order', async () => {
+    it('combines input schemas by merging what each one validates', async () => {
       const contract = oc
-        .input(z.looseObject({ name: z.string() }))
-        .input(extraInputSchema)
+        .input(z.object({ name: z.string() }))
+        .input(z.object({ age: z.number().describe('Age of the person') }))
 
       const tool = implementToolFactory()(contract)
       const combined = tool.inputSchema as any
 
-      expect(combined).not.toBe(extraInputSchema)
-
+      /**
+       * Both schemas strip the fragment declared by the other, so they must each validate the
+       * original value instead of what the previous one returned.
+       */
       await expect(
-        combined['~standard'].validate({ name: 'Alice', age: 18 }),
+        combined['~standard'].validate({ name: 'Alice', age: 18, unknown: true }),
       ).resolves.toEqual({ value: { name: 'Alice', age: 18 } })
 
       const failed = await combined['~standard'].validate({ name: 'Alice' })
       expect(failed.issues).toEqual([expect.objectContaining({ path: ['age'] })])
     })
 
+    it('combines non-object input schemas by piping validation in order', async () => {
+      const contract = oc
+        .input(type<string, string>(value => `first__${value}`))
+        .input(type<string, string>(value => `second__${value}`))
+
+      const tool = implementToolFactory()(contract)
+      const combined = tool.inputSchema as any
+
+      await expect(
+        combined['~standard'].validate('INPUT'),
+      ).resolves.toEqual({ value: 'second__first__INPUT' })
+    })
+
     it('combines input json schemas with allOf and hoists $schema to the root', () => {
       const contract = oc
-        .input(z.looseObject({ name: z.string() }))
+        .input(z.object({ name: z.string() }))
         .input(extraInputSchema)
 
       const tool = implementToolFactory()(contract)
@@ -156,7 +171,7 @@ describe('implementToolFactory', () => {
 
     it('converts json schema using only the schemas that support it', () => {
       const contract = oc
-        .input(z.looseObject({ name: z.string() }))
+        .input(z.object({ name: z.string() }))
         .input(type<{ age: number }>())
 
       const tool = implementToolFactory()(contract)

--- a/packages/ai-sdk/src/tool.test.ts
+++ b/packages/ai-sdk/src/tool.test.ts
@@ -95,6 +95,27 @@ describe('implementToolFactory', () => {
       expect(failed.issues).toEqual([expect.objectContaining({ path: ['age'] })])
     })
 
+    it('combines input schema fragments nested one level deep', async () => {
+      const contract = oc
+        .input(z.object({ params: z.object({ id: z.string() }) }))
+        .input(z.object({ params: z.object({ slug: z.string() }), query: z.object({ page: z.number() }) }))
+
+      const tool = implementToolFactory()(contract)
+      const combined = tool.inputSchema as any
+
+      await expect(
+        combined['~standard'].validate({
+          params: { id: 'ID', slug: 'SLUG', unknown: true },
+          query: { page: 1 },
+        }),
+      ).resolves.toEqual({
+        value: {
+          params: { id: 'ID', slug: 'SLUG' },
+          query: { page: 1 },
+        },
+      })
+    })
+
     it('combines non-object input schemas by piping validation in order', async () => {
       const contract = oc
         .input(type<string, string>(value => `first__${value}`))

--- a/packages/ai-sdk/src/tool.ts
+++ b/packages/ai-sdk/src/tool.ts
@@ -8,7 +8,7 @@ import type { FunctionTool } from './tool-meta'
 import { getAsyncIteratorObjectSchemaDetails } from '@orpc/contract'
 import { combineJsonSchemasWithComposition } from '@orpc/json-schema'
 import { call, Procedure } from '@orpc/server'
-import { ORPC_NAME, resolveMaybeOptionalOptions, toArray } from '@orpc/shared'
+import { isPlainObject, ORPC_NAME, resolveMaybeOptionalOptions, toArray } from '@orpc/shared'
 import { tool } from 'ai'
 import { getAiSdkToolMeta } from './tool-meta'
 
@@ -42,7 +42,7 @@ function combineJsonSchemas(jsonSchemas: Record<string, unknown>[]): Record<stri
   return { $schema, ...combined }
 }
 
-function combineSchemas(schemas: AnySchema[]): undefined | FlexibleSchema {
+function combineSchemas(schemas: AnySchema[], merge: boolean): undefined | FlexibleSchema {
   if (schemas.length === 0) {
     return undefined
   }
@@ -70,14 +70,20 @@ function combineSchemas(schemas: AnySchema[]): undefined | FlexibleSchema {
       async validate(value: unknown) {
         let current = value
 
-        for (const schema of schemas) {
-          const result = await schema['~standard'].validate(current)
+        /**
+         * Mirrors the server: stacked object input schemas each validate the original value and are
+         * merged afterwards, output schemas stay piped.
+         */
+        for (const [index, schema] of schemas.entries()) {
+          const result = await schema['~standard'].validate(merge && isPlainObject(current) ? value : current)
 
           if (result.issues) {
             return result
           }
 
-          current = result.value
+          current = merge && index !== 0 && isPlainObject(current) && isPlainObject(result.value)
+            ? { ...current, ...result.value }
+            : result.value
         }
 
         return { value: current }
@@ -109,7 +115,7 @@ function getIteratorYieldSchemas(schemas: AnySchema[]): AnySchema[] | undefined 
 
 function combineOutputSchemas(outputSchemas: AnySchema[]): FlexibleSchema | undefined {
   const yieldSchemas = getIteratorYieldSchemas(outputSchemas)
-  return combineSchemas([...(yieldSchemas ?? outputSchemas)].reverse())
+  return combineSchemas([...(yieldSchemas ?? outputSchemas)].reverse(), false)
 }
 
 /**
@@ -192,7 +198,7 @@ export function implementToolFactory(_options: ImplementToolFactoryOptions = {})
     return tool({
       ...defaults,
       ...toolOptions,
-      inputSchema: combineSchemas(inputSchemas) ?? ANY_SCHEMA,
+      inputSchema: combineSchemas(inputSchemas, true) ?? ANY_SCHEMA,
       outputSchema: combineOutputSchemas(outputSchemas),
     })
   }

--- a/packages/ai-sdk/src/tool.ts
+++ b/packages/ai-sdk/src/tool.ts
@@ -8,7 +8,7 @@ import type { FunctionTool } from './tool-meta'
 import { getAsyncIteratorObjectSchemaDetails } from '@orpc/contract'
 import { combineJsonSchemasWithComposition } from '@orpc/json-schema'
 import { call, Procedure } from '@orpc/server'
-import { isPlainObject, ORPC_NAME, resolveMaybeOptionalOptions, toArray } from '@orpc/shared'
+import { isPlainObject, mergeTwoLevels, ORPC_NAME, resolveMaybeOptionalOptions, toArray } from '@orpc/shared'
 import { tool } from 'ai'
 import { getAiSdkToolMeta } from './tool-meta'
 
@@ -81,9 +81,7 @@ function combineSchemas(schemas: AnySchema[], merge: boolean): undefined | Flexi
             return result
           }
 
-          current = merge && index !== 0 && isPlainObject(current) && isPlainObject(result.value)
-            ? { ...current, ...result.value }
-            : result.value
+          current = merge && index !== 0 ? mergeTwoLevels(current, result.value) : result.value
         }
 
         return { value: current }

--- a/packages/contract/src/plugins/request-validation.test.ts
+++ b/packages/contract/src/plugins/request-validation.test.ts
@@ -20,6 +20,16 @@ describe('requestValidationLinkPlugin', () => {
     meta: {},
   })
 
+  const stackedObjectProcedure = new ProcedureContract({
+    inputSchemas: [
+      z.object({ parent: z.string() }),
+      z.object({ child: z.string() }),
+    ],
+    outputSchemas: [],
+    errorMap: {},
+    meta: {},
+  })
+
   const withoutInputSchemaProcedure = new ProcedureContract({
     outputSchemas: [],
     errorMap: {},
@@ -28,6 +38,7 @@ describe('requestValidationLinkPlugin', () => {
 
   const contract = {
     chainedProcedure,
+    stackedObjectProcedure,
     nested: {
       chainedProcedure,
     },
@@ -97,6 +108,31 @@ describe('requestValidationLinkPlugin', () => {
 
     expect(output).toBe('__output__')
     expect(codec.encodeInput).toHaveBeenCalledWith(2, ['chainedProcedure'], { context: {} })
+  })
+
+  it('merges what every stacked object schema validates', async () => {
+    codec.encodeInput.mockResolvedValueOnce({
+      method: 'POST',
+      url: '/stackedObjectProcedure',
+      headers: {},
+      body: '__encoded__',
+    })
+    transport.send.mockResolvedValueOnce({
+      status: 200,
+      headers: {},
+      resolveBody: () => Promise.resolve('__body__'),
+    })
+    codec.decodeResponse.mockResolvedValueOnce({ kind: 'output', output: '__output__' })
+
+    const input = { parent: 'PARENT', child: 'CHILD', unknown: 'UNKNOWN' }
+    const output = await linkUsingValidatedInput.call(['stackedObjectProcedure'], input as any, { context: {} })
+
+    expect(output).toBe('__output__')
+    expect(codec.encodeInput).toHaveBeenCalledWith(
+      { parent: 'PARENT', child: 'CHILD' },
+      ['stackedObjectProcedure'],
+      { context: {} },
+    )
   })
 
   it('skips validation when the procedure has no input schemas', async () => {

--- a/packages/contract/src/plugins/request-validation.test.ts
+++ b/packages/contract/src/plugins/request-validation.test.ts
@@ -30,6 +30,16 @@ describe('requestValidationLinkPlugin', () => {
     meta: {},
   })
 
+  const nestedObjectProcedure = new ProcedureContract({
+    inputSchemas: [
+      z.object({ params: z.object({ id: z.string() }) }),
+      z.object({ params: z.object({ slug: z.string() }), query: z.object({ page: z.number() }) }),
+    ],
+    outputSchemas: [],
+    errorMap: {},
+    meta: {},
+  })
+
   const withoutInputSchemaProcedure = new ProcedureContract({
     outputSchemas: [],
     errorMap: {},
@@ -39,6 +49,7 @@ describe('requestValidationLinkPlugin', () => {
   const contract = {
     chainedProcedure,
     stackedObjectProcedure,
+    nestedObjectProcedure,
     nested: {
       chainedProcedure,
     },
@@ -131,6 +142,31 @@ describe('requestValidationLinkPlugin', () => {
     expect(codec.encodeInput).toHaveBeenCalledWith(
       { parent: 'PARENT', child: 'CHILD' },
       ['stackedObjectProcedure'],
+      { context: {} },
+    )
+  })
+
+  it('merges stacked object schema fragments nested one level deep', async () => {
+    codec.encodeInput.mockResolvedValueOnce({
+      method: 'POST',
+      url: '/nestedObjectProcedure',
+      headers: {},
+      body: '__encoded__',
+    })
+    transport.send.mockResolvedValueOnce({
+      status: 200,
+      headers: {},
+      resolveBody: () => Promise.resolve('__body__'),
+    })
+    codec.decodeResponse.mockResolvedValueOnce({ kind: 'output', output: '__output__' })
+
+    const input = { params: { id: 'ID', slug: 'SLUG', unknown: 'UNKNOWN' }, query: { page: 1 } }
+    const output = await linkUsingValidatedInput.call(['nestedObjectProcedure'], input as any, { context: {} })
+
+    expect(output).toBe('__output__')
+    expect(codec.encodeInput).toHaveBeenCalledWith(
+      { params: { id: 'ID', slug: 'SLUG' }, query: { page: 1 } },
+      ['nestedObjectProcedure'],
       { context: {} },
     )
   })

--- a/packages/contract/src/plugins/request-validation.ts
+++ b/packages/contract/src/plugins/request-validation.ts
@@ -2,7 +2,7 @@ import type { ClientContext } from '@orpc/client'
 import type { StandardLinkOptions, StandardLinkPlugin } from '@orpc/client/standard'
 import type { RouterContract } from '../router'
 import { ORPCError } from '@orpc/client'
-import { isPlainObject, toArray } from '@orpc/shared'
+import { isPlainObject, mergeTwoLevels, toArray } from '@orpc/shared'
 import { ValidationError } from '../error'
 import { getProcedureContractOrThrow } from '../router-utils'
 
@@ -69,9 +69,7 @@ export class RequestValidationLinkPlugin<T extends ClientContext> implements Sta
             })
           }
 
-          currentInput = index !== 0 && isPlainObject(currentInput) && isPlainObject(result.value)
-            ? { ...currentInput, ...result.value }
-            : result.value
+          currentInput = index !== 0 ? mergeTwoLevels(currentInput, result.value) : result.value
         }
 
         return this.forwardValidatedInput

--- a/packages/contract/src/plugins/request-validation.ts
+++ b/packages/contract/src/plugins/request-validation.ts
@@ -2,7 +2,7 @@ import type { ClientContext } from '@orpc/client'
 import type { StandardLinkOptions, StandardLinkPlugin } from '@orpc/client/standard'
 import type { RouterContract } from '../router'
 import { ORPCError } from '@orpc/client'
-import { toArray } from '@orpc/shared'
+import { isPlainObject, toArray } from '@orpc/shared'
 import { ValidationError } from '../error'
 import { getProcedureContractOrThrow } from '../router-utils'
 
@@ -43,28 +43,35 @@ export class RequestValidationLinkPlugin<T extends ClientContext> implements Sta
       interceptors: [...toArray(options.interceptors), async ({ next, ...interceptorOptions }) => {
         const procedure = getProcedureContractOrThrow(this.contract, interceptorOptions.path)
 
-        let currentInput = interceptorOptions.input
+        const inputSchemas = toArray(procedure['~orpc'].inputSchemas)
+        const originalInput = interceptorOptions.input
+        let currentInput = originalInput
 
-        if (procedure['~orpc'].inputSchemas) {
-          for (const schema of procedure['~orpc'].inputSchemas) {
-            const result = await schema['~standard'].validate(currentInput)
+        for (const [index, schema] of inputSchemas.entries()) {
+          /**
+           * Mirrors the server: stacked object schemas each validate the original input and are
+           * merged afterwards, anything else stays piped.
+           */
+          const validating = inputSchemas.length > 1 && isPlainObject(currentInput) ? originalInput : currentInput
+          const result = await schema['~standard'].validate(validating)
 
-            if (result.issues) {
-              throw new ORPCError('BAD_REQUEST', {
+          if (result.issues) {
+            throw new ORPCError('BAD_REQUEST', {
+              message: 'Input validation failed',
+              data: {
+                issues: result.issues,
+              },
+              cause: new ValidationError({
                 message: 'Input validation failed',
-                data: {
-                  issues: result.issues,
-                },
-                cause: new ValidationError({
-                  message: 'Input validation failed',
-                  issues: result.issues,
-                  invalidData: currentInput,
-                }),
-              })
-            }
-
-            currentInput = result.value
+                issues: result.issues,
+                invalidData: validating,
+              }),
+            })
           }
+
+          currentInput = index !== 0 && isPlainObject(currentInput) && isPlainObject(result.value)
+            ? { ...currentInput, ...result.value }
+            : result.value
         }
 
         return this.forwardValidatedInput

--- a/packages/server/src/procedure-client.test.ts
+++ b/packages/server/src/procedure-client.test.ts
@@ -602,6 +602,76 @@ describe('createProcedureClient', () => {
     })
   })
 
+  describe('with stacked object schemas', () => {
+    it('composes every schema fragment into a single flat input', async () => {
+      const rootMid = vi.fn(({ next }) => next())
+      const parentMid = vi.fn(({ next }) => next())
+      const childMid = vi.fn(({ next }) => next())
+
+      const procedure = os
+        .use(rootMid)
+        .input(z.object({ parent: z.string().transform(value => `parent__${value}`) }))
+        .use(parentMid)
+        .input(z.object({ child: z.string().transform(value => `child__${value}`) }))
+        .use(childMid)
+        .handler(({ input }) => input)
+
+      const client = createProcedureClient(procedure)
+
+      await expect(client({ parent: 'PARENT', child: 'CHILD', unknown: 'UNKNOWN' } as any))
+        .resolves
+        .toEqual({ parent: 'parent__PARENT', child: 'child__CHILD' })
+
+      expect(rootMid).toHaveBeenCalledWith(expect.any(Object), { parent: 'PARENT', child: 'CHILD', unknown: 'UNKNOWN' }, expect.any(Function))
+      expect(parentMid).toHaveBeenCalledWith(expect.any(Object), { parent: 'parent__PARENT' }, expect.any(Function))
+      expect(childMid).toHaveBeenCalledWith(expect.any(Object), { parent: 'parent__PARENT', child: 'child__CHILD' }, expect.any(Function))
+    })
+
+    it('lets a loose schema keep the properties it accepts', async () => {
+      const parentMid = vi.fn(({ next }) => next())
+
+      const procedure = os
+        .input(z.looseObject({ parent: z.string().transform(value => `parent__${value}`) }))
+        .use(parentMid)
+        .input(z.object({ child: z.string().transform(value => `child__${value}`) }))
+        .handler(({ input }) => input)
+
+      const client = createProcedureClient(procedure)
+
+      await expect(client({ parent: 'PARENT', child: 'CHILD', unknown: 'UNKNOWN' } as any))
+        .resolves
+        .toEqual({ parent: 'parent__PARENT', child: 'child__CHILD', unknown: 'UNKNOWN' })
+
+      expect(parentMid).toHaveBeenCalledWith(expect.any(Object), { parent: 'parent__PARENT', child: 'CHILD', unknown: 'UNKNOWN' }, expect.any(Function))
+    })
+
+    it('keeps piping input schemas that do not validate into a plain object', async () => {
+      const procedure = os
+        .input(ContractModule.asyncIteratorObject(ContractModule.type<string, string>(value => `first__${value}`)))
+        .input(ContractModule.asyncIteratorObject(ContractModule.type<string, string>(value => `second__${value}`)))
+        .handler(({ input }) => input)
+
+      const client = createProcedureClient(procedure)
+      const output = await client((async function* () {
+        yield 'INPUT'
+      })())
+
+      expect(isAsyncIteratorObject(output)).toBe(true)
+      await expect(output.next()).resolves.toEqual({ done: false, value: 'second__first__INPUT' })
+    })
+
+    it('keeps piping output schemas', async () => {
+      const procedure = os
+        .output(z.looseObject({ first: z.string() }))
+        .output(z.looseObject({ second: z.string() }))
+        .handler(() => ({ first: 'FIRST', second: 'SECOND' }) as any)
+
+      const client = createProcedureClient(procedure)
+
+      await expect(client()).resolves.toEqual({ first: 'FIRST', second: 'SECOND' })
+    })
+  })
+
   describe('disable validations', () => {
     const inputSchema = z.object({ value: z.string() })
     const outputSchema = z.object({ value: z.string() })

--- a/packages/server/src/procedure-client.test.ts
+++ b/packages/server/src/procedure-client.test.ts
@@ -627,6 +627,23 @@ describe('createProcedureClient', () => {
       expect(childMid).toHaveBeenCalledWith(expect.any(Object), { parent: 'parent__PARENT', child: 'child__CHILD' }, expect.any(Function))
     })
 
+    it('composes fragments nested one level deep', async () => {
+      const procedure = os
+        .input(z.object({ params: z.object({ id: z.string() }) }))
+        .input(z.object({ params: z.object({ slug: z.string() }), query: z.object({ page: z.number() }) }))
+        .handler(({ input }) => input)
+
+      const client = createProcedureClient(procedure)
+
+      await expect(client({
+        params: { id: 'ID', slug: 'SLUG', unknown: 'UNKNOWN' },
+        query: { page: 1 },
+      } as any)).resolves.toEqual({
+        params: { id: 'ID', slug: 'SLUG' },
+        query: { page: 1 },
+      })
+    })
+
     it('lets a loose schema keep the properties it accepts', async () => {
       const parentMid = vi.fn(({ next }) => next())
 

--- a/packages/server/src/procedure-client.ts
+++ b/packages/server/src/procedure-client.ts
@@ -7,7 +7,7 @@ import type { MiddlewareDone } from './middleware'
 import type { AnyProcedure, Procedure, ProcedureHandlerOptions } from './procedure'
 import { cloneORPCError, ORPCError, wrapAsyncIteratorPreservingEventMeta } from '@orpc/client'
 import { createORPCErrorConstructorMap, reconcileORPCError, ValidationError } from '@orpc/contract'
-import { intercept, isAsyncIteratorObject, isPlainObject, override, resolveMaybeOptionalOptions, runWithSpan, toArray, traceAsyncIterator, traceReadableStream, value } from '@orpc/shared'
+import { intercept, isAsyncIteratorObject, isPlainObject, mergeTwoLevels, override, resolveMaybeOptionalOptions, runWithSpan, toArray, traceAsyncIterator, traceReadableStream, value } from '@orpc/shared'
 import { unlazy } from './lazy'
 
 export type ProcedureClient<
@@ -232,9 +232,7 @@ async function executeProcedureInternal(procedure: AnyProcedure, options: Proced
           inputSchemas.length > 1 && isPlainObject(currentInput) ? options.input : currentInput,
         )
 
-        currentInput = i !== 0 && isPlainObject(currentInput) && isPlainObject(validated)
-          ? { ...currentInput, ...validated }
-          : validated
+        currentInput = i !== 0 ? mergeTwoLevels(currentInput, validated) : validated
       }
     }
 

--- a/packages/server/src/procedure-client.ts
+++ b/packages/server/src/procedure-client.ts
@@ -7,7 +7,7 @@ import type { MiddlewareDone } from './middleware'
 import type { AnyProcedure, Procedure, ProcedureHandlerOptions } from './procedure'
 import { cloneORPCError, ORPCError, wrapAsyncIteratorPreservingEventMeta } from '@orpc/client'
 import { createORPCErrorConstructorMap, reconcileORPCError, ValidationError } from '@orpc/contract'
-import { intercept, isAsyncIteratorObject, override, resolveMaybeOptionalOptions, runWithSpan, toArray, traceAsyncIterator, traceReadableStream, value } from '@orpc/shared'
+import { intercept, isAsyncIteratorObject, isPlainObject, override, resolveMaybeOptionalOptions, runWithSpan, toArray, traceAsyncIterator, traceReadableStream, value } from '@orpc/shared'
 import { unlazy } from './lazy'
 
 export type ProcedureClient<
@@ -219,9 +219,22 @@ async function executeProcedureInternal(procedure: AnyProcedure, options: Proced
       ? inputSchemas.length
       : orderedMiddlewares[midIndex]!.inputSchemasLengthAtUse ?? 0
 
+    /**
+     * Stacked object schemas each validate the original input and are merged afterwards, so every
+     * schema can declare its own fragment without the previous ones stripping or rejecting it.
+     * Anything else stays piped, which keeps schemas like `asyncIteratorObject` wrapping each other.
+     */
     if (!procedure['~orpc'].disableInputValidation) {
       for (let i = startInputIndex; i < endInputIndex; i++) {
-        currentInput = await validateInput(i, inputSchemas[i]!, currentInput)
+        const validated = await validateInput(
+          i,
+          inputSchemas[i]!,
+          inputSchemas.length > 1 && isPlainObject(currentInput) ? options.input : currentInput,
+        )
+
+        currentInput = i !== 0 && isPlainObject(currentInput) && isPlainObject(validated)
+          ? { ...currentInput, ...validated }
+          : validated
       }
     }
 

--- a/packages/shared/src/object.test.ts
+++ b/packages/shared/src/object.test.ts
@@ -1,7 +1,7 @@
 import * as a from 'arktype'
 import * as v from 'valibot'
 import z from 'zod'
-import { bindMethods, clone, findDeepMatches, get, getConstructor, getConstructors, isPlainObject, isPropertyKey, NullProtoObj, omit, set } from './object'
+import { bindMethods, clone, findDeepMatches, get, getConstructor, getConstructors, isPlainObject, isPropertyKey, mergeTwoLevels, NullProtoObj, omit, set } from './object'
 
 it('findDeepMatches', () => {
   const { maps, values } = findDeepMatches(v => typeof v === 'string', {
@@ -229,6 +229,71 @@ describe('set', () => {
     expect(Object.hasOwn(root, '__proto__')).toBe(true)
     // eslint-disable-next-line no-proto, no-restricted-properties
     expect((root as any).__proto__).toBe('value')
+  })
+})
+
+describe('mergeTwoLevels', () => {
+  it('merges the root level', () => {
+    expect(mergeTwoLevels({ a: 1, shared: 'first' }, { b: 2, shared: 'second' })).toEqual({
+      a: 1,
+      b: 2,
+      shared: 'second',
+    })
+  })
+
+  it('merges one level deeper', () => {
+    expect(mergeTwoLevels(
+      { user: { name: 'NAME', shared: 'first' } },
+      { user: { age: 1, shared: 'second' } },
+    )).toEqual({
+      user: { name: 'NAME', age: 1, shared: 'second' },
+    })
+  })
+
+  it('replaces anything deeper than two levels', () => {
+    expect(mergeTwoLevels(
+      { user: { address: { city: 'CITY' } } },
+      { user: { address: { zip: 'ZIP' } } },
+    )).toEqual({
+      user: { address: { zip: 'ZIP' } },
+    })
+  })
+
+  it('replaces when the values are not both plain objects', () => {
+    const date = new Date()
+
+    expect(mergeTwoLevels({ a: 1 }, 'REPLACED')).toBe('REPLACED')
+    expect(mergeTwoLevels('REPLACED', { a: 1 })).toEqual({ a: 1 })
+    expect(mergeTwoLevels({ a: { b: 1 } }, { a: [1] })).toEqual({ a: [1] })
+    expect(mergeTwoLevels({ a: { b: 1 } }, { a: date })).toEqual({ a: date })
+    expect(mergeTwoLevels({ a: undefined }, { a: { b: 1 } })).toEqual({ a: { b: 1 } })
+  })
+
+  it('returns a new object', () => {
+    const first = { a: { b: 1 } }
+    const merged = mergeTwoLevels(first, { a: { c: 2 } }) as any
+
+    expect(merged).not.toBe(first)
+    expect(first).toEqual({ a: { b: 1 } })
+  })
+
+  it('reads own properties only and keeps special keys as own properties', () => {
+    const merged = mergeTwoLevels({}, JSON.parse('{ "__proto__": { "polluted": true } }')) as any
+
+    // `{}.__proto__` resolves to Object.prototype, which must not be merged in as if it were own
+    expect(Object.getOwnPropertyDescriptor(merged, '__proto__')?.value).toEqual({ polluted: true })
+    expect(Object.getPrototypeOf(merged)).toBe(Object.prototype)
+    expect(({} as any).polluted).toBeUndefined()
+  })
+
+  it('ignores inherited values when merging one level deeper', () => {
+    const first = Object.create({ inherited: { a: 1 } })
+    first.own = { b: 2 }
+
+    expect(mergeTwoLevels({ ...first }, { inherited: { c: 3 }, own: { d: 4 } })).toEqual({
+      inherited: { c: 3 },
+      own: { b: 2, d: 4 },
+    })
   })
 })
 

--- a/packages/shared/src/object.ts
+++ b/packages/shared/src/object.ts
@@ -131,10 +131,12 @@ export function mergeTwoLevels(first: unknown, second: unknown): unknown {
   // Spread keeps special keys like __proto__ as own properties instead of re-parenting the result.
   const result: Record<PropertyKey, unknown> = { ...first, ...second }
 
-  // Object.keys and Object.hasOwn skip the prototype, `first.__proto__` would otherwise
-  // resolve to Object.prototype and be merged in as if it were an own property.
-  for (const key of Object.keys(second)) {
-    const firstValue = Object.hasOwn(first, key) ? first[key] : undefined
+  for (const key in second) {
+    if (!Object.hasOwn(first, key)) {
+      continue
+    }
+
+    const firstValue = first[key]
     const secondValue = second[key]
 
     if (isPlainObject(firstValue) && isPlainObject(secondValue)) {

--- a/packages/shared/src/object.ts
+++ b/packages/shared/src/object.ts
@@ -119,6 +119,32 @@ function defineOwnProperty(object: object, key: PropertyKey, value: unknown): vo
   })
 }
 
+/**
+ * Merges two values by copying the second over the first, repeating the merge one level deeper for
+ * nested plain objects. Anything that is not a pair of plain objects is replaced by the second one.
+ */
+export function mergeTwoLevels(first: unknown, second: unknown): unknown {
+  if (!isPlainObject(first) || !isPlainObject(second)) {
+    return second
+  }
+
+  // Spread keeps special keys like __proto__ as own properties instead of re-parenting the result.
+  const result: Record<PropertyKey, unknown> = { ...first, ...second }
+
+  // Object.keys and Object.hasOwn skip the prototype, `first.__proto__` would otherwise
+  // resolve to Object.prototype and be merged in as if it were an own property.
+  for (const key of Object.keys(second)) {
+    const firstValue = Object.hasOwn(first, key) ? first[key] : undefined
+    const secondValue = second[key]
+
+    if (isPlainObject(firstValue) && isPlainObject(secondValue)) {
+      defineOwnProperty(result, key, { ...firstValue, ...secondValue })
+    }
+  }
+
+  return result
+}
+
 export function omit<T extends object, K extends keyof T>(
   obj: T,
   keys: readonly K[],


### PR DESCRIPTION
Multiple `.input()` calls typed as an intersection but validated by piping, so a plain `z.object` stripped the fields the next schema needed. Object input schemas now each validate the original input and the results are merged, so procedure inheritance composes into one flat input without `z.looseObject`.

```ts
const cabinet = authed.input(v.object({ cabinet: v.picklist(cabinetCodes) }))
const operator = cabinet.input(v.object({ operatorId: v.pipe(v.string(), v.uuid()) }))

const update = operator
  .input(v.object({ data: storageWriteDataSchema }))
  .handler(({ input }) => {
    // { cabinet, operatorId, data }
  })
```

### Fixes

- Merging covers the first two levels, so structured inputs like `{ params, query }` compose per group, not just at the root.
- Fields no schema declares are still dropped, so the input stays closed and the client type gains no index signature.
- Middleware sees the fields validated before it, the handler sees them all.
- Non-object values still pipe, so `asyncIteratorObject` and transform chains are unchanged. Loose schemas still pass their extra fields through.
- The request validation plugin and the AI SDK tool input schema follow the same rule, so client and server agree.
- `.output` is untouched, stacking it still needs loose object schemas.

### Notes

Input schemas no longer pipe into each other. That was never expressible in the types, `.input(z.string()).input(z.number())` already infers `never`. Two AI SDK fixtures relied on it and were rewritten.

The merge lives in `mergeTwoLevels` in `@orpc/shared`, shared by the three call sites. It reads own properties only, so `first.__proto__` is not mistaken for an own value.

### Testing

`pnpm test`, `pnpm type:check` and `pnpm lint` pass. The four changed source files are at 100% statement, branch and function coverage.

Closes #1850