### PR TITLE
docs: add TanStack AI integration

### DIFF
--- a/apps/content/docs/integrations/tanstack-ai.mdx
+++ b/apps/content/docs/integrations/tanstack-ai.mdx
@@ -1,0 +1,107 @@
+---
+title: "TanStack AI Integration"
+description: "Learn how to use oRPC as a transport for TanStack AI chat streams, through the oRPC client or as a plain Server-Sent Events endpoint."
+sidebar:
+  label: "TanStack AI"
+---
+
+:::warning
+This documentation is based on TanStack AI v0.x, which is still evolving. For a refresher, review the [TanStack AI documentation](https://tanstack.com/ai/latest).
+:::
+
+## Transport
+
+TanStack AI's `chat` returns an [AsyncIteratorObject](/docs/async-iterator-object) of stream chunks, so a procedure can return it directly and oRPC streams every chunk to the client.
+
+### Server
+
+```ts
+import type { UIMessage } from '@tanstack/ai'
+import { os, type } from '@orpc/server'
+import { chat } from '@tanstack/ai'
+import { openaiText } from '@tanstack/ai-openai'
+
+export const streamChat = os
+  .input(type<{ messages: UIMessage[] }>())
+  .handler(({ input, signal }) => {
+    const abortController = new AbortController()
+    signal?.addEventListener('abort', () => abortController.abort(), { once: true })
+
+    return chat({
+      adapter: openaiText('gpt-5.5'),
+      systemPrompts: ['You are a helpful assistant.'],
+      messages: input.messages,
+      abortController,
+    })
+  })
+```
+
+### Client
+
+Pass an oRPC client call as the `fetcher` of `useChat`. The `fetcher` option accepts a promise of an `AsyncIterable` of stream chunks, which is exactly what an oRPC client call returns.
+
+```tsx
+import { useState } from 'react'
+import { useChat } from '@tanstack/ai-react'
+import { client } from './client'
+
+export function Example() {
+  const { messages, sendMessage, isLoading } = useChat({
+    fetcher: ({ messages }, { signal }) =>
+      client.streamChat({ messages }, { signal }),
+  })
+  const [input, setInput] = useState('')
+
+  return (
+    <>
+      {messages.map(message => (
+        <div key={message.id}>
+          {message.role === 'user' ? 'User: ' : 'AI: '}
+          {message.parts.map((part, index) =>
+            part.type === 'text' ? <span key={index}>{part.content}</span> : null,
+          )}
+        </div>
+      ))}
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          if (input.trim() && !isLoading) {
+            sendMessage(input)
+            setInput('')
+          }
+        }}
+      >
+        <input
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          disabled={isLoading}
+          placeholder="Say something..."
+        />
+        <button type="submit" disabled={isLoading}>
+          Submit
+        </button>
+      </form>
+    </>
+  )
+}
+```
+
+:::tip
+With [OpenAPIHandler](/docs/openapi/handler), TanStack AI's built-in `fetchServerSentEvents` connection can talk to a [routed](/docs/openapi/routing) procedure directly, no custom fetcher needed: oRPC streams [event iterators](/docs/async-iterator-object) as standard [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events).
+
+```ts
+export const streamChat = os
+  .meta(openapi({ method: 'POST', path: '/chat' }))
+  .input(type<{ messages: UIMessage[] }>())
+  .handler(({ input }) => chat({
+    adapter: openaiText('gpt-5.5'),
+    messages: input.messages,
+  }))
+
+const { messages, sendMessage, isLoading } = useChat({
+  connection: fetchServerSentEvents('/api/chat'), // handler prefix + route path
+})
+```
+
+:::

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "@standardserver/fetch": "^0.8.0",
     "@standardserver/peer": "^0.8.0",
     "@standardserver/shared": "^0.8.0",
+    "@tanstack/ai": "^0.45.1",
+    "@tanstack/ai-client": "^0.23.3",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^26.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,12 @@ importers:
       '@standardserver/shared':
         specifier: ^0.8.0
         version: 0.8.0
+      '@tanstack/ai':
+        specifier: ^0.45.1
+        version: 0.45.1(@opentelemetry/api@1.9.1)(zod@4.4.3)
+      '@tanstack/ai-client':
+        specifier: ^0.23.3
+        version: 0.23.3(@opentelemetry/api@1.9.1)(zod@4.4.3)
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -1277,6 +1283,14 @@ importers:
         version: 4.4.3
 
 packages:
+
+  '@ag-ui/core@0.1.1-canary.beta.0':
+    resolution: {integrity: sha512-zcP3RH5p3HJTZ0kyQxNOL1blnVFTDpaShitR7UMS/thwFdl48V6CAG+WQBcYEu/dfa8mKonRez88N0Ok+nEI+w==}
+    peerDependencies:
+      zod: ^3.25.18 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@ai-sdk/gateway@3.0.13':
     resolution: {integrity: sha512-g7nE4PFtngOZNZSy1lOPpkC+FAiHxqBJXqyRMEG7NUrEVZlz5goBdtHg1YgWRJIX776JTXAmbOI5JreAKVAsVA==}
@@ -5035,11 +5049,34 @@ packages:
       csstype:
         optional: true
 
+  '@tanstack/ai-client@0.23.3':
+    resolution: {integrity: sha512-be/Jd9YOGlvoJzZP6dfgVcm7lnUhShDCMJertZdg0/cT5IAaOYoSWgvTptckVpIeXbk/B9x0GLVC8JJ9qCfyFw==}
+
+  '@tanstack/ai-event-client@0.8.0':
+    resolution: {integrity: sha512-UzhGQERwGU0yymziuGiHXNnKRZeR2JaGoPXeNzKuHwQtUmvMu1H8g0C9wpkpksj+pmTQPhdEBUOMlU6NhLDVpA==}
+
+  '@tanstack/ai-utils@0.4.0':
+    resolution: {integrity: sha512-xqvAgPJkIuGk1m+jZKyb7vBTQIaBmUD9EVzlPkDWWMp80n69uwL0TnBZCVk+OwL9goTQiFy648dnBfLsiJgl6A==}
+
+  '@tanstack/ai@0.45.1':
+    resolution: {integrity: sha512-mrqSBKX7loqm/+DUkqtHkCfr/yTCdWtmAdUd/yw2VtSNb9O61hJwB7ymGj2TU10darGLolqBxi/jGvZK9dK0hw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
   '@tanstack/angular-query-experimental@5.101.4':
     resolution: {integrity: sha512-6JznduBS7eTKRLGl2RoI+Y0nBLayJrbGQPyn8DLsJrNimYPLlUyIZV9GZLsq3aYoyjuaxwbDRWz2eZEWhtSk3Q==}
     peerDependencies:
       '@angular/common': '>=16.0.0'
       '@angular/core': '>=16.0.0'
+
+  '@tanstack/devtools-event-client@0.4.4':
+    resolution: {integrity: sha512-6T5Yop/793YI+H+5J8Hsyj4kCih9sl4t3ElLgKioW5hk3ocn+ZdSJ94tT7vL7uabxSugWYBZlOTMPzEw2puvQw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@tanstack/match-sorter-utils@8.19.4':
     resolution: {integrity: sha512-Wo1iKt2b9OT7d+YGhvEPD3DXvPv2etTusIMhMUoG7fbhmxcXCtIjJDEygy91Y2JFlwGyjqiBPRozme7UD8hoqg==}
@@ -9402,6 +9439,9 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -11697,6 +11737,10 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@ag-ui/core@0.1.1-canary.beta.0(zod@4.4.3)':
+    optionalDependencies:
+      zod: 4.4.3
 
   '@ai-sdk/gateway@3.0.13(zod@4.4.3)':
     dependencies:
@@ -15923,6 +15967,33 @@ snapshots:
       - preact
       - react
 
+  '@tanstack/ai-client@0.23.3(@opentelemetry/api@1.9.1)(zod@4.4.3)':
+    dependencies:
+      '@tanstack/ai': 0.45.1(@opentelemetry/api@1.9.1)(zod@4.4.3)
+      '@tanstack/ai-event-client': 0.8.0
+      '@tanstack/ai-utils': 0.4.0
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - zod
+
+  '@tanstack/ai-event-client@0.8.0':
+    dependencies:
+      '@tanstack/devtools-event-client': 0.4.4
+
+  '@tanstack/ai-utils@0.4.0': {}
+
+  '@tanstack/ai@0.45.1(@opentelemetry/api@1.9.1)(zod@4.4.3)':
+    dependencies:
+      '@ag-ui/core': 0.1.1-canary.beta.0(zod@4.4.3)
+      '@standard-schema/spec': 1.1.0
+      '@tanstack/ai-event-client': 0.8.0
+      '@tanstack/ai-utils': 0.4.0
+      partial-json: 0.1.7
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+    transitivePeerDependencies:
+      - zod
+
   '@tanstack/angular-query-experimental@5.101.4(@angular/common@22.1.1(@angular/core@22.1.1(rxjs@7.8.2))(rxjs@7.8.2))(@angular/core@22.1.1(rxjs@7.8.2))':
     dependencies:
       '@angular/common': 22.1.1(@angular/core@22.1.1(rxjs@7.8.2))(rxjs@7.8.2)
@@ -15930,6 +16001,8 @@ snapshots:
       '@tanstack/query-core': 5.101.4
     optionalDependencies:
       '@tanstack/query-devtools': 5.101.4
+
+  '@tanstack/devtools-event-client@0.4.4': {}
 
   '@tanstack/match-sorter-utils@8.19.4':
     dependencies:
@@ -21120,6 +21193,8 @@ snapshots:
       entities: 8.0.0
 
   parseurl@1.3.3: {}
+
+  partial-json@0.1.7: {}
 
   path-browserify@1.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,3 +45,5 @@ minimumReleaseAgeExclude:
   - '@standardserver/shared@0.7.1 || 0.8.0'
   - '@standardserver/aws-lambda@0.7.1 || 0.8.0'
   - '@standardserver/fastify@0.7.1 || 0.8.0'
+  - '@tanstack/ai-client@0.23.3'
+  - '@tanstack/ai@0.45.1'

--- a/tests/integrations/tanstack-ai.test.ts
+++ b/tests/integrations/tanstack-ai.test.ts
@@ -1,0 +1,129 @@
+import type { AnyTextAdapter, StreamChunk, TextOptions, UIMessage } from '@tanstack/ai'
+import type { AddressInfo } from 'node:net'
+import { serve } from '@hono/node-server'
+import { createORPCClient } from '@orpc/client'
+import { openapi } from '@orpc/openapi'
+import { OpenAPIHandler, OpenAPILink } from '@orpc/openapi/fetch'
+import { os, type } from '@orpc/server'
+import { isAsyncIteratorObject } from '@orpc/shared'
+import { chat, EventType } from '@tanstack/ai'
+import { fetchServerSentEvents } from '@tanstack/ai-client'
+
+/**
+ * Minimal TextAdapter that echoes the last user message, so the real `chat()`
+ * engine runs without an API key. Docs examples use `openaiText` in its place.
+ */
+function mockText(): AnyTextAdapter {
+  const adapter = {
+    kind: 'text' as const,
+    name: 'mock',
+    model: 'mock-echo-1',
+    async* chatStream(options: TextOptions<Record<string, any>>): AsyncIterable<StreamChunk> {
+      const runId = options.runId ?? 'run_mock'
+      const threadId = options.threadId ?? 'thread_mock'
+      const messageId = 'msg_mock'
+
+      yield { type: EventType.RUN_STARTED, runId, threadId, model: 'mock-echo-1', timestamp: Date.now() }
+      yield { type: EventType.TEXT_MESSAGE_START, messageId, role: 'assistant', model: 'mock-echo-1', timestamp: Date.now() }
+
+      const lastUser = [...(options.messages ?? [])].reverse().find(m => m.role === 'user')
+      const lastContent = typeof lastUser?.content === 'string'
+        ? lastUser.content
+        : JSON.stringify(lastUser?.content)
+
+      let content = ''
+      for (const delta of ['echo: ', lastContent]) {
+        content += delta
+        yield { type: EventType.TEXT_MESSAGE_CONTENT, messageId, delta, content, model: 'mock-echo-1', timestamp: Date.now() }
+      }
+
+      yield { type: EventType.TEXT_MESSAGE_END, messageId, model: 'mock-echo-1', timestamp: Date.now() }
+      yield { type: EventType.RUN_FINISHED, runId, threadId, model: 'mock-echo-1', timestamp: Date.now(), finishReason: 'stop' }
+    },
+    structuredOutput: async (): Promise<never> => {
+      throw new Error('mock adapter does not support structured output')
+    },
+  }
+
+  return adapter as unknown as AnyTextAdapter
+}
+
+/** the docs example procedure, consumed both through the oRPC client and TanStack AI's built-in connections */
+const router = {
+  streamChat: os
+    .meta(openapi({ method: 'POST', path: '/chat' }))
+    .input(type<{ messages: UIMessage[] }>())
+    .handler(({ input, signal }) => {
+      const abortController = new AbortController()
+      signal?.addEventListener('abort', () => abortController.abort(), { once: true })
+
+      return chat({
+        adapter: mockText(),
+        messages: input.messages,
+        abortController,
+      })
+    }),
+}
+
+const handler = new OpenAPIHandler(router)
+
+const server = serve({
+  fetch: async (request: Request) => {
+    const { response } = await handler.handle(request, { prefix: '/api' })
+    return response ?? new Response('Not Found', { status: 404 })
+  },
+  port: 0,
+})
+
+afterAll(() => {
+  server.close()
+})
+
+const origin = `http://localhost:${(server.address() as AddressInfo).port}`
+
+const link = new OpenAPILink(router as any, { url: '/api', origin })
+const client: any = createORPCClient(link)
+
+const userMessages: UIMessage[] = [
+  { id: '1', role: 'user', parts: [{ type: 'text', content: 'ping' }] },
+]
+
+async function collect(stream: AsyncIterable<StreamChunk>): Promise<StreamChunk[]> {
+  const chunks: StreamChunk[] = []
+  for await (const chunk of stream) {
+    chunks.push(chunk)
+  }
+  return chunks
+}
+
+function collectText(chunks: StreamChunk[]): string {
+  return chunks
+    .filter(chunk => chunk.type === EventType.TEXT_MESSAGE_CONTENT)
+    .map(chunk => chunk.delta)
+    .join('')
+}
+
+function expectChatStream(chunks: StreamChunk[]): void {
+  expect(chunks.at(0)?.type).toBe(EventType.RUN_STARTED)
+  expect(chunks.at(-1)?.type).toBe(EventType.RUN_FINISHED)
+  expect(collectText(chunks)).toContain('ping')
+}
+
+it('chat() returns an async iterator object, so procedures can return it directly', () => {
+  const stream = chat({ adapter: mockText(), messages: userMessages })
+
+  expect(isAsyncIteratorObject(stream)).toBe(true)
+})
+
+it('streams through the oRPC client as an async iterator object, compatible with useChat fetcher', async () => {
+  const stream = await client.streamChat({ messages: userMessages })
+
+  expect(isAsyncIteratorObject(stream)).toBe(true)
+  expectChatStream(await collect(stream))
+})
+
+it('is consumable by tanstack ai\'s built-in fetchServerSentEvents connection', async () => {
+  const connection = fetchServerSentEvents(`${origin}/api/chat`)
+
+  expectChatStream(await collect(connection.connect(userMessages)))
+})


### PR DESCRIPTION
Adds a TanStack AI integration docs page and e2e tests that keep its examples working. oRPC procedures can return `chat()` directly since it is an async iterator object, so streaming works with no conversion helper on either side.

## Docs

- New `docs/integrations/tanstack-ai.mdx` covering the transport: a procedure returning `chat()`, consumed with `useChat`'s `fetcher` option (it accepts the promise of an async iterable an oRPC client call returns).
- A tip shows the zero-client path: with `OpenAPIHandler`, a routed procedure is directly consumable by TanStack AI's built-in `fetchServerSentEvents` connection, since oRPC streams event iterators as standard SSE.

## Tests

- `tests/integrations/tanstack-ai.test.ts` runs the real `chat()` engine against a mock text adapter (no API key needed) through a single `OpenAPIHandler` server and asserts:
  - `chat()` returns an async iterator object, the property the docs examples rely on.
  - The oRPC client delivers the stream intact, matching the `useChat` fetcher contract.
  - The routed endpoint is consumable by the real `fetchServerSentEvents` connection from `@tanstack/ai-client`.
- If a future TanStack AI release breaks either assumption, these fail immediately.

Examples were also verified end-to-end in the next playground (both transports streaming in the browser) before the playground edits were reverted.

Resolves #1541