### PR TITLE
fix(client): resolve default fetch lazily so interception tools work regardless of link construction order

### DIFF
--- a/packages/client/src/adapters/fetch/rpc-link.test.ts
+++ b/packages/client/src/adapters/fetch/rpc-link.test.ts
@@ -150,10 +150,39 @@ describe('rpcLink', () => {
         method: 'POST',
         redirect: 'manual',
       }),
+    )
+  })
+
+  it('uses the current global fetch even when it is patched after link construction', async ({ onTestFinished }) => {
+    const orpc = createORPCClient(new RPCLink({
+      origin: 'http://api.example.com/',
+    })) as any
+
+    const fetchSpy = vi.fn(async () => {
+      return new Response(JSON.stringify({ json: 'pong' }), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      })
+    })
+
+    const originalFetch = globalThis.fetch
+    ;(globalThis as any).fetch = fetchSpy
+
+    onTestFinished(() => {
+      globalThis.fetch = originalFetch
+    })
+
+    await expect(orpc.ping('input')).resolves.toEqual('pong')
+
+    expect(fetchSpy).toHaveBeenCalledOnce()
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'http://api.example.com/ping',
       expect.objectContaining({
-        context: {},
+        method: 'POST',
+        redirect: 'manual',
       }),
-      ['ping'],
     )
   })
 

--- a/packages/client/src/adapters/fetch/transport.ts
+++ b/packages/client/src/adapters/fetch/transport.ts
@@ -56,7 +56,7 @@ export interface FetchLinkTransportOptions<T extends ClientContext> {
   /**
    * Override the default fetch implementation.
    *
-   * @default globalThis.fetch.bind(globalThis)
+   * @default (url, init) => globalThis.fetch(url, init)
    */
   fetch?(url: string, init: RequestInit, options: ClientOptions<T>, path: string[]): Promise<Response>
 
@@ -78,7 +78,9 @@ export class FetchLinkTransport<T extends ClientContext> implements StandardLink
     options = new CompositeFetchLinkTransportPlugin(options.plugins).initFetchLinkTransportOptions(options)
 
     this.origin = options.origin
-    this.fetch = options.fetch ?? globalThis.fetch.bind(globalThis)
+    // Resolve `globalThis.fetch` lazily so interception tools (msw, undici MockAgent, etc.)
+    // that patch it after this transport is constructed still take effect.
+    this.fetch = options.fetch ?? ((url, init) => (globalThis.fetch)(url, init))
     this.toFetchRequestOptions = options.toFetchRequest
     this.fetchInterceptors = options.fetchInterceptors
   }


### PR DESCRIPTION
FetchLinkTransport captured `globalThis.fetch` at construction time (`options.fetch ?? globalThis.fetch.bind(globalThis)`), so any link created before a tool patches the global fetch — msw's `setupServer`, undici's `MockAgent`, and similar interceptors — permanently bypassed the patched implementation, surfacing as confusing ECONNREFUSED failures in tests. The default is now a late-bound wrapper, `(url, init) => globalThis.fetch(url, init)`, resolved on every request.

## Fixes

- Links constructed before fetch interception is installed are now intercepted correctly; construction order no longer matters.
- The default now forwards only `(url, init)` to the global fetch, matching the native signature; an explicit `fetch` option still receives `(url, init, options, path)` as before.

## Testing

- New regression test constructs the link first, patches `globalThis.fetch` afterward, and verifies the patched fetch is used.
- Existing default-fetch test updated to the native two-argument call shape; all fetch adapter tests pass, `pnpm type:check` clean across packages.

This was the only eager-binding site — the websocket and message-port transports take explicit instances.