### PR TITLE
docs: sync home footer logo to the donut brand mark

### DIFF
--- a/apps/content/pages/_home/Footer.astro
+++ b/apps/content/pages/_home/Footer.astro
@@ -64,12 +64,16 @@ const years = `${FIRST_YEAR}-${new Date().getFullYear()}`
           aria-hidden="true"
           class="size-5"
           fill="none"
-          viewBox="0 0 60 60"
+          viewBox="0 0 256 256"
           xmlns="http://www.w3.org/2000/svg"
         >
           <path
-            d="M4 45L17 37.5V22.5L30 15L43 22.5V7.5L30 0L4 15V45ZM56 15L43 22.5V37.5L30 45L17 37.5V52.5L30 60L56 45V15Z"
+            d="M121 254C100 253 78 246 60 234C48 226 47 221 59 216C78 209 87 200 95 181C100 169 103 168 113 171C150 181 181 152 173 115C171 109 171 105 173 103C175 100 176 99 185 95C200 88 210 79 217 67C223 57 225 55 230 57C238 61 249 85 252 106C266 186 203 258 121 254Z"
             fill="currentColor"></path>
+          <path
+            d="M40 207C27 205 17 195 11 178C4 161 1 147 1 131C1 92 13 63 40 37C46 31 48 29 57 23C67 16 70 14 78 11C115 -4 151 -2 189 16C223 32 219 65 181 84C166 92 159 92 145 88C120 79 100 86 88 108C82 119 81 127 85 142C90 160 90 168 82 183C74 199 56 209 40 207ZM114 39A7 7 0 0 1 121 27L146 41A7 7 0 0 1 140 53ZM71 59A7 7 0 0 1 81 68L61 89A7 7 0 0 1 52 81ZM32 129A7 7 0 0 1 40 119L57 133A7 7 0 0 1 49 143Z"
+            fill="#ff6ca5"
+            fill-rule="evenodd"></path>
         </svg>
         <span class="font-display text-base font-semibold tracking-tight">oRPC</span>
       </a>

--- a/apps/content/pages/_home/Footer.astro
+++ b/apps/content/pages/_home/Footer.astro
@@ -1,4 +1,8 @@
 ---
+// Astro inlines the SVG and spreads our props onto its root <svg>, so the mark
+// stays in sync with the file the header and favicon are generated from.
+import Logo from '../../logo.svg'
+
 interface FooterLink {
   label: string
   href: string
@@ -60,21 +64,7 @@ const years = `${FIRST_YEAR}-${new Date().getFullYear()}`
   <div class="grid gap-10 sm:grid-cols-2 lg:grid-cols-[minmax(0,1fr)_repeat(4,auto)] lg:gap-16">
     <div>
       <a href="/" class="inline-flex items-center gap-2.5" aria-label="oRPC home">
-        <svg
-          aria-hidden="true"
-          class="size-5"
-          fill="none"
-          viewBox="0 0 256 256"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M121 254C100 253 78 246 60 234C48 226 47 221 59 216C78 209 87 200 95 181C100 169 103 168 113 171C150 181 181 152 173 115C171 109 171 105 173 103C175 100 176 99 185 95C200 88 210 79 217 67C223 57 225 55 230 57C238 61 249 85 252 106C266 186 203 258 121 254Z"
-            fill="currentColor"></path>
-          <path
-            d="M40 207C27 205 17 195 11 178C4 161 1 147 1 131C1 92 13 63 40 37C46 31 48 29 57 23C67 16 70 14 78 11C115 -4 151 -2 189 16C223 32 219 65 181 84C166 92 159 92 145 88C120 79 100 86 88 108C82 119 81 127 85 142C90 160 90 168 82 183C74 199 56 209 40 207ZM114 39A7 7 0 0 1 121 27L146 41A7 7 0 0 1 140 53ZM71 59A7 7 0 0 1 81 68L61 89A7 7 0 0 1 52 81ZM32 129A7 7 0 0 1 40 119L57 133A7 7 0 0 1 49 143Z"
-            fill="#ff6ca5"
-            fill-rule="evenodd"></path>
-        </svg>
+        <Logo aria-hidden="true" class="size-5" />
         <span class="font-display text-base font-semibold tracking-tight">oRPC</span>
       </a>
       <p class="mt-4 max-w-xs text-sm leading-relaxed text-muted-foreground">


### PR DESCRIPTION
The home page footer was still drawing the old monochrome hex-mesh mark inline, so the footer and the header disagreed on the brand after #1837. It now imports `logo.svg` directly, so it can never drift again.

## Fixes

- Footer logo matches the rest of the site's branding, including the pink frosting.
- Astro inlines the imported SVG and spreads the props onto its root `<svg>`, so the mark keeps the same `size-5` sizing and `aria-hidden`, and the crescent still tracks the footer's foreground in light and dark mode.
- The next logo change only has to touch `logo.svg`.

## Testing

Built a minimal Astro page against the same Astro version the docs site runs to confirm the import renders: the output is the full mark with `viewBox` preserved and the props applied. A repo-wide grep confirms no other copy of the old hex-mesh mark remains. No full docs build was run.