### PR TITLE
docs: add lifecycle diagrams for handlers, links, and server-side clients

### DIFF
--- a/apps/content/docs/client/server-side.mdx
+++ b/apps/content/docs/client/server-side.mdx
@@ -151,4 +151,23 @@ export const base = os
 
 ## Lifecycle
 
-TODO: add lifecycle diagram
+The diagram below shows how a call flows through a server-side client. By default, middlewares registered before `.input` run before input validation, and the rest run after it:
+
+```mermaid
+sequenceDiagram
+  actor Caller
+  participant Validator as Input/Output Validator
+  participant Handler
+
+  Caller ->> Validator: input, signal, lastEventId, ...
+  Note over Validator: interceptors
+  Note over Validator: middlewares registered before .input
+  Validator ->> Validator: validate input
+  Validator -->> Caller: if invalid input
+  Note over Validator: middlewares registered after .input
+  Validator ->> Handler: validated input
+  Handler ->> Handler: execute handler
+  Handler ->> Validator: output or error
+  Validator ->> Validator: validate output
+  Validator ->> Caller: output or error
+```

--- a/apps/content/docs/openapi/handler.mdx
+++ b/apps/content/docs/openapi/handler.mdx
@@ -317,4 +317,32 @@ const handler = new OpenAPIHandler(router, {
 
 ## Lifecycle
 
-TODO: add lifecycle diagram
+The diagram below shows how a request flows through `OpenAPIHandler` and where each interceptor type runs:
+
+```mermaid
+sequenceDiagram
+  actor Client
+  participant Adapter as Adapter (Fetch, Node, ...)
+  participant Handler as OpenAPIHandler
+  participant Procedure as Server-Side Procedure Client
+
+  Client ->> Adapter: request
+  Note over Adapter: adapter interceptors (e.g. fetchInterceptors)
+  Adapter ->> Handler: standard request
+  Note over Handler: routingInterceptors
+  Handler ->> Handler: find matching procedure
+  Handler -->> Adapter: if not matched
+  Note over Handler: interceptors
+  Handler ->> Handler: decode input
+  Handler ->> Procedure: input, signal, lastEventId, ...
+  Note over Procedure: clientInterceptors
+  Procedure ->> Procedure: execute procedure
+  Procedure ->> Handler: output or error
+  Handler ->> Handler: encode output or error
+  Handler ->> Adapter: standard response
+  Adapter ->> Client: response
+```
+
+:::info
+The server-side procedure client follows the [Server-Side Client Lifecycle](/docs/client/server-side#lifecycle), and `clientInterceptors` behave like server-side client `interceptors`.
+:::

--- a/apps/content/docs/openapi/link.mdx
+++ b/apps/content/docs/openapi/link.mdx
@@ -344,4 +344,24 @@ const link = new OpenAPILink(contract, {
 
 ## Lifecycle
 
-TODO: add lifecycle diagram
+The diagram below shows how a call flows through `OpenAPILink` and where each interceptor type runs:
+
+```mermaid
+sequenceDiagram
+  actor Caller
+  participant L as OpenAPILink
+  participant Transport as Transport (Fetch, ...)
+  participant Server
+
+  Caller ->> L: path, input, signal, lastEventId, ...
+  Note over L: interceptors
+  L ->> L: encode request
+  Note over L: transportInterceptors
+  L ->> Transport: standard request
+  Note over Transport: adapter interceptors (e.g. fetchInterceptors)
+  Transport ->> Server: request
+  Server ->> Transport: response
+  Transport ->> L: standard response
+  L ->> L: decode response
+  L ->> Caller: output or error
+```

--- a/apps/content/docs/rpc/handler.mdx
+++ b/apps/content/docs/rpc/handler.mdx
@@ -369,4 +369,32 @@ const handler = new RPCHandler(router, {
 
 ## Lifecycle
 
-TODO: add lifecycle diagram
+The diagram below shows how a request flows through `RPCHandler` and where each interceptor type runs:
+
+```mermaid
+sequenceDiagram
+  actor Client
+  participant Adapter as Adapter (Fetch, Node, ...)
+  participant Handler as RPCHandler
+  participant Procedure as Server-Side Procedure Client
+
+  Client ->> Adapter: request
+  Note over Adapter: adapter interceptors (e.g. fetchInterceptors)
+  Adapter ->> Handler: standard request
+  Note over Handler: routingInterceptors
+  Handler ->> Handler: find matching procedure
+  Handler -->> Adapter: if not matched
+  Note over Handler: interceptors
+  Handler ->> Handler: decode input
+  Handler ->> Procedure: input, signal, lastEventId, ...
+  Note over Procedure: clientInterceptors
+  Procedure ->> Procedure: execute procedure
+  Procedure ->> Handler: output or error
+  Handler ->> Handler: encode output or error
+  Handler ->> Adapter: standard response
+  Adapter ->> Client: response
+```
+
+:::info
+The server-side procedure client follows the [Server-Side Client Lifecycle](/docs/client/server-side#lifecycle), and `clientInterceptors` behave like server-side client `interceptors`.
+:::

--- a/apps/content/docs/rpc/link.mdx
+++ b/apps/content/docs/rpc/link.mdx
@@ -369,4 +369,24 @@ const link = new RPCLink({
 
 ## Lifecycle
 
-TODO: add lifecycle diagram
+The diagram below shows how a call flows through `RPCLink` and where each interceptor type runs:
+
+```mermaid
+sequenceDiagram
+  actor Caller
+  participant L as RPCLink
+  participant Transport as Transport (Fetch, ...)
+  participant Server
+
+  Caller ->> L: path, input, signal, lastEventId, ...
+  Note over L: interceptors
+  L ->> L: encode request
+  Note over L: transportInterceptors
+  L ->> Transport: standard request
+  Note over Transport: adapter interceptors (e.g. fetchInterceptors)
+  Transport ->> Server: request
+  Server ->> Transport: response
+  Transport ->> L: standard response
+  L ->> L: decode response
+  L ->> Caller: output or error
+```


### PR DESCRIPTION
Fills the five "TODO: add lifecycle diagram" placeholders in the docs with mermaid sequence diagrams. RPCHandler, OpenAPIHandler, RPCLink, OpenAPILink, and the server-side client pages now show where each interceptor layer runs and how requests flow end to end.

## Notes

- Diagrams are drawn from the current v2 code paths (StandardHandler, StandardLink, procedure client), not the v1 diagrams, since the interceptor layers were renamed in v2 (routingInterceptors, transportInterceptors, adapter-specific fetchInterceptors, ...).
- Handler pages link the procedure-client step to the new Server-Side Client Lifecycle section, and the server-side page notes the default middleware/validation ordering.

## Testing

- All five diagrams parse cleanly with the mermaid version Blume bundles (11.16.1).
- `blume validate --strict` passes, including the new cross-page anchor link.