### PR TITLE
docs: add pub/sub and rate limiting to the comparison page

### DIFF
--- a/apps/content/docs/comparison.mdx
+++ b/apps/content/docs/comparison.mdx
@@ -49,6 +49,8 @@ oRPC serves the same procedures over its [RPC protocol](/docs/rpc/protocol) and 
 | [Hibernation APIs (Cloudflare WebSocket Hibernation, ...)](/docs/integrations/hibernation) | ✅ | 🛑 | 🛑 |
 | [Message Port (Electron, browser extensions, workers, ...)](/docs/adapters/message-port) | ✅ | 🟡 | 🛑 |
 | [Batch requests](/docs/plugins/batch) | ✅ | ✅ | 🛑 |
+| [Pub/Sub publisher (Redis, Upstash, Durable Objects, ...)](/docs/helpers/publisher) | ✅ | 🟡 | 🛑 |
+| [Rate limiting (Redis, Upstash, Cloudflare, ...)](/docs/helpers/ratelimit) | ✅ | 🛑 | 🟡 |
 | [Client plugins and interceptors](/docs/rpc/link) | ✅ | ✅ | 🛑 |
 | [TanStack Query integration (React)](/docs/integrations/tanstack-query) | ✅ | ✅ | 🟡 |
 | [TanStack Query integration (Vue, Solid, Svelte, Angular)](/docs/integrations/tanstack-query) | ✅ | 🟡 | 🛑 |
@@ -56,7 +58,7 @@ oRPC serves the same procedures over its [RPC protocol](/docs/rpc/protocol) and 
 | [AI SDK integration](/docs/integrations/ai-sdk) | ✅ | 🛑 | 🛑 |
 | [Next.js Server Actions support](/docs/integrations/next) | ✅ | ✅ | 🛑 |
 | [Built-in plugins (CORS, CSRF, Retry, ...)](/docs/plugins/cors) | ✅ | 🛑 | ✅ |
-| [Built-in helpers (cookie, encryption, rate limit, pub/sub, ...)](/docs/helpers/cookie) | ✅ | 🛑 | ✅ |
+| [Built-in helpers (cookie, encryption, signing, ...)](/docs/helpers/cookie) | ✅ | 🛑 | ✅ |
 | [NestJS integration](/docs/integrations/nest) | ✅ | 🟡 | 🛑 |
 | [OpenTelemetry integration](/docs/integrations/opentelemetry) | ✅ | 🛑 | 🟡 |
 


### PR DESCRIPTION
The comparison page listed pub/sub and rate limiting only inside the generic "built-in helpers" row, so two features that tRPC and Hono do not ship first-party were easy to miss. Each now gets its own row in the Integrations & Ecosystem table, linking to the helper docs and naming the supported backends.

The helpers row is relabeled to "cookie, encryption, signing, ..." so the two features are not counted twice.

Marks: tRPC gets 🟡 for pub/sub because subscriptions exist but you supply your own broker for anything multi-instance, and 🛑 for rate limiting since nothing is first-party or documented. Hono gets 🛑 for pub/sub, consistent with the existing Server-Sent Events row, and 🟡 for rate limiting because `hono-rate-limiter` is third-party.

Testing: all four link targets resolve to existing pages. The docs build was not run.