### PR TITLE
chore(content): link releases on GitHub instead of a changelog page

### DIFF
--- a/apps/content/blume.config.ts
+++ b/apps/content/blume.config.ts
@@ -17,13 +17,6 @@ export default defineConfig({
           'blog/**/*.{md,mdx}',
         ],
       },
-      {
-        type: 'github-releases',
-        prefix: 'changelog',
-        owner: 'middleapi',
-        repo: 'orpc',
-        prereleases: true,
-      },
     ],
   },
   github: {
@@ -48,17 +41,18 @@ export default defineConfig({
     tabs: [
       { label: 'Documentation', path: '/docs' },
       { label: 'Blog', path: '/blog', href: '/blog' },
-      { label: 'Changelog', path: '/changelog', href: '/changelog' },
       { label: 'Comparison', path: '/docs', href: '/docs/comparison' },
+      { label: 'From V1', path: '/docs', href: '/docs/migrations/from-v1' },
       {
         label: 'More',
         path: '',
         items: [
-          { label: 'V1 Documentation', path: 'https://v1.orpc.dev' },
+          { label: 'Releases', path: 'https://github.com/middleapi/orpc/releases' },
           { label: 'Discussions', path: 'https://github.com/middleapi/orpc/discussions' },
           { label: 'Sponsors', path: 'https://github.com/sponsors/dinwwwh' },
           { label: 'LLM Context', path: 'https://orpc.dev/llms.txt' },
           { label: 'LLM Context (Full)', path: 'https://orpc.dev/llms-full.txt' },
+          { label: 'V1 Documentation', path: 'https://v1.orpc.dev' },
         ],
       },
     ],

--- a/apps/content/components/blume/MobileNav.astro
+++ b/apps/content/components/blume/MobileNav.astro
@@ -18,7 +18,7 @@ const { items, currentRoute, strings } = Astro.props;
 ---
 
 {/* From `md` the header's inline tab bar takes over; keep the drawer
-    list only when there is no page tree to show (e.g. the changelog). */}
+    list only when there is no page tree to show (e.g. the blog). */}
 <SectionsNav
   class={`mb-4 border-border border-b pb-4${items.length > 0 ? " md:hidden" : ""}`}
   currentRoute={currentRoute}

--- a/apps/content/pages/_home/Footer.astro
+++ b/apps/content/pages/_home/Footer.astro
@@ -37,7 +37,7 @@ const columns: { title: string, links: FooterLink[] }[] = [
       { label: 'Playgrounds', href: '/docs/playgrounds' },
       { label: 'Comparison', href: '/docs/comparison' },
       { label: 'Blog', href: '/blog' },
-      { label: 'Changelog', href: '/changelog' },
+      { label: 'Releases', href: 'https://github.com/middleapi/orpc/releases' },
       { label: 'V1 documentation', href: 'https://v1.orpc.dev' },
     ],
   },

--- a/apps/content/pages/_home/Hero.astro
+++ b/apps/content/pages/_home/Hero.astro
@@ -18,11 +18,13 @@ const install = 'npx skills add middleapi/orpc'
   <div class="relative mx-auto max-w-6xl px-6 pt-16 pb-14 sm:pt-24 sm:pb-20">
     <div class="mx-auto max-w-3xl text-center">
       <a
-        href="/changelog"
+        href="https://github.com/middleapi/orpc/releases"
+        rel="noopener"
+        target="_blank"
         class="inline-flex items-center gap-2 rounded-full border border-border bg-background/60 py-1 pr-3 pl-1.5 text-xs font-medium text-muted-foreground backdrop-blur transition-colors hover:border-foreground/25 hover:text-foreground"
       >
         <span class="rounded-full bg-accent px-2 py-0.5 text-[0.6875rem] text-accent-foreground">v2 beta</span>
-        Follow along in the changelog
+        Follow the releases on GitHub
         <Icon name="arrow-right" size={12} />
       </a>
 


### PR DESCRIPTION
The docs site built a `/changelog` route from a `github-releases` content source that mirrored the repo's releases. That source is gone, so the site now links straight to GitHub releases instead of maintaining a second copy of them, and the v1 migration guide gets its own top-level tab.

## Fixes

Every link that pointed at `/changelog` now goes to the releases page, so nothing 404s once the route disappears: the header tab is dropped in favour of the new **Releases** entry in the "More" menu, and the footer link and the home hero badge both point at GitHub.

## Testing

`pnpm lint` passes, the touched `.astro` files compile clean, and `tsc` on `apps/content` shows no new errors.