### PR TITLE
docs: write the Getting Started guide

### DIFF
--- a/apps/content/docs/getting-started.mdx
+++ b/apps/content/docs/getting-started.mdx
@@ -76,6 +76,7 @@ A few things to notice:
 Clients reach your router through an HTTP server. `RPCHandler` does the translation: it matches each incoming request to a procedure, validates the input, runs your handler, and sends the result back. This example uses [Node's built-in HTTP module](/docs/adapters/node-http). The same router also runs on Bun, Deno, and Cloudflare Workers through the [Fetch API adapter](/docs/adapters/fetch-api).
 
 ```ts twoslash
+/// <reference types="node" />
 import { router } from './shared/getting-started'
 // ---cut---
 import { createServer } from 'node:http'

--- a/apps/content/docs/getting-started.mdx
+++ b/apps/content/docs/getting-started.mdx
@@ -5,4 +5,193 @@ sidebar:
   icon: rocket
 ---
 
-// TODO
+oRPC turns plain TypeScript functions into a fully typed API. You write each procedure once, and oRPC gives you a typed client, a REST API with an OpenAPI document, and typed event streams, all without code generation. This guide builds the smallest complete setup: a router, a server, and a typed client calling it.
+
+:::tip[Prefer a running example?]
+Open one of the [playgrounds](/docs/playgrounds) in StackBlitz and follow along in a complete project.
+:::
+
+## Installation
+
+Install the server and client packages, plus a schema library for validation. This guide uses [Zod](https://zod.dev/), but [Valibot](https://valibot.dev/), [ArkType](https://arktype.io/), and any other [Standard Schema](https://standardschema.dev/) library work the same way.
+
+```package-install
+npm install @orpc/server@beta @orpc/client@beta zod
+```
+
+## Define a Router
+
+Procedures are the functions of your API. Build them with the `os` builder and implement their logic in `.handler`. A router is a plain object that groups procedures, nested as deeply as you like.
+
+```ts twoslash
+declare function parseJWT(token: string | undefined): { userId: number } | null
+// ---cut---
+import type { IncomingHttpHeaders } from 'node:http'
+import { ORPCError, os } from '@orpc/server'
+import * as z from 'zod'
+
+const PlanetSchema = z.object({
+  id: z.number().int().min(1),
+  name: z.string(),
+  description: z.string().optional(),
+})
+
+export const listPlanet = os
+  .input(
+    z.object({
+      limit: z.number().int().min(1).max(100).optional(),
+      cursor: z.number().int().min(0).default(0),
+    }),
+  )
+  .handler(async ({ input }) => {
+    // your list code here
+    return [{ id: 1, name: 'name' }]
+  })
+
+export const findPlanet = os
+  .input(PlanetSchema.pick({ id: true }))
+  .handler(async ({ input }) => {
+    // your find code here
+    return { id: 1, name: 'name' }
+  })
+
+export const createPlanet = os
+  .$context<{ headers: IncomingHttpHeaders }>()
+  .use(({ context, next }) => {
+    const user = parseJWT(context.headers.authorization?.split(' ')[1])
+
+    if (user) {
+      return next({ context: { user } })
+    }
+
+    throw new ORPCError('UNAUTHORIZED')
+  })
+  .input(PlanetSchema.omit({ id: true }))
+  .handler(async ({ input, context }) => {
+    // your create code here
+    return { id: 1, name: 'name' }
+  })
+
+export const router = {
+  planet: {
+    list: listPlanet,
+    find: findPlanet,
+    create: createPlanet,
+  },
+}
+```
+
+A few things to notice:
+
+- `.input` validates requests before your handler runs. No `.output` schema is needed: the client's result type flows straight from the handler's return type.
+- `createPlanet` declares what it needs from the environment with [`.$context`](/docs/context) and injects `user` through [middleware](/docs/middleware) with `.use`. `parseJWT` stands in for your own token verification.
+- Throw an [`ORPCError`](/docs/error-handling) to reject a call with a specific error code.
+
+:::info
+`.handler` is the only required step. Every other chain is optional. Learn more in the [Procedure documentation](/docs/procedure).
+:::
+
+## Create a Server
+
+This example serves the router over HTTP with the [Node adapter](/docs/adapters/node-http). The same router also runs on Bun, Deno, and Cloudflare Workers through the [Fetch API adapter](/docs/adapters/fetch-api).
+
+```ts twoslash
+import { router } from './shared/getting-started'
+// ---cut---
+import { createServer } from 'node:http'
+import { onError } from '@orpc/server'
+import { RPCHandler } from '@orpc/server/node'
+import { CORSHandlerPlugin } from '@orpc/server/plugins'
+
+const handler = new RPCHandler(router, {
+  plugins: [
+    new CORSHandlerPlugin(),
+  ],
+  interceptors: [
+    onError((error) => {
+      console.error(error)
+    }),
+  ],
+})
+
+const server = createServer(async (req, res) => {
+  const { matched } = await handler.handle(req, res, {
+    prefix: '/rpc',
+    context: { headers: req.headers }, // <- initial context
+  })
+
+  if (matched) {
+    return
+  }
+
+  res.statusCode = 404
+  res.end('Not found')
+})
+
+server.listen(3000, '127.0.0.1', () => console.log('Listening on 127.0.0.1:3000'))
+```
+
+The `context` passed to `handle` fulfills what `createPlanet` declared with `.$context`: it carries each request's headers, so the auth middleware can check the `authorization` header the client sends.
+
+`RPCHandler` serves procedures over oRPC's fast [RPC protocol](/docs/rpc/protocol). Learn more in the [RPC Handler documentation](/docs/rpc/handler).
+
+:::info
+oRPC can also serve the same router as a REST API. Add [routing metadata](/docs/openapi/routing) to your procedures, serve them with the [OpenAPI Handler](/docs/openapi/handler), and generate an [OpenAPI specification](/docs/openapi/specification) from the same definitions.
+:::
+
+## Create a Client
+
+Pass an [RPC Link](/docs/rpc/link) to `createORPCClient` to build a fully typed client:
+
+```ts twoslash
+import type { router } from './shared/getting-started'
+// ---cut---
+import type { RouterClient } from '@orpc/server'
+import { createORPCClient } from '@orpc/client'
+import { RPCLink } from '@orpc/client/fetch'
+
+const link = new RPCLink({
+  origin: 'http://127.0.0.1:3000',
+  url: '/rpc', // <- must match the server's prefix
+  headers: { authorization: 'Bearer token' }, // <- checked by createPlanet's middleware
+})
+
+export const orpc: RouterClient<typeof router> = createORPCClient(link)
+```
+
+:::tip
+The client only needs the router's type. Import it with `import type`, or export the `RouterClient<typeof router>` type from the server, so no server code ends up in your client bundle. Learn more in the [Client-Side Clients documentation](/docs/client/client-side).
+:::
+
+When the client runs in the same process as the server, skip the network entirely and call procedures through a [server-side client](/docs/client/server-side).
+
+## Call a Procedure
+
+Call your procedures like local functions, with end-to-end type safety and autocompletion:
+
+```ts twoslash
+import { client as orpc } from './shared/getting-started'
+// ---cut---
+const planet = await orpc.planet.find({ id: 1 })
+
+orpc.planet.create
+//          ^|
+
+//
+
+//
+
+//
+//
+```
+
+Inputs are validated before your handler runs, and `planet` is typed from the handler's return value. Renaming a procedure or changing its schema is reflected in the client immediately, with no code generation step in between.
+
+## Next Steps
+
+- Master the core primitives: [Procedure](/docs/procedure), [Router](/docs/router), [Middleware](/docs/middleware), [Context](/docs/context), and [Error Handling](/docs/error-handling)
+- Stream typed events over SSE with [AsyncIteratorObject](/docs/async-iterator-object)
+- Expose the same router as a REST API with the [OpenAPI Handler](/docs/openapi/handler) and generate its [OpenAPI specification](/docs/openapi/specification)
+- Define your API as a [contract first](/docs/contract/procedure), then let TypeScript enforce the implementation
+- Integrate with your stack: [TanStack Query](/docs/integrations/tanstack-query), [SWR](/docs/integrations/swr), [Pinia Colada](/docs/integrations/pinia-colada), [Next.js](/docs/integrations/next), and [NestJS](/docs/integrations/nest)
+- Deploy on your runtime with the [adapters](/docs/adapters/node-http) for Node, Fetch API environments, Fastify, AWS Lambda, and more

--- a/apps/content/docs/getting-started.mdx
+++ b/apps/content/docs/getting-started.mdx
@@ -146,9 +146,6 @@ orpc.planet.create
 //
 
 //
-
-//
-//
 ```
 
 `planet` is typed from the handler's return value, invalid input is rejected before your handler runs, and renaming a procedure on the server is a compile error in the client. There is no generated code to keep in sync.

--- a/apps/content/docs/getting-started.mdx
+++ b/apps/content/docs/getting-started.mdx
@@ -5,7 +5,13 @@ sidebar:
   icon: rocket
 ---
 
-oRPC turns plain TypeScript functions into a fully typed API. You write each procedure once, and oRPC gives you a typed client, a REST API with an OpenAPI document, and typed event streams, all without code generation. This guide builds the smallest complete setup: a router, a server, and a typed client calling it.
+Building an API usually means defining HTTP endpoints on the server, calling them from the client, and keeping both sides' types in sync by hand. oRPC removes that gap: you write plain TypeScript functions on the server, and clients call them like local functions. Input is validated at runtime, types flow end to end, and there is no code generation step.
+
+This guide takes the shortest path through oRPC:
+
+1. Define procedures (the functions of your API) and group them into a router.
+2. Serve the router over HTTP.
+3. Call it from a fully typed client.
 
 :::tip[Prefer a running example?]
 Open one of the [playgrounds](/docs/playgrounds) in StackBlitz and follow along in a complete project.
@@ -13,7 +19,7 @@ Open one of the [playgrounds](/docs/playgrounds) in StackBlitz and follow along 
 
 ## Installation
 
-Install the server and client packages, plus a schema library for validation. This guide uses [Zod](https://zod.dev/), but [Valibot](https://valibot.dev/), [ArkType](https://arktype.io/), and any other [Standard Schema](https://standardschema.dev/) library work the same way.
+Install the server and client packages, plus a schema library for validating input at runtime. This guide uses [Zod](https://zod.dev/), but [Valibot](https://valibot.dev/), [ArkType](https://arktype.io/), and any other [Standard Schema](https://standardschema.dev/) library work the same way.
 
 ```package-install
 npm install @orpc/server@beta @orpc/client@beta zod
@@ -21,60 +27,38 @@ npm install @orpc/server@beta @orpc/client@beta zod
 
 ## Define a Router
 
-Procedures are the functions of your API. Build them with the `os` builder and implement their logic in `.handler`. A router is a plain object that groups procedures, nested as deeply as you like.
+A procedure is a function that clients can call remotely. Build one with the `os` builder (short for oRPC server): optionally describe the input it accepts with a schema, then implement it with `.handler`. A router is a plain object that groups procedures and gives each one its calling path, like `planet.list`.
 
 ```ts twoslash
-declare function parseJWT(token: string | undefined): { userId: number } | null
-// ---cut---
-import type { IncomingHttpHeaders } from 'node:http'
-import { ORPCError, os } from '@orpc/server'
+import { os } from '@orpc/server'
 import * as z from 'zod'
 
-const PlanetSchema = z.object({
-  id: z.number().int().min(1),
-  name: z.string(),
-  description: z.string().optional(),
-})
-
-export const listPlanet = os
-  .input(
-    z.object({
-      limit: z.number().int().min(1).max(100).optional(),
-      cursor: z.number().int().min(0).default(0),
-    }),
-  )
-  .handler(async ({ input }) => {
-    // your list code here
-    return [{ id: 1, name: 'name' }]
+export const listPlanets = os
+  .handler(async () => {
+    // replace with your database query
+    return [
+      { id: 1, name: 'Earth' },
+      { id: 2, name: 'Mars' },
+    ]
   })
 
 export const findPlanet = os
-  .input(PlanetSchema.pick({ id: true }))
+  .input(z.object({ id: z.number() }))
   .handler(async ({ input }) => {
-    // your find code here
-    return { id: 1, name: 'name' }
+    // replace with your database query
+    return { id: input.id, name: 'Earth' }
   })
 
 export const createPlanet = os
-  .$context<{ headers: IncomingHttpHeaders }>()
-  .use(({ context, next }) => {
-    const user = parseJWT(context.headers.authorization?.split(' ')[1])
-
-    if (user) {
-      return next({ context: { user } })
-    }
-
-    throw new ORPCError('UNAUTHORIZED')
-  })
-  .input(PlanetSchema.omit({ id: true }))
-  .handler(async ({ input, context }) => {
-    // your create code here
-    return { id: 1, name: 'name' }
+  .input(z.object({ name: z.string(), description: z.string().optional() }))
+  .handler(async ({ input }) => {
+    // replace with your database insert
+    return { id: 3, ...input }
   })
 
 export const router = {
   planet: {
-    list: listPlanet,
+    list: listPlanets,
     find: findPlanet,
     create: createPlanet,
   },
@@ -83,42 +67,24 @@ export const router = {
 
 A few things to notice:
 
-- `.input` validates requests before your handler runs. No `.output` schema is needed: the client's result type flows straight from the handler's return type.
-- `createPlanet` declares what it needs from the environment with [`.$context`](/docs/context) and injects `user` through [middleware](/docs/middleware) with `.use`. `parseJWT` stands in for your own token verification.
-- Throw an [`ORPCError`](/docs/error-handling) to reject a call with a specific error code.
-
-:::info
-`.handler` is the only required step. Every other chain is optional. Learn more in the [Procedure documentation](/docs/procedure).
-:::
+- `.input` validates each call before your handler runs and types `input` inside it. `listPlanets` skips it: a procedure without `.input` simply takes no arguments.
+- No `.output` schema is needed: the client's result type flows straight from the handler's return type.
+- Procedures can do much more: share [middleware](/docs/middleware), require [context](/docs/context) such as an authenticated user, and declare typed [errors](/docs/error-handling). Learn more in the [Procedure documentation](/docs/procedure).
 
 ## Create a Server
 
-This example serves the router over HTTP with the [Node adapter](/docs/adapters/node-http). The same router also runs on Bun, Deno, and Cloudflare Workers through the [Fetch API adapter](/docs/adapters/fetch-api).
+Clients reach your router through an HTTP server. `RPCHandler` does the translation: it matches each incoming request to a procedure, validates the input, runs your handler, and sends the result back. This example uses [Node's built-in HTTP module](/docs/adapters/node-http). The same router also runs on Bun, Deno, and Cloudflare Workers through the [Fetch API adapter](/docs/adapters/fetch-api).
 
 ```ts twoslash
 import { router } from './shared/getting-started'
 // ---cut---
 import { createServer } from 'node:http'
-import { onError } from '@orpc/server'
 import { RPCHandler } from '@orpc/server/node'
-import { CORSHandlerPlugin } from '@orpc/server/plugins'
 
-const handler = new RPCHandler(router, {
-  plugins: [
-    new CORSHandlerPlugin(),
-  ],
-  interceptors: [
-    onError((error) => {
-      console.error(error)
-    }),
-  ],
-})
+const handler = new RPCHandler(router)
 
 const server = createServer(async (req, res) => {
-  const { matched } = await handler.handle(req, res, {
-    prefix: '/rpc',
-    context: { headers: req.headers }, // <- initial context
-  })
+  const { matched } = await handler.handle(req, res, { prefix: '/rpc' })
 
   if (matched) {
     return
@@ -131,9 +97,7 @@ const server = createServer(async (req, res) => {
 server.listen(3000, '127.0.0.1', () => console.log('Listening on 127.0.0.1:3000'))
 ```
 
-The `context` passed to `handle` fulfills what `createPlanet` declared with `.$context`: it carries each request's headers, so the auth middleware can check the `authorization` header the client sends.
-
-`RPCHandler` serves procedures over oRPC's fast [RPC protocol](/docs/rpc/protocol). Learn more in the [RPC Handler documentation](/docs/rpc/handler).
+Every procedure is now reachable under the `/rpc` prefix. Requests that are not oRPC calls fall through, so you can handle them yourself, here with a plain 404. For CORS, logging, and other options, see the [RPC Handler documentation](/docs/rpc/handler).
 
 :::info
 oRPC can also serve the same router as a REST API. Add [routing metadata](/docs/openapi/routing) to your procedures, serve them with the [OpenAPI Handler](/docs/openapi/handler), and generate an [OpenAPI specification](/docs/openapi/specification) from the same definitions.
@@ -141,7 +105,7 @@ oRPC can also serve the same router as a REST API. Add [routing metadata](/docs/
 
 ## Create a Client
 
-Pass an [RPC Link](/docs/rpc/link) to `createORPCClient` to build a fully typed client:
+On the client, `RPCLink` is the counterpart of `RPCHandler`: it turns your function calls into HTTP requests. Pass it to `createORPCClient`, and type the result with `RouterClient<typeof router>` so the client knows every procedure, its input, and its output.
 
 ```ts twoslash
 import type { router } from './shared/getting-started'
@@ -153,7 +117,6 @@ import { RPCLink } from '@orpc/client/fetch'
 const link = new RPCLink({
   origin: 'http://127.0.0.1:3000',
   url: '/rpc', // <- must match the server's prefix
-  headers: { authorization: 'Bearer token' }, // <- checked by createPlanet's middleware
 })
 
 export const orpc: RouterClient<typeof router> = createORPCClient(link)
@@ -163,15 +126,17 @@ export const orpc: RouterClient<typeof router> = createORPCClient(link)
 The client only needs the router's type. Import it with `import type`, or export the `RouterClient<typeof router>` type from the server, so no server code ends up in your client bundle. Learn more in the [Client-Side Clients documentation](/docs/client/client-side).
 :::
 
-When the client runs in the same process as the server, skip the network entirely and call procedures through a [server-side client](/docs/client/server-side).
+When the caller runs in the same process as the server, for example during server-side rendering, skip HTTP entirely with a [server-side client](/docs/client/server-side).
 
 ## Call a Procedure
 
-Call your procedures like local functions, with end-to-end type safety and autocompletion:
+That is the whole setup. Call your procedures like local functions and let your editor do the rest:
 
 ```ts twoslash
 import { client as orpc } from './shared/getting-started'
 // ---cut---
+const planets = await orpc.planet.list()
+
 const planet = await orpc.planet.find({ id: 1 })
 
 orpc.planet.create
@@ -185,13 +150,13 @@ orpc.planet.create
 //
 ```
 
-Inputs are validated before your handler runs, and `planet` is typed from the handler's return value. Renaming a procedure or changing its schema is reflected in the client immediately, with no code generation step in between.
+`planet` is typed from the handler's return value, invalid input is rejected before your handler runs, and renaming a procedure on the server is a compile error in the client. There is no generated code to keep in sync.
 
 ## Next Steps
 
-- Master the core primitives: [Procedure](/docs/procedure), [Router](/docs/router), [Middleware](/docs/middleware), [Context](/docs/context), and [Error Handling](/docs/error-handling)
-- Stream typed events over SSE with [AsyncIteratorObject](/docs/async-iterator-object)
+- Learn the building blocks in depth: [Procedure](/docs/procedure) and [Router](/docs/router)
+- Add authentication and logging with [Middleware](/docs/middleware) and [Context](/docs/context), and reject calls with typed [errors](/docs/error-handling)
+- Stream typed events over Server-Sent Events (SSE) with [AsyncIteratorObject](/docs/async-iterator-object)
 - Expose the same router as a REST API with the [OpenAPI Handler](/docs/openapi/handler) and generate its [OpenAPI specification](/docs/openapi/specification)
 - Define your API as a [contract first](/docs/contract/procedure), then let TypeScript enforce the implementation
 - Integrate with your stack: [TanStack Query](/docs/integrations/tanstack-query), [SWR](/docs/integrations/swr), [Pinia Colada](/docs/integrations/pinia-colada), [Next.js](/docs/integrations/next), and [NestJS](/docs/integrations/nest)
-- Deploy on your runtime with the [adapters](/docs/adapters/node-http) for Node, Fetch API environments, Fastify, AWS Lambda, and more

--- a/apps/content/shared/getting-started.ts
+++ b/apps/content/shared/getting-started.ts
@@ -1,0 +1,55 @@
+import * as z from 'zod'
+import type { RouterClient } from '@orpc/server'
+import { ORPCError, os } from '@orpc/server'
+import type { IncomingHttpHeaders } from 'node:http'
+
+declare function parseJWT(token: string | undefined): { userId: number } | null
+
+export const PlanetSchema = z.object({
+  id: z.number().int().min(1),
+  name: z.string(),
+  description: z.string().optional(),
+})
+
+export const listPlanet = os
+  .input(
+    z.object({
+      limit: z.number().int().min(1).max(100).optional(),
+      cursor: z.number().int().min(0).default(0),
+    }),
+  )
+  .handler(async ({ input }) => {
+    return [{ id: 1, name: 'name' }]
+  })
+
+export const findPlanet = os
+  .input(PlanetSchema.pick({ id: true }))
+  .handler(async ({ input }) => {
+    return { id: 1, name: 'name' }
+  })
+
+export const createPlanet = os
+  .$context<{ headers: IncomingHttpHeaders }>()
+  .use(({ context, next }) => {
+    const user = parseJWT(context.headers.authorization?.split(' ')[1])
+
+    if (user) {
+      return next({ context: { user } })
+    }
+
+    throw new ORPCError('UNAUTHORIZED')
+  })
+  .input(PlanetSchema.omit({ id: true }))
+  .handler(async ({ input, context }) => {
+    return { id: 1, name: 'name' }
+  })
+
+export const router = {
+  planet: {
+    list: listPlanet,
+    find: findPlanet,
+    create: createPlanet,
+  },
+}
+
+export const client = {} as RouterClient<typeof router>

--- a/apps/content/shared/getting-started.ts
+++ b/apps/content/shared/getting-started.ts
@@ -1,52 +1,30 @@
 import * as z from 'zod'
 import type { RouterClient } from '@orpc/server'
-import { ORPCError, os } from '@orpc/server'
-import type { IncomingHttpHeaders } from 'node:http'
+import { os } from '@orpc/server'
 
-declare function parseJWT(token: string | undefined): { userId: number } | null
-
-export const PlanetSchema = z.object({
-  id: z.number().int().min(1),
-  name: z.string(),
-  description: z.string().optional(),
-})
-
-export const listPlanet = os
-  .input(
-    z.object({
-      limit: z.number().int().min(1).max(100).optional(),
-      cursor: z.number().int().min(0).default(0),
-    }),
-  )
-  .handler(async ({ input }) => {
-    return [{ id: 1, name: 'name' }]
+export const listPlanets = os
+  .handler(async () => {
+    return [
+      { id: 1, name: 'Earth' },
+      { id: 2, name: 'Mars' },
+    ]
   })
 
 export const findPlanet = os
-  .input(PlanetSchema.pick({ id: true }))
+  .input(z.object({ id: z.number() }))
   .handler(async ({ input }) => {
-    return { id: 1, name: 'name' }
+    return { id: input.id, name: 'Earth' }
   })
 
 export const createPlanet = os
-  .$context<{ headers: IncomingHttpHeaders }>()
-  .use(({ context, next }) => {
-    const user = parseJWT(context.headers.authorization?.split(' ')[1])
-
-    if (user) {
-      return next({ context: { user } })
-    }
-
-    throw new ORPCError('UNAUTHORIZED')
-  })
-  .input(PlanetSchema.omit({ id: true }))
-  .handler(async ({ input, context }) => {
-    return { id: 1, name: 'name' }
+  .input(z.object({ name: z.string(), description: z.string().optional() }))
+  .handler(async ({ input }) => {
+    return { id: 3, ...input }
   })
 
 export const router = {
   planet: {
-    list: listPlanet,
+    list: listPlanets,
     find: findPlanet,
     create: createPlanet,
   },


### PR DESCRIPTION
Replaces the \`// TODO\` placeholder on \`/docs/getting-started\` with a complete guide aimed at readers who have never used oRPC: define a router, serve it over HTTP, and call it from a fully typed client.

## Content

- Every concept is introduced in plain words as it first appears (procedure, router, \`os\`, \`RPCHandler\`, \`RPCLink\`), and the intro maps the whole guide as three numbered steps.
- The happy path stays minimal: three schema-validated procedures, a zero-options \`RPCHandler\` on Node's HTTP module, and a two-option \`RPCLink\`. Middleware, context, typed errors, SSE streams, OpenAPI, contract-first, and integrations are linked at the point of relevance and in Next Steps rather than inlined.
- A new \`shared/getting-started.ts\` twoslash fixture mirrors the page's visible router exactly, so rendered hover types show precisely what the handlers return and back the page's "the result type flows from the handler" teaching.

## Verification

- All twoslash snippets typecheck against the workspace packages, including \`new RPCHandler(router)\` with no options and \`handle\` without \`context\`; type assertions confirm the client output types come from handler return types with no schema-added fields.
- Internal links all resolve to existing pages, install commands use the \`@beta\` tags, and eslint passes.