### PR TITLE
chore(content): tint tip callouts green instead of brand pink

### DIFF
--- a/apps/content/theme.css
+++ b/apps/content/theme.css
@@ -281,6 +281,24 @@ main#blume-content {
 /* Non-owned chrome                                                 */
 /* ---------------------------------------------------------------- */
 
+/* Blume tints `:::tip` blocks with the accent color, which here is the brand
+   pink — a tip then reads as an alarm, barely distinguishable from the red
+   `:::danger` blocks. Green instead (GitHub's alert convention); the docs use
+   no `success`/`check` callouts for it to collide with. Matched on Blume's own
+   accent utilities, the only marker the tip variant leaves in the markup. */
+aside[class~='bg-accent/10'] {
+  border-color: color-mix(in oklab, var(--color-green-500) 25%, transparent);
+  background-color: color-mix(in oklab, var(--color-green-500) 10%, transparent);
+}
+
+aside[class~='bg-accent/10'] [class~='text-accent'] {
+  color: var(--color-green-600);
+}
+
+:root[data-theme='dark'] aside[class~='bg-accent/10'] [class~='text-accent'] {
+  color: var(--color-green-400);
+}
+
 /* Search trigger: wide, quiet gray box like the reference header */
 [data-blume-search-open] {
   height: 2.375rem;


### PR DESCRIPTION
Blume tints `:::tip` callouts with the theme accent, which on this site is the brand pink. Tips therefore looked like alarms and were hard to tell apart from the red `:::danger` blocks. They are green now, following GitHub's alert convention.

## Fixes

`:::tip` blocks (33 across the docs) render with a green frame, fill, and icon in both themes, matching the exact tokens Blume uses for its other callout variants (`green-500` for frame and fill, `green-600`/`green-400` for the icon). Green is unclaimed here: the docs use no `success` or `check` callouts.

## Testing

Verified on `/docs/getting-started` in the dev server: the callout's computed fill and border are `green-500` at 10%/25%, and the icon resolves to `green-600` in light mode and `green-400` in dark.

## Notes for reviewers

The override matches Blume's own `bg-accent/10` utility, the only marker the tip variant leaves in the markup, since `Callout.astro` is not overridable through config. It wins the cascade unconditionally: Tailwind emits its utilities inside `@layer utilities`, while `theme.css` is unlayered.
