### PR TITLE
chore(content): close unclosed install code fence on Generate from OpenAPI page

### DIFF
--- a/apps/content/docs/contract/generate-from-openapi.mdx
+++ b/apps/content/docs/contract/generate-from-openapi.mdx
@@ -19,6 +19,7 @@ Install Hey API:
 
 ```package-install
 npm install -D @hey-api/openapi-ts@next
+```
 
 Create an `openapi-ts.config.ts` file pointing at your specification. It can be a local file or a URL:
 


### PR DESCRIPTION
The install snippet on the Generate Contract from OpenAPI page opened a `package-install` fence without closing it, so the following paragraph and the `openapi-ts.config.ts` example rendered as broken text inside the code block. Adding the missing closing fence restores the page's intended structure.

## Testing

- `pnpm docs:validate` passes (JSDoc backlinks and `blume validate --strict`).