### PR TITLE
refactor(ratelimit): record procedure and path with each rate-limit check

### DIFF
--- a/packages/ratelimit/src/handler-plugin.test.ts
+++ b/packages/ratelimit/src/handler-plugin.test.ts
@@ -15,12 +15,16 @@ describe('ratelimitHandlerPlugin', () => {
   it('adds rate limit headers to a successful response after a limit check', async () => {
     const reset = Date.now() + 60000
 
-    handlerFn.mockImplementationOnce(({ context }) => {
-      context[RATELIMIT_HANDLER_PLUGIN_CONTEXT_SYMBOL].results.push({
-        success: true,
-        limit: 100,
-        remaining: 50,
-        reset,
+    handlerFn.mockImplementationOnce(({ context, path, procedure }) => {
+      context[RATELIMIT_HANDLER_PLUGIN_CONTEXT_SYMBOL].checks.push({
+        path,
+        procedure,
+        result: {
+          success: true,
+          limit: 100,
+          remaining: 50,
+          reset,
+        },
       })
     })
 
@@ -35,12 +39,16 @@ describe('ratelimitHandlerPlugin', () => {
   it('adds retry-after when a request is rejected for exceeding the limit', async () => {
     const reset = Date.now() + 60000
 
-    handlerFn.mockImplementationOnce(({ context }) => {
-      context[RATELIMIT_HANDLER_PLUGIN_CONTEXT_SYMBOL].results.push({
-        success: false,
-        limit: 100,
-        remaining: 50,
-        reset,
+    handlerFn.mockImplementationOnce(({ context, path, procedure }) => {
+      context[RATELIMIT_HANDLER_PLUGIN_CONTEXT_SYMBOL].checks.push({
+        path,
+        procedure,
+        result: {
+          success: false,
+          limit: 100,
+          remaining: 50,
+          reset,
+        },
       })
 
       throw new ORPCError('TOO_MANY_REQUESTS')
@@ -66,35 +74,55 @@ describe('ratelimitHandlerPlugin', () => {
   it('uses the most restrictive limit when multiple checks run for one request', async () => {
     const reset = Date.now() + 60000
 
-    handlerFn.mockImplementationOnce(({ context }) => {
-      context[RATELIMIT_HANDLER_PLUGIN_CONTEXT_SYMBOL].results.push({
-        success: false,
+    handlerFn.mockImplementationOnce(({ context, path, procedure }) => {
+      context[RATELIMIT_HANDLER_PLUGIN_CONTEXT_SYMBOL].checks.push({
+        path,
+        procedure,
+        result: {
+          success: false,
+        },
       })
 
-      context[RATELIMIT_HANDLER_PLUGIN_CONTEXT_SYMBOL].results.push({
-        success: false,
+      context[RATELIMIT_HANDLER_PLUGIN_CONTEXT_SYMBOL].checks.push({
+        path,
+        procedure,
+        result: {
+          success: false,
+        },
       })
 
-      context[RATELIMIT_HANDLER_PLUGIN_CONTEXT_SYMBOL].results.push({
-        success: false,
-        limit: 100,
-        remaining: 3,
-        reset,
+      context[RATELIMIT_HANDLER_PLUGIN_CONTEXT_SYMBOL].checks.push({
+        path,
+        procedure,
+        result: {
+          success: false,
+          limit: 100,
+          remaining: 3,
+          reset,
+        },
       })
 
-      context[RATELIMIT_HANDLER_PLUGIN_CONTEXT_SYMBOL].results.push({
-        success: false,
-        limit: 100,
-        remaining: 2,
-        reset,
+      context[RATELIMIT_HANDLER_PLUGIN_CONTEXT_SYMBOL].checks.push({
+        path,
+        procedure,
+        result: {
+          success: false,
+          limit: 100,
+          remaining: 2,
+          reset,
+        },
       })
 
       // remaining is lowest but success: true so it still low priority to pick
-      context[RATELIMIT_HANDLER_PLUGIN_CONTEXT_SYMBOL].results.push({
-        success: true,
-        limit: 100,
-        remaining: 1,
-        reset,
+      context[RATELIMIT_HANDLER_PLUGIN_CONTEXT_SYMBOL].checks.push({
+        path,
+        procedure,
+        result: {
+          success: true,
+          limit: 100,
+          remaining: 1,
+          reset,
+        },
       })
     })
 

--- a/packages/ratelimit/src/handler-plugin.ts
+++ b/packages/ratelimit/src/handler-plugin.ts
@@ -1,4 +1,4 @@
-import type { Context } from '@orpc/server'
+import type { AnyProcedure, Context } from '@orpc/server'
 import type { StandardHandlerOptions, StandardHandlerPlugin, StandardHandlerRoutingInterceptor } from '@orpc/server/standard'
 import type { StandardHeaders } from '@standardserver/core'
 import type { RateLimitResult } from './types'
@@ -11,7 +11,7 @@ export interface RateLimitHandlerPluginContext {
     /**
      * The result of the ratelimiter after applying limits
      */
-    results: RateLimitResult[]
+    checks: { procedure: AnyProcedure, path: string[], result: RateLimitResult }[]
   }
 }
 
@@ -26,7 +26,7 @@ export class RateLimitHandlerPlugin<T extends Context> implements StandardHandle
 
   init(options: StandardHandlerOptions<T>): StandardHandlerOptions<T> {
     const routingInterceptor: StandardHandlerRoutingInterceptor<T> = async (interceptorOptions) => {
-      const pluginContext: Exclude<RateLimitHandlerPluginContext[typeof RATELIMIT_HANDLER_PLUGIN_CONTEXT_SYMBOL], undefined> = { results: [] }
+      const pluginContext: Exclude<RateLimitHandlerPluginContext[typeof RATELIMIT_HANDLER_PLUGIN_CONTEXT_SYMBOL], undefined> = { checks: [] }
 
       const result = await interceptorOptions.next({
         ...interceptorOptions,
@@ -36,24 +36,24 @@ export class RateLimitHandlerPlugin<T extends Context> implements StandardHandle
         } satisfies RateLimitHandlerPluginContext,
       })
 
-      if (result.matched && pluginContext.results.length) {
-        const exceededResults = pluginContext.results.filter(r => !r.success)
+      if (result.matched && pluginContext.checks.length) {
+        const exceededChecks = pluginContext.checks.filter(r => !r.result.success)
 
         // Pick the most constrained result: prefer exceeded limits, fall back to all results.
         // Treat undefined remaining as 0 — unknown capacity is assumed fully exhausted.
-        const mostConstrained = (exceededResults.length ? exceededResults : pluginContext.results).reduce(
-          (a, b) => (a.remaining ?? Infinity) <= (b.remaining ?? Infinity) ? a : b,
+        const mostConstrained = (exceededChecks.length ? exceededChecks : pluginContext.checks).reduce(
+          (a, b) => (a.result.remaining ?? Infinity) <= (b.result.remaining ?? Infinity) ? a : b,
         )
 
         const headers: StandardHeaders = {
           ...result.response.headers,
-          'ratelimit-limit': mostConstrained.limit?.toString(),
-          'ratelimit-remaining': mostConstrained.remaining?.toString(),
-          'ratelimit-reset': mostConstrained.reset?.toString(),
+          'ratelimit-limit': mostConstrained.result.limit?.toString(),
+          'ratelimit-remaining': mostConstrained.result.remaining?.toString(),
+          'ratelimit-reset': mostConstrained.result.reset?.toString(),
         }
 
-        if (result.response.status >= 400 && !mostConstrained.success && mostConstrained.reset !== undefined) {
-          headers['retry-after'] = Math.max(0, Math.ceil((mostConstrained.reset - Date.now()) / 1000)).toString()
+        if (result.response.status >= 400 && !mostConstrained.result.success && mostConstrained.result.reset !== undefined) {
+          headers['retry-after'] = Math.max(0, Math.ceil((mostConstrained.result.reset - Date.now()) / 1000)).toString()
         }
 
         return {

--- a/packages/ratelimit/src/middleware.test.ts
+++ b/packages/ratelimit/src/middleware.test.ts
@@ -82,11 +82,13 @@ describe('ratelimit', () => {
 
   it('push result into handler plugin context if exists', async () => {
     const limiter = createLimiter(success)
-    const ctx = { results: [] }
-    await call(os.use(ratelimit({ limiter, key: 'k' })).handler(() => 'ok'), undefined, {
+    const ctx = { checks: [] }
+    const procedure = os.use(ratelimit({ limiter, key: 'k' })).handler(() => 'ok')
+    await call(procedure, undefined, {
       context: { [RATELIMIT_HANDLER_PLUGIN_CONTEXT_SYMBOL]: ctx },
+      path: ['__path__'],
     })
-    expect(ctx).toHaveProperty('results', [success])
+    expect(ctx).toHaveProperty('checks', [{ path: ['__path__'], procedure, result: success }])
   })
 
   it('communicate with middleware context, and isolated', async () => {

--- a/packages/ratelimit/src/middleware.ts
+++ b/packages/ratelimit/src/middleware.ts
@@ -78,7 +78,7 @@ export function ratelimit<
 
     const pluginContext = (middlewareOptions.context as RateLimitHandlerPluginContext)[RATELIMIT_HANDLER_PLUGIN_CONTEXT_SYMBOL]
     if (pluginContext) {
-      pluginContext.results.push(result)
+      pluginContext.checks.push({ path: middlewareOptions.path, procedure: middlewareOptions.procedure, result })
     }
 
     if (!result.success) {


### PR DESCRIPTION
The ratelimit handler plugin context now records which procedure each rate-limit check ran on. Each entry in the plugin context is `{ procedure, path, result }` (renamed from a bare `RateLimitResult[]` under `results` to `checks`), so response interceptors and future consumers can tell which procedure produced which limit result.

## Changes

- The `ratelimit` middleware pushes the current `procedure` and `path` alongside the limiter result into the handler plugin context.
- Header selection behavior is unchanged: the plugin still picks the most constrained result across all checks for the `ratelimit-*` and `retry-after` headers.

## Testing

- Plugin and middleware tests updated to the new entry shape; all ratelimit tests pass.
- `pnpm type:check` passes across all packages.