### PR TITLE
chore(content): show the page rail from 1280px on a full-width frame

### DIFF
--- a/apps/content/pages/blog/[...slug].astro
+++ b/apps/content/pages/blog/[...slug].astro
@@ -115,7 +115,7 @@ const postJsonLd = {
   />
   {/*
     The docs frame: theme.css centers `[data-blume-doc-grid]` on the header
-    width and, from 96rem, sizes any grid whose class carries `xl:grid-cols-`.
+    width and, from 80rem, sizes any grid whose class carries `xl:grid-cols-`.
     The nav column stays empty here, which keeps the article centered opposite
     the table of contents.
   */}
@@ -208,11 +208,12 @@ const postJsonLd = {
       </div>
     </article>
 
-    {/* theme.css owns the rail's visibility and vertical metrics (it only
-        appears once the three-column frame fits); the rest is styling. */}
+    {/* `hidden xl:block` is how Blume's own rail appears with the third
+        column, and the mobile collapsible above takes over below it;
+        theme.css owns the vertical metrics. */}
     <aside
       aria-label={ui.toc.title}
-      class="sticky overflow-y-auto scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent px-4 pb-10 text-sm xl:col-start-3"
+      class="sticky hidden overflow-y-auto scrollbar-thin scrollbar-thumb-border scrollbar-track-transparent px-4 pb-10 text-sm xl:col-start-3 xl:block"
       data-blume-toc
     >
       <TableOfContents headings={tocHeadings} title={ui.toc.title} variant="desktop" />

--- a/apps/content/theme.css
+++ b/apps/content/theme.css
@@ -48,6 +48,20 @@
   min-height: calc(100vh - var(--docs-header-height));
 }
 
+/* Below 2xl the frame spans the viewport, so the docs grid pays for its
+   TOC rail out of the gutters the frame would otherwise leave empty
+   rather than out of the prose column. Every layout is drawn against
+   this variable — the header on all of them, the grid on docs and blog
+   posts — so one declaration keeps the landing page, the blog, and the
+   docs on the same container at any given viewport. Under the frame
+   width it is what `min()` already resolved to, so the widths this
+   actually changes run from 81.875rem to 2xl. */
+@media (max-width: 95.9375rem) {
+  :root {
+    --docs-frame-width: 100%;
+  }
+}
+
 @media (min-width: 64rem) {
   /* Scoped to grids that carry Blume's own responsive column classes:
      "bare" pages (the changelog index) render a single centered column
@@ -71,22 +85,31 @@
   }
 }
 
-/* TOC appears only when the full three-column frame fits (like the
-   reference's max-2xl collapse). */
+/* TOC rail: like the nav rail it sits under the shorter header, and it
+   opens level with the content column's first line. Both rails carry
+   `sticky`, so these metrics only apply once `hidden xl:block` reveals
+   them — the tier Blume also stops rendering the mobile `<details>`
+   fallback at. */
 [data-blume-toc] {
-  display: none;
+  top: var(--docs-header-height);
+  height: calc(100dvh - var(--docs-header-height));
+  padding-top: 3rem;
 }
 
+/* Three columns from that same tier. The nav rail holds its two-column
+   width so nothing shifts as the TOC appears, and the content column
+   takes whatever the full-width frame has left over. */
+@media (min-width: 80rem) {
+  [data-blume-doc-grid][class*='xl:grid-cols-'] {
+    grid-template-columns: 14.5rem minmax(0, 1fr) 16.5rem;
+  }
+}
+
+/* From 2xl the frame stops growing, so the rail can take its wider
+   width and the prose column its designed measure. */
 @media (min-width: 96rem) {
   [data-blume-doc-grid][class*='xl:grid-cols-'] {
     grid-template-columns: 15.875rem minmax(0, 51.25rem) 16.5rem;
-  }
-
-  [data-blume-toc] {
-    display: block;
-    top: var(--docs-header-height);
-    height: calc(100dvh - var(--docs-header-height));
-    padding-top: 3rem;
   }
 }
 


### PR DESCRIPTION
The "on this page" rail now appears from 1280px instead of 1536px, and below 1536px the layout frame spans the viewport so the third column is paid for out of the gutters the centered frame left empty rather than out of the prose column. The landing page, docs, blog, and changelog all sit on the same container width at any given viewport.

## Fixes

- Between 1280px and 1535px there was no table of contents at all: the rail waited for 1536px while the mobile collapsible that stands in for it stops rendering at 1280px. The rail now takes over exactly where the collapsible leaves off.
- The header no longer sits on a different width than the page beneath it in that range.
- The blog post rail follows the same rules as the docs rail instead of its own; theme.css no longer toggles either one's visibility.

## Testing

- Header, grid, rail, and collapsible measured against a dev server on `/`, `/docs`, `/blog`, a blog post, `/changelog`, and a changelog entry at 768, 1024, 1279, 1280, 1400, 1535, 1536, and 1920px: the rail is hidden below 1280px everywhere and sticky under the header above it, the container width matches across page types at every width, and no page overflows horizontally.
- Nothing at or above 1536px moved, and nothing below 81.875rem moved.
- `pnpm lint` and `pnpm docs:validate` pass.
