### PR TITLE
fix(server): let batch request headers win over sub-request headers

### DIFF
--- a/packages/server/src/plugins/batch.test.ts
+++ b/packages/server/src/plugins/batch.test.ts
@@ -404,7 +404,7 @@ describe('batchHandlerPlugin', () => {
       })
     }
 
-    it('merges batch request headers into sub-requests and lets sub-requests win', async () => {
+    it('merges batch request headers into sub-requests and lets the batch request win', async () => {
       const { handler, seenHeaders } = createHeaderCapturingHandler()
 
       await handler.handle(createBatchRequestWithHeaders(
@@ -415,9 +415,20 @@ describe('batchHandlerPlugin', () => {
       expect(seenHeaders[0]).toMatchObject({
         'x-from-batch': 'batch',
         'x-from-sub-request': 'sub-request',
-        'x-overridden': 'sub-request',
+        'x-overridden': 'batch',
       })
       expect(seenHeaders[0]!['orpc-batch']).toBeUndefined()
+    })
+
+    it('prevents a sub-request from spoofing a header the batch request already carries', async () => {
+      const { handler, seenHeaders } = createHeaderCapturingHandler()
+
+      await handler.handle(createBatchRequestWithHeaders(
+        { authorization: 'Bearer real' },
+        { authorization: 'Bearer spoofed' },
+      ))
+
+      expect(seenHeaders[0]!.authorization).toEqual('Bearer real')
     })
   })
 

--- a/packages/server/src/plugins/batch.ts
+++ b/packages/server/src/plugins/batch.ts
@@ -28,7 +28,8 @@ export interface BatchHandlerPluginOptions<T extends Context> {
   /**
    * Map each subrequest in the batch before it is processed.
    *
-   * @default merges the batch request headers into the subrequest and remove `orpc-batch` header to prevent nested batching
+   * @default merges the batch request headers into the subrequest, giving them priority over
+   * the subrequest headers, and removes the `orpc-batch` header to prevent nested batching
    */
   mapSubrequest?: (subrequest: StandardLazyRequest, batchOptions: StandardHandlerRoutingInterceptorOptions<T>) => StandardLazyRequest
 
@@ -102,8 +103,13 @@ export class BatchHandlerPlugin<T extends Context> implements StandardHandlerPlu
     this.mapSubrequest = options.mapSubrequest ?? ((subRequest, { request: batchRequest }) => ({
       ...subRequest,
       headers: {
-        ...batchRequest.headers,
         ...subRequest.headers,
+        /**
+         * The batch request headers win over the subrequest ones. They are the only ones the
+         * transport actually saw, so headers the browser injects on its own, such as `cookie`
+         * or `origin`, cannot be overridden by a subrequest, which is just request payload.
+         */
+        ...batchRequest.headers,
         'orpc-batch': undefined, // useful in case batch plugin is used multiple times
       },
     }))


### PR DESCRIPTION
The batch handler's default `mapSubrequest` merged the batch root request headers into each sub-request but let the sub-request win on collision. That order is now flipped, so the batch request headers take priority.

The batch root request is the only part the transport actually saw. Its headers are set by the browser (`cookie`, `origin`, `sec-fetch-*`) or by a proxy (`x-forwarded-for`, `authorization`), while a sub-request is client-controlled request payload. A sub-request can no longer overwrite them.

## Compatibility

With the default `BatchLinkPlugin`, behavior is unchanged. Its batch headers are the headers common to every sub-request, and its default `mapSubrequest` strips those from each sub-request, so the two sets never collide. Only setups with a custom client `headers` option, or a hand-rolled client, that deliberately set a per-sub-request override of a batch-level header are affected. They can restore the old merge through the `mapSubrequest` option.

## Testing

`packages/server`, `packages/client`, and the root `tests/` suites pass, along with `pnpm lint` and `pnpm type:check`. The existing header-merge test now asserts the new precedence, and a spoofing test covers a sub-request trying to override an `authorization` header carried by the batch request.