### PR TITLE
feat(openapi): add allow option to OpenAPIReferenceHandlerPlugin

### DIFF
--- a/apps/content/docs/plugins/openapi-reference.mdx
+++ b/apps/content/docs/plugins/openapi-reference.mdx
@@ -83,6 +83,21 @@ npm install swagger-ui @types/swagger-ui
 You can also load custom assets for the docs UI by setting `providerScriptUrl` and `providerCssUrl`.
 :::
 
+## Restricting Access
+
+By default, the docs UI and OpenAPI specification are publicly accessible. Use `allow` to serve them conditionally. When it resolves to `false`, the request falls through as unmatched, as if the plugin were not installed.
+
+```ts
+const handler = new OpenAPIHandler(router, {
+  plugins: [
+    new OpenAPIReferenceHandlerPlugin({
+      spec: () => generator.generate(router),
+      allow: async ({ context }) => context.user !== undefined,
+    }),
+  ]
+})
+```
+
 ## Learn More
 
 For implementation details, see the [source code](https://github.com/middleapi/orpc/blob/main/packages/openapi/src/plugins/openapi-reference.ts).

--- a/packages/openapi/src/plugins/openapi-reference.test.ts
+++ b/packages/openapi/src/plugins/openapi-reference.test.ts
@@ -119,6 +119,44 @@ describe('openAPIReferenceHandlerPlugin', () => {
     expect(spec).not.toHaveBeenCalled()
   })
 
+  it('returns the unmatched result when allow resolves to false', async () => {
+    const spec = vi.fn().mockResolvedValue(createSpec())
+    const allow = vi.fn().mockResolvedValue(false)
+    const plugin = new OpenAPIReferenceHandlerPlugin({ spec, allow })
+    const { interceptor } = getInterceptor(plugin)
+    const nextResult = { matched: false as const }
+
+    for (const url of ['/', '/spec.json'] as const) {
+      const { result } = await invoke(interceptor, { url, nextResult })
+
+      expect(result).toBe(nextResult)
+    }
+
+    expect(allow).toHaveBeenCalledTimes(2)
+    expect(allow).toHaveBeenCalledWith(expect.objectContaining({
+      context: {},
+      request: expect.objectContaining({ url: '/spec.json' }),
+    }))
+    expect(spec).not.toHaveBeenCalled()
+  })
+
+  it('serves normally when allow resolves to true, without calling it for unrelated paths', async () => {
+    const spec = vi.fn().mockResolvedValue(createSpec())
+    const allow = vi.fn().mockResolvedValue(true)
+    const plugin = new OpenAPIReferenceHandlerPlugin({ spec, allow })
+    const { interceptor } = getInterceptor(plugin)
+
+    await invoke(interceptor, { url: '/not-found' })
+
+    expect(allow).not.toHaveBeenCalled()
+
+    const { result } = await invoke(interceptor, { url: '/spec.json' })
+
+    expect(allow).toHaveBeenCalledOnce()
+    expect(result.matched).toBe(true)
+    expect(result.response?.status).toBe(200)
+  })
+
   it('serves the OpenAPI spec file from a custom spec path with a runtime prefix', async () => {
     const specDocument = createSpec('Generated API')
     const spec = vi.fn().mockResolvedValue(specDocument)

--- a/packages/openapi/src/plugins/openapi-reference.ts
+++ b/packages/openapi/src/plugins/openapi-reference.ts
@@ -26,6 +26,16 @@ export interface OpenAPIReferenceHandlerPluginOptions<T extends Context, TProvid
   spec: Value<Promisable<OpenAPIDocument>, [StandardHandlerRoutingInterceptorOptions<T>]>
 
   /**
+   * Determines whether the docs UI and OpenAPI JSON are allowed to be served for a request.
+   * When it resolves to `false`, the request falls through as unmatched,
+   * as if the plugin were not installed. Useful for restricting access
+   * to authenticated users.
+   *
+   * @default true
+   */
+  allow?: Value<Promisable<boolean>, [StandardHandlerRoutingInterceptorOptions<T>]>
+
+  /**
    * The URL path at which to serve the OpenAPI JSON.
    *
    * @default '/spec.json'
@@ -102,6 +112,7 @@ export class OpenAPIReferenceHandlerPlugin<
   name = '~openapi-reference'
 
   private readonly spec: OpenAPIReferenceHandlerPluginOptions<T, TProvider>['spec']
+  private readonly allow: Exclude<OpenAPIReferenceHandlerPluginOptions<T, TProvider>['allow'], undefined>
   private readonly specPath: Exclude<OpenAPIReferenceHandlerPluginOptions<T, TProvider>['specPath'], undefined>
   private readonly provider: Exclude<OpenAPIReferenceHandlerPluginOptions<T, TProvider>['provider'], undefined>
   private readonly providerConfig: OpenAPIReferenceHandlerPluginOptions<T, TProvider>['providerConfig']
@@ -113,6 +124,7 @@ export class OpenAPIReferenceHandlerPlugin<
 
   constructor(options: OpenAPIReferenceHandlerPluginOptions<T, TProvider>) {
     this.spec = options.spec
+    this.allow = options.allow ?? true
     this.specPath = options.specPath ?? '/spec.json'
     this.provider = options.provider ?? 'scalar' as TProvider
     this.providerConfig = options.providerConfig
@@ -147,6 +159,10 @@ export class OpenAPIReferenceHandlerPlugin<
           )
 
           if (!isSpecPath && !isDocsPath) {
+            return result
+          }
+
+          if (!await value(this.allow, routingInterceptorOptions)) {
             return result
           }
 

--- a/packages/openapi/src/plugins/openapi-reference.ts
+++ b/packages/openapi/src/plugins/openapi-reference.ts
@@ -30,8 +30,6 @@ export interface OpenAPIReferenceHandlerPluginOptions<T extends Context, TProvid
    * When it resolves to `false`, the request falls through as unmatched,
    * as if the plugin were not installed. Useful for restricting access
    * to authenticated users.
-   *
-   * @default true
    */
   allow?: Value<Promisable<boolean>, [StandardHandlerRoutingInterceptorOptions<T>]>
 
@@ -112,7 +110,7 @@ export class OpenAPIReferenceHandlerPlugin<
   name = '~openapi-reference'
 
   private readonly spec: OpenAPIReferenceHandlerPluginOptions<T, TProvider>['spec']
-  private readonly allow: Exclude<OpenAPIReferenceHandlerPluginOptions<T, TProvider>['allow'], undefined>
+  private readonly allow: OpenAPIReferenceHandlerPluginOptions<T, TProvider>['allow']
   private readonly specPath: Exclude<OpenAPIReferenceHandlerPluginOptions<T, TProvider>['specPath'], undefined>
   private readonly provider: Exclude<OpenAPIReferenceHandlerPluginOptions<T, TProvider>['provider'], undefined>
   private readonly providerConfig: OpenAPIReferenceHandlerPluginOptions<T, TProvider>['providerConfig']
@@ -124,7 +122,7 @@ export class OpenAPIReferenceHandlerPlugin<
 
   constructor(options: OpenAPIReferenceHandlerPluginOptions<T, TProvider>) {
     this.spec = options.spec
-    this.allow = options.allow ?? true
+    this.allow = options.allow
     this.specPath = options.specPath ?? '/spec.json'
     this.provider = options.provider ?? 'scalar' as TProvider
     this.providerConfig = options.providerConfig
@@ -162,7 +160,7 @@ export class OpenAPIReferenceHandlerPlugin<
             return result
           }
 
-          if (!await value(this.allow, routingInterceptorOptions)) {
+          if (await value(this.allow, routingInterceptorOptions) === false) {
             return result
           }
 


### PR DESCRIPTION
Adds an `allow` option to `OpenAPIReferenceHandlerPlugin` so the docs UI and OpenAPI spec can be served conditionally, for example only to authenticated users. When it resolves to `false`, the request falls through as unmatched, as if the plugin were not installed, so unauthorized clients cannot tell the docs and spec paths exist.

Resolves #1907

## Design

- `allow: Value<Promisable<boolean>, [StandardHandlerRoutingInterceptorOptions<T>]>`, defaulting to `true`. It receives the same options as `spec`, `docsTitle`, and `docsHead`, so decisions can use the handler context or request headers.
- Evaluated only after a docs/spec path matches, so no check runs on unrelated requests.

## Testing

- Denied requests return the unmatched result for both paths without generating the spec, and the predicate receives the routing interceptor options.
- The predicate is never called for unrelated paths; behavior is unchanged when the option is omitted.
- Docs gain a "Restricting Access" section on the plugin page.