### PR TITLE
chore: clarify Conventional Commit scope rules for PR titles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,4 +22,7 @@ pnpm --filter @orpc/server build   # build one package (unbuild); builds are NOT
 - Root vitest config (`vitest.config.ts`) runs all `*.test.ts` with `globals: true`, plus a jsdom project for `*.test.tsx` in `packages/next` and `packages/tanstack-query`.
 - Exceptions: `packages/bun` runs with `bun test`, `packages/cloudflare` with its own vitest (workerd) — both are excluded from the root vitest and root tsconfig, as is `packages/nest`. Run their tests via `pnpm --filter <pkg> test`.
 - Docs site (Blume): `cd apps/content && pnpm dev` (`blume dev`); `pnpm build` runs `blume build`. Content lives in `.mdx` files; custom pages in `apps/content/pages/`. The dev server caches content-collection frontmatter for custom pages — restart it after editing blog-post frontmatter. `pnpm docs:validate` (root) runs the JSDoc backlink checker plus `blume validate --strict` (links, anchors, assets); CI runs it too.
-- PR titles follow Conventional Commits with the package as scope (e.g. `feat(server): ...`).
+- PR titles follow Conventional Commits. Scope rules:
+  - Use the package name (e.g. `feat(server): ...`), or `rpc`/`openapi` for changes tied to a protocol rather than a single package, such as its serializers, handlers, links, or dedicated plugins.
+  - Use `content` only for the docs site itself (styles, Blume config, ...), and only with the `chore` type — never `feat`/`fix`/`perf`/`docs`, since these changes do not affect library users. Documentation about a package or protocol uses that package/protocol scope instead (e.g. `docs(openapi): ...`).
+  - Omit the scope when the change is too broad for a single one.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,10 @@ This repository uses:
 8. **Commit & Push**:
    - Commit should follow the [Conventional Commits Cheatsheet](https://gist.github.com/Zekfad/f51cb06ac76e2457f11c80ed705c95a3) but not required because we usually use `Squash and Merge`.
 9. **Pull Request**: Open a PR against `main` (or corresponding version branch).
-   - our PR title should follow the [Conventional Commits Cheatsheet](https://gist.github.com/Zekfad/f51cb06ac76e2457f11c80ed705c95a3), with scope corresponding to the package.
+   - our PR title should follow the [Conventional Commits Cheatsheet](https://gist.github.com/Zekfad/f51cb06ac76e2457f11c80ed705c95a3). Scope rules:
+     - Use the package name (e.g. `feat(server): ...`), or `rpc`/`openapi` for changes tied to a protocol rather than a single package, such as its serializers, handlers, links, or dedicated plugins.
+     - Use `content` only for the docs site itself (styles, Blume config, ...), and only with the `chore` type — never `feat`/`fix`/`perf`/`docs`, since these changes do not affect library users. Documentation about a package or protocol uses that package/protocol scope instead (e.g. `docs(openapi): ...`).
+     - Omit the scope when the change is too broad for a single one.
    - In the description, summarize your changes and reference any related issue, e.g., `Fixes #123`.
 
 ## JSDoc & Documentation Links


### PR DESCRIPTION
The scope guidance for PR titles was a single vague line ("scope corresponding to the package"). This spells out the actual conventions in both CONTRIBUTING.md and CLAUDE.md, verified against the repo's commit history.

## Changes

- Scope is the package name, or `rpc`/`openapi` for changes tied to a protocol rather than a single package (serializers, handlers, links, dedicated plugins).
- `content` is reserved for the docs site itself (styles, Blume config) and only pairs with `chore` — never `feat`/`fix`/`perf`/`docs`, since those changes do not affect library users. Documentation about a package or protocol uses that package/protocol scope instead.
- Scope is omitted when the change is too broad for a single one.