### PR TITLE
docs(msw): list @orpc/experimental-msw on the API Reference page

### DIFF
--- a/apps/content/docs/api-reference.mdx
+++ b/apps/content/docs/api-reference.mdx
@@ -47,6 +47,7 @@ For questions the reference does not answer, [oRPC on DeepWiki](https://deepwiki
 | [@orpc/pinia-colada](https://npmx.dev/package-docs/@orpc/pinia-colada) | Integrate with Pinia Colada. | [Pinia Colada](/docs/integrations/pinia-colada) |
 | [@orpc/swr](https://npmx.dev/package-docs/@orpc/swr) | Integrate with SWR. | [SWR](/docs/integrations/swr) |
 | [@orpc/experimental-effect](https://npmx.dev/package-docs/@orpc/experimental-effect) | Integrate with Effect. | [Effect](/docs/integrations/effect) |
+| [@orpc/experimental-msw](https://npmx.dev/package-docs/@orpc/experimental-msw) | Mock procedures at the network level with typed MSW request handlers. | [MSW](/docs/integrations/msw) |
 | [@orpc/nest](https://npmx.dev/package-docs/@orpc/nest) | Implement your contract with NestJS. | [NestJS](/docs/integrations/nest) |
 | [@orpc/node](https://npmx.dev/package-docs/@orpc/node) | Node.js plugins for static file serving and large uploads. | [Static File](/docs/plugins/static-file), [Tmp File Upload](/docs/plugins/tmp-file-upload), [Batch Response Compression](/docs/plugins/batch-response-compression) |
 | [@orpc/bun](https://npmx.dev/package-docs/@orpc/bun) | Bun Redis adapters for Publisher and Rate Limit. | [Publisher](/docs/helpers/publisher), [Rate Limit](/docs/helpers/ratelimit) |


### PR DESCRIPTION
The API Reference page now lists `@orpc/experimental-msw` in the Framework and Ecosystem Integrations table, so the new MSW package added in #1899 is discoverable from the reference index like every other package.

The row links to the package docs on npmx (the package is published as `2.0.0-beta.29`, so the link resolves) and to the [MSW guide](https://orpc.dev/docs/integrations/msw).