### PR TITLE
docs(tanstack-query): document SSR for streamed and live queries

### DIFF
--- a/apps/content/docs/integrations/tanstack-query.mdx
+++ b/apps/content/docs/integrations/tanstack-query.mdx
@@ -504,14 +504,20 @@ const query = useInfiniteQuery(
 )
 ```
 
-## Custom Serializers
+## Server-Side Rendering (SSR)
 
-If needed, you can extend the default TanStack Query serializer to support additional types supported by oRPC. Learn more about [RPC Serializers](/docs/rpc/serializer) and [TanStack Query Server Rendering & Hydration](https://tanstack.com/query/latest/docs/framework/react/guides/ssr).
+When [server-side rendering](/docs/best-practices/optimizing-ssr) with [TanStack Query hydration](https://tanstack.com/query/latest/docs/framework/react/guides/ssr), two things need special care: oRPC types that JSON cannot represent, and streamed or live queries that never complete.
+
+### Custom Serializers
+
+If needed, you can extend the default TanStack Query serializer to support additional types supported by oRPC. Learn more about [RPC Serializers](/docs/rpc/serializer).
 
 ```ts
-import { RPCSerializer } from '@orpc/client'
+import { RPCJsonSerializer } from '@orpc/client'
+import { hashKey, QueryClient } from '@tanstack/react-query' // or any framework adapter, e.g. @tanstack/vue-query 
 
-const serializer = new RPCSerializer({
+// similar to `RPCSerializer` but more typesafe
+const serializer = new RPCJsonSerializer({
   handlers: {
     // put custom serializers here
   },
@@ -520,22 +526,114 @@ const serializer = new RPCSerializer({
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      queryKeyHashFn(queryKey) {
-        const serialized = serializer.serialize(queryKey, { useFormDataForBlobFields: false })
-        return JSON.stringify(serialized)
-      },
       staleTime: 60 * 1000, // > 0 to prevent immediate refetching on mount
+
+      queryKeyHashFn: (queryKey) => {
+        const { json, meta } = serializer.serialize(queryKey)
+
+        return hashKey([
+          json,
+          meta?.map(entry => JSON.stringify(entry)).sort(),
+        ])
+      },
     },
     dehydrate: {
-      serializeData(data) {
-        return serializer.serialize(data, { useFormDataForBlobFields: false })
-      }
+      serializeData: (data) => {
+        const { json, meta } = serializer.serialize(data)
+        return { json, meta }
+      },
     },
     hydrate: {
       deserializeData(data) {
         return serializer.deserialize(data)
-      }
+      },
     },
+  },
+})
+```
+
+### Streamed and Live Queries
+
+[Streamed](#streamed-query-options) and [live](#live-query-options) queries can stay open indefinitely, so prefetching them during SSR would block rendering forever. The fix: cancel the stream on the server once the query succeeds and dehydrate the result, then refetch on the client to open a new stream.
+
+#### Cancel Server Streams on Success
+
+Only active streams hold `success` status while still `fetching`: streamed queries as soon as they connect, live queries once the first event arrives. Silently cancel queries in that state; the data received so far is kept, so prefetching settles and dehydration works as usual.
+
+```ts
+export function createServerQueryClient(): QueryClient {
+  const queryClient = new QueryClient()
+  
+  if (typeof window === 'undefined') {
+    cancelStreamsOnSuccess(queryClient)
   }
+
+  return queryClient
+}
+
+function cancelStreamsOnSuccess(queryClient: QueryClient): void {
+  const cancelled = new Set<string>()
+
+  queryClient.getQueryCache().subscribe(({ query }) => {
+    if (
+      query.state.status !== 'success' // no successful snapshot yet
+      || query.state.fetchStatus !== 'fetching' // already settled
+      || cancelled.has(query.queryHash)
+    ) {
+      return
+    }
+
+    cancelled.add(query.queryHash)
+    void query.cancel({ silent: true })
+  })
+}
+```
+
+:::warning
+Server-side query clients only. In the browser this would cancel active streams and background refetches.
+:::
+
+#### Resume Streams on the Client
+
+Hydrated data is a static snapshot, and a positive `staleTime` like the one [configured above](#custom-serializers) marks it fresh, so the client never refetches and no new stream opens. Fix this with `refetchOnMount: 'always'`, either globally on the browser query client:
+
+```ts
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60 * 1000,
+      refetchOnMount: 'always',
+    },
+  },
+})
+```
+
+Or scoped to streamed and live queries with a [plugin](#plugins). Call sites can still override these defaults.
+
+```ts
+import type { RouterUtilsPlugin } from '@orpc/tanstack-query'
+
+const streamingSSRPlugin: RouterUtilsPlugin<typeof client> = {
+  name: 'streaming-ssr',
+  initProcedureOptions(_path, options) {
+    return {
+      ...options,
+      streamedOptions: {
+        ...options.streamedOptions,
+        // the server dehydrates streamed queries as an empty array,
+        // so initialData makes prefetching them optional
+        initialData: [],
+        refetchOnMount: 'always',
+      },
+      liveOptions: {
+        ...options.liveOptions,
+        refetchOnMount: 'always',
+      },
+    }
+  },
+}
+
+export const orpc = createTanstackQueryUtils(client, {
+  plugins: [streamingSSRPlugin],
 })
 ```

--- a/packages/client/src/rpc-json-serializer.ts
+++ b/packages/client/src/rpc-json-serializer.ts
@@ -173,6 +173,12 @@ export interface RPCJsonSerializerOptions {
   omitUndefinedProperties?: boolean | undefined
 }
 
+/**
+ * Serializes and deserializes native types like Date, BigInt, Set, and Map
+ * into a JSON value plus separate metadata describing how to restore them.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/tanstack-query#custom-serializers | TanStack Query Integration - Custom Serializers}
+ */
 export class RPCJsonSerializer {
   private readonly handlers: Exclude<RPCJsonSerializerOptions['handlers'], undefined>
   private readonly inlineBuiltInHandlers: boolean

--- a/packages/tanstack-query/src/plugin.ts
+++ b/packages/tanstack-query/src/plugin.ts
@@ -4,6 +4,11 @@ import type { ProcedureUtilsOptions } from './procedure-utils'
 import type { RouterUtilsOptions } from './router-utils'
 import { sortPlugins } from '@orpc/shared'
 
+/**
+ * Plugin that packages reusable defaults and interceptors for router utils.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/tanstack-query#plugins | TanStack Query Integration - Plugins}
+ */
 export interface RouterUtilsPlugin<T extends AnyNestedClient> extends OrderablePlugin {
   /**
    * Initializes the router utils plugin and returns updated router utils options.


### PR DESCRIPTION
Documents how to server render streamed and live queries with TanStack Query, and merges the existing Custom Serializers section into a single Server-Side Rendering (SSR) section.

## Docs

- New "Streamed and Live Queries" guide: prefetching a never-ending stream no longer blocks SSR. A cache subscription silently cancels server streams once the query succeeds, so the snapshot dehydrates as usual, and `refetchOnMount: 'always'` (globally or scoped via a `RouterUtilsPlugin`) reopens the stream on the client.
- The plugin also sets `initialData: []` for streamed queries, making prefetching them optional since the server dehydrates them as an empty array anyway.
- Custom Serializers example now uses `RPCJsonSerializer` with `hashKey`, and both topics live under one SSR section with a shared intro.

## Verification

- Every code block type-checks against the real `@orpc/tanstack-query` and `@tanstack/react-query` APIs (verified via scratch `test-d` files with the package tsconfig).
- Silent-cancel behavior (`query.cancel({ silent: true })` keeps streamed data and lets prefetch settle) confirmed against query-core source.
