### PR TITLE
docs(node): note openAsBlob bugs with files over 2 GiB

### DIFF
--- a/apps/content/docs/plugins/tmp-file-upload.mdx
+++ b/apps/content/docs/plugins/tmp-file-upload.mdx
@@ -60,6 +60,10 @@ const uploadVideo = os
 Temporary files are removed when the request finishes. A streaming response body, an event iterator or a raw stream, keeps them alive until it completes. Any other response is transmitted after removal, so a response that embeds the upload itself, as a `File` or inside `FormData`, needs the content copied or the file moved first. A moved or removed file can no longer be read through its `File` instance.
 :::
 
+:::warning
+Node's [`fs.openAsBlob`](https://nodejs.org/api/fs.html#fsopenasblobpath-options), which backs `TmpFile`, has [known bugs](https://github.com/nodejs/node/issues/52585) with files over 2 GiB: `size` is truncated above 4 GiB and `slice()` is unreliable above 2 GiB, while whole-file reads like `stream()` stay correct. A handler that needs the size of, or random access into, such an upload should [stat](https://nodejs.org/api/fs.html#fspromisesstatpath-options) or read its `path` directly.
+:::
+
 ## Limiting Body Sizes
 
 Use `maxBodySize` to limit each kind of request body by what it actually costs. All three kinds are required together, so none is left unbounded by accident; set a kind to `Number.POSITIVE_INFINITY` to deliberately leave it unlimited. A body over its limit rejects with `PAYLOAD_TOO_LARGE`.

--- a/packages/node/src/tmp-file-upload-handler-plugin.ts
+++ b/packages/node/src/tmp-file-upload-handler-plugin.ts
@@ -62,6 +62,13 @@ export interface TmpFileUploadHandlerPluginOptions {
  * A `File` whose content lives in a temporary file on disk and is read lazily,
  * so it can represent an upload far larger than available memory.
  *
+ * @remarks
+ * Node's `fs.openAsBlob`, which backs this class, has known bugs with files
+ * over 2 GiB ({@link https://github.com/nodejs/node/issues/52585}): `size` is
+ * truncated above 4 GiB and `slice()` is unreliable above 2 GiB, while
+ * whole-file reads like `stream()` stay correct. When size or random access
+ * matters for such a file, stat or read {@link path} directly.
+ *
  * @see {@link https://orpc.dev/docs/plugins/tmp-file-upload | Tmp File Upload Plugin}
  */
 export class TmpFile extends File {


### PR DESCRIPTION
`TmpFile` is backed by Node's `fs.openAsBlob`, which misreports very large files. The Tmp File Upload plugin docs and the `TmpFile` JSDoc now warn about it, so users spooling multi-gigabyte uploads know which parts of the `File` API they can trust.

Verified on Node v22.23.2 with a sparse 5 GiB file: `size` reports the true size modulo 4 GiB (5 GiB comes back as 1 GiB, a uint32 truncation), a `slice()` spanning the 2 GiB boundary returns an empty blob, and `stream()` delivers every byte correctly. Tracked upstream at https://github.com/nodejs/node/issues/52585, still open.

## Docs

Whole-file streaming of huge uploads keeps working as documented. Handlers that need the size of, or random access into, such an upload are pointed at the `TmpFile.path` to stat or read directly.

## Testing

`pnpm docs:validate` passes: no JSDoc backlink errors across 204 symbols and 315 orpc.dev links, and `blume validate --strict` reports no broken links.