### PR TITLE
test(bun): adapt skipped and hanging tests to Bun 1.4

### DIFF
--- a/packages/bun/src/redis-ratelimit.test.ts
+++ b/packages/bun/src/redis-ratelimit.test.ts
@@ -139,15 +139,19 @@ describe.skipIf(!REDIS_URL)('bun redis rate limiter integration', async () => {
   }, { timeout: 20_000 })
 
   it('rethrows non-NOSCRIPT client errors', async () => {
-    const disconnectedRedis = new RedisClient('rediss://invalid')
-    const limiter = new BunRedisRateLimiter(disconnectedRedis, {
-      maxRequests: 3,
-      window: 10_000,
-    })
+    const limiter = await createTestingRateLimiter()
+    const errorScriptSha = await redis.send('SCRIPT', [
+      'LOAD',
+      'return redis.error_reply("something went wrong")',
+    ]) as string
+    ; (limiter as any).scriptSha = errorScriptSha
 
     await expect(
-      limiter.limit('closed-client'),
-    ).rejects.toThrow()
+      limiter.limit('non-noscript'),
+    ).rejects.toThrow('something went wrong')
+
+    // the sha must not be reset, proving the NOSCRIPT reload path was not taken
+    expect((limiter as any).scriptSha).toEqual(errorScriptSha)
   }, { timeout: 20_000 })
 
   it('rejects invalid weights', async () => {

--- a/packages/bun/tests/rpc/cancel-and-abort.test.ts
+++ b/packages/bun/tests/rpc/cancel-and-abort.test.ts
@@ -38,8 +38,7 @@ describe.each([
     expect(handler.mock.calls[0]![0].signal.aborted).toBe(true)
   })
 
-  // TODO: https://github.com/oven-sh/bun/issues/33227
-  it.skipIf(adapter === 'bun-fetch' || adapter === 'compression-bun-fetch')('server should cancel AsyncIteratorObject response and abort request when client cancels', async () => {
+  it('server should cancel AsyncIteratorObject response and abort request when client cancels', async () => {
     const cancel = vi.fn()
     handler.mockResolvedValueOnce(new AsyncIteratorClass(
       async () => {
@@ -62,7 +61,8 @@ describe.each([
     await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true })
   })
 
-  // TODO: https://github.com/oven-sh/bun/issues/33227
+  // TODO: https://github.com/oven-sh/bun/issues/33227 is fixed for async iterator (SSE) responses in Bun 1.4,
+  // but cancelling an octet stream response still does not abort the request on the server
   it.skipIf(adapter === 'bun-fetch' || adapter === 'compression-bun-fetch')('server should cancel octet stream response and abort request when client cancels', async () => {
     const cancel = vi.fn()
     handler.mockResolvedValueOnce(new ReadableStream({

--- a/packages/bun/tests/rpc/data-transfer.test.ts
+++ b/packages/bun/tests/rpc/data-transfer.test.ts
@@ -21,7 +21,8 @@ describe.each([
   }
   const client = createClientServer(router)
 
-  // TODO: fix blob content type problem when compression is enabled
+  // TODO: related to https://github.com/oven-sh/bun/issues/32801 - Bun's blob()/formData() do not
+  // derive the type from the Content-Type header, so the blob type is lost after (de)compression
   const supportedDataTypes = adapter.includes('compression')
     ? builtInRPCSupportDataTypes.filter(({ name }) => name !== 'blob')
     : builtInRPCSupportDataTypes

--- a/packages/bun/tests/rpc/data-transfer.test.ts
+++ b/packages/bun/tests/rpc/data-transfer.test.ts
@@ -21,8 +21,12 @@ describe.each([
   }
   const client = createClientServer(router)
 
-  // TODO: fix blob content type problem
-  it.skipIf(adapter.includes('compression')).each(builtInRPCSupportDataTypes)('should support $name', async ({ value, expected }) => {
+  // TODO: fix blob content type problem when compression is enabled
+  const supportedDataTypes = adapter.includes('compression')
+    ? builtInRPCSupportDataTypes.filter(({ name }) => name !== 'blob')
+    : builtInRPCSupportDataTypes
+
+  it.each(supportedDataTypes)('should support $name', async ({ value, expected }) => {
     const actual = await client.ping(value)
 
     if (typeof expected === 'function') {


### PR DESCRIPTION
Re-checked every temporarily skipped test in `packages/bun` against Bun 1.4.0 (and Bun 1.3.14 for comparison) and re-enabled the ones that now pass. Also fixed the redis rate limiter test that hangs on Bun 1.4. The suite goes from 59 pass / 71 skip (with one Redis-gated failure) to 122 pass / 6 skip / 0 fail with Redis available, stable across repeated runs.

## Unskipped

- Cancel AsyncIteratorObject response on `bun-fetch` adapters: oven-sh/bun#33227 is fixed in Bun 1.4 (fails on 1.3.14, passes on 1.4.0). CI installs latest Bun 1.x, so this is safe there.
- All compression data-type tests except `blob`: only the blob content type is actually broken, so the skip now filters out just that case instead of the whole `.each`.

## Skips kept, comments updated

- Cancel octet stream response on `bun-fetch`: still fails on 1.4.0; the #33227 fix only covers SSE/async-iterator responses, `reader.cancel()` on an octet stream still never reaches the server-side cancel.
- Blob over compression: fails on both 1.3 and 1.4. Root cause isolated to Bun ignoring the Content-Type header in `Response#blob()` for ReadableStream bodies (related to oven-sh/bun#32801, referenced in the skip comment so it can be unskipped once fixed upstream).
- Both websocket parallel-transfer tests: the octet-stream one times out deterministically; the AsyncIteratorObject one passes in isolation but fails 100% of full-suite runs with out-of-order messages, so the Bun websocket simultaneous-messages bug is still real under load.

The commented-out `file` data type was also retried: oven-sh/bun#32801 is still open and still fails, so it stays disabled unchanged.

## Fixed

- `rethrows non-NOSCRIPT client errors` no longer times out on Bun 1.4: Bun 1.4 changed `RedisClient` to silently retry unreachable hosts forever instead of rejecting after the connection timeout, so the dead-connection setup never settled. The test now loads a Lua script that always errors and primes the cached `scriptSha` with it, asserting the exact error propagates and the sha is not reset - deterministic, ~30s faster, and it pins the rethrow branch more precisely than before.

## Testing

- `bun test` in `packages/bun` with Redis: 122 pass / 6 skip / 0 fail; without Redis: 97 pass / 31 skip / 0 fail across 3 consecutive runs
- eslint and `tsc -b` clean