### PR TITLE
docs(content): use a 500MB file limit in the tmp file upload example

### DIFF
--- a/apps/content/docs/plugins/tmp-file-upload.mdx
+++ b/apps/content/docs/plugins/tmp-file-upload.mdx
@@ -73,13 +73,13 @@ const handler = new RPCHandler(router, {
          * Content parsed into memory: JSON, URL-encoded forms, and the
          * plain fields of a multipart body. Usually the lowest limit.
          */
-        memory: 1024 * 1024,
+        memory: 1024 * 1024, // 1MB
 
         /**
          * Content streamed into temporary files: file bodies and the
          * file parts of a multipart body combined.
          */
-        file: 10 * 1024 * 1024 * 1024,
+        file: 500 * 1024 * 1024, // 500MB
 
         /**
          * Content consumed as a stream: event streams and raw binary


### PR DESCRIPTION
The `maxBodySize` example on the Tmp File Upload Plugin page used a 10GB file limit, which reads as a suggested default rather than an illustration. It now shows 500MB, and every numeric limit carries its size in plain units so the arithmetic does not have to be read.

## Docs

- `file` limit in the example is 500MB instead of 10GB.
- `memory` and `file` are annotated with `// 1MB` and `// 500MB`.
- `stream` is unchanged; `Number.POSITIVE_INFINITY` has no size to annotate.