### PR TITLE
chore: add Open Collective funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,7 +2,7 @@
 
 github: [dinwwwh] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
+open_collective: middleapi
 ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
 community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/apps/content/blume.config.ts
+++ b/apps/content/blume.config.ts
@@ -49,7 +49,8 @@ export default defineConfig({
         items: [
           { label: 'Releases', path: 'https://github.com/middleapi/orpc/releases' },
           { label: 'Discussions', path: 'https://github.com/middleapi/orpc/discussions' },
-          { label: 'Sponsors', path: 'https://github.com/sponsors/dinwwwh' },
+          { label: 'GitHub Sponsors', path: 'https://github.com/sponsors/dinwwwh' },
+          { label: 'Open Collective', path: 'https://opencollective.com/middleapi' },
           { label: 'LLM Context', path: 'https://orpc.dev/llms.txt' },
           { label: 'LLM Context (Full)', path: 'https://orpc.dev/llms-full.txt' },
           { label: 'V1 Documentation', path: 'https://v1.orpc.dev' },

--- a/apps/content/pages/_home/Comparison.astro
+++ b/apps/content/pages/_home/Comparison.astro
@@ -86,7 +86,7 @@ const numbers = [
           full feature matrix and reproducible benchmarks on the comparison page.
         </p>
       </div>
-      <a class="orpc-btn orpc-btn-ghost shrink-0" href="/docs/comparison">
+      <a class="orpc-btn orpc-btn-ghost shrink-0 self-start sm:self-auto" href="/docs/comparison">
         Full comparison
         <Icon name="arrow-right" size={15} />
       </a>

--- a/apps/content/pages/_home/Footer.astro
+++ b/apps/content/pages/_home/Footer.astro
@@ -47,7 +47,8 @@ const columns: { title: string, links: FooterLink[] }[] = [
       { label: 'GitHub', href: 'https://github.com/middleapi/orpc' },
       { label: 'Discord', href: 'https://discord.gg/TXEbwRBvQn' },
       { label: 'Discussions', href: 'https://github.com/middleapi/orpc/discussions' },
-      { label: 'Sponsors', href: 'https://github.com/sponsors/dinwwwh' },
+      { label: 'GitHub Sponsors', href: 'https://github.com/sponsors/dinwwwh' },
+      { label: 'Open Collective', href: 'https://opencollective.com/middleapi' },
       // Same-origin but not a page: leaving the site for a raw text dump in the
       // current tab is a dead end, so it opens in a new one like the rest.
       { label: 'LLM context', href: '/llms.txt', external: true },

--- a/apps/content/pages/_home/Packages.astro
+++ b/apps/content/pages/_home/Packages.astro
@@ -111,7 +111,7 @@ const packages = [
           bolted on.
         </p>
       </div>
-      <a class="orpc-btn orpc-btn-ghost shrink-0" href="/docs/api-reference">
+      <a class="orpc-btn orpc-btn-ghost shrink-0 self-start sm:self-auto" href="/docs/api-reference">
         All packages
         <Icon name="arrow-right" size={15} />
       </a>

--- a/apps/content/pages/_home/Sponsors.astro
+++ b/apps/content/pages/_home/Sponsors.astro
@@ -40,22 +40,12 @@ const past = pastSponsors()
               that goes into it.
             </p>
           </div>
-          <div class="flex shrink-0 flex-col gap-2">
-            <a
-              class="orpc-btn orpc-btn-ghost justify-center"
-              href={GITHUB_SPONSOR_URL}
-              rel="noopener"
-              target="_blank"
-            >
+          <div class="flex shrink-0 flex-col items-start gap-2">
+            <a class="orpc-btn orpc-btn-ghost" href={GITHUB_SPONSOR_URL} rel="noopener" target="_blank">
               <Icon name="heart" size={15} />
               GitHub Sponsors
             </a>
-            <a
-              class="orpc-btn orpc-btn-ghost justify-center"
-              href={OPEN_COLLECTIVE_URL}
-              rel="noopener"
-              target="_blank"
-            >
+            <a class="orpc-btn orpc-btn-ghost" href={OPEN_COLLECTIVE_URL} rel="noopener" target="_blank">
               <Icon name="hand-coins" size={15} />
               Open Collective
             </a>

--- a/apps/content/pages/_home/Sponsors.astro
+++ b/apps/content/pages/_home/Sponsors.astro
@@ -40,7 +40,7 @@ const past = pastSponsors()
               that goes into it.
             </p>
           </div>
-          <div class="flex shrink-0 flex-col items-start gap-2">
+          <div class="flex shrink-0 flex-col gap-2 self-start sm:self-auto">
             <a class="orpc-btn orpc-btn-ghost" href={GITHUB_SPONSOR_URL} rel="noopener" target="_blank">
               <Icon name="heart" size={15} />
               GitHub Sponsors

--- a/apps/content/pages/_home/Sponsors.astro
+++ b/apps/content/pages/_home/Sponsors.astro
@@ -5,7 +5,8 @@ import Icon from 'blume/components/Icon.astro'
 import { relAttribute } from '../../sponsors/ads'
 import { pastSponsors, sponsorTiers } from '../../sponsors/data'
 
-const SPONSOR_URL = 'https://github.com/sponsors/dinwwwh'
+const GITHUB_SPONSOR_URL = 'https://github.com/sponsors/dinwwwh'
+const OPEN_COLLECTIVE_URL = 'https://opencollective.com/middleapi'
 const PAST_SPONSORS_URL = 'https://htmlpreview.github.io/?https://github.com/middleapi/static/blob/main/sponsors.svg'
 
 const tiers = sponsorTiers()
@@ -39,10 +40,26 @@ const past = pastSponsors()
               that goes into it.
             </p>
           </div>
-          <a class="orpc-btn orpc-btn-ghost shrink-0" href={SPONSOR_URL} rel="noopener" target="_blank">
-            <Icon name="heart" size={15} />
-            Become a sponsor
-          </a>
+          <div class="flex shrink-0 flex-col gap-2">
+            <a
+              class="orpc-btn orpc-btn-ghost justify-center"
+              href={GITHUB_SPONSOR_URL}
+              rel="noopener"
+              target="_blank"
+            >
+              <Icon name="heart" size={15} />
+              GitHub Sponsors
+            </a>
+            <a
+              class="orpc-btn orpc-btn-ghost justify-center"
+              href={OPEN_COLLECTIVE_URL}
+              rel="noopener"
+              target="_blank"
+            >
+              <Icon name="hand-coins" size={15} />
+              Open Collective
+            </a>
+          </div>
         </div>
 
         {highlights.length > 0 && (

--- a/apps/content/sponsors/CoffeeCard.astro
+++ b/apps/content/sponsors/CoffeeCard.astro
@@ -1,7 +1,9 @@
 ---
 // The "Keep it brewing" card pinned to the bottom of the desktop on-this-page
-// aside, linking straight to the $5/month ☕ Backer tier checkout on GitHub
-// Sponsors so one click lands on the tier instead of the profile page.
+// aside. Opening it reveals the two places to sponsor — the GitHub Sponsors
+// profile and the Open Collective page — so the sponsor picks their platform
+// and the tier there. Same `<details>` dropdown pattern as the header's
+// "More" menu, popping upward since the card sits at the rail's bottom.
 //
 // Pinning without owning RootLayout: the aside flex rule in theme.css plus
 // `order-1` place the card after Blume's non-overridable PageActions, `mt-auto`
@@ -12,23 +14,46 @@
 // (positioned dropdown containers, later in the DOM) from showing through.
 import Icon from 'blume/components/Icon.astro'
 
-const COFFEE_TIER_HREF = 'https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114'
+const SPONSOR_PAGES = [
+  { label: 'GitHub Sponsors', icon: 'github', href: 'https://github.com/sponsors/dinwwwh' },
+  { label: 'Open Collective', icon: 'hand-coins', href: 'https://opencollective.com/middleapi' },
+]
 ---
 
 <div class="sticky bottom-0 z-10 order-1 mt-auto bg-background py-4">
-  <a
-    class="group flex items-center gap-3 rounded-blume border border-border px-3 py-2.5 transition hover:border-accent/50 hover:bg-accent/10 focus-visible:border-accent/50 focus-visible:bg-accent/10"
-    href={COFFEE_TIER_HREF}
-    rel="noopener"
-    target="_blank"
-    title="Sponsor oRPC for $5 a month on GitHub Sponsors"
-  >
-    <span class="flex size-8 flex-none items-center justify-center rounded-md bg-accent/15 text-accent transition-transform group-hover:-rotate-6">
-      <Icon name="coffee" size={16} />
-    </span>
-    <span class="flex flex-col gap-0.5">
-      <span class="text-sm leading-tight font-semibold text-foreground">Keep it brewing</span>
-      <span class="text-xs leading-tight text-muted-foreground">$5/month</span>
-    </span>
-  </a>
+  <details class="group relative">
+    <summary
+      class="group/card flex cursor-pointer list-none items-center gap-3 rounded-blume border border-border px-3 py-2.5 transition hover:border-accent/50 hover:bg-accent/10 focus-visible:border-accent/50 focus-visible:bg-accent/10 [&::-webkit-details-marker]:hidden"
+      title="Choose GitHub Sponsors or Open Collective"
+    >
+      <span class="flex size-8 flex-none items-center justify-center rounded-md bg-accent/15 text-accent transition-transform group-hover/card:-rotate-6">
+        <Icon name="coffee" size={16} />
+      </span>
+      <span class="flex flex-col gap-0.5">
+        <span class="text-sm leading-tight font-semibold text-foreground">Keep it brewing</span>
+        <span class="text-xs leading-tight text-muted-foreground">Become a sponsor</span>
+      </span>
+      <Icon
+        class="ms-auto text-muted-foreground transition-transform group-open:rotate-180"
+        name="chevron-up"
+        size={13}
+      />
+    </summary>
+    <div class="absolute inset-x-0 bottom-full z-10 mb-1 rounded-blume border border-border bg-background p-1 shadow-xl">
+      {
+        SPONSOR_PAGES.map(page => (
+          <a
+            class="flex items-center gap-2 rounded-md px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            href={page.href}
+            rel="noopener"
+            target="_blank"
+          >
+            <Icon name={page.icon} size={15} />
+            <span class="flex-1">{page.label}</span>
+            <Icon class="opacity-60" name="arrow-up-right" size={13} />
+          </a>
+        ))
+      }
+    </div>
+  </details>
 </div>

--- a/apps/content/sponsors/ads.ts
+++ b/apps/content/sponsors/ads.ts
@@ -33,20 +33,32 @@ export interface AdSponsor {
   background?: { light: string, dark: string }
 }
 
-/** The grid is a fixed 8 cells; positions outside this range are a type error. */
-export const AD_POSITIONS = [1, 2, 3, 4, 5, 6, 7, 8] as const
+/**
+ * The grid starts at six cells and grows to fit the highest sold position,
+ * rounded up to an even count — it renders as two columns on `md`, so an odd
+ * total would leave a hole in the last row.
+ */
+const DEFAULT_SLOT_COUNT = 6
 
-export type AdPosition = typeof AD_POSITIONS[number]
+const soldPositions = slots
+  .map(({ position }) => position)
+  .filter(position => Number.isInteger(position) && position >= 1)
 
-function isAdPosition(position: number): position is AdPosition {
-  return (AD_POSITIONS as readonly number[]).includes(position)
-}
+const slotCount = Math.max(DEFAULT_SLOT_COUNT, ...soldPositions)
 
-// Keyed off the generated file; a position outside the grid is dropped rather
-// than crashing the build over a data typo upstream.
+export const AD_POSITIONS: readonly number[] = Array.from(
+  { length: slotCount + (slotCount % 2) },
+  (_, index) => index + 1,
+)
+
+export type AdPosition = number
+
+// Keyed off the generated file; a position that is not one of the grid's cells
+// (fractional, zero, negative) is dropped rather than crashing the build over
+// a data typo upstream.
 const inventory: Partial<Record<AdPosition, AdSponsor>> = {}
 for (const { position, ...sponsor } of slots) {
-  if (isAdPosition(position)) {
+  if (AD_POSITIONS.includes(position)) {
     inventory[position] = sponsor
   }
 }

--- a/packages/ai-sdk/README.md
+++ b/packages/ai-sdk/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/ai-sdk/README.md
+++ b/packages/ai-sdk/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/ai-sdk/package.json
+++ b/packages/ai-sdk/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "AI SDK integration for oRPC: turn contracts and procedures into typesafe AI SDK tools",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/arktype/README.md
+++ b/packages/arktype/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/arktype/README.md
+++ b/packages/arktype/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/arktype/package.json
+++ b/packages/arktype/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "ArkType integration for oRPC: convert ArkType schemas into JSON Schema for OpenAPI generation",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/bun/README.md
+++ b/packages/bun/README.md
@@ -67,7 +67,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/bun/README.md
+++ b/packages/bun/README.md
@@ -67,7 +67,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "Bun integration for oRPC: Redis-backed pub/sub and rate limiting using Bun's built-in Redis client",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "Consume oRPC and OpenAPI APIs with end-to-end type safety over HTTP, WebSocket, or message ports",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/cloudflare/README.md
+++ b/packages/cloudflare/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/cloudflare/README.md
+++ b/packages/cloudflare/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "Cloudflare integration for oRPC: Durable Object pub/sub and Workers rate limiting adapters",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/contract/README.md
+++ b/packages/contract/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "Define typesafe API contracts as the single source of truth for oRPC, powered by Standard Schema",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/effect/README.md
+++ b/packages/effect/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/effect/README.md
+++ b/packages/effect/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "Effect integration for oRPC: build typesafe procedures with Effect",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/evlog/README.md
+++ b/packages/evlog/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/evlog/README.md
+++ b/packages/evlog/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/evlog/package.json
+++ b/packages/evlog/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "Evlog integration for oRPC: wide-event logging for typesafe APIs",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/hibernation/README.md
+++ b/packages/hibernation/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/hibernation/README.md
+++ b/packages/hibernation/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/hibernation/package.json
+++ b/packages/hibernation/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "Hibernation API support for oRPC, including Cloudflare Durable Objects' WebSocket Hibernation",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/json-schema/README.md
+++ b/packages/json-schema/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/json-schema/README.md
+++ b/packages/json-schema/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/json-schema/package.json
+++ b/packages/json-schema/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "JSON Schema conversion and smart request coercion for oRPC and OpenAPI",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/msw/README.md
+++ b/packages/msw/README.md
@@ -70,29 +70,22 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
-
-### 🏆 Platinum Sponsor
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>
-   <td align="center"><a href="https://screenshotone.com/?ref=orpc" target="_blank" rel="sponsored noopener" title="ScreenshotOne.com"><img src="https://avatars.githubusercontent.com/u/97035603?v=4" width="279" alt="ScreenshotOne.com"/><br />ScreenshotOne.com</a></td>
+   <td width="2000"><a href="https://screenshotone.com/?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener" title="The screenshot API for developers"><img src="https://avatars.githubusercontent.com/u/97035603?v=4" width="64" align="left" hspace="12" alt="ScreenshotOne.com"/><b>ScreenshotOne.com</b></a><br /><sub>The screenshot API for developers</sub></td>
+  </tr>
+  <tr>
+   <td width="2000"><a href="https://misskey.io/?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Decentralized microblogging SNS born on Earth"><img src="https://github.com/MisskeyIO.png" width="64" align="left" hspace="12" alt="MisskeyHQ"/><b>MisskeyHQ</b></a><br /><sub>Decentralized microblogging SNS born on Earth</sub></td>
   </tr>
 </table>
 
-### 🥈 Silver Sponsor
+### Organization Sponsors
 
 <table>
   <tr>
-   <td align="center"><a href="https://misskey.io/?ref=orpc" target="_blank" rel="sponsored noopener" title="村上さん"><img src="https://avatars.githubusercontent.com/u/37681609?u=0dd4c7e4ba937cbb52b068c55914b1d8164dc0c7&amp;v=4" width="209" alt="村上さん"/><br />村上さん</a></td>
-  </tr>
-</table>
-
-### Generous Sponsors
-
-<table>
-  <tr>
-   <td align="center"><a href="https://github.com/ln-markets?ref=orpc" target="_blank" rel="sponsored noopener" title="LN Markets"><img src="https://avatars.githubusercontent.com/u/70597625?v=4" width="167" alt="LN Markets"/><br />LN Markets</a></td>
+   <td align="center"><a href="https://lnmarkets.com/?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="LN Markets"><img src="https://avatars.githubusercontent.com/u/70597625?v=4" width="167" alt="LN Markets"/><br />LN Markets</a></td>
   </tr>
 </table>
 
@@ -100,26 +93,26 @@ Like what we build over at [middleapi](https://github.com/middleapi)? You can he
 
 <table>
   <tr>
-   <td align="center"><a href="https://github.com/hrmcdonald?ref=orpc" target="_blank" rel="sponsored noopener" title="Reece McDonald"><img src="https://avatars.githubusercontent.com/u/39349270?v=4" width="139" alt="Reece McDonald"/><br />Reece McDonald</a></td>
-   <td align="center"><a href="https://github.com/u1-liquid?ref=orpc" target="_blank" rel="sponsored noopener" title="あわわわとーにゅ"><img src="https://avatars.githubusercontent.com/u/17376330?u=de3353804be889f009f7e0a1582daf04d0ab292d&amp;v=4" width="139" alt="あわわわとーにゅ"/><br />あわわわとーにゅ</a></td>
-   <td align="center"><a href="https://github.com/nicognaW?ref=orpc" target="_blank" rel="sponsored noopener" title="nk"><img src="https://avatars.githubusercontent.com/u/66731869?u=4699bda3a9092d3ec34fbd959450767bcc8b8b6d&amp;v=4" width="139" alt="nk"/><br />nk</a></td>
-   <td align="center"><a href="https://github.com/supastarter?ref=orpc" target="_blank" rel="sponsored noopener" title="supastarter"><img src="https://avatars.githubusercontent.com/u/110960143?v=4" width="139" alt="supastarter"/><br />supastarter</a></td>
-   <td align="center"><a href="https://github.com/divmgl?ref=orpc" target="_blank" rel="sponsored noopener" title="Dexter Miguel"><img src="https://avatars.githubusercontent.com/u/5452298?u=645993204be8696c085ecf0d228c3062efe2ed65&amp;v=4" width="139" alt="Dexter Miguel"/><br />Dexter Miguel</a></td>
-   <td align="center"><a href="https://github.com/herrfugbaum?ref=orpc" target="_blank" rel="sponsored noopener" title="herrfugbaum"><img src="https://avatars.githubusercontent.com/u/12859776?u=644dc1666d0220bc0468eb0de3c56b919f635b16&amp;v=4" width="139" alt="herrfugbaum"/><br />herrfugbaum</a></td>
+   <td align="center"><a href="https://github.com/hrmcdonald?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Reece McDonald"><img src="https://avatars.githubusercontent.com/u/39349270?v=4" width="139" alt="Reece McDonald"/><br />Reece McDonald</a></td>
+   <td align="center"><a href="https://soymilk.party/?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="あわわわとーにゅ"><img src="https://avatars.githubusercontent.com/u/17376330?u=de3353804be889f009f7e0a1582daf04d0ab292d&amp;v=4" width="139" alt="あわわわとーにゅ"/><br />あわわわとーにゅ</a></td>
+   <td align="center"><a href="https://github.com/nicognaW?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="nk"><img src="https://avatars.githubusercontent.com/u/66731869?u=4699bda3a9092d3ec34fbd959450767bcc8b8b6d&amp;v=4" width="139" alt="nk"/><br />nk</a></td>
+   <td align="center"><a href="https://supastarter.dev/?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="supastarter"><img src="https://avatars.githubusercontent.com/u/110960143?v=4" width="139" alt="supastarter"/><br />supastarter</a></td>
+   <td align="center"><a href="https://github.com/divmgl?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Dexter Miguel"><img src="https://avatars.githubusercontent.com/u/5452298?u=645993204be8696c085ecf0d228c3062efe2ed65&amp;v=4" width="139" alt="Dexter Miguel"/><br />Dexter Miguel</a></td>
+   <td align="center"><a href="https://github.com/herrfugbaum?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="herrfugbaum"><img src="https://avatars.githubusercontent.com/u/12859776?u=644dc1666d0220bc0468eb0de3c56b919f635b16&amp;v=4" width="139" alt="herrfugbaum"/><br />herrfugbaum</a></td>
   </tr>
   <tr>
-   <td align="center"><a href="https://github.com/ryota-murakami?ref=orpc" target="_blank" rel="sponsored noopener" title="Ryota Murakami"><img src="https://avatars.githubusercontent.com/u/5501268?u=599389e03340734325726ca3f8f423c021d47d7f&amp;v=4" width="139" alt="Ryota Murakami"/><br />Ryota Murakami</a></td>
-   <td align="center"><a href="https://github.com/dcramer?ref=orpc" target="_blank" rel="sponsored noopener" title="David Cramer"><img src="https://avatars.githubusercontent.com/u/23610?v=4" width="139" alt="David Cramer"/><br />David Cramer</a></td>
-   <td align="center"><a href="https://github.com/valerii15298?ref=orpc" target="_blank" rel="sponsored noopener" title="Valerii Petryniak"><img src="https://avatars.githubusercontent.com/u/44531564?u=88ac74d9bacd20401518441907acad21063cd397&amp;v=4" width="139" alt="Valerii Petryniak"/><br />Valerii Petryniak</a></td>
-   <td align="center"><a href="https://github.com/letstri?ref=orpc" target="_blank" rel="sponsored noopener" title="Valerii Strilets"><img src="https://avatars.githubusercontent.com/u/13253748?u=c7b10399ccc8f8081e24db94ec32cd9858e86ac3&amp;v=4" width="139" alt="Valerii Strilets"/><br />Valerii Strilets</a></td>
-   <td align="center"><a href="https://github.com/K-Mistele?ref=orpc" target="_blank" rel="sponsored noopener" title="Kyle Mistele"><img src="https://avatars.githubusercontent.com/u/18430555?u=3afebeb81de666e35aaac3ed46f14159d7603ffb&amp;v=4" width="139" alt="Kyle Mistele"/><br />Kyle Mistele</a></td>
-   <td align="center"><a href="https://github.com/christ12938?ref=orpc" target="_blank" rel="sponsored noopener" title="christ12938"><img src="https://avatars.githubusercontent.com/u/25758598?v=4" width="139" alt="christ12938"/><br />christ12938</a></td>
+   <td align="center"><a href="https://laststance.io/?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Ryota Murakami"><img src="https://avatars.githubusercontent.com/u/5501268?u=599389e03340734325726ca3f8f423c021d47d7f&amp;v=4" width="139" alt="Ryota Murakami"/><br />Ryota Murakami</a></td>
+   <td align="center"><a href="https://cra.mr/?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="David Cramer"><img src="https://avatars.githubusercontent.com/u/23610?v=4" width="139" alt="David Cramer"/><br />David Cramer</a></td>
+   <td align="center"><a href="https://valerii15298.github.io/?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Valerii Petryniak"><img src="https://avatars.githubusercontent.com/u/44531564?u=88ac74d9bacd20401518441907acad21063cd397&amp;v=4" width="139" alt="Valerii Petryniak"/><br />Valerii Petryniak</a></td>
+   <td align="center"><a href="https://letstri.dev/?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Valerii Strilets"><img src="https://avatars.githubusercontent.com/u/13253748?u=c7b10399ccc8f8081e24db94ec32cd9858e86ac3&amp;v=4" width="139" alt="Valerii Strilets"/><br />Valerii Strilets</a></td>
+   <td align="center"><a href="https://blacklight.sh/?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Kyle Mistele"><img src="https://avatars.githubusercontent.com/u/18430555?u=3afebeb81de666e35aaac3ed46f14159d7603ffb&amp;v=4" width="139" alt="Kyle Mistele"/><br />Kyle Mistele</a></td>
+   <td align="center"><a href="https://github.com/christ12938?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="christ12938"><img src="https://avatars.githubusercontent.com/u/25758598?v=4" width="139" alt="christ12938"/><br />christ12938</a></td>
   </tr>
   <tr>
-   <td align="center"><a href="https://github.com/Ryanjso?ref=orpc" target="_blank" rel="sponsored noopener" title="Ryan Soderberg"><img src="https://avatars.githubusercontent.com/u/39172778?u=5ed913c31d57e7221b75784abcad48c7ebddde27&amp;v=4" width="139" alt="Ryan Soderberg"/><br />Ryan Soderberg</a></td>
-   <td align="center"><a href="https://github.com/itigoore01?ref=orpc" target="_blank" rel="sponsored noopener" title="shota"><img src="https://avatars.githubusercontent.com/u/11831107?u=c976a6dc7e055eb026304c46c99100ed22b0c8e0&amp;v=4" width="139" alt="shota"/><br />shota</a></td>
-   <td align="center"><a href="https://github.com/ellis-driscoll?ref=orpc" target="_blank" rel="sponsored noopener" title="Ellis Driscoll"><img src="https://avatars.githubusercontent.com/u/70685966?u=c5f95bc33b5991d9744abe00052542e4a2ed3cb9&amp;v=4" width="139" alt="Ellis Driscoll"/><br />Ellis Driscoll</a></td>
-   <td align="center"><a href="https://github.com/hoangbn?ref=orpc" target="_blank" rel="sponsored noopener" title="Hoang Nguyen"><img src="https://avatars.githubusercontent.com/u/38968280?u=c90084c6de65c56facabab7ba13a72a49ddbc3e4&amp;v=4" width="139" alt="Hoang Nguyen"/><br />Hoang Nguyen</a></td>
+   <td align="center"><a href="https://github.com/Ryanjso?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Ryan Soderberg"><img src="https://avatars.githubusercontent.com/u/39172778?u=5ed913c31d57e7221b75784abcad48c7ebddde27&amp;v=4" width="139" alt="Ryan Soderberg"/><br />Ryan Soderberg</a></td>
+   <td align="center"><a href="https://github.com/itigoore01?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="shota"><img src="https://avatars.githubusercontent.com/u/11831107?u=c976a6dc7e055eb026304c46c99100ed22b0c8e0&amp;v=4" width="139" alt="shota"/><br />shota</a></td>
+   <td align="center"><a href="https://github.com/ellis-driscoll?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Ellis Driscoll"><img src="https://avatars.githubusercontent.com/u/70685966?u=c5f95bc33b5991d9744abe00052542e4a2ed3cb9&amp;v=4" width="139" alt="Ellis Driscoll"/><br />Ellis Driscoll</a></td>
+   <td align="center"><a href="https://github.com/hoangbn?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Hoang Nguyen"><img src="https://avatars.githubusercontent.com/u/38968280?u=c90084c6de65c56facabab7ba13a72a49ddbc3e4&amp;v=4" width="139" alt="Hoang Nguyen"/><br />Hoang Nguyen</a></td>
   </tr>
 </table>
 
@@ -127,31 +120,31 @@ Like what we build over at [middleapi](https://github.com/middleapi)? You can he
 
 <table>
   <tr>
-   <td align="center"><a href="https://github.com/rhinodavid?ref=orpc" target="_blank" rel="sponsored noopener" title="David Walsh"><img src="https://avatars.githubusercontent.com/u/5778036?u=b5521f07d2f88c3db2a0dae62b5f2f8357214af0&amp;v=4" width="119" alt="David Walsh"/><br />David Walsh</a></td>
-   <td align="center"><a href="https://github.com/Robbe95?ref=orpc" target="_blank" rel="sponsored noopener" title="Robbe Vaes"><img src="https://avatars.githubusercontent.com/u/44748019?u=e0232402c045ad4eac7cbd217f1f47e083103b89&amp;v=4" width="119" alt="Robbe Vaes"/><br />Robbe Vaes</a></td>
-   <td align="center"><a href="https://github.com/aidansunbury?ref=orpc" target="_blank" rel="sponsored noopener" title="Aidan Sunbury"><img src="https://avatars.githubusercontent.com/u/64103161?v=4" width="119" alt="Aidan Sunbury"/><br />Aidan Sunbury</a></td>
-   <td align="center"><a href="https://github.com/soonoo?ref=orpc" target="_blank" rel="sponsored noopener" title="soonoo"><img src="https://avatars.githubusercontent.com/u/5436405?u=5d0b4aa955c87e30e6bda7f0cccae5402da99528&amp;v=4" width="119" alt="soonoo"/><br />soonoo</a></td>
-   <td align="center"><a href="https://github.com/kporten?ref=orpc" target="_blank" rel="sponsored noopener" title="Kevin Porten"><img src="https://avatars.githubusercontent.com/u/1839345?u=dc2263d5cfe0d927ce1a0be04a1d55dd6b55405c&amp;v=4" width="119" alt="Kevin Porten"/><br />Kevin Porten</a></td>
-   <td align="center"><a href="https://github.com/pumpkinlink?ref=orpc" target="_blank" rel="sponsored noopener" title="Denis"><img src="https://avatars.githubusercontent.com/u/11864620?u=5f47bbe6c65d0f6f5cf011021490238e4b0593d0&amp;v=4" width="119" alt="Denis"/><br />Denis</a></td>
-   <td align="center"><a href="https://github.com/christopher-kapic?ref=orpc" target="_blank" rel="sponsored noopener" title="Christopher Kapic"><img src="https://avatars.githubusercontent.com/u/59740769?u=e7ad4b72b5bf6c9eb1644c26dbf3332a8f987377&amp;v=4" width="119" alt="Christopher Kapic"/><br />Christopher Kapic</a></td>
+   <td align="center"><a href="https://github.com/rhinodavid?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="David Walsh"><img src="https://avatars.githubusercontent.com/u/5778036?u=b5521f07d2f88c3db2a0dae62b5f2f8357214af0&amp;v=4" width="119" alt="David Walsh"/><br />David Walsh</a></td>
+   <td align="center"><a href="https://robbevaes.be/?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Robbe Vaes"><img src="https://avatars.githubusercontent.com/u/44748019?u=e0232402c045ad4eac7cbd217f1f47e083103b89&amp;v=4" width="119" alt="Robbe Vaes"/><br />Robbe Vaes</a></td>
+   <td align="center"><a href="https://github.com/aidansunbury?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Aidan Sunbury"><img src="https://avatars.githubusercontent.com/u/64103161?v=4" width="119" alt="Aidan Sunbury"/><br />Aidan Sunbury</a></td>
+   <td align="center"><a href="https://github.com/soonoo?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="soonoo"><img src="https://avatars.githubusercontent.com/u/5436405?u=5d0b4aa955c87e30e6bda7f0cccae5402da99528&amp;v=4" width="119" alt="soonoo"/><br />soonoo</a></td>
+   <td align="center"><a href="https://kevinporten.dev/?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Kevin Porten"><img src="https://avatars.githubusercontent.com/u/1839345?u=dc2263d5cfe0d927ce1a0be04a1d55dd6b55405c&amp;v=4" width="119" alt="Kevin Porten"/><br />Kevin Porten</a></td>
+   <td align="center"><a href="https://github.com/pumpkinlink?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Denis"><img src="https://avatars.githubusercontent.com/u/11864620?u=5f47bbe6c65d0f6f5cf011021490238e4b0593d0&amp;v=4" width="119" alt="Denis"/><br />Denis</a></td>
+   <td align="center"><a href="https://github.com/christopher-kapic?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Christopher Kapic"><img src="https://avatars.githubusercontent.com/u/59740769?u=e7ad4b72b5bf6c9eb1644c26dbf3332a8f987377&amp;v=4" width="119" alt="Christopher Kapic"/><br />Christopher Kapic</a></td>
   </tr>
   <tr>
-   <td align="center"><a href="https://github.com/thomasballinger?ref=orpc" target="_blank" rel="sponsored noopener" title="Tom Ballinger"><img src="https://avatars.githubusercontent.com/u/458879?u=4b045ac75d721b6ac2b42a74d7d37f61f0414031&amp;v=4" width="119" alt="Tom Ballinger"/><br />Tom Ballinger</a></td>
-   <td align="center"><a href="https://github.com/SSam0419?ref=orpc" target="_blank" rel="sponsored noopener" title="Sam"><img src="https://avatars.githubusercontent.com/u/102863520?u=3c89611f549d5070be232eb4532f690c8f2e7a65&amp;v=4" width="119" alt="Sam"/><br />Sam</a></td>
-   <td align="center"><a href="https://github.com/Titoine?ref=orpc" target="_blank" rel="sponsored noopener" title="Titoine"><img src="https://avatars.githubusercontent.com/u/3514286?u=1bb1e86b0c99c8a1121372e56d51a177eea12191&amp;v=4" width="119" alt="Titoine"/><br />Titoine</a></td>
-   <td align="center"><a href="https://github.com/Mnigos?ref=orpc" target="_blank" rel="sponsored noopener" title="Igor Makowski"><img src="https://avatars.githubusercontent.com/u/56691628?u=ee8c879478f7c151b9156aef6c74243fa3e247a8&amp;v=4" width="119" alt="Igor Makowski"/><br />Igor Makowski</a></td>
-   <td align="center"><a href="https://github.com/hanayashiki?ref=orpc" target="_blank" rel="sponsored noopener" title="hanayashiki"><img src="https://avatars.githubusercontent.com/u/26056783?u=06c3b9205a16fd41a871e82da1cc2a09306d53f5&amp;v=4" width="119" alt="hanayashiki"/><br />hanayashiki</a></td>
-   <td align="center"><a href="https://github.com/ldub?ref=orpc" target="_blank" rel="sponsored noopener" title="Lev Dubinets"><img src="https://avatars.githubusercontent.com/u/3114081?u=f547f5d5012cab54851f1b1ad72d10e537f78fc2&amp;v=4" width="119" alt="Lev Dubinets"/><br />Lev Dubinets</a></td>
-   <td align="center"><a href="https://github.com/mr-kelly?ref=orpc" target="_blank" rel="sponsored noopener" title="Kelly Peilin Chan"><img src="https://avatars.githubusercontent.com/u/520852?u=6b0f7105f694e7b5cacf410a3f04c7044b469dc8&amp;v=4" width="119" alt="Kelly Peilin Chan"/><br />Kelly Peilin Chan</a></td>
+   <td align="center"><a href="http://ballingt.com/?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Tom Ballinger"><img src="https://avatars.githubusercontent.com/u/458879?u=4b045ac75d721b6ac2b42a74d7d37f61f0414031&amp;v=4" width="119" alt="Tom Ballinger"/><br />Tom Ballinger</a></td>
+   <td align="center"><a href="https://lee-sam.com/?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Sam"><img src="https://avatars.githubusercontent.com/u/102863520?u=3c89611f549d5070be232eb4532f690c8f2e7a65&amp;v=4" width="119" alt="Sam"/><br />Sam</a></td>
+   <td align="center"><a href="https://github.com/Titoine?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Titoine"><img src="https://avatars.githubusercontent.com/u/3514286?u=1bb1e86b0c99c8a1121372e56d51a177eea12191&amp;v=4" width="119" alt="Titoine"/><br />Titoine</a></td>
+   <td align="center"><a href="https://rigtch.fm/?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Igor Makowski"><img src="https://avatars.githubusercontent.com/u/56691628?u=ee8c879478f7c151b9156aef6c74243fa3e247a8&amp;v=4" width="119" alt="Igor Makowski"/><br />Igor Makowski</a></td>
+   <td align="center"><a href="https://blog.cwang.io/?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="hanayashiki"><img src="https://avatars.githubusercontent.com/u/26056783?u=06c3b9205a16fd41a871e82da1cc2a09306d53f5&amp;v=4" width="119" alt="hanayashiki"/><br />hanayashiki</a></td>
+   <td align="center"><a href="https://dubinets.io/?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Lev Dubinets"><img src="https://avatars.githubusercontent.com/u/3114081?u=f547f5d5012cab54851f1b1ad72d10e537f78fc2&amp;v=4" width="119" alt="Lev Dubinets"/><br />Lev Dubinets</a></td>
+   <td align="center"><a href="https://bika.ai/?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Kelly Peilin Chan"><img src="https://avatars.githubusercontent.com/u/520852?u=6b0f7105f694e7b5cacf410a3f04c7044b469dc8&amp;v=4" width="119" alt="Kelly Peilin Chan"/><br />Kelly Peilin Chan</a></td>
   </tr>
   <tr>
-   <td align="center"><a href="https://github.com/guyariely?ref=orpc" target="_blank" rel="sponsored noopener" title="Guy Ariely"><img src="https://avatars.githubusercontent.com/u/42813496?u=edb6b7f563bf28e160a290832e7da57c0506f8ca&amp;v=4" width="119" alt="Guy Ariely"/><br />Guy Ariely</a></td>
-   <td align="center"><a href="https://github.com/piscis?ref=orpc" target="_blank" rel="sponsored noopener" title="Alex"><img src="https://avatars.githubusercontent.com/u/326163?u=b245f368bd940cf51d08c0b6bf55f8257f359437&amp;v=4" width="119" alt="Alex"/><br />Alex</a></td>
-   <td align="center"><a href="https://github.com/finom?ref=orpc" target="_blank" rel="sponsored noopener" title="Andrey Gubanov"><img src="https://avatars.githubusercontent.com/u/1082083?u=c5f2daf7ebece498e85c83367bb37b4e10e2649d&amp;v=4" width="119" alt="Andrey Gubanov"/><br />Andrey Gubanov</a></td>
+   <td align="center"><a href="https://guyariely.com/?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Guy Ariely"><img src="https://avatars.githubusercontent.com/u/42813496?u=edb6b7f563bf28e160a290832e7da57c0506f8ca&amp;v=4" width="119" alt="Guy Ariely"/><br />Guy Ariely</a></td>
+   <td align="center"><a href="https://piscis.dev/?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Alex"><img src="https://avatars.githubusercontent.com/u/326163?u=b245f368bd940cf51d08c0b6bf55f8257f359437&amp;v=4" width="119" alt="Alex"/><br />Alex</a></td>
+   <td align="center"><a href="https://opensource.gubanov.eu/?ref=middleapi&amp;utm_source=middleapi&amp;utm_medium=sponsor" target="_blank" rel="noopener sponsored" title="Andrey Gubanov"><img src="https://avatars.githubusercontent.com/u/1082083?u=c5f2daf7ebece498e85c83367bb37b4e10e2649d&amp;v=4" width="119" alt="Andrey Gubanov"/><br />Andrey Gubanov</a></td>
   </tr>
 </table>
 
-With thanks to 37 past sponsors who helped get oRPC here.
+With thanks to [37 past sponsors](https://htmlpreview.github.io/?https://github.com/middleapi/static/blob/main/sponsors.svg) who helped get oRPC here.
 
 ## References
 

--- a/packages/msw/README.md
+++ b/packages/msw/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/msw/package.json
+++ b/packages/msw/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "MSW integration for oRPC: mock procedures at the network level with typed MSW request handlers",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/nest/README.md
+++ b/packages/nest/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "NestJS integration for oRPC: implement typesafe contracts in NestJS controllers",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "Next.js integration for oRPC: call typesafe procedures through Next.js Server Functions",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "Node.js plugins for oRPC: static file serving, temporary file uploads, and batch response compression",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/openapi/README.md
+++ b/packages/openapi/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "Generate OpenAPI specs from oRPC routers and serve OpenAPI-compliant APIs with end-to-end type safety",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "OpenTelemetry integration for oRPC: distributed tracing for typesafe APIs",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/pinia-colada/README.md
+++ b/packages/pinia-colada/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/pinia-colada/README.md
+++ b/packages/pinia-colada/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/pinia-colada/package.json
+++ b/packages/pinia-colada/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "Pinia Colada integration for oRPC: typesafe queries and mutations for Vue",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/pino/README.md
+++ b/packages/pino/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/pino/README.md
+++ b/packages/pino/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/pino/package.json
+++ b/packages/pino/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "Pino integration for oRPC: structured logging for typesafe APIs",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/publisher/README.md
+++ b/packages/publisher/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/publisher/README.md
+++ b/packages/publisher/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "Typesafe pub/sub for oRPC event streaming, with memory, Redis, and Upstash adapters",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/ratelimit/README.md
+++ b/packages/ratelimit/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/ratelimit/README.md
+++ b/packages/ratelimit/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/ratelimit/package.json
+++ b/packages/ratelimit/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "Rate limiting for oRPC procedures, with memory, Redis, and Upstash adapters",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "Build typesafe APIs with oRPC: RPC and OpenAPI support, middleware, and adapters for Node.js, Bun, Deno, Fetch, Fastify, WebSocket, AWS Lambda, and more",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "Internal utilities shared across oRPC packages",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/swr/README.md
+++ b/packages/swr/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/swr/README.md
+++ b/packages/swr/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/swr/package.json
+++ b/packages/swr/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "SWR integration for oRPC: typesafe React data fetching hooks",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/tanstack-query/README.md
+++ b/packages/tanstack-query/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/tanstack-query/README.md
+++ b/packages/tanstack-query/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/tanstack-query/package.json
+++ b/packages/tanstack-query/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "TanStack Query integration for oRPC: typesafe queries, mutations, streaming, and SSR for React, Vue, Solid, Svelte, and Angular",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/trpc/README.md
+++ b/packages/trpc/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/trpc/README.md
+++ b/packages/trpc/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "tRPC interop for oRPC: reuse existing tRPC routers with oRPC clients and OpenAPI",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/valibot/README.md
+++ b/packages/valibot/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/valibot/README.md
+++ b/packages/valibot/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/valibot/package.json
+++ b/packages/valibot/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "Valibot integration for oRPC: convert Valibot schemas into JSON Schema for OpenAPI generation",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/zod/README.md
+++ b/packages/zod/README.md
@@ -70,7 +70,7 @@ You can read the documentation [here](https://orpc.dev).
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -4,7 +4,10 @@
   "version": "2.0.0-beta.29",
   "description": "Zod integration for oRPC: convert Zod schemas into JSON Schema for OpenAPI generation",
   "license": "MIT",
-  "funding": "https://github.com/sponsors/dinwwwh",
+  "funding": [
+    "https://github.com/sponsors/dinwwwh",
+    "https://opencollective.com/middleapi"
+  ],
   "homepage": "https://orpc.dev",
   "repository": {
     "type": "git",

--- a/playgrounds/bun/README.md
+++ b/playgrounds/bun/README.md
@@ -25,7 +25,7 @@ Then play with your app and open [http://localhost:16686](http://localhost:16686
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/playgrounds/bun/README.md
+++ b/playgrounds/bun/README.md
@@ -25,7 +25,7 @@ Then play with your app and open [http://localhost:16686](http://localhost:16686
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/playgrounds/cloudflare/README.md
+++ b/playgrounds/cloudflare/README.md
@@ -25,7 +25,7 @@ Then play with your app and open [http://localhost:16686](http://localhost:16686
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/playgrounds/cloudflare/README.md
+++ b/playgrounds/cloudflare/README.md
@@ -25,7 +25,7 @@ Then play with your app and open [http://localhost:16686](http://localhost:16686
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/playgrounds/nest/README.md
+++ b/playgrounds/nest/README.md
@@ -24,7 +24,7 @@ Then play with your app and open [http://localhost:16686](http://localhost:16686
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/playgrounds/nest/README.md
+++ b/playgrounds/nest/README.md
@@ -24,7 +24,7 @@ Then play with your app and open [http://localhost:16686](http://localhost:16686
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/playgrounds/next/README.md
+++ b/playgrounds/next/README.md
@@ -25,7 +25,7 @@ Then play with your app and open [http://localhost:16686](http://localhost:16686
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
 
 <table>
   <tr>

--- a/playgrounds/next/README.md
+++ b/playgrounds/next/README.md
@@ -25,7 +25,7 @@ Then play with your app and open [http://localhost:16686](http://localhost:16686
 
 ## Sponsors
 
-Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀
+Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀
 
 <table>
   <tr>

--- a/scripts/sync-sponsors.ts
+++ b/scripts/sync-sponsors.ts
@@ -133,7 +133,7 @@ function buildSponsorsSection(sponsors: Sponsor[]): string {
   const lines = [
     '## Sponsors',
     '',
-    'Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going here: [GitHub Sponsors](https://github.com/sponsors/dinwwwh). Every bit helps! 🚀',
+    'Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀',
     '',
   ]
 

--- a/scripts/sync-sponsors.ts
+++ b/scripts/sync-sponsors.ts
@@ -133,7 +133,7 @@ function buildSponsorsSection(sponsors: Sponsor[]): string {
   const lines = [
     '## Sponsors',
     '',
-    'Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi), or simply [keep it brewing](https://github.com/sponsors/dinwwwh/sponsorships?tier_id=475114) with a $5/month coffee. Every bit helps! 🚀',
+    'Like what we build over at [middleapi](https://github.com/middleapi)? You can help keep it going through [GitHub Sponsors](https://github.com/sponsors/dinwwwh) or [Open Collective](https://opencollective.com/middleapi). Every bit helps! 🚀',
     '',
   ]
 


### PR DESCRIPTION
Adds the middleapi Open Collective (https://opencollective.com/middleapi) as a funding option everywhere sponsors can find us: the GitHub Sponsor button, npm, the READMEs, and the docs site. No link points at a specific tier; sponsors pick their platform and tier themselves.

## Changes

- `.github/FUNDING.yml` now lists the `middleapi` Open Collective, so it shows up under the repository's Sponsor button.
- Every published package's `funding` field is now an array with both the GitHub Sponsors profile and the Open Collective link, so `npm fund` and npm package pages surface both.
- The sponsors blurb in all 32 READMEs (generated by `scripts/sync-sponsors.ts`) links GitHub Sponsors and Open Collective.
- Docs site: the "Keep it brewing" aside card is now a chooser that pops up GitHub Sponsors and Open Collective; the header "More" menu, home footer, and home sponsors section link both platforms. Home section buttons are compact and left-aligned on narrow screens, and the stacked sponsor pair shares one width.

## Testing

- Verified on the docs dev server: the chooser opens upward with both links, header/footer/home links render, no console or server errors, and button layout checked at 375/578/800/1280px widths.