### PR TITLE
chore(content): pin a coffee sponsor card to the docs aside

### DIFF
--- a/apps/content/components/blume/TableOfContents.astro
+++ b/apps/content/components/blume/TableOfContents.astro
@@ -1,6 +1,7 @@
 ---
 import type { Heading } from "blume/core/types.ts";
 import Icon from "blume/components/Icon.astro";
+import CoffeeCard from "../../sponsors/CoffeeCard.astro";
 
 interface Props {
   /** Headings to list (already filtered to the depths shown in the TOC). */
@@ -65,6 +66,7 @@ const { headings, title, variant } = Astro.props;
           ))}
         </ul>
       </blume-toc>
+      <CoffeeCard />
     </>
   )
 }

--- a/apps/content/sponsors/CoffeeCard.astro
+++ b/apps/content/sponsors/CoffeeCard.astro
@@ -1,0 +1,34 @@
+---
+// The "Keep it brewing" card pinned to the bottom of the desktop on-this-page
+// aside, linking straight to the $5/month ☕ Backer tier checkout on GitHub
+// Sponsors so one click lands on the tier instead of the profile page.
+//
+// Pinning without owning RootLayout: the aside flex rule in theme.css plus
+// `order-1` place the card after Blume's non-overridable PageActions, `mt-auto`
+// rests it at the rail's bottom when the content is short, and `sticky
+// bottom-0` keeps it in view once the rail scrolls. The wrapper owns the
+// rail's bottom padding (theme.css zeroes the aside's) so the resting and
+// stuck positions coincide; its solid background and `z-10` keep the actions
+// (positioned dropdown containers, later in the DOM) from showing through.
+import Icon from 'blume/components/Icon.astro'
+
+const COFFEE_TIER_HREF = 'https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114'
+---
+
+<div class="sticky bottom-0 z-10 order-1 mt-auto bg-background py-4">
+  <a
+    class="group flex items-center gap-3 rounded-blume border border-border px-3 py-2.5 transition hover:border-accent/50 hover:bg-accent/10 focus-visible:border-accent/50 focus-visible:bg-accent/10"
+    href={COFFEE_TIER_HREF}
+    rel="noopener"
+    target="_blank"
+    title="Sponsor oRPC for $5 a month on GitHub Sponsors"
+  >
+    <span class="flex size-8 flex-none items-center justify-center rounded-md bg-accent/15 text-accent transition-transform group-hover:-rotate-6">
+      <Icon name="coffee" size={16} />
+    </span>
+    <span class="flex flex-col gap-0.5">
+      <span class="text-sm leading-tight font-semibold text-foreground">Keep it brewing</span>
+      <span class="text-xs leading-tight text-muted-foreground">$5/month</span>
+    </span>
+  </a>
+</div>

--- a/apps/content/theme.css
+++ b/apps/content/theme.css
@@ -304,6 +304,22 @@ main#blume-content {
 /* Non-owned chrome                                                 */
 /* ---------------------------------------------------------------- */
 
+/* The desktop on-this-page aside renders the owned TableOfContents (which
+   carries the coffee card) before Blume's non-overridable PageActions. Flexing
+   the aside lets the card's `order-1` + `mt-auto` pin it to the bottom of the
+   rail without owning RootLayout. The card's sticky wrapper owns the bottom
+   spacing instead of the aside's pb-10, so the card rests at the same offset
+   whether the rail scrolls (stuck at bottom-0) or not (mt-auto). */
+aside[data-blume-toc] {
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 0;
+}
+
+aside[data-blume-toc] > * {
+  flex: none;
+}
+
 /* Blume tints `:::tip` blocks with the accent color, which here is the brand
    pink — a tip then reads as an alarm, barely distinguishable from the red
    `:::danger` blocks. Green instead (GitHub's alert convention); the docs use


### PR DESCRIPTION
The desktop on-this-page aside now ends with a small "Keep it brewing" card that links straight to the $5/month ☕ Backer tier checkout on GitHub Sponsors, so one click lands on the tier instead of the profile page. The card stays visible at the bottom of the rail on every docs and blog page with a table of contents.

## Behavior

- Short rails rest the card at the bottom of the viewport; long rails keep it pinned while the TOC and actions scroll behind it, with no jump between the resting and stuck positions.
- The actions' dropdown containers no longer paint over the card while scrolling under it; opened dropdown menus still layer above everything.
- Both themes render the brand accent correctly: true pink in dark mode, the darker AA-contrast pink in light mode.

## Implementation

Blume renders PageActions after the TOC slot and offers no override for it, so the aside is flexed in `theme.css` and the card (rendered by the owned TableOfContents) is placed below the actions with `order`, `mt-auto`, and `sticky bottom-0` — no Blume internals touched.

## Testing

- Verified live on `blume dev`: card placement, stick/rest offsets, paint order, link target, and theme colors checked on short- and long-TOC pages at normal and 430px viewport heights; no console errors or failed requests.