### PR TITLE
chore: add descriptions and keywords to package.json for npm SEO

### DIFF
--- a/packages/ai-sdk/package.json
+++ b/packages/ai-sdk/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/ai-sdk",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "AI SDK integration for oRPC: turn contracts and procedures into typesafe AI SDK tools",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -12,7 +13,13 @@
   },
   "keywords": [
     "orpc",
-    "ai-sdk"
+    "ai",
+    "ai-sdk",
+    "tools",
+    "llm",
+    "agents",
+    "typescript",
+    "typesafe"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/arktype/package.json
+++ b/packages/arktype/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/arktype",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "ArkType integration for oRPC: convert ArkType schemas into JSON Schema for OpenAPI generation",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -11,7 +12,13 @@
     "directory": "packages/arktype"
   },
   "keywords": [
-    "orpc"
+    "orpc",
+    "arktype",
+    "json-schema",
+    "openapi",
+    "validation",
+    "typescript",
+    "typesafe"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/bun",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "Bun integration for oRPC: Redis-backed pub/sub and rate limiting using Bun's built-in Redis client",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -10,6 +11,14 @@
     "url": "git+https://github.com/middleapi/orpc.git",
     "directory": "packages/bun"
   },
+  "keywords": [
+    "orpc",
+    "bun",
+    "redis",
+    "pubsub",
+    "ratelimit",
+    "typescript"
+  ],
   "sideEffects": false,
   "publishConfig": {
     "exports": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/client",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "Consume oRPC and OpenAPI APIs with end-to-end type safety over HTTP, WebSocket, or message ports",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -11,7 +12,15 @@
     "directory": "packages/client"
   },
   "keywords": [
-    "orpc"
+    "orpc",
+    "rpc",
+    "api",
+    "typescript",
+    "typesafe",
+    "client",
+    "fetch",
+    "websocket",
+    "openapi"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/cloudflare",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "Cloudflare integration for oRPC: Durable Object pub/sub and Workers rate limiting adapters",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -12,7 +13,12 @@
   },
   "keywords": [
     "orpc",
-    "cloudflare workers"
+    "cloudflare",
+    "cloudflare-workers",
+    "durable-objects",
+    "ratelimit",
+    "pubsub",
+    "typescript"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/contract",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "Define typesafe API contracts as the single source of truth for oRPC, powered by Standard Schema",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -11,7 +12,15 @@
     "directory": "packages/contract"
   },
   "keywords": [
-    "orpc"
+    "orpc",
+    "rpc",
+    "api",
+    "typescript",
+    "typesafe",
+    "contract",
+    "contract-first",
+    "standard-schema",
+    "openapi"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/experimental-effect",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "Effect integration for oRPC: build typesafe procedures with Effect",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -12,7 +13,11 @@
   },
   "keywords": [
     "orpc",
-    "effect"
+    "effect",
+    "effect-ts",
+    "rpc",
+    "typescript",
+    "typesafe"
   ],
   "sideEffects": [
     "./dist/extensions/effect.mjs",

--- a/packages/evlog/package.json
+++ b/packages/evlog/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/evlog",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "Evlog integration for oRPC: wide-event logging for typesafe APIs",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -12,7 +13,11 @@
   },
   "keywords": [
     "orpc",
-    "evlog"
+    "evlog",
+    "logging",
+    "wide-events",
+    "observability",
+    "typescript"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/hibernation/package.json
+++ b/packages/hibernation/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/hibernation",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "Hibernation API support for oRPC, including Cloudflare Durable Objects' WebSocket Hibernation",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -12,7 +13,11 @@
   },
   "keywords": [
     "orpc",
-    "hibernation"
+    "hibernation",
+    "websocket",
+    "cloudflare",
+    "durable-objects",
+    "typescript"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/json-schema/package.json
+++ b/packages/json-schema/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/json-schema",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "JSON Schema conversion and smart request coercion for oRPC and OpenAPI",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -11,7 +12,12 @@
     "directory": "packages/json-schema"
   },
   "keywords": [
-    "orpc"
+    "orpc",
+    "json-schema",
+    "openapi",
+    "coercion",
+    "validation",
+    "typescript"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/nest",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "NestJS integration for oRPC: implement typesafe contracts in NestJS controllers",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -10,6 +11,16 @@
     "url": "git+https://github.com/middleapi/orpc.git",
     "directory": "packages/nest"
   },
+  "keywords": [
+    "orpc",
+    "nestjs",
+    "nest",
+    "contract-first",
+    "rpc",
+    "openapi",
+    "typescript",
+    "typesafe"
+  ],
   "sideEffects": false,
   "publishConfig": {
     "exports": {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/next",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "Next.js integration for oRPC: call typesafe procedures through Next.js Server Functions",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -12,7 +13,14 @@
   },
   "keywords": [
     "orpc",
-    "next"
+    "nextjs",
+    "next",
+    "server-functions",
+    "server-actions",
+    "react",
+    "rpc",
+    "typescript",
+    "typesafe"
   ],
   "sideEffects": [
     "./dist/extensions/actionable.mjs"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/node",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "Node.js plugins for oRPC: static file serving, temporary file uploads, and batch response compression",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -12,7 +13,12 @@
   },
   "keywords": [
     "orpc",
-    "node"
+    "nodejs",
+    "node",
+    "static-files",
+    "file-upload",
+    "compression",
+    "typescript"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/openapi",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "Generate OpenAPI specs from oRPC routers and serve OpenAPI-compliant APIs with end-to-end type safety",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -12,7 +13,15 @@
   },
   "keywords": [
     "orpc",
-    "openapi"
+    "rpc",
+    "api",
+    "typescript",
+    "typesafe",
+    "openapi",
+    "swagger",
+    "scalar",
+    "json-schema",
+    "rest"
   ],
   "sideEffects": [
     "./dist/extensions/route.mjs"
@@ -92,9 +101,15 @@
     "swagger-ui": ">=5.32.6"
   },
   "peerDependenciesMeta": {
-    "@scalar/api-reference": { "optional": true },
-    "@types/swagger-ui": { "optional": true },
-    "swagger-ui": { "optional": true }
+    "@scalar/api-reference": {
+      "optional": true
+    },
+    "@types/swagger-ui": {
+      "optional": true
+    },
+    "swagger-ui": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@hey-api/spec-types": "0.0.0-next-20260408030107",

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/opentelemetry",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "OpenTelemetry integration for oRPC: distributed tracing for typesafe APIs",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -11,7 +12,12 @@
     "directory": "packages/opentelemetry"
   },
   "keywords": [
-    "orpc"
+    "orpc",
+    "opentelemetry",
+    "otel",
+    "tracing",
+    "observability",
+    "typescript"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/pinia-colada/package.json
+++ b/packages/pinia-colada/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/pinia-colada",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "Pinia Colada integration for oRPC: typesafe queries and mutations for Vue",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -14,7 +15,11 @@
     "orpc",
     "vue",
     "pinia",
-    "pinia-colada"
+    "pinia-colada",
+    "query",
+    "mutation",
+    "typescript",
+    "typesafe"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/pino/package.json
+++ b/packages/pino/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/pino",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "Pino integration for oRPC: structured logging for typesafe APIs",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -12,7 +13,11 @@
   },
   "keywords": [
     "orpc",
-    "pino"
+    "pino",
+    "logging",
+    "logger",
+    "observability",
+    "typescript"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/publisher",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "Typesafe pub/sub for oRPC event streaming, with memory, Redis, and Upstash adapters",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -11,7 +12,15 @@
     "directory": "packages/publisher"
   },
   "keywords": [
-    "orpc"
+    "orpc",
+    "pubsub",
+    "publish-subscribe",
+    "events",
+    "event-iterator",
+    "sse",
+    "redis",
+    "upstash",
+    "typescript"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/ratelimit/package.json
+++ b/packages/ratelimit/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/ratelimit",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "Rate limiting for oRPC procedures, with memory, Redis, and Upstash adapters",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -12,7 +13,13 @@
   },
   "keywords": [
     "orpc",
-    "ratelimit"
+    "ratelimit",
+    "rate-limiting",
+    "redis",
+    "upstash",
+    "middleware",
+    "api",
+    "typescript"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/server",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "Build typesafe APIs with oRPC: RPC and OpenAPI support, middleware, and adapters for Node.js, Bun, Deno, Fetch, Fastify, WebSocket, AWS Lambda, and more",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -11,7 +12,20 @@
     "directory": "packages/server"
   },
   "keywords": [
-    "orpc"
+    "orpc",
+    "rpc",
+    "api",
+    "typescript",
+    "typesafe",
+    "server",
+    "openapi",
+    "middleware",
+    "nodejs",
+    "bun",
+    "deno",
+    "fastify",
+    "websocket",
+    "aws-lambda"
   ],
   "sideEffects": [
     "./dist/extensions/callable.mjs"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/shared",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "Internal utilities shared across oRPC packages",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",

--- a/packages/swr/package.json
+++ b/packages/swr/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/swr",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "SWR integration for oRPC: typesafe React data fetching hooks",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -12,8 +13,13 @@
   },
   "keywords": [
     "orpc",
+    "swr",
     "react",
-    "swr"
+    "hooks",
+    "data-fetching",
+    "query",
+    "typescript",
+    "typesafe"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/tanstack-query/package.json
+++ b/packages/tanstack-query/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/tanstack-query",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "TanStack Query integration for oRPC: typesafe queries, mutations, streaming, and SSR for React, Vue, Solid, Svelte, and Angular",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -12,7 +13,17 @@
   },
   "keywords": [
     "orpc",
-    "tanstack query"
+    "tanstack-query",
+    "react-query",
+    "vue-query",
+    "solid-query",
+    "svelte-query",
+    "angular-query",
+    "query",
+    "mutation",
+    "ssr",
+    "typescript",
+    "typesafe"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/trpc",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "tRPC interop for oRPC: reuse existing tRPC routers with oRPC clients and OpenAPI",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -12,7 +13,13 @@
   },
   "keywords": [
     "orpc",
-    "trpc"
+    "trpc",
+    "interop",
+    "migration",
+    "rpc",
+    "openapi",
+    "typescript",
+    "typesafe"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/valibot/package.json
+++ b/packages/valibot/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/valibot",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "Valibot integration for oRPC: convert Valibot schemas into JSON Schema for OpenAPI generation",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -12,7 +13,12 @@
   },
   "keywords": [
     "orpc",
-    "valibot"
+    "valibot",
+    "json-schema",
+    "openapi",
+    "validation",
+    "typescript",
+    "typesafe"
   ],
   "sideEffects": false,
   "publishConfig": {

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -2,6 +2,7 @@
   "name": "@orpc/zod",
   "type": "module",
   "version": "2.0.0-beta.29",
+  "description": "Zod integration for oRPC: convert Zod schemas into JSON Schema for OpenAPI generation",
   "license": "MIT",
   "funding": "https://github.com/sponsors/dinwwwh",
   "homepage": "https://orpc.dev",
@@ -12,7 +13,12 @@
   },
   "keywords": [
     "orpc",
-    "zod"
+    "zod",
+    "json-schema",
+    "openapi",
+    "validation",
+    "typescript",
+    "typesafe"
   ],
   "sideEffects": false,
   "publishConfig": {


### PR DESCRIPTION
Adds a `description` and an expanded `keywords` list to every public package's `package.json`. No package had a description before and most only carried the `orpc` keyword, so npm search had almost nothing to index beyond the package name.

## Changes

- Every package now has a one-line description leading with the terms people actually search for (Zod, TanStack Query, OpenAPI, rate limiting, pub/sub, ...), sourced from the root README's package list and verified against each package's source.
- Keywords now cover each package's ecosystem (`react-query`, `server-actions`, `durable-objects`, `otel`, ...); core packages share a `rpc` / `api` / `typescript` / `typesafe` / `openapi` base. `@orpc/shared` stays minimal since it is internal.
- `homepage`, `repository`, and `funding` were already set everywhere and are untouched. The only incidental formatting change is `packages/openapi`'s `peerDependenciesMeta` expanding to the multiline style the other packages already use.