### PR TITLE
chore(content): thin out and spread inline sponsor slots

### DIFF
--- a/apps/content/sponsors/inject.ts
+++ b/apps/content/sponsors/inject.ts
@@ -2,7 +2,9 @@ import { readFile } from 'node:fs/promises'
 import { dirname, join, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-export const WORDS_PER_AD = 200
+export const WORDS_PER_AD = 300
+export const EXTRA_WORDS_AFTER_GRID_AD = 100
+export const MAX_ADS_PER_PAGE = 4
 export const SLOT_TAG = '<SponsorSlot />'
 export const GRID_SLOT_TAG = '<SponsorSlot grid />'
 
@@ -10,13 +12,22 @@ export const GRID_SLOT_TAG = '<SponsorSlot grid />'
  * Insert `<SponsorSlot />` tags into MDX source. One simple rule: walk the
  * page accumulating words (code blocks count; fences are tracked only so a
  * `##` inside one is ignored), and place a slot right before a `##` heading
- * whenever it is the page's first heading or at least `WORDS_PER_AD` words
- * have passed since the last slot, resetting the count. If the trailing
+ * whenever it is the page's first heading or at least a gap's worth of words
+ * has passed since the last slot, resetting the count. If the trailing
  * content also clears the bar — or the page never triggered at all — one
  * more slot goes at the end. Frontmatter is left untouched.
  *
+ * The gap is `WORDS_PER_AD`, widened to an even `total / MAX_ADS_PER_PAGE`
+ * once a page is long enough to blow past the cap, so a long page spreads its
+ * slots down the whole page instead of front-loading them at one every
+ * `WORDS_PER_AD` and running dry after the opening sections. Either way at
+ * most `MAX_ADS_PER_PAGE` slots land on a page.
+ *
  * Wherever the page's first slot lands it gets the `grid` variant, which lists
- * every position at once; the rest stay two-cell rotating slots.
+ * every position at once; the rest stay two-cell rotating slots. Since that
+ * one slot already carries every sponsor, the run behind it never closes
+ * before `WORDS_PER_AD + EXTRA_WORDS_AFTER_GRID_AD` words, which only binds
+ * on pages short enough to still be using the unwidened gap.
  */
 export function injectSlots(source: string): string {
   const lines = source.split('\n')
@@ -29,28 +40,31 @@ export function injectSlots(source: string): string {
     }
   }
 
+  const countWords = (text: string) => text.match(/\S+/g)?.length ?? 0
+  const gap = Math.max(WORDS_PER_AD, countWords(lines.slice(bodyStart).join('\n')) / MAX_ADS_PER_PAGE)
+  const gridGap = Math.max(gap, WORDS_PER_AD + EXTRA_WORDS_AFTER_GRID_AD)
+  const gapAfter = (placed: number) => placed === 0 ? 0 : placed === 1 ? gridGap : gap
+
   let inFence = false
-  let seenH2 = false
   let words = 0
   const insertBefore: number[] = []
-  for (let i = bodyStart; i < lines.length; i++) {
+  for (let i = bodyStart; i < lines.length && insertBefore.length < MAX_ADS_PER_PAGE; i++) {
     const trimmed = lines[i]!.trim()
     if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) {
       inFence = !inFence
     }
-    else if (!inFence && /^##\s/.test(trimmed) && (!seenH2 || words >= WORDS_PER_AD)) {
-      seenH2 = true
+    else if (!inFence && /^##\s/.test(trimmed) && words >= gapAfter(insertBefore.length)) {
       insertBefore.push(i)
       words = 0
     }
-    words += trimmed === '' ? 0 : trimmed.split(/\s+/).length
+    words += countWords(trimmed)
   }
 
   // Splice bottom-up so earlier indices stay valid.
   for (let i = insertBefore.length - 1; i >= 0; i--) {
     lines.splice(insertBefore[i]!, 0, '', i === 0 ? GRID_SLOT_TAG : SLOT_TAG, '')
   }
-  if (insertBefore.length === 0 || words >= WORDS_PER_AD) {
+  if (insertBefore.length < MAX_ADS_PER_PAGE && words >= gapAfter(insertBefore.length)) {
     lines.push('', insertBefore.length === 0 ? GRID_SLOT_TAG : SLOT_TAG, '')
   }
 


### PR DESCRIPTION
Sponsor slots ran one per 200 words with no ceiling, so a long docs page turned into a column of ads: the v1 migration guide carried 11. Slots now start at one per 300 words and stop at 4 per page, and any page long enough to hit that cap widens its gap to an even quarter of the page, so the 4 spread top to bottom instead of piling into the opening sections. The first slot on every page renders the grid variant that already lists every sponsor, so the run behind it is held open to at least 400 words.

Across the 97 docs and blog pages, mean slots per page drop from 2.6 to 1.8 and the worst page from 11 to 4. 82% of pages now carry the grid slot plus at most one more.

## Placement

On the longest page the four slots land at 4%, 32%, 58% and 86% of rendered page height, measured in the browser rather than in words. Short pages keep the grid slot alone, and slots still attach only to `##` headings, so nothing is injected mid-section.

## Testing

Checked in the dev server: rendered slot counts on five docs pages match what the injector predicts, the grid slot leads every page with its full sponsor list, later slots carry two cells each, and the console is clean.

Behavior was also swept over every docs and blog page, asserting no page exceeds the cap, exactly one grid slot per page, no two slots closer than their gap, and page content and frontmatter preserved byte for byte. Twelve edge cases pass, including empty and frontmatter-only sources, `##` inside a code fence, clustered headings, cap saturation, and both trailing-tail branches.