### PR TITLE
docs: add orpc-file-router into ecosystem

### DIFF
--- a/apps/content/docs/ecosystem.mdx
+++ b/apps/content/docs/ecosystem.mdx
@@ -12,3 +12,7 @@ Built something on top of oRPC? [Open a pull request](https://github.com/middlea
 ## AI
 
 <GithubInfo owner="mi3lix9" repo="orpc-mcp" />
+
+## Routing
+
+<GithubInfo owner="Prains" repo="orpc-file-router" />

--- a/apps/content/docs/ecosystem.mdx
+++ b/apps/content/docs/ecosystem.mdx
@@ -13,6 +13,6 @@ Built something on top of oRPC? [Open a pull request](https://github.com/middlea
 
 <GithubInfo owner="mi3lix9" repo="orpc-mcp" />
 
-## Routing
+## Tooling
 
 <GithubInfo owner="Prains" repo="orpc-file-router" />


### PR DESCRIPTION
adds [orpc-file-router](https://github.com/Prains/orpc-file-router) under a new `## Routing` section

it generates `router.gen.ts` from a directory of route files — one file per procedure, directories become namespaces — so the router object no longer has to be hand-maintained as a project grows

what it keeps intact:

- **types** — import paths in the generated file are static, so `RouterClient<typeof router>` still infers down to each procedure
- **laziness** — every leaf is wrapped in `os.lazy()`, and leaves also carry `openapi.prefix` + `openapi.path` metadata, so `OpenAPIHandler` keeps directory-level laziness instead of unwrapping the whole tree on the first request

it also validates the things that fail silently at runtime otherwise — a route file without `export default`, and names such as `then` or `~orpc` that are unreachable through the client proxy — and ships a cli, a watch mode and a vite plugin

published on npm as `orpc-file-router`, maintained in its own repository

follows the existing entry format — `GithubInfo` component, no hand-written blurb to keep in sync
