### PR TITLE
docs(node): add blog post on the tmp file upload plugin

### DIFF
--- a/apps/content/blog/uploads-bigger-than-your-ram.mdx
+++ b/apps/content/blog/uploads-bigger-than-your-ram.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Handling File Uploads Bigger Than Your RAM in JavaScript"
-description: "Stream large file uploads to disk in any JavaScript runtime while keeping the standard File API: lazy blobs, safe temp file cleanup, and per-category body size limits."
+description: "Stream large file uploads to disk in any JavaScript runtime while keeping the standard File API. Lazy blobs, safe temp file cleanup, per-category body size limits, and the oRPC plugin that packages it all."
 type: blog
 date: 2026-08-17
 search:
@@ -26,21 +26,21 @@ const video = form.get('video') as File
 
 It looks harmless. It is a memory bomb. [`request.formData()`](https://developer.mozilla.org/en-US/docs/Web/API/Request/formData) resolves only after the entire body is parsed, and on the server that means buffering every byte in memory. Its siblings are no better: `.blob()`, `.arrayBuffer()`, `.bytes()`, and `.text()` all buffer the whole body the same way. A 2 GB video becomes 2 GB of heap. Five concurrent uploads become 10 GB. Your 512 MB container dies before your handler runs, in framework code you never wrote.
 
-The standard `File` and `FormData` APIs made uploads pleasant, and quietly made them dangerous.
+oRPC's [Tmp File Upload Handler Plugin](/docs/plugins/tmp-file-upload) escapes this trap: uploads of any size spool to disk while your handlers keep receiving standard `File` objects. This post shares how it works, because every idea in it is portable to any JavaScript stack, and the interesting parts are the ones nobody warns you about.
 
 ## The Old Fix: Stream Uploads to Temp Files
 
-PHP has streamed uploads into temporary files [since practically forever](https://www.php.net/manual/en/features.file-upload.post-method.php): your script receives a `tmp_name` path, not a buffer. Express had a whole [ecosystem of streaming multipart parsers](https://bytearcher.com/articles/formidable-vs-busboy-vs-multer-vs-multiparty/): busboy hands you a readable stream per file, formidable and [multer](https://github.com/expressjs/multer) spool to disk on top of it.
+This is not a new problem, and the old solutions were good. PHP has streamed uploads into temporary files [since practically forever](https://www.php.net/manual/en/features.file-upload.post-method.php): your script receives a `tmp_name` path, not a buffer. Express had a whole [ecosystem of streaming multipart parsers](https://bytearcher.com/articles/formidable-vs-busboy-vs-multer-vs-multiparty/): busboy hands you a readable stream per file, formidable and [multer](https://github.com/expressjs/multer) spool to disk on top of it.
 
 Then the fetch-standard era arrived. Every runtime speaks `Request` and `Response`, which is great, but `await request.formData()` became the blessed path and the temp-file wisdom was traded for API convenience.
 
-So the question behind this post: can you keep the standard `File` API and still handle uploads of any size in constant memory?
+So the challenge is to have both: the standard `File` API that validation libraries and application code already understand, and constant memory for uploads of any size.
 
 ## A File That Lives on Disk
 
 Browsers never buffered your files in the first place. A `File` picked from an `<input>` is a lazy, disk-backed handle; nothing is read until you call `.stream()` or `.arrayBuffer()`. Chrome even spills its blob store to disk when memory runs short. [The hidden nuance of the JavaScript File API](https://nickb.dev/blog/the-hidden-nuance-of-the-javascript-file-api/) is a great tour of this asymmetry: `File` was always a handle to bytes plus a size and a type. Buffering is an implementation shortcut, not a law.
 
-Server runtimes can play the same trick. Node ships [`fs.openAsBlob`](https://nodejs.org/api/fs.html#fsopenasblobpath-options), which returns a `Blob` whose bytes stay on disk and are read lazily. Bun ships the same idea as a first-class primitive, [`Bun.file`](https://bun.com/docs/api/file-io), Deno covers it through its [Node compatibility layer](https://docs.deno.com/api/node/fs/~/openAsBlob), and [lazy-file](https://www.npmjs.com/package/@remix-run/lazy-file) generalizes it to arbitrary sources. Stream the incoming bytes to a temp file, then wrap the result:
+Server runtimes can play the same trick. Node ships [`fs.openAsBlob`](https://nodejs.org/api/fs.html#fsopenasblobpath-options), which returns a `Blob` whose bytes stay on disk and are read lazily. Bun ships the same idea as a first-class primitive, [`Bun.file`](https://bun.com/docs/api/file-io), Deno covers it through its [Node compatibility layer](https://docs.deno.com/api/node/fs/~/openAsBlob), and [lazy-file](https://www.npmjs.com/package/@remix-run/lazy-file) generalizes it to arbitrary sources. Stream the incoming bytes to a temp file, then wrap the result. This is the entire heart of the plugin:
 
 ```ts
 export class TmpFile extends File {
@@ -97,17 +97,19 @@ createServer(async (req, res) => {
 }).listen(3000)
 ```
 
-[`pipeline`](https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-callback) handles backpressure, so a fast client cannot outrun your disk and pile bytes up in memory. Multipart bodies need a streaming parser like busboy to split the parts, but the per-file principle is exactly this. It is not even Node-specific: Bun implements both `node:http` and `fs.openAsBlob`, so the example runs there unchanged. The piece that looks trivial is the real hard part: that `finally`.
+[`pipeline`](https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-callback) handles backpressure, so a fast client cannot outrun your disk and pile bytes up in memory. Multipart bodies need a streaming parser like busboy to split the parts, but the per-file principle is exactly this. It is not even Node-specific: Bun implements both `node:http` and `fs.openAsBlob`, so the example runs there unchanged.
+
+If this were the whole story, the plugin would be fifty lines. The piece of the example that looks trivial is where production begins: that `finally`.
 
 ## When to Delete the Temp Files
 
-Writing bytes to a temp file is the easy 20%. Making them reliably disappear is the other 80%.
+Spooling bytes to disk is the easy 20%. Most of the plugin's design went into making them reliably disappear, and each problem applies to any implementation of this pattern.
 
-**When is a request "done"?** Deleting when the handler returns is wrong: a streaming response, like an event stream or a raw binary stream, may read the upload *while* transmitting, and would fail halfway. The rule that works: if the response body is a stream or an async iterator, deletion rides on the body finishing. That also covers clients that vanish mid-download, since cancelling the body reaches the same finish hook. Every other response is sent after removal, so temp files live exactly as long as anything can read them, and not a request longer.
+**When is a request "done"?** Deleting when the handler returns is wrong: a streaming response, like an event stream or a raw binary stream, may read the upload *while* transmitting, and would fail halfway. So the plugin inspects the response: if its body is a stream or an async iterator, deletion rides on the body finishing. That also covers clients that vanish mid-download, since cancelling the body reaches the same finish hook. Every other response is sent after removal. Temp files live exactly as long as anything can read them, and not a request longer.
 
 **Open handles.** Each request gets its own directory under the OS temp dir, and content lands through self-contained appends instead of long-lived file handles: at most one transient descriptor per in-flight write, however many files the request carries. A burst of uploads cannot exhaust the descriptor table, and deletion never fights an open handle, which matters on Windows where deleting an open file is an error.
 
-**Failure isolation.** Disk full is your problem; a malformed multipart body is the client's. Filesystem failures surface as internal server errors with details only on the error's `cause`, never serialized to the client; parse failures stay bad requests. And a failed cleanup must not change the request outcome: a response that succeeded should never turn into an error over a temp file the OS will reap anyway.
+**Failure isolation.** Disk full is your problem; a malformed multipart body is the client's. The plugin keeps the two apart: filesystem failures surface as internal server errors with details only on the error's `cause`, never serialized to the client, while parse failures stay bad requests. And a failed cleanup never changes the request outcome, because a response that succeeded should not turn into an error over a temp file the OS will reap anyway.
 
 ## Three Body Size Limits, Not One
 
@@ -117,15 +119,19 @@ Most body-limit middleware takes a single number. Once uploads spool to disk, a 
 - A byte of **upload** touches memory only as a passing chunk on its way to disk. You can afford about a thousand times more of these.
 - A byte of an **event stream** is consumed on the fly and costs almost nothing to relay.
 
-One limit prices all three at the highest rate, so take three: `memory`, `file`, and `stream`. Configuring one requires configuring all three, so nothing is left unbounded by accident; unlimited must be spelled `Number.POSITIVE_INFINITY`, on purpose.
+One limit prices all three at the highest rate, so the plugin takes three: `memory`, `file`, and `stream`. It even [subsumes a generic request-limit plugin](/docs/plugins/request-limit), sizing each kind of body to what it actually costs. Configuring one limit requires configuring all three, so nothing is left unbounded by accident; unlimited must be spelled `Number.POSITIVE_INFINITY`, on purpose.
 
-Enforcement has its own subtlety: `Content-Length` is a hint, not a fact. [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-content-length) allows it to be absent, and a hostile client can lie. Use the declared length to reject oversized requests early for free, but count the bytes as they arrive and cut the request off mid-stream with `413 Payload Too Large` the moment it crosses the line. Bound a multipart body by `memory + file` in total, framing included, so bulk hidden in part headers is caught too.
+Enforcement has its own subtlety: `Content-Length` is a hint, not a fact. [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-content-length) allows it to be absent, and a hostile client can lie. The plugin uses the declared length only to reject oversized requests early, then counts bytes as they arrive and cuts the request off mid-stream with `413 Payload Too Large` the moment it crosses the line. A multipart body is bounded by `memory + file` in total, framing included, so bulk hidden in part headers is caught too.
 
-## Where This Landed
+## Constant-Memory File Uploads in oRPC
 
-Everything above ships as the [Tmp File Upload Handler Plugin](/docs/plugins/tmp-file-upload) in `@orpc/node`. One plugin, zero changes to your procedures:
+All of the above is one plugin and zero changes to your procedures:
 
 ```ts
+import { TmpFile, TmpFileUploadHandlerPlugin } from '@orpc/node'
+import { RPCHandler } from '@orpc/server/node'
+import { rename } from 'node:fs/promises'
+
 const handler = new RPCHandler(router, {
   plugins: [
     new TmpFileUploadHandlerPlugin({
@@ -147,6 +153,8 @@ const uploadVideo = os
   })
 ```
 
+File bodies and multipart file parts spool to disk; JSON and text fields parse normally. Validation sees standard `File` objects, so schemas like `z.file()` just work, and `TmpFile.path` turns "save the upload" into a rename instead of a gigabyte copy.
+
 :::warning
 Temporary files are removed when the request finishes. Move or copy an upload inside your handler if you need it afterwards.
 :::
@@ -154,3 +162,5 @@ Temporary files are removed when the request finishes. Move or copy an upload in
 ## The Takeaway
 
 The `File` interface never demanded buffering; we defaulted to it because it was the shortest code. Browsers knew better all along, PHP knew the right shape in the 90s, and every major JavaScript runtime now gives servers lazy blobs to express it cleanly. The remaining engineering is about lifetimes, not bytes: know when the last reader is done, price each kind of byte at what it costs, and never trust a header you can count for yourself.
+
+If you use oRPC, the [Tmp File Upload Handler Plugin](/docs/plugins/tmp-file-upload) is one import away. If you are building your own, steal the lifetimes.

--- a/apps/content/blog/uploads-bigger-than-your-ram.mdx
+++ b/apps/content/blog/uploads-bigger-than-your-ram.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Handling File Uploads Bigger Than Your RAM"
-description: "Streaming uploads to disk behind the standard File API: lazy blobs, the platform's 2 GiB potholes, deletion timing, and why one size limit is never enough."
+description: "Streaming uploads to disk behind the standard File API: lazy blobs, deletion timing, and why one size limit is never enough."
 type: blog
 date: 2026-08-17
 search:
@@ -32,7 +32,7 @@ The standard `File` and `FormData` APIs made uploads pleasant, and quietly made 
 
 This is not a new problem, and the old solutions were good. PHP has streamed uploads into temporary files [since practically forever](https://www.php.net/manual/en/features.file-upload.post-method.php): your script receives a `tmp_name` path, not a buffer. The Express era had a whole [ecosystem of streaming multipart parsers](https://bytearcher.com/articles/formidable-vs-busboy-vs-multer-vs-multiparty/): busboy hands you a readable stream per file as the bytes arrive, formidable and [multer](https://github.com/expressjs/multer) spool to disk on top of that.
 
-Then the fetch-standard era arrived. Every runtime speaks `Request` and `Response` now, which is genuinely great, but `await request.formData()` became the blessed path and the temp-file wisdom got traded away for API convenience. The trade is worse than it looks, because the buffering path is not just hungry, it is capped: Node's multipart parser has been [reported to give up entirely past 2 GiB](https://smoores.dev/post/overcoming_io_limits/), failing with an error that looks like a malformed body rather than a size problem.
+Then the fetch-standard era arrived. Every runtime speaks `Request` and `Response` now, which is genuinely great, but `await request.formData()` became the blessed path and the temp-file wisdom got traded away for API convenience.
 
 So the question that led to this work was: can you have both? Keep the standard `File` API that validation libraries and application code already understand, and still parse an upload of any size in constant memory?
 
@@ -61,16 +61,6 @@ export class TmpFile extends File {
 `super([blob], ...)` does not copy anything: composing a `File` from blob parts just references them. The result is a real `File` that weighs a few hundred bytes regardless of content size. Schema validation passes, `instanceof File` is true, `.stream()` reads from disk, and code that never heard of temp files cannot tell the difference. The one extra affordance is `.path`, so instead of copying gigabytes you can `rename` them into place.
 
 There is one honest caveat: a disk-backed `Blob` is a promise that the bytes will still be there when read. Move or delete the underlying file and later reads fail.
-
-### The 2 GiB Potholes
-
-"Any size" is where the platform starts to creak, so I measured instead of trusting the docs. On Node v22.23.2, I created a sparse 5 GiB file and opened it with `openAsBlob`:
-
-- `blob.size` reported 1 GiB: the true size modulo 4 GiB, a classic unsigned 32-bit truncation.
-- A ten-byte `slice()` across the 2 GiB boundary came back empty. Slicing further out can crash outright ([nodejs/node#52585](https://github.com/nodejs/node/issues/52585), still open).
-- `blob.stream()`, however, delivered all 5,368,709,120 bytes correctly.
-
-The whole-file streaming path is solid, which is exactly the path a spool-then-stream design exercises, but if your handler needs `.size` or random access past 2 GiB, read from the temp file's path directly until that issue is fixed. And these limits are not unique to blobs: `fs.readFile` refuses anything over 2 GiB with `ERR_FS_FILE_TOO_LARGE` (I verified this too), because libuv caps individual I/O calls at `INT32_MAX` bytes. Past 2 GiB, streaming is not an optimization, it is the only correct interface.
 
 ## The Hard Part Is Deleting Them
 
@@ -126,4 +116,4 @@ Temporary files are removed when the request finishes. Move or copy an upload in
 
 ## The Takeaway
 
-The `File` interface never demanded buffering; we defaulted to it because it was the shortest code. Browsers knew better all along, PHP knew the right shape in the 90s, and the platform now gives servers lazy blobs to express it cleanly, potholes and all. The remaining engineering is not about bytes. It is about lifetimes: knowing exactly when the last reader is done, pricing each kind of byte at what it actually costs, and never trusting a header you can count for yourself.
+The `File` interface never demanded buffering; we defaulted to it because it was the shortest code. Browsers knew better all along, PHP knew the right shape in the 90s, and the platform now gives servers lazy blobs to express it cleanly. The remaining engineering is not about bytes. It is about lifetimes: knowing exactly when the last reader is done, pricing each kind of byte at what it actually costs, and never trusting a header you can count for yourself.

--- a/apps/content/blog/uploads-bigger-than-your-ram.mdx
+++ b/apps/content/blog/uploads-bigger-than-your-ram.mdx
@@ -60,6 +60,43 @@ export class TmpFile extends File {
 
 `super([blob], ...)` does not copy anything: composing a `File` from blob parts just references them. The result is a real `File` that weighs a few hundred bytes regardless of content size. Schema validation passes, `instanceof File` is true, `.stream()` reads from disk, and code that never heard of temp files cannot tell the difference. The one extra affordance is `.path`, so instead of copying gigabytes you can `rename` them into place.
 
+The whole trick fits in a plain `node:http` server, no framework required:
+
+```ts
+import { createWriteStream, openAsBlob } from 'node:fs'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { pipeline } from 'node:stream/promises'
+
+createServer(async (req, res) => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'upload-'))
+  const tmpPath = path.join(dir, 'upload')
+
+  try {
+    // constant memory, no matter how large the body is
+    await pipeline(req, createWriteStream(tmpPath))
+
+    const file = new TmpFile(
+      await openAsBlob(tmpPath),
+      tmpPath,
+      'video.mp4',
+      { type: req.headers['content-type'] },
+    )
+
+    // hand it to anything that expects a standard File
+    console.log(file.name, file.size, file instanceof File)
+    res.end('ok')
+  }
+  finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}).listen(3000)
+```
+
+[`pipeline`](https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-callback) handles backpressure, so a fast client cannot outrun your disk and pile bytes up in memory. A multipart body needs a streaming parser like busboy on top to split the parts, but the per-file principle is exactly this. The part of the example that looks trivial and is not: that `finally`.
+
 There is one honest caveat: a disk-backed `Blob` is a promise that the bytes will still be there when read. Move or delete the underlying file and later reads fail.
 
 ## The Hard Part Is Deleting Them

--- a/apps/content/blog/uploads-bigger-than-your-ram.mdx
+++ b/apps/content/blog/uploads-bigger-than-your-ram.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Handling File Uploads Bigger Than Your RAM in Node.js"
-description: "Stream large file uploads to disk in Node.js while keeping the standard File API: lazy blobs with fs.openAsBlob, safe temp file cleanup, and per-category body size limits."
+title: "Handling File Uploads Bigger Than Your RAM in JavaScript"
+description: "Stream large file uploads to disk in any JavaScript runtime while keeping the standard File API: lazy blobs, safe temp file cleanup, and per-category body size limits."
 type: blog
 date: 2026-08-17
 search:
@@ -40,7 +40,7 @@ So the question behind this post: can you keep the standard `File` API and still
 
 Browsers never buffered your files in the first place. A `File` picked from an `<input>` is a lazy, disk-backed handle; nothing is read until you call `.stream()` or `.arrayBuffer()`. Chrome even spills its blob store to disk when memory runs short. [The hidden nuance of the JavaScript File API](https://nickb.dev/blog/the-hidden-nuance-of-the-javascript-file-api/) is a great tour of this asymmetry: `File` was always a handle to bytes plus a size and a type. Buffering is an implementation shortcut, not a law.
 
-Node can play the same trick. [`fs.openAsBlob`](https://nodejs.org/api/fs.html#fsopenasblobpath-options) returns a `Blob` whose bytes stay on disk and are read lazily. Bun ships the same idea as a first-class primitive, [`Bun.file`](https://bun.com/docs/api/file-io), and [lazy-file](https://www.npmjs.com/package/@remix-run/lazy-file) generalizes it to arbitrary sources. Stream the incoming bytes to a temp file, then wrap the result:
+Server runtimes can play the same trick. Node ships [`fs.openAsBlob`](https://nodejs.org/api/fs.html#fsopenasblobpath-options), which returns a `Blob` whose bytes stay on disk and are read lazily. Bun ships the same idea as a first-class primitive, [`Bun.file`](https://bun.com/docs/api/file-io), Deno covers it through its [Node compatibility layer](https://docs.deno.com/api/node/fs/~/openAsBlob), and [lazy-file](https://www.npmjs.com/package/@remix-run/lazy-file) generalizes it to arbitrary sources. Stream the incoming bytes to a temp file, then wrap the result:
 
 ```ts
 export class TmpFile extends File {
@@ -153,4 +153,4 @@ Temporary files are removed when the request finishes. Move or copy an upload in
 
 ## The Takeaway
 
-The `File` interface never demanded buffering; we defaulted to it because it was the shortest code. Browsers knew better all along, PHP knew the right shape in the 90s, and Node now gives servers lazy blobs to express it cleanly. The remaining engineering is about lifetimes, not bytes: know when the last reader is done, price each kind of byte at what it costs, and never trust a header you can count for yourself.
+The `File` interface never demanded buffering; we defaulted to it because it was the shortest code. Browsers knew better all along, PHP knew the right shape in the 90s, and every major JavaScript runtime now gives servers lazy blobs to express it cleanly. The remaining engineering is about lifetimes, not bytes: know when the last reader is done, price each kind of byte at what it costs, and never trust a header you can count for yourself.

--- a/apps/content/blog/uploads-bigger-than-your-ram.mdx
+++ b/apps/content/blog/uploads-bigger-than-your-ram.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Handling File Uploads Bigger Than Your RAM"
-description: "How oRPC streams uploads to disk behind the standard File API, and the parts that turned out to be genuinely tricky: lazy Blobs, deletion timing, and why one size limit is never enough."
+description: "Streaming uploads to disk behind the standard File API: lazy blobs, the platform's 2 GiB potholes, deletion timing, and why one size limit is never enough."
 type: blog
 date: 2026-08-17
 search:
@@ -24,27 +24,23 @@ const form = await request.formData()
 const video = form.get('video') as File
 ```
 
-It reads like nothing. It is also a memory bomb. [`request.formData()`](https://developer.mozilla.org/en-US/docs/Web/API/Request/formData) parses the entire body before it resolves, and on the server that means buffering every byte into memory. A 2 GB video becomes 2 GB of heap. Five people uploading at once become 10 GB. Your container has 512 MB, so the process dies before your handler even runs, and it dies in framework code you never wrote.
+It reads like nothing. It is also a memory bomb. [`request.formData()`](https://developer.mozilla.org/en-US/docs/Web/API/Request/formData) resolves only after the entire body is parsed, and on the server that means buffering every byte into memory. A 2 GB video becomes 2 GB of heap. Five people uploading at once become 10 GB. Your container has 512 MB, so the process dies before your handler even runs, and it dies in framework code you never wrote.
 
 The standard `File` and `FormData` APIs made uploads pleasant, and quietly made them dangerous.
 
 ## We Solved This Decades Ago, Then Forgot
 
-This is not a new problem, and the old solutions were good. PHP has streamed uploads into temporary files [since practically forever](https://www.php.net/manual/en/features.file-upload.post-method.php): your script receives a `tmp_name` path, not a buffer. In the Express era, [multer](https://github.com/expressjs/multer) did the same with its disk storage, built on busboy's streaming multipart parser.
+This is not a new problem, and the old solutions were good. PHP has streamed uploads into temporary files [since practically forever](https://www.php.net/manual/en/features.file-upload.post-method.php): your script receives a `tmp_name` path, not a buffer. The Express era had a whole [ecosystem of streaming multipart parsers](https://bytearcher.com/articles/formidable-vs-busboy-vs-multer-vs-multiparty/): busboy hands you a readable stream per file as the bytes arrive, formidable and [multer](https://github.com/expressjs/multer) spool to disk on top of that.
 
-Then the fetch-standard era arrived. Every runtime speaks `Request` and `Response` now, which is genuinely great, but `await request.formData()` became the blessed path and the temp-file wisdom got traded away for API convenience.
+Then the fetch-standard era arrived. Every runtime speaks `Request` and `Response` now, which is genuinely great, but `await request.formData()` became the blessed path and the temp-file wisdom got traded away for API convenience. The trade is worse than it looks, because the buffering path is not just hungry, it is capped: Node's multipart parser has been [reported to give up entirely past 2 GiB](https://smoores.dev/post/overcoming_io_limits/), failing with an error that looks like a malformed body rather than a size problem.
 
-So the question that led to oRPC's new upload handler was: can you have both? Keep the standard `File` API that validation libraries and application code already understand, and still parse a 50 GB upload in constant memory?
-
-It turns out yes, and the way there is more interesting than I expected.
+So the question that led to this work was: can you have both? Keep the standard `File` API that validation libraries and application code already understand, and still parse an upload of any size in constant memory?
 
 ## A File That Lives on Disk
 
-The key piece is [`fs.openAsBlob`](https://nodejs.org/api/fs.html#fsopenasblobpath-options), a small Node.js API that deserves more attention. It returns a `Blob` whose bytes stay on disk and are read lazily when someone calls `.stream()`, `.arrayBuffer()`, or `.text()`.
+Here is the thing: browsers never buffered your files in the first place. A `File` picked from an `<input>` is a lazy, disk-backed handle, and reading it is deferred until someone calls `.stream()` or `.arrayBuffer()`. Chrome even manages a blob store that spills to disk when memory runs short. [The hidden nuance of the JavaScript File API](https://nickb.dev/blog/the-hidden-nuance-of-the-javascript-file-api/) is a great tour of this asymmetry: the interface was always a handle to bytes plus a size and a type, and buffering everything in memory is an implementation shortcut, not a law.
 
-That works because a `Blob` was never required to be a buffer. The interface is a handle to bytes plus a size and a type. Browsers have always backed blobs with whatever they liked. Buffering everything in memory was an implementation shortcut, not a law.
-
-So the upload handler streams incoming bytes to a temporary file, then wraps the result:
+Servers can play the same trick. Node ships [`fs.openAsBlob`](https://nodejs.org/api/fs.html#fsopenasblobpath-options), which returns a `Blob` whose bytes stay on disk and are read lazily, and userland has [lazy-file](https://github.com/mjackson/lazy-file) for the same idea over arbitrary sources. So the upload handler streams incoming bytes to a temporary file, then wraps the result:
 
 ```ts
 export class TmpFile extends File {
@@ -62,21 +58,25 @@ export class TmpFile extends File {
 }
 ```
 
-`super([blob], ...)` does not copy anything: composing a `File` from blob parts just references them. The result is a real `File` that happens to weigh a few hundred bytes regardless of content size. Schema validation passes, `instanceof File` is true, `.stream()` reads from disk, and code that never heard of the plugin cannot tell the difference. The one extra affordance is `.path`, so instead of copying gigabytes you can move them:
+`super([blob], ...)` does not copy anything: composing a `File` from blob parts just references them. The result is a real `File` that weighs a few hundred bytes regardless of content size. Schema validation passes, `instanceof File` is true, `.stream()` reads from disk, and code that never heard of temp files cannot tell the difference. The one extra affordance is `.path`, so instead of copying gigabytes you can `rename` them into place.
 
-```ts
-if (input.video instanceof TmpFile) {
-  await rename(input.video.path, `./videos/${crypto.randomUUID()}`)
-}
-```
+There is one honest caveat: a disk-backed `Blob` is a promise that the bytes will still be there when read. Move or delete the underlying file and later reads fail.
 
-There is one honest caveat: a disk-backed `Blob` is a promise that the bytes will still be there when read. Move or delete the underlying file and later reads fail. Which brings us to the actually hard part.
+### The 2 GiB Potholes
+
+"Any size" is where the platform starts to creak, so I measured instead of trusting the docs. On Node v22.23.2, I created a sparse 5 GiB file and opened it with `openAsBlob`:
+
+- `blob.size` reported 1 GiB: the true size modulo 4 GiB, a classic unsigned 32-bit truncation.
+- A ten-byte `slice()` across the 2 GiB boundary came back empty. Slicing further out can crash outright ([nodejs/node#52585](https://github.com/nodejs/node/issues/52585), still open).
+- `blob.stream()`, however, delivered all 5,368,709,120 bytes correctly.
+
+The whole-file streaming path is solid, which is exactly the path a spool-then-stream design exercises, but if your handler needs `.size` or random access past 2 GiB, read from the temp file's path directly until that issue is fixed. And these limits are not unique to blobs: `fs.readFile` refuses anything over 2 GiB with `ERR_FS_FILE_TOO_LARGE` (I verified this too), because libuv caps individual I/O calls at `INT32_MAX` bytes. Past 2 GiB, streaming is not an optimization, it is the only correct interface.
 
 ## The Hard Part Is Deleting Them
 
-Writing bytes to a temp file is the easy 20%. Making them reliably disappear is where the design work went.
+Writing bytes to a temp file is the easy 20%. Making them reliably disappear is where the design work went, and none of it is specific to any framework.
 
-**When is a request "done"?** The obvious rule, delete when the handler returns, is wrong. A handler can return a streaming response, like an event stream or a raw binary stream, that reads the upload *while* transmitting. Delete at return time and the response fails halfway. So the handler inspects what came back: if the response body is a stream or an async iterator, deletion rides on the body finishing instead of the handler returning. That rule also covers clients that disappear mid-download, because the server cancels the body and cancellation reaches the same finish hook. Every non-streaming response is sent after removal, so the temp files live exactly as long as anything can read them, and not a request longer.
+**When is a request "done"?** The obvious rule, delete when the handler returns, is wrong. A handler can return a streaming response, like an event stream or a raw binary stream, that reads the upload *while* transmitting. Delete at return time and the response fails halfway. The rule that works: inspect what the handler returned, and if the response body is a stream or an async iterator, deletion rides on the body finishing instead of the handler returning. That also covers clients that disappear mid-download, because the server cancels the body and cancellation reaches the same finish hook. Every non-streaming response is sent after removal, so the temp files live exactly as long as anything can read them, and not a request longer.
 
 **Open handles.** Each request that spools an upload gets its own directory under the OS temp dir, and content lands through self-contained appends rather than long-lived file handles. However many files a request carries, it holds at most one transient descriptor per in-flight write, so a burst of uploads cannot exhaust the process's descriptor table. As a bonus, deletion never fights an open handle, which matters on Windows where deleting an open file is an error.
 
@@ -90,43 +90,40 @@ Most body-limit middleware takes a single number. But once uploads spool to disk
 - A byte of **upload** touches memory only as a passing chunk on its way to disk. You can afford about a thousand times more of these.
 - A byte of an **event stream** is consumed on the fly and costs almost nothing to relay.
 
-One limit forces you to price all three at the highest rate. So the plugin takes three:
+One limit forces you to price all three at the highest rate, so the design takes three: `memory`, `file`, and `stream`, and when limits are configured, all three kinds are required, so no category is left unbounded by accident. Unlimited must be spelled `Number.POSITIVE_INFINITY`, on purpose.
+
+The enforcement side has its own subtlety: `Content-Length` is a hint, not a fact. [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-content-length) allows it to be absent, and a hostile client can simply lie. So an oversized declared length rejects immediately for free, but the real enforcement counts bytes as they arrive and cuts the request off mid-stream with `413 Payload Too Large` the moment it crosses the line. A multipart body is bounded by `memory + file` in total, framing included, so a body that hides its bulk in part headers rather than part content is caught too.
+
+## Where This Landed
+
+Everything above ships as the [Tmp File Upload Handler Plugin](/docs/plugins/tmp-file-upload) in `@orpc/node`. One plugin, zero changes to your procedures:
 
 ```ts
-new TmpFileUploadHandlerPlugin({
-  maxBodySize: {
-    memory: 1024 * 1024, // JSON, forms, multipart text fields
-    file: 500 * 1024 * 1024, // uploads spooled to disk
-    stream: Number.POSITIVE_INFINITY, // event streams, raw streams
-  },
-})
-```
-
-Two details here are the kind you only get right by being paranoid. First, when the option is given, all three kinds are required, so no category is left unbounded by accident: unlimited must be spelled `Number.POSITIVE_INFINITY`, on purpose. Second, `Content-Length` is treated as a hint, not a fact. [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-content-length) allows it to be absent, and a hostile client can simply lie. So an oversized declared length rejects immediately for free, but the real enforcement counts bytes as they arrive and cuts the request off mid-stream with `PAYLOAD_TOO_LARGE` the moment it crosses the line. A multipart body is bounded by `memory + file` in total, framing included, so a body that hides its bulk in part headers rather than part content is caught too.
-
-## If You Use oRPC
-
-Everything above ships as the [Tmp File Upload Handler Plugin](/docs/plugins/tmp-file-upload) in `@orpc/node`, currently in beta. One plugin, zero changes to your procedures:
-
-```ts
-import { TmpFileUploadHandlerPlugin } from '@orpc/node'
-import { RPCHandler } from '@orpc/server/node'
-
 const handler = new RPCHandler(router, {
   plugins: [
-    new TmpFileUploadHandlerPlugin(),
+    new TmpFileUploadHandlerPlugin({
+      maxBodySize: {
+        memory: 1024 * 1024, // JSON, forms, multipart text fields
+        file: 500 * 1024 * 1024, // uploads spooled to disk
+        stream: Number.POSITIVE_INFINITY, // event streams, raw streams
+      },
+    }),
   ],
 })
+
+const uploadVideo = os
+  .input(z.object({ video: z.file() }))
+  .handler(async ({ input }) => {
+    if (input.video instanceof TmpFile) {
+      await rename(input.video.path, `./videos/${crypto.randomUUID()}`)
+    }
+  })
 ```
 
-Your handlers keep receiving standard `File` instances. The only visible differences are that huge uploads no longer eat your heap, and `TmpFile` gives you a `.path` to `rename` instead of copy.
-
 :::warning
-Temporary files are removed when the request finishes. Move or copy an upload inside your handler if you need it afterwards, and don't return the upload itself as a non-streaming response body, since it would be read after removal.
+Temporary files are removed when the request finishes. Move or copy an upload inside your handler if you need it afterwards.
 :::
 
 ## The Takeaway
 
-The lesson I keep relearning from this kind of work: standard APIs and efficient implementations are rarely in real tension. The `File` interface never demanded buffering; we defaulted to it because it was the shortest code. PHP knew the right shape in the 90s, the platform now gives us lazy blobs to express it cleanly, and the remaining engineering is not about bytes at all. It is about lifetimes: knowing exactly when the last reader is done, and pricing each kind of byte at what it actually costs you.
-
-If that is the kind of care you want in the rest of your API layer too, [oRPC](https://orpc.dev) is built the same way, end to end.
+The `File` interface never demanded buffering; we defaulted to it because it was the shortest code. Browsers knew better all along, PHP knew the right shape in the 90s, and the platform now gives servers lazy blobs to express it cleanly, potholes and all. The remaining engineering is not about bytes. It is about lifetimes: knowing exactly when the last reader is done, pricing each kind of byte at what it actually costs, and never trusting a header you can count for yourself.

--- a/apps/content/blog/uploads-bigger-than-your-ram.mdx
+++ b/apps/content/blog/uploads-bigger-than-your-ram.mdx
@@ -40,7 +40,7 @@ So the question behind this post: can you keep the standard `File` API and still
 
 Browsers never buffered your files in the first place. A `File` picked from an `<input>` is a lazy, disk-backed handle; nothing is read until you call `.stream()` or `.arrayBuffer()`. Chrome even spills its blob store to disk when memory runs short. [The hidden nuance of the JavaScript File API](https://nickb.dev/blog/the-hidden-nuance-of-the-javascript-file-api/) is a great tour of this asymmetry: `File` was always a handle to bytes plus a size and a type. Buffering is an implementation shortcut, not a law.
 
-Node can play the same trick. [`fs.openAsBlob`](https://nodejs.org/api/fs.html#fsopenasblobpath-options) returns a `Blob` whose bytes stay on disk and are read lazily; [lazy-file](https://www.npmjs.com/package/@remix-run/lazy-file) does the same over arbitrary sources. Stream the incoming bytes to a temp file, then wrap the result:
+Node can play the same trick. [`fs.openAsBlob`](https://nodejs.org/api/fs.html#fsopenasblobpath-options) returns a `Blob` whose bytes stay on disk and are read lazily. Bun ships the same idea as a first-class primitive, [`Bun.file`](https://bun.com/docs/api/file-io), and [lazy-file](https://www.npmjs.com/package/@remix-run/lazy-file) generalizes it to arbitrary sources. Stream the incoming bytes to a temp file, then wrap the result:
 
 ```ts
 export class TmpFile extends File {
@@ -97,7 +97,7 @@ createServer(async (req, res) => {
 }).listen(3000)
 ```
 
-[`pipeline`](https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-callback) handles backpressure, so a fast client cannot outrun your disk and pile bytes up in memory. Multipart bodies need a streaming parser like busboy to split the parts, but the per-file principle is exactly this. The piece that looks trivial is the real hard part: that `finally`.
+[`pipeline`](https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-callback) handles backpressure, so a fast client cannot outrun your disk and pile bytes up in memory. Multipart bodies need a streaming parser like busboy to split the parts, but the per-file principle is exactly this. It is not even Node-specific: Bun implements both `node:http` and `fs.openAsBlob`, so the example runs there unchanged. The piece that looks trivial is the real hard part: that `finally`.
 
 ## When to Delete the Temp Files
 

--- a/apps/content/blog/uploads-bigger-than-your-ram.mdx
+++ b/apps/content/blog/uploads-bigger-than-your-ram.mdx
@@ -1,0 +1,132 @@
+---
+title: "Handling File Uploads Bigger Than Your RAM"
+description: "How oRPC streams uploads to disk behind the standard File API, and the parts that turned out to be genuinely tricky: lazy Blobs, deletion timing, and why one size limit is never enough."
+type: blog
+date: 2026-08-17
+search:
+  tags:
+    - Engineering
+authors:
+    name: Định Lê
+    role: Creator of oRPC
+    url: https://github.com/dinwwwh
+    avatar: https://github.com/dinwwwh.png
+ai:
+  exclude: true
+---
+
+## The Innocent Line of Code
+
+Almost every modern JavaScript server handles uploads with some variation of this:
+
+```ts
+const form = await request.formData()
+const video = form.get('video') as File
+```
+
+It reads like nothing. It is also a memory bomb. [`request.formData()`](https://developer.mozilla.org/en-US/docs/Web/API/Request/formData) parses the entire body before it resolves, and on the server that means buffering every byte into memory. A 2 GB video becomes 2 GB of heap. Five people uploading at once become 10 GB. Your container has 512 MB, so the process dies before your handler even runs, and it dies in framework code you never wrote.
+
+The standard `File` and `FormData` APIs made uploads pleasant, and quietly made them dangerous.
+
+## We Solved This Decades Ago, Then Forgot
+
+This is not a new problem, and the old solutions were good. PHP has streamed uploads into temporary files [since practically forever](https://www.php.net/manual/en/features.file-upload.post-method.php): your script receives a `tmp_name` path, not a buffer. In the Express era, [multer](https://github.com/expressjs/multer) did the same with its disk storage, built on busboy's streaming multipart parser.
+
+Then the fetch-standard era arrived. Every runtime speaks `Request` and `Response` now, which is genuinely great, but `await request.formData()` became the blessed path and the temp-file wisdom got traded away for API convenience.
+
+So the question that led to oRPC's new upload handler was: can you have both? Keep the standard `File` API that validation libraries and application code already understand, and still parse a 50 GB upload in constant memory?
+
+It turns out yes, and the way there is more interesting than I expected.
+
+## A File That Lives on Disk
+
+The key piece is [`fs.openAsBlob`](https://nodejs.org/api/fs.html#fsopenasblobpath-options), a small Node.js API that deserves more attention. It returns a `Blob` whose bytes stay on disk and are read lazily when someone calls `.stream()`, `.arrayBuffer()`, or `.text()`.
+
+That works because a `Blob` was never required to be a buffer. The interface is a handle to bytes plus a size and a type. Browsers have always backed blobs with whatever they liked. Buffering everything in memory was an implementation shortcut, not a law.
+
+So the upload handler streams incoming bytes to a temporary file, then wraps the result:
+
+```ts
+export class TmpFile extends File {
+  constructor(
+    blob: Blob,
+    /**
+     * Absolute path of the temporary file holding this file's content.
+     */
+    readonly path: string,
+    name: string,
+    options?: FilePropertyBag,
+  ) {
+    super([blob], name, options)
+  }
+}
+```
+
+`super([blob], ...)` does not copy anything: composing a `File` from blob parts just references them. The result is a real `File` that happens to weigh a few hundred bytes regardless of content size. Schema validation passes, `instanceof File` is true, `.stream()` reads from disk, and code that never heard of the plugin cannot tell the difference. The one extra affordance is `.path`, so instead of copying gigabytes you can move them:
+
+```ts
+if (input.video instanceof TmpFile) {
+  await rename(input.video.path, `./videos/${crypto.randomUUID()}`)
+}
+```
+
+There is one honest caveat: a disk-backed `Blob` is a promise that the bytes will still be there when read. Move or delete the underlying file and later reads fail. Which brings us to the actually hard part.
+
+## The Hard Part Is Deleting Them
+
+Writing bytes to a temp file is the easy 20%. Making them reliably disappear is where the design work went.
+
+**When is a request "done"?** The obvious rule, delete when the handler returns, is wrong. A handler can return a streaming response, like an event stream or a raw binary stream, that reads the upload *while* transmitting. Delete at return time and the response fails halfway. So the handler inspects what came back: if the response body is a stream or an async iterator, deletion rides on the body finishing instead of the handler returning. That rule also covers clients that disappear mid-download, because the server cancels the body and cancellation reaches the same finish hook. Every non-streaming response is sent after removal, so the temp files live exactly as long as anything can read them, and not a request longer.
+
+**Open handles.** Each request that spools an upload gets its own directory under the OS temp dir, and content lands through self-contained appends rather than long-lived file handles. However many files a request carries, it holds at most one transient descriptor per in-flight write, so a burst of uploads cannot exhaust the process's descriptor table. As a bonus, deletion never fights an open handle, which matters on Windows where deleting an open file is an error.
+
+**Failure isolation.** Disk full is your problem; a malformed multipart body is the client's. The two must not blur: filesystem failures surface as internal server errors with details attached only to the error's `cause`, which never serializes to the client, while parse failures stay bad requests. And if cleanup itself fails, the request outcome must not change, because a response that succeeded should never turn into an error over a temp file the OS will reap anyway.
+
+## One Size Limit Is the Wrong Number of Size Limits
+
+Most body-limit middleware takes a single number. But once uploads spool to disk, a byte is no longer a byte:
+
+- A byte of **JSON** sits in memory from arrival until parsing ends. It is the most expensive byte you accept.
+- A byte of **upload** touches memory only as a passing chunk on its way to disk. You can afford about a thousand times more of these.
+- A byte of an **event stream** is consumed on the fly and costs almost nothing to relay.
+
+One limit forces you to price all three at the highest rate. So the plugin takes three:
+
+```ts
+new TmpFileUploadHandlerPlugin({
+  maxBodySize: {
+    memory: 1024 * 1024, // JSON, forms, multipart text fields
+    file: 500 * 1024 * 1024, // uploads spooled to disk
+    stream: Number.POSITIVE_INFINITY, // event streams, raw streams
+  },
+})
+```
+
+Two details here are the kind you only get right by being paranoid. First, when the option is given, all three kinds are required, so no category is left unbounded by accident: unlimited must be spelled `Number.POSITIVE_INFINITY`, on purpose. Second, `Content-Length` is treated as a hint, not a fact. [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-content-length) allows it to be absent, and a hostile client can simply lie. So an oversized declared length rejects immediately for free, but the real enforcement counts bytes as they arrive and cuts the request off mid-stream with `PAYLOAD_TOO_LARGE` the moment it crosses the line. A multipart body is bounded by `memory + file` in total, framing included, so a body that hides its bulk in part headers rather than part content is caught too.
+
+## If You Use oRPC
+
+Everything above ships as the [Tmp File Upload Handler Plugin](/docs/plugins/tmp-file-upload) in `@orpc/node`, currently in beta. One plugin, zero changes to your procedures:
+
+```ts
+import { TmpFileUploadHandlerPlugin } from '@orpc/node'
+import { RPCHandler } from '@orpc/server/node'
+
+const handler = new RPCHandler(router, {
+  plugins: [
+    new TmpFileUploadHandlerPlugin(),
+  ],
+})
+```
+
+Your handlers keep receiving standard `File` instances. The only visible differences are that huge uploads no longer eat your heap, and `TmpFile` gives you a `.path` to `rename` instead of copy.
+
+:::warning
+Temporary files are removed when the request finishes. Move or copy an upload inside your handler if you need it afterwards, and don't return the upload itself as a non-streaming response body, since it would be read after removal.
+:::
+
+## The Takeaway
+
+The lesson I keep relearning from this kind of work: standard APIs and efficient implementations are rarely in real tension. The `File` interface never demanded buffering; we defaulted to it because it was the shortest code. PHP knew the right shape in the 90s, the platform now gives us lazy blobs to express it cleanly, and the remaining engineering is not about bytes at all. It is about lifetimes: knowing exactly when the last reader is done, and pricing each kind of byte at what it actually costs you.
+
+If that is the kind of care you want in the rest of your API layer too, [oRPC](https://orpc.dev) is built the same way, end to end.

--- a/apps/content/blog/uploads-bigger-than-your-ram.mdx
+++ b/apps/content/blog/uploads-bigger-than-your-ram.mdx
@@ -40,7 +40,7 @@ So the question behind this post: can you have both? The standard `File` API tha
 
 Here is the thing: browsers never buffered your files in the first place. A `File` picked from an `<input>` is a lazy, disk-backed handle, and reading it is deferred until someone calls `.stream()` or `.arrayBuffer()`. Chrome even manages a blob store that spills to disk when memory runs short. [The hidden nuance of the JavaScript File API](https://nickb.dev/blog/the-hidden-nuance-of-the-javascript-file-api/) is a great tour of this asymmetry: the interface was always a handle to bytes plus a size and a type, and buffering everything in memory is an implementation shortcut, not a law.
 
-Servers can play the same trick. Node ships [`fs.openAsBlob`](https://nodejs.org/api/fs.html#fsopenasblobpath-options), which returns a `Blob` whose bytes stay on disk and are read lazily, and userland has [lazy-file](https://github.com/mjackson/lazy-file) for the same idea over arbitrary sources. Stream the incoming bytes to a temporary file, then wrap the result:
+Servers can play the same trick. Node ships [`fs.openAsBlob`](https://nodejs.org/api/fs.html#fsopenasblobpath-options), which returns a `Blob` whose bytes stay on disk and are read lazily, and userland has [lazy-file](https://www.npmjs.com/package/@remix-run/lazy-file) for the same idea over arbitrary sources. Stream the incoming bytes to a temporary file, then wrap the result:
 
 ```ts
 export class TmpFile extends File {

--- a/apps/content/blog/uploads-bigger-than-your-ram.mdx
+++ b/apps/content/blog/uploads-bigger-than-your-ram.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Handling File Uploads Bigger Than Your RAM"
-description: "Streaming uploads to disk behind the standard File API: lazy blobs, deletion timing, and why one size limit is never enough."
+title: "Handling File Uploads Bigger Than Your RAM in Node.js"
+description: "Stream large file uploads to disk in Node.js while keeping the standard File API: lazy blobs with fs.openAsBlob, safe temp file cleanup, and per-category body size limits."
 type: blog
 date: 2026-08-17
 search:
@@ -15,32 +15,32 @@ ai:
   exclude: true
 ---
 
-## The Innocent Line of Code
+## Why request.formData() Runs Out of Memory
 
-Almost every modern JavaScript server handles uploads with some variation of this:
+Almost every modern JavaScript server handles uploads like this:
 
 ```ts
 const form = await request.formData()
 const video = form.get('video') as File
 ```
 
-It reads like nothing. It is also a memory bomb. [`request.formData()`](https://developer.mozilla.org/en-US/docs/Web/API/Request/formData) resolves only after the entire body is parsed, and on the server that means buffering every byte into memory. A 2 GB video becomes 2 GB of heap. Five people uploading at once become 10 GB. Your container has 512 MB, so the process dies before your handler even runs, and it dies in framework code you never wrote.
+It looks harmless. It is a memory bomb. [`request.formData()`](https://developer.mozilla.org/en-US/docs/Web/API/Request/formData) resolves only after the entire body is parsed, and on the server that means buffering every byte in memory. A 2 GB video becomes 2 GB of heap. Five concurrent uploads become 10 GB. Your 512 MB container dies before your handler runs, in framework code you never wrote.
 
 The standard `File` and `FormData` APIs made uploads pleasant, and quietly made them dangerous.
 
-## We Solved This Decades Ago, Then Forgot
+## The Old Fix: Stream Uploads to Temp Files
 
-This is not a new problem, and the old solutions were good. PHP has streamed uploads into temporary files [since practically forever](https://www.php.net/manual/en/features.file-upload.post-method.php): your script receives a `tmp_name` path, not a buffer. The Express era had a whole [ecosystem of streaming multipart parsers](https://bytearcher.com/articles/formidable-vs-busboy-vs-multer-vs-multiparty/): busboy hands you a readable stream per file as the bytes arrive, formidable and [multer](https://github.com/expressjs/multer) spool to disk on top of that.
+PHP has streamed uploads into temporary files [since practically forever](https://www.php.net/manual/en/features.file-upload.post-method.php): your script receives a `tmp_name` path, not a buffer. Express had a whole [ecosystem of streaming multipart parsers](https://bytearcher.com/articles/formidable-vs-busboy-vs-multer-vs-multiparty/): busboy hands you a readable stream per file, formidable and [multer](https://github.com/expressjs/multer) spool to disk on top of it.
 
-Then the fetch-standard era arrived. Every runtime speaks `Request` and `Response` now, which is genuinely great, but `await request.formData()` became the blessed path and the temp-file wisdom got traded away for API convenience.
+Then the fetch-standard era arrived. Every runtime speaks `Request` and `Response`, which is great, but `await request.formData()` became the blessed path and the temp-file wisdom was traded for API convenience.
 
-So the question behind this post: can you have both? The standard `File` API that validation libraries and application code already understand, and constant memory for uploads of any size?
+So the question behind this post: can you keep the standard `File` API and still handle uploads of any size in constant memory?
 
 ## A File That Lives on Disk
 
-Here is the thing: browsers never buffered your files in the first place. A `File` picked from an `<input>` is a lazy, disk-backed handle, and reading it is deferred until someone calls `.stream()` or `.arrayBuffer()`. Chrome even manages a blob store that spills to disk when memory runs short. [The hidden nuance of the JavaScript File API](https://nickb.dev/blog/the-hidden-nuance-of-the-javascript-file-api/) is a great tour of this asymmetry: the interface was always a handle to bytes plus a size and a type, and buffering everything in memory is an implementation shortcut, not a law.
+Browsers never buffered your files in the first place. A `File` picked from an `<input>` is a lazy, disk-backed handle; nothing is read until you call `.stream()` or `.arrayBuffer()`. Chrome even spills its blob store to disk when memory runs short. [The hidden nuance of the JavaScript File API](https://nickb.dev/blog/the-hidden-nuance-of-the-javascript-file-api/) is a great tour of this asymmetry: `File` was always a handle to bytes plus a size and a type. Buffering is an implementation shortcut, not a law.
 
-Servers can play the same trick. Node ships [`fs.openAsBlob`](https://nodejs.org/api/fs.html#fsopenasblobpath-options), which returns a `Blob` whose bytes stay on disk and are read lazily, and userland has [lazy-file](https://www.npmjs.com/package/@remix-run/lazy-file) for the same idea over arbitrary sources. Stream the incoming bytes to a temporary file, then wrap the result:
+Node can play the same trick. [`fs.openAsBlob`](https://nodejs.org/api/fs.html#fsopenasblobpath-options) returns a `Blob` whose bytes stay on disk and are read lazily; [lazy-file](https://www.npmjs.com/package/@remix-run/lazy-file) does the same over arbitrary sources. Stream the incoming bytes to a temp file, then wrap the result:
 
 ```ts
 export class TmpFile extends File {
@@ -58,7 +58,9 @@ export class TmpFile extends File {
 }
 ```
 
-`super([blob], ...)` does not copy anything: composing a `File` from blob parts just references them. The result is a real `File` that weighs a few hundred bytes no matter how large its content is. Schema validation passes, `instanceof File` is true, `.stream()` reads from disk, and code that never heard of temp files cannot tell the difference. The one extra affordance is `.path`, so instead of copying gigabytes you can `rename` them into place. The one caveat: a disk-backed `Blob` is a promise that the bytes will still be there when read, so move or delete the underlying file and later reads fail.
+`super([blob], ...)` copies nothing: a `File` composed from blob parts just references them. The result is a real `File` weighing a few hundred bytes regardless of content size. Schema validation passes, `instanceof File` is true, `.stream()` reads from disk. Code that never heard of temp files cannot tell the difference, and `.path` lets you `rename` gigabytes into place instead of copying them. One caveat: a disk-backed `Blob` assumes the bytes stay put. Move or delete the file and later reads fail.
+
+## A Minimal Streaming Upload Server with node:http
 
 The whole trick fits in a plain `node:http` server, no framework required:
 
@@ -95,29 +97,29 @@ createServer(async (req, res) => {
 }).listen(3000)
 ```
 
-[`pipeline`](https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-callback) handles backpressure, so a fast client cannot outrun your disk and pile bytes up in memory. A multipart body needs a streaming parser like busboy on top to split the parts, but the per-file principle is exactly this. And the piece of the example that looks trivial is the actual hard part: that `finally`.
+[`pipeline`](https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-callback) handles backpressure, so a fast client cannot outrun your disk and pile bytes up in memory. Multipart bodies need a streaming parser like busboy to split the parts, but the per-file principle is exactly this. The piece that looks trivial is the real hard part: that `finally`.
 
-## The Hard Part Is Deleting Them
+## When to Delete the Temp Files
 
 Writing bytes to a temp file is the easy 20%. Making them reliably disappear is the other 80%.
 
-**When is a request "done"?** The obvious rule, delete when the handler returns, is wrong. A handler can return a streaming response, like an event stream or a raw binary stream, that reads the upload *while* transmitting. Delete at return time and the response fails halfway. The rule that works: if the response body is a stream or an async iterator, deletion rides on the body finishing instead of the handler returning. That also covers clients that disappear mid-download, because the server cancels the body and cancellation reaches the same finish hook. Every other response is sent after removal, so the temp files live exactly as long as anything can read them, and not a request longer.
+**When is a request "done"?** Deleting when the handler returns is wrong: a streaming response, like an event stream or a raw binary stream, may read the upload *while* transmitting, and would fail halfway. The rule that works: if the response body is a stream or an async iterator, deletion rides on the body finishing. That also covers clients that vanish mid-download, since cancelling the body reaches the same finish hook. Every other response is sent after removal, so temp files live exactly as long as anything can read them, and not a request longer.
 
-**Open handles.** Each request that spools an upload gets its own directory under the OS temp dir, and content lands through self-contained appends rather than long-lived file handles. However many files a request carries, it holds at most one transient descriptor per in-flight write, so a burst of uploads cannot exhaust the process's descriptor table. And deletion never fights an open handle, which matters on Windows where deleting an open file is an error.
+**Open handles.** Each request gets its own directory under the OS temp dir, and content lands through self-contained appends instead of long-lived file handles: at most one transient descriptor per in-flight write, however many files the request carries. A burst of uploads cannot exhaust the descriptor table, and deletion never fights an open handle, which matters on Windows where deleting an open file is an error.
 
-**Failure isolation.** Disk full is your problem; a malformed multipart body is the client's. The two must not blur: filesystem failures surface as internal server errors with details attached only to the error's `cause`, which never serializes to the client, while parse failures stay bad requests. And if cleanup itself fails, the request outcome must not change, because a response that succeeded should never turn into an error over a temp file the OS will reap anyway.
+**Failure isolation.** Disk full is your problem; a malformed multipart body is the client's. Filesystem failures surface as internal server errors with details only on the error's `cause`, never serialized to the client; parse failures stay bad requests. And a failed cleanup must not change the request outcome: a response that succeeded should never turn into an error over a temp file the OS will reap anyway.
 
-## One Size Limit Is the Wrong Number of Size Limits
+## Three Body Size Limits, Not One
 
-Most body-limit middleware takes a single number. But once uploads spool to disk, a byte is no longer a byte:
+Most body-limit middleware takes a single number. Once uploads spool to disk, a byte is no longer a byte:
 
 - A byte of **JSON** sits in memory from arrival until parsing ends. It is the most expensive byte you accept.
 - A byte of **upload** touches memory only as a passing chunk on its way to disk. You can afford about a thousand times more of these.
 - A byte of an **event stream** is consumed on the fly and costs almost nothing to relay.
 
-One limit forces you to price all three at the highest rate, so the design takes three: `memory`, `file`, and `stream`. Configuring one requires configuring all three, so no category is left unbounded by accident; unlimited must be spelled `Number.POSITIVE_INFINITY`, on purpose.
+One limit prices all three at the highest rate, so take three: `memory`, `file`, and `stream`. Configuring one requires configuring all three, so nothing is left unbounded by accident; unlimited must be spelled `Number.POSITIVE_INFINITY`, on purpose.
 
-Enforcement has its own subtlety: `Content-Length` is a hint, not a fact. [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-content-length) allows it to be absent, and a hostile client can simply lie. An oversized declared length rejects immediately for free, but the real enforcement counts bytes as they arrive and cuts the request off mid-stream with `413 Payload Too Large` the moment it crosses the line. A multipart body is bounded by `memory + file` in total, framing included, so a body that hides its bulk in part headers rather than part content is caught too.
+Enforcement has its own subtlety: `Content-Length` is a hint, not a fact. [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-content-length) allows it to be absent, and a hostile client can lie. Use the declared length to reject oversized requests early for free, but count the bytes as they arrive and cut the request off mid-stream with `413 Payload Too Large` the moment it crosses the line. Bound a multipart body by `memory + file` in total, framing included, so bulk hidden in part headers is caught too.
 
 ## Where This Landed
 
@@ -151,4 +153,4 @@ Temporary files are removed when the request finishes. Move or copy an upload in
 
 ## The Takeaway
 
-The `File` interface never demanded buffering; we defaulted to it because it was the shortest code. Browsers knew better all along, PHP knew the right shape in the 90s, and the platform now gives servers lazy blobs to express it cleanly. The remaining engineering is not about bytes. It is about lifetimes: knowing exactly when the last reader is done, pricing each kind of byte at what it actually costs, and never trusting a header you can count for yourself.
+The `File` interface never demanded buffering; we defaulted to it because it was the shortest code. Browsers knew better all along, PHP knew the right shape in the 90s, and Node now gives servers lazy blobs to express it cleanly. The remaining engineering is about lifetimes, not bytes: know when the last reader is done, price each kind of byte at what it costs, and never trust a header you can count for yourself.

--- a/apps/content/blog/uploads-bigger-than-your-ram.mdx
+++ b/apps/content/blog/uploads-bigger-than-your-ram.mdx
@@ -15,16 +15,16 @@ ai:
   exclude: true
 ---
 
-## Why request.formData() Runs Out of Memory
+## Why request.formData() and Friends Run Out of Memory
 
-Almost every modern JavaScript server handles uploads like this:
+The common way to read an upload in a fetch-standard server:
 
 ```ts
 const form = await request.formData()
 const video = form.get('video') as File
 ```
 
-It looks harmless. It is a memory bomb. [`request.formData()`](https://developer.mozilla.org/en-US/docs/Web/API/Request/formData) resolves only after the entire body is parsed, and on the server that means buffering every byte in memory. A 2 GB video becomes 2 GB of heap. Five concurrent uploads become 10 GB. Your 512 MB container dies before your handler runs, in framework code you never wrote.
+It looks harmless. It is a memory bomb. [`request.formData()`](https://developer.mozilla.org/en-US/docs/Web/API/Request/formData) resolves only after the entire body is parsed, and on the server that means buffering every byte in memory. Its siblings are no better: `.blob()`, `.arrayBuffer()`, `.bytes()`, and `.text()` all buffer the whole body the same way. A 2 GB video becomes 2 GB of heap. Five concurrent uploads become 10 GB. Your 512 MB container dies before your handler runs, in framework code you never wrote.
 
 The standard `File` and `FormData` APIs made uploads pleasant, and quietly made them dangerous.
 

--- a/apps/content/blog/uploads-bigger-than-your-ram.mdx
+++ b/apps/content/blog/uploads-bigger-than-your-ram.mdx
@@ -34,13 +34,13 @@ This is not a new problem, and the old solutions were good. PHP has streamed upl
 
 Then the fetch-standard era arrived. Every runtime speaks `Request` and `Response` now, which is genuinely great, but `await request.formData()` became the blessed path and the temp-file wisdom got traded away for API convenience.
 
-So the question that led to this work was: can you have both? Keep the standard `File` API that validation libraries and application code already understand, and still parse an upload of any size in constant memory?
+So the question behind this post: can you have both? The standard `File` API that validation libraries and application code already understand, and constant memory for uploads of any size?
 
 ## A File That Lives on Disk
 
 Here is the thing: browsers never buffered your files in the first place. A `File` picked from an `<input>` is a lazy, disk-backed handle, and reading it is deferred until someone calls `.stream()` or `.arrayBuffer()`. Chrome even manages a blob store that spills to disk when memory runs short. [The hidden nuance of the JavaScript File API](https://nickb.dev/blog/the-hidden-nuance-of-the-javascript-file-api/) is a great tour of this asymmetry: the interface was always a handle to bytes plus a size and a type, and buffering everything in memory is an implementation shortcut, not a law.
 
-Servers can play the same trick. Node ships [`fs.openAsBlob`](https://nodejs.org/api/fs.html#fsopenasblobpath-options), which returns a `Blob` whose bytes stay on disk and are read lazily, and userland has [lazy-file](https://github.com/mjackson/lazy-file) for the same idea over arbitrary sources. So the upload handler streams incoming bytes to a temporary file, then wraps the result:
+Servers can play the same trick. Node ships [`fs.openAsBlob`](https://nodejs.org/api/fs.html#fsopenasblobpath-options), which returns a `Blob` whose bytes stay on disk and are read lazily, and userland has [lazy-file](https://github.com/mjackson/lazy-file) for the same idea over arbitrary sources. Stream the incoming bytes to a temporary file, then wrap the result:
 
 ```ts
 export class TmpFile extends File {
@@ -58,7 +58,7 @@ export class TmpFile extends File {
 }
 ```
 
-`super([blob], ...)` does not copy anything: composing a `File` from blob parts just references them. The result is a real `File` that weighs a few hundred bytes regardless of content size. Schema validation passes, `instanceof File` is true, `.stream()` reads from disk, and code that never heard of temp files cannot tell the difference. The one extra affordance is `.path`, so instead of copying gigabytes you can `rename` them into place.
+`super([blob], ...)` does not copy anything: composing a `File` from blob parts just references them. The result is a real `File` that weighs a few hundred bytes no matter how large its content is. Schema validation passes, `instanceof File` is true, `.stream()` reads from disk, and code that never heard of temp files cannot tell the difference. The one extra affordance is `.path`, so instead of copying gigabytes you can `rename` them into place. The one caveat: a disk-backed `Blob` is a promise that the bytes will still be there when read, so move or delete the underlying file and later reads fail.
 
 The whole trick fits in a plain `node:http` server, no framework required:
 
@@ -95,17 +95,15 @@ createServer(async (req, res) => {
 }).listen(3000)
 ```
 
-[`pipeline`](https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-callback) handles backpressure, so a fast client cannot outrun your disk and pile bytes up in memory. A multipart body needs a streaming parser like busboy on top to split the parts, but the per-file principle is exactly this. The part of the example that looks trivial and is not: that `finally`.
-
-There is one honest caveat: a disk-backed `Blob` is a promise that the bytes will still be there when read. Move or delete the underlying file and later reads fail.
+[`pipeline`](https://nodejs.org/api/stream.html#streampipelinesource-transforms-destination-callback) handles backpressure, so a fast client cannot outrun your disk and pile bytes up in memory. A multipart body needs a streaming parser like busboy on top to split the parts, but the per-file principle is exactly this. And the piece of the example that looks trivial is the actual hard part: that `finally`.
 
 ## The Hard Part Is Deleting Them
 
-Writing bytes to a temp file is the easy 20%. Making them reliably disappear is where the design work went, and none of it is specific to any framework.
+Writing bytes to a temp file is the easy 20%. Making them reliably disappear is the other 80%.
 
-**When is a request "done"?** The obvious rule, delete when the handler returns, is wrong. A handler can return a streaming response, like an event stream or a raw binary stream, that reads the upload *while* transmitting. Delete at return time and the response fails halfway. The rule that works: inspect what the handler returned, and if the response body is a stream or an async iterator, deletion rides on the body finishing instead of the handler returning. That also covers clients that disappear mid-download, because the server cancels the body and cancellation reaches the same finish hook. Every non-streaming response is sent after removal, so the temp files live exactly as long as anything can read them, and not a request longer.
+**When is a request "done"?** The obvious rule, delete when the handler returns, is wrong. A handler can return a streaming response, like an event stream or a raw binary stream, that reads the upload *while* transmitting. Delete at return time and the response fails halfway. The rule that works: if the response body is a stream or an async iterator, deletion rides on the body finishing instead of the handler returning. That also covers clients that disappear mid-download, because the server cancels the body and cancellation reaches the same finish hook. Every other response is sent after removal, so the temp files live exactly as long as anything can read them, and not a request longer.
 
-**Open handles.** Each request that spools an upload gets its own directory under the OS temp dir, and content lands through self-contained appends rather than long-lived file handles. However many files a request carries, it holds at most one transient descriptor per in-flight write, so a burst of uploads cannot exhaust the process's descriptor table. As a bonus, deletion never fights an open handle, which matters on Windows where deleting an open file is an error.
+**Open handles.** Each request that spools an upload gets its own directory under the OS temp dir, and content lands through self-contained appends rather than long-lived file handles. However many files a request carries, it holds at most one transient descriptor per in-flight write, so a burst of uploads cannot exhaust the process's descriptor table. And deletion never fights an open handle, which matters on Windows where deleting an open file is an error.
 
 **Failure isolation.** Disk full is your problem; a malformed multipart body is the client's. The two must not blur: filesystem failures surface as internal server errors with details attached only to the error's `cause`, which never serializes to the client, while parse failures stay bad requests. And if cleanup itself fails, the request outcome must not change, because a response that succeeded should never turn into an error over a temp file the OS will reap anyway.
 
@@ -117,9 +115,9 @@ Most body-limit middleware takes a single number. But once uploads spool to disk
 - A byte of **upload** touches memory only as a passing chunk on its way to disk. You can afford about a thousand times more of these.
 - A byte of an **event stream** is consumed on the fly and costs almost nothing to relay.
 
-One limit forces you to price all three at the highest rate, so the design takes three: `memory`, `file`, and `stream`, and when limits are configured, all three kinds are required, so no category is left unbounded by accident. Unlimited must be spelled `Number.POSITIVE_INFINITY`, on purpose.
+One limit forces you to price all three at the highest rate, so the design takes three: `memory`, `file`, and `stream`. Configuring one requires configuring all three, so no category is left unbounded by accident; unlimited must be spelled `Number.POSITIVE_INFINITY`, on purpose.
 
-The enforcement side has its own subtlety: `Content-Length` is a hint, not a fact. [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-content-length) allows it to be absent, and a hostile client can simply lie. So an oversized declared length rejects immediately for free, but the real enforcement counts bytes as they arrive and cuts the request off mid-stream with `413 Payload Too Large` the moment it crosses the line. A multipart body is bounded by `memory + file` in total, framing included, so a body that hides its bulk in part headers rather than part content is caught too.
+Enforcement has its own subtlety: `Content-Length` is a hint, not a fact. [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110#name-content-length) allows it to be absent, and a hostile client can simply lie. An oversized declared length rejects immediately for free, but the real enforcement counts bytes as they arrive and cuts the request off mid-stream with `413 Payload Too Large` the moment it crosses the line. A multipart body is bounded by `memory + file` in total, framing included, so a body that hides its bulk in part headers rather than part content is caught too.
 
 ## Where This Landed
 


### PR DESCRIPTION
Adds an engineering blog post, [/blog/uploads-bigger-than-your-ram](https://orpc.dev/blog/uploads-bigger-than-your-ram), written for any web developer, not just oRPC users. It walks from why `await request.formData()` is a memory bomb, through disk-backed `File` objects via `fs.openAsBlob` with a runnable plain `node:http` example, to the two design problems that actually matter: deletion timing and per-category body limits. It closes with the plugin setup and a link to the docs.

## Content

- New post at `apps/content/blog/uploads-bigger-than-your-ram.mdx` with a new `Engineering` tag, which adds a filter tab on `/blog` alongside `Announcements`.
- The `node:http` example was run as-is on Node v22.23.2 and Bun 1.3.14, producing a genuine lazy `File` in constant memory; behavior claims match the plugin source (cleanup deferred only for streaming response bodies, multipart bounded by `memory + file`, `Content-Length` used only for early rejection).
- References prior art (browser File internals, the busboy/formidable/multer ecosystem, Bun.file, lazy-file) with live links.

## Testing

- `pnpm docs:validate` passes: 0 backlink errors, no broken links under `blume validate --strict`.