### PR TITLE
docs(playgrounds): support TanStack Query SSR in the Next.js playground

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -6,6 +6,12 @@
       "runtimeExecutable": "env",
       "runtimeArgs": ["NODE_OPTIONS=--max-old-space-size=8192", "pnpm", "--filter", "@orpc/content", "dev"],
       "port": 4321
+    },
+    {
+      "name": "next-playground",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "@orpc/next-playground", "dev"],
+      "port": 3000
     }
   ]
 }

--- a/apps/content/docs/integrations/tanstack-query.mdx
+++ b/apps/content/docs/integrations/tanstack-query.mdx
@@ -620,8 +620,6 @@ const streamingSSRPlugin: RouterUtilsPlugin<typeof client> = {
       ...options,
       streamedOptions: {
         ...options.streamedOptions,
-        // the server dehydrates streamed queries as an empty array,
-        // so initialData makes prefetching them optional
         initialData: [],
         refetchOnMount: 'always',
       },

--- a/playgrounds/next/package.json
+++ b/playgrounds/next/package.json
@@ -26,6 +26,7 @@
     "@orpc/tanstack-query": "beta",
     "@orpc/zod": "beta",
     "@tanstack/react-query": "^5.101.4",
+    "@tanstack/react-query-next-experimental": "^5.101.4",
     "@types/node": "^26.2.0",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",

--- a/playgrounds/next/src/app/providers.tsx
+++ b/playgrounds/next/src/app/providers.tsx
@@ -1,14 +1,17 @@
 'use client'
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { useState } from 'react'
+import { QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryStreamedHydration } from '@tanstack/react-query-next-experimental'
+import { getQueryClient } from '@/lib/query-client'
 
 export function Providers(props: { children: React.ReactNode }) {
-  const [queryClient] = useState(() => new QueryClient())
+  const queryClient = getQueryClient()
 
   return (
     <QueryClientProvider client={queryClient}>
-      {props.children}
+      <ReactQueryStreamedHydration>
+        {props.children}
+      </ReactQueryStreamedHydration>
     </QueryClientProvider>
   )
 }

--- a/playgrounds/next/src/lib/orpc.ts
+++ b/playgrounds/next/src/lib/orpc.ts
@@ -46,8 +46,6 @@ const streamingSSRPlugin: RouterUtilsPlugin<typeof client> = {
       ...options,
       streamedOptions: {
         ...options.streamedOptions,
-        // the server dehydrates streamed queries as an empty array,
-        // so initialData makes prefetching them optional
         initialData: [],
         refetchOnMount: 'always',
       },

--- a/playgrounds/next/src/lib/orpc.ts
+++ b/playgrounds/next/src/lib/orpc.ts
@@ -2,6 +2,7 @@ import type { router } from '@/routers'
 import type { RouterClient } from '@orpc/server'
 import { createORPCClient } from '@orpc/client'
 import { RPCLink } from '@orpc/client/fetch'
+import type { RouterUtilsPlugin } from '@orpc/tanstack-query'
 import { createRouterUtils } from '@orpc/tanstack-query'
 import type { RetryLinkPluginContext } from '@orpc/client/plugins'
 import { BatchLinkPlugin, RetryLinkPlugin } from '@orpc/client/plugins'
@@ -32,4 +33,32 @@ const link = new RPCLink({
 
 export const client: RouterClient<typeof router, ClientContext> = createORPCClient(link)
 
-export const orpc = createRouterUtils(client)
+/**
+ * Streamed and live queries dehydrate as static snapshots during SSR, so the
+ * client must always refetch on mount to open a new stream after hydration.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/tanstack-query#streamed-and-live-queries | TanStack Query Integration - Streamed and Live Queries}
+ */
+const streamingSSRPlugin: RouterUtilsPlugin<typeof client> = {
+  name: 'streaming-ssr',
+  initProcedureOptions(_path, options) {
+    return {
+      ...options,
+      streamedOptions: {
+        ...options.streamedOptions,
+        // the server dehydrates streamed queries as an empty array,
+        // so initialData makes prefetching them optional
+        initialData: [],
+        refetchOnMount: 'always',
+      },
+      liveOptions: {
+        ...options.liveOptions,
+        refetchOnMount: 'always',
+      },
+    }
+  },
+}
+
+export const orpc = createRouterUtils(client, {
+  plugins: [streamingSSRPlugin],
+})

--- a/playgrounds/next/src/lib/query-client.ts
+++ b/playgrounds/next/src/lib/query-client.ts
@@ -1,0 +1,96 @@
+import { environmentManager, hashKey, QueryClient } from '@tanstack/react-query'
+import { RPCJsonSerializer } from '@orpc/client'
+
+let browserQueryClient: QueryClient | undefined
+
+/**
+ * Returns the query client for the current environment: a fresh one per
+ * request on the server, a shared singleton in the browser.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/tanstack-query#server-side-rendering-ssr | TanStack Query Integration - Server-Side Rendering (SSR)}
+ */
+export function getQueryClient(): QueryClient {
+  if (environmentManager.isServer()) {
+    return createQueryClient()
+  }
+
+  browserQueryClient ??= createQueryClient()
+  return browserQueryClient
+}
+
+// similar to `RPCSerializer` but more typesafe
+const serializer = new RPCJsonSerializer({
+  handlers: {
+    // put custom serializers here
+  },
+})
+
+/**
+ * Query client preconfigured for SSR: oRPC-aware (de)serialization for
+ * hydration, plus server-side cancellation of never-ending streams.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/tanstack-query#custom-serializers | TanStack Query Integration - Custom Serializers}
+ */
+function createQueryClient(): QueryClient {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000, // > 0 to prevent immediate refetching on mount
+
+        queryKeyHashFn: (queryKey) => {
+          const { json, meta } = serializer.serialize(queryKey)
+
+          return hashKey([
+            json,
+            meta?.map(entry => JSON.stringify(entry)).sort(),
+          ])
+        },
+      },
+      dehydrate: {
+        serializeData: (data) => {
+          const { json, meta } = serializer.serialize(data)
+          return { json, meta }
+        },
+      },
+      hydrate: {
+        deserializeData(data) {
+          return serializer.deserialize(data)
+        },
+      },
+    },
+  })
+
+  if (environmentManager.isServer()) {
+    cancelStreamsOnSuccess(queryClient)
+  }
+
+  return queryClient
+}
+
+/**
+ * Streamed and live queries can stay open indefinitely and would block SSR
+ * forever. Only active streams hold `success` status while still `fetching`,
+ * so silently cancel queries in that state: the data received so far is kept,
+ * prefetching settles, and dehydration works as usual.
+ *
+ * Server-side query clients only. In the browser this would cancel active
+ * streams and background refetches.
+ *
+ * @see {@link https://orpc.dev/docs/integrations/tanstack-query#streamed-and-live-queries | TanStack Query Integration - Streamed and Live Queries}
+ */
+function cancelStreamsOnSuccess(queryClient: QueryClient): void {
+  const cancelled = new Set<string>()
+
+  queryClient.getQueryCache().subscribe(({ query }) => {
+    if (
+      query.state.status !== 'success' // no successful snapshot yet
+      || query.state.fetchStatus !== 'fetching' // already settled
+      || cancelled.has(query.queryHash)
+    ) {
+      return
+    }
+
+    cancelled.add(query.queryHash)
+    void query.cancel({ silent: true })
+  })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1248,6 +1248,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.101.4
         version: 5.101.4(react@19.2.8)
+      '@tanstack/react-query-next-experimental':
+        specifier: ^5.101.4
+        version: 5.101.4(@tanstack/react-query@5.101.4(react@19.2.8))(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@types/node':
         specifier: ^26.2.0
         version: 26.2.0
@@ -5087,6 +5090,13 @@ packages:
 
   '@tanstack/query-devtools@5.101.4':
     resolution: {integrity: sha512-z5IPHnDX3aUWeTWlRKLyooBQekaCAw4xRpZqPQ390RiWTDBcTynjpPT221BArw0u2+pnQMdGvPQI9YNNubBcmA==}
+
+  '@tanstack/react-query-next-experimental@5.101.4':
+    resolution: {integrity: sha512-JI9fJjsCSyqS5leRtDkR8iFlQeNEw1qfjkFkCkU5wZog08IzB+mgRnhDlp8O4iwECdgQcR6lP6YxAfkUzXXN0Q==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.101.4
+      next: ^13 || ^14 || ^15 || ^16
+      react: ^18 || ^19
 
   '@tanstack/react-query@5.101.4':
     resolution: {integrity: sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==}
@@ -16012,6 +16022,12 @@ snapshots:
 
   '@tanstack/query-devtools@5.101.4':
     optional: true
+
+  '@tanstack/react-query-next-experimental@5.101.4(@tanstack/react-query@5.101.4(react@19.2.8))(next@16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@tanstack/react-query': 5.101.4(react@19.2.8)
+      next: 16.3.0(@babel/core@7.29.7(supports-color@10.2.2))(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react: 19.2.8
 
   '@tanstack/react-query@5.101.4(react@19.2.8)':
     dependencies:

--- a/scripts/verify-docs-jsdoc.ts
+++ b/scripts/verify-docs-jsdoc.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile } from 'node:fs/promises'
+import { access, readdir, readFile } from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
 import { parseArgs } from 'node:util'
@@ -15,6 +15,7 @@ import ts from 'typescript'
 const ROOT_DIR = process.cwd()
 const CONTENT_DIR = path.join(ROOT_DIR, 'apps/content')
 const PACKAGES_DIR = path.join(ROOT_DIR, 'packages')
+const PLAYGROUNDS_DIR = path.join(ROOT_DIR, 'playgrounds')
 const SITE_URL_PREFIX = 'https://orpc.dev/'
 const DOCS_URL_PREFIX = 'https://orpc.dev/docs/'
 
@@ -434,63 +435,107 @@ function checkMention(
 const ORPC_URL_RE = /https:\/\/orpc\.dev[^\s)}\]|'"`]*/g
 
 /**
+ * Routes served outside the markdown content: custom Astro pages
+ * (apps/content/pages). Their anchors cannot be verified, so links to them
+ * are checked for existence only.
+ */
+async function collectCustomPageRoutes(): Promise<Set<string>> {
+  const routes = new Set<string>()
+
+  for (const file of await findFiles(path.join(CONTENT_DIR, 'pages'), '.astro')) {
+    const relPath = path.relative(path.join(CONTENT_DIR, 'pages'), file).replaceAll(path.sep, '/')
+
+    // underscore-prefixed segments are not routed; dynamic routes are unpredictable
+    if (relPath.split('/').some(part => part.startsWith('_') || part.startsWith('['))) {
+      continue
+    }
+
+    routes.add(relPath.replace(/\.astro$/, '').replace(/(?:^|\/)index$/, ''))
+  }
+
+  return routes
+}
+
+async function isPublicAsset(pagePath: string): Promise<boolean> {
+  if (!pagePath) {
+    return false
+  }
+
+  try {
+    await access(path.join(CONTENT_DIR, 'public', pagePath))
+    return true
+  }
+  catch {
+    return false
+  }
+}
+
+/**
  * Validates that every `https://orpc.dev...` URL appearing anywhere in package
- * sources (inline markdown links, member-level docs, ...) points to an existing
- * content page and heading. Existence only — titles are enforced on `@see` tags.
+ * or playground sources (inline markdown links, member-level docs, ...) points to
+ * an existing content page and heading. Existence only — titles are enforced on
+ * `@see` tags.
  */
 async function scanSourceLinks(context: CheckContext, filterDirs: Set<string> | undefined): Promise<number> {
   let scanned = 0
-  const entries = await readdir(PACKAGES_DIR, { withFileTypes: true })
+  const customPageRoutes = await collectCustomPageRoutes()
 
-  for (const entry of entries) {
-    if (!entry.isDirectory() || (filterDirs && !filterDirs.has(entry.name))) {
-      continue
-    }
+  for (const baseDir of [PACKAGES_DIR, PLAYGROUNDS_DIR]) {
+    const groupPrefix = path.relative(ROOT_DIR, baseDir)
+    const entries = await readdir(baseDir, { withFileTypes: true })
 
-    const srcDir = path.join(PACKAGES_DIR, entry.name, 'src')
-    let files: string[]
-
-    try {
-      files = [...await findFiles(srcDir, '.ts'), ...await findFiles(srcDir, '.tsx')]
-    }
-    catch {
-      continue
-    }
-
-    for (const file of files) {
-      if (/\.(?:test|test-d|bench)\./.test(file) || file.includes('__tests__') || file.includes('__mocks__')) {
+    for (const entry of entries) {
+      if (!entry.isDirectory() || (filterDirs && !filterDirs.has(entry.name))) {
         continue
       }
 
-      const lines = (await readFile(file, 'utf8')).split('\n')
+      const srcDir = path.join(baseDir, entry.name, 'src')
+      let files: string[]
 
-      for (const [index, line] of lines.entries()) {
-        for (const match of line.matchAll(ORPC_URL_RE)) {
-          const url = match[0].replace(/[.,;:]+$/, '')
-          scanned += 1
+      try {
+        files = [...await findFiles(srcDir, '.ts'), ...await findFiles(srcDir, '.tsx')]
+      }
+      catch {
+        continue
+      }
 
-          const report = (code: string, message: string): void => {
-            context.issues.push({
-              severity: 'error',
-              code,
-              message,
-              group: `packages/${entry.name}`,
-              label: 'link',
-              location: `${path.relative(ROOT_DIR, file)}:${index + 1}`,
-            })
-          }
+      for (const file of files) {
+        if (/\.(?:test|test-d|bench)\./.test(file) || file.includes('__tests__') || file.includes('__mocks__')) {
+          continue
+        }
 
-          const [rawPath = '', anchor] = url.slice(SITE_URL_PREFIX.length - 1).split('#')
-          const pagePath = rawPath.replace(/^\/+/, '').replace(/\/+$/, '')
-          const page = context.pages.get(pagePath)
+        const lines = (await readFile(file, 'utf8')).split('\n')
 
-          if (!page) {
-            report('E4', `link page "/${pagePath}" has no apps/content/${pagePath || 'index'}.md`)
-            continue
-          }
+        for (const [index, line] of lines.entries()) {
+          for (const match of line.matchAll(ORPC_URL_RE)) {
+            const url = match[0].replace(/[.,;:]+$/, '')
+            scanned += 1
 
-          if (anchor !== undefined && !page.slugs.has(anchor)) {
-            report('E5', `anchor "#${anchor}" not found in apps/content/${pagePath || 'index'}.md`)
+            const report = (code: string, message: string): void => {
+              context.issues.push({
+                severity: 'error',
+                code,
+                message,
+                group: `${groupPrefix}/${entry.name}`,
+                label: 'link',
+                location: `${path.relative(ROOT_DIR, file)}:${index + 1}`,
+              })
+            }
+
+            const [rawPath = '', anchor] = url.slice(SITE_URL_PREFIX.length - 1).split('#')
+            const pagePath = rawPath.replace(/^\/+/, '').replace(/\/+$/, '')
+            const page = context.pages.get(pagePath)
+
+            if (!page) {
+              if (!customPageRoutes.has(pagePath) && !await isPublicAsset(pagePath)) {
+                report('E4', `link page "/${pagePath}" has no apps/content/${pagePath || 'index'}.md`)
+              }
+              continue
+            }
+
+            if (anchor !== undefined && !page.slugs.has(anchor)) {
+              report('E5', `anchor "#${anchor}" not found in apps/content/${pagePath || 'index'}.md`)
+            }
           }
         }
       }


### PR DESCRIPTION
Makes the Next.js playground fully compatible with TanStack Query server-side rendering via `@tanstack/react-query-next-experimental`, following the setup documented in [TanStack Query Integration - SSR](https://orpc.dev/docs/integrations/tanstack-query#server-side-rendering-ssr). Suspense queries now execute during SSR and stream-hydrate into the browser cache, so the planet list renders in the initial HTML and is never refetched on mount.

## Playground

- New `lib/query-client.ts` exports `getQueryClient()`: a fresh query client per server request, a singleton in the browser. The client uses `RPCJsonSerializer` for dehydrate/hydrate and query key hashing, and server-side clients silently cancel streamed/live queries once they hold a successful snapshot so they cannot block SSR.
- `Providers` wraps children in `ReactQueryStreamedHydration`.
- A `streaming-ssr` router utils plugin sets `refetchOnMount: 'always'` (plus `initialData: []` for streamed queries), so the chat subscription reopens its stream after hydration.
- SSR-related code links back to the relevant docs sections.

## Docs link checker

`scripts/verify-docs-jsdoc.ts` now scans `playgrounds/*/src` for `orpc.dev` links in addition to `packages/*/src`. Links to custom Astro pages (e.g. the homepage) and `public/` assets (e.g. `/icon.svg`) are recognized as valid instead of being reported as missing markdown pages.

## Testing

- Verified against a running dev server: the initial HTML contains the planet rows plus dehydrated query state; a clean browser load makes no client `planet/list` request while `message/subscribe` opens on mount as intended.
- `curl` of the page (SSR only) triggers `planet/list` but never opens the chat stream.
- `tsc --noEmit`, eslint, and `node scripts/verify-docs-jsdoc.ts` (0 errors across 329 links, playgrounds included) all pass.