### PR TITLE
fix: stop error-code lookups resolving through Object.prototype

### DIFF
--- a/packages/contract/src/error-factory.test.ts
+++ b/packages/contract/src/error-factory.test.ts
@@ -225,4 +225,12 @@ describe('createORPCErrorConstructorMap', () => {
     expect('BAD_GATEWAY' in constructors).toBe(true)
     expect('ANY_THING' in constructors).toBe(false)
   })
+
+  it('does not resolve error codes through Object.prototype', () => {
+    const e = (constructors as any).toString()
+
+    expect(e.code).toEqual('toString')
+    expect(e.defined).toEqual(false)
+    expect(e.inferable).toEqual(false)
+  })
 })

--- a/packages/contract/src/error-factory.ts
+++ b/packages/contract/src/error-factory.ts
@@ -4,7 +4,7 @@ import type { ErrorMap, ErrorMapItem } from './error'
 import type { AnySchema, InferSchemaInput, Schema } from './schema'
 
 import { ORPCError } from '@orpc/client'
-import { resolveMaybeOptionalOptions } from '@orpc/shared'
+import { getOwn, resolveMaybeOptionalOptions } from '@orpc/shared'
 import { ValidationError } from './error'
 import { type } from './schema-utils'
 
@@ -162,7 +162,7 @@ export function createORPCErrorConstructorMap<T extends ErrorMap>(errorMap: T): 
 
       const item: ORPCErrorConstructorMapItem<string, unknown> = (...rest) => {
         const options = resolveMaybeOptionalOptions(rest)
-        const config = errorMap[code]
+        const config = getOwn(errorMap as ErrorMap, code)
 
         const error = new ORPCError(code, {
           message: options.message ?? config?.message,

--- a/packages/contract/src/error-utils.test.ts
+++ b/packages/contract/src/error-utils.test.ts
@@ -280,4 +280,11 @@ describe('reconcileORPCError', () => {
       expect(validated.inferable).toBe(true)
     })
   })
+
+  it('does not resolve error codes through Object.prototype', async () => {
+    const error = new ORPCError('toString', { message: 'm', data: 'd' })
+    ;(error.defined as any) = true
+
+    expect((await reconcileORPCError({}, error)).defined).toBe(false)
+  })
 })

--- a/packages/contract/src/error-utils.ts
+++ b/packages/contract/src/error-utils.ts
@@ -2,6 +2,7 @@ import type { AnyORPCError } from '@orpc/client'
 import type { Writable } from '@orpc/shared'
 import type { ErrorMap } from './error'
 import { cloneORPCError } from '@orpc/client'
+import { getOwn } from '@orpc/shared'
 
 export type MergedErrorMap<T1 extends ErrorMap, T2 extends ErrorMap>
   = keyof T1 extends never | keyof T2
@@ -16,7 +17,7 @@ export async function reconcileORPCError(
   map: ErrorMap,
   error: AnyORPCError,
 ): Promise<AnyORPCError> {
-  const config = map[error.code]
+  const config = getOwn(map, error.code)
 
   if (!config) {
     // Do not check `error.inferable` here, because even when config is undefined,

--- a/packages/effect/src/error.test.ts
+++ b/packages/effect/src/error.test.ts
@@ -206,4 +206,13 @@ describe('catchORPCErrorCodes', () => {
 
     expect(exit).toEqual(Exit.fail(error))
   })
+
+  it('does not resolve error codes through Object.prototype', async () => {
+    const error = new ORPCError('toString')
+    const exit = await Effect.runPromiseExit(
+      catchORPCErrorCodes(Effect.fail(error), {} as any) as Effect.Effect<unknown, unknown>,
+    )
+
+    expect(exit).toEqual(Exit.fail(error))
+  })
 })

--- a/packages/effect/src/error.ts
+++ b/packages/effect/src/error.ts
@@ -1,5 +1,6 @@
 import type { AnyORPCError, ORPCErrorCode } from '@orpc/server'
 import { ORPCError } from '@orpc/server'
+import { getOwn } from '@orpc/shared'
 import { Effect, Function } from 'effect'
 
 /**
@@ -144,8 +145,8 @@ export const catchORPCErrorCodes: {
     cases: Record<string, ((error: AnyORPCError) => Effect.Effect<any, any, any>) | undefined>,
   ) => self.pipe(
     Effect.catchIf(
-      (error): error is AnyORPCError => error instanceof ORPCError && typeof cases[error.code] === 'function',
-      error => cases[error.code]!(error),
+      (error): error is AnyORPCError => error instanceof ORPCError && typeof getOwn(cases, error.code) === 'function',
+      error => getOwn(cases, error.code)!(error),
     ),
   ),
 )

--- a/packages/json-schema/src/smart-coercion-link-plugin.test.ts
+++ b/packages/json-schema/src/smart-coercion-link-plugin.test.ts
@@ -145,4 +145,17 @@ describe('smartCoercionLinkPlugin', () => {
       return true
     })
   })
+
+  it('leaves defined errors with prototype-named codes untouched', async () => {
+    const contract = oc.router({ users: { get: oc.errors({ FORBIDDEN: { data: z.object({ number: z.number() }) } }) } })
+    const plugin = new SmartCoercionLinkPlugin(contract)
+
+    const definedORPCError = new ORPCError('toString', { data: { number: '123' } })
+    ;(definedORPCError as any).defined = true
+
+    const interceptor = plugin.init({} as any).interceptors?.[0]
+    const next = vi.fn().mockThrowOnce(definedORPCError)
+
+    await expect(interceptor?.({ path: ['users', 'get'], next } as any)).rejects.toBe(definedORPCError)
+  })
 })

--- a/packages/json-schema/src/smart-coercion-link-plugin.test.ts
+++ b/packages/json-schema/src/smart-coercion-link-plugin.test.ts
@@ -145,17 +145,4 @@ describe('smartCoercionLinkPlugin', () => {
       return true
     })
   })
-
-  it('leaves defined errors with prototype-named codes untouched', async () => {
-    const contract = oc.router({ users: { get: oc.errors({ FORBIDDEN: { data: z.object({ number: z.number() }) } }) } })
-    const plugin = new SmartCoercionLinkPlugin(contract)
-
-    const definedORPCError = new ORPCError('toString', { data: { number: '123' } })
-    ;(definedORPCError as any).defined = true
-
-    const interceptor = plugin.init({} as any).interceptors?.[0]
-    const next = vi.fn().mockThrowOnce(definedORPCError)
-
-    await expect(interceptor?.({ path: ['users', 'get'], next } as any)).rejects.toBe(definedORPCError)
-  })
 })

--- a/packages/json-schema/src/smart-coercion-link-plugin.test.ts
+++ b/packages/json-schema/src/smart-coercion-link-plugin.test.ts
@@ -145,17 +145,4 @@ describe('smartCoercionLinkPlugin', () => {
       return true
     })
   })
-
-  it('does not resolve error codes through Object.prototype', async () => {
-    const contract = oc.router({ users: { get: oc.errors({ FORBIDDEN: { data: z.object({ number: z.number() }) } }) } })
-    const plugin = new SmartCoercionLinkPlugin(contract)
-
-    const definedORPCError = new ORPCError('toString', { data: { number: '123' } })
-    ;(definedORPCError as any).defined = true
-
-    const interceptor = plugin.init({} as any).interceptors?.[0]
-    const next = vi.fn().mockThrowOnce(definedORPCError)
-
-    await expect(interceptor?.({ path: ['users', 'get'], next } as any)).rejects.toBe(definedORPCError)
-  })
 })

--- a/packages/json-schema/src/smart-coercion-link-plugin.test.ts
+++ b/packages/json-schema/src/smart-coercion-link-plugin.test.ts
@@ -145,4 +145,17 @@ describe('smartCoercionLinkPlugin', () => {
       return true
     })
   })
+
+  it('does not resolve error codes through Object.prototype', async () => {
+    const contract = oc.router({ users: { get: oc.errors({ FORBIDDEN: { data: z.object({ number: z.number() }) } }) } })
+    const plugin = new SmartCoercionLinkPlugin(contract)
+
+    const definedORPCError = new ORPCError('toString', { data: { number: '123' } })
+    ;(definedORPCError as any).defined = true
+
+    const interceptor = plugin.init({} as any).interceptors?.[0]
+    const next = vi.fn().mockThrowOnce(definedORPCError)
+
+    await expect(interceptor?.({ path: ['users', 'get'], next } as any)).rejects.toBe(definedORPCError)
+  })
 })

--- a/packages/json-schema/src/smart-coercion-link-plugin.ts
+++ b/packages/json-schema/src/smart-coercion-link-plugin.ts
@@ -5,7 +5,7 @@ import type { JsonSchemaConverter } from './convert'
 import type { JsonSchema } from './types'
 import { cloneORPCError, ORPCError } from '@orpc/client'
 import { getProcedureContractOrThrow } from '@orpc/contract'
-import { toArray } from '@orpc/shared'
+import { getOwn, toArray } from '@orpc/shared'
 import { JsonSchemaCoercer } from './coercer'
 import { DelegatingJsonSchemaConverter } from './convert'
 import { StandardJsonSchemaConverter } from './standard-json-schema-converter'
@@ -68,7 +68,7 @@ export class SmartCoercionLinkPlugin<T extends ClientContext> implements Standar
             }
 
             const errorMap: ErrorMap = procedure['~orpc'].errorMap
-            const dataSchema = errorMap[error.code]?.data
+            const dataSchema = getOwn(errorMap, error.code)?.data
 
             if (!dataSchema) {
               throw error

--- a/packages/openapi/src/adapters/standard/openapi-handler-codec.test.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler-codec.test.ts
@@ -858,6 +858,13 @@ describe('openAPIHandlerCodec', () => {
       expect(serializer.serialize).toHaveBeenNthCalledWith(2, secondError.toJSON())
     })
 
+    it('does not resolve error codes through Object.prototype', async () => {
+      const serializer = { serialize: vi.fn(), deserialize: vi.fn() } as any
+      const codec = new OpenAPIHandlerCodec({ procedure: os.handler(vi.fn()) }, { serializer })
+
+      expect((await codec.encodeError(new ORPCError('toString' as any))).status).toEqual(DEFAULT_ERROR_STATUS)
+    })
+
     it('can custom error status via errorStatuses option', () => {
       const serializer = {
         serialize: vi.fn().mockReturnValueOnce('__serialized_override__'),

--- a/packages/openapi/src/adapters/standard/openapi-handler-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler-codec.ts
@@ -7,7 +7,7 @@ import type { OpenAPIMeta } from '../../meta'
 import type { OpenAPIMatcherOptions } from './openapi-matcher'
 import { COMMON_ERROR_STATUS_MAP } from '@orpc/client'
 import { DEFAULT_ERROR_STATUS, DEFAULT_SUCCESS_STATUS } from '@orpc/server'
-import { isPlainObject, isTypescriptObject, NullProtoObj, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
+import { getOwn, isPlainObject, isTypescriptObject, NullProtoObj, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
 import { parseStandardUrl } from '@standardserver/core'
 import {
   DEFAULT_OPENAPI_INPUT_STRUCTURE,
@@ -137,7 +137,7 @@ export class OpenAPIHandlerCodecCore<T extends Context> {
   }
 
   encodeError(error: AnyORPCError): Promisable<StandardResponse> {
-    const status = this.errorStatusMap[error.code] ?? DEFAULT_ERROR_STATUS
+    const status = getOwn(this.errorStatusMap, error.code) ?? DEFAULT_ERROR_STATUS
 
     return {
       status,

--- a/packages/server/src/adapters/standard/rpc-handler-codec.test.ts
+++ b/packages/server/src/adapters/standard/rpc-handler-codec.test.ts
@@ -225,6 +225,14 @@ describe('rpcHandlerCodec', () => {
       expect(serializer.serialize).toHaveBeenCalledWith(error.toJSON())
     })
 
+    it('does not resolve error codes through Object.prototype', async () => {
+      const serializer = { serialize: vi.fn(), deserialize: vi.fn() } as any
+      const codec = new RPCHandlerCodec(router, { serializer })
+      const error = new ORPCError('toString' as any)
+
+      expect((await codec.encodeError(error, procedure as any, ['ping'], options as any)).status).toEqual(DEFAULT_ERROR_STATUS)
+    })
+
     it('custom status with errorStatusCodes option', () => {
       const serializer = {
         serialize: vi.fn()

--- a/packages/server/src/adapters/standard/rpc-handler-codec.ts
+++ b/packages/server/src/adapters/standard/rpc-handler-codec.ts
@@ -7,7 +7,7 @@ import type { AnyRouter } from '../../router'
 import type { StandardHandlerCodec, StandardHandlerCodecResolvedProcedure, StandardHandlerHandleOptions } from '../standard'
 import type { RPCMatcherOptions } from './rpc-matcher'
 import { COMMON_ERROR_STATUS_MAP, RPCSerializer } from '@orpc/client'
-import { parseEmptyableJSON, value } from '@orpc/shared'
+import { getOwn, parseEmptyableJSON, value } from '@orpc/shared'
 import { parseStandardUrl } from '@standardserver/core'
 import { DEFAULT_ERROR_STATUS, DEFAULT_SUCCESS_STATUS } from '../../constants'
 import { RPCMatcher } from './rpc-matcher'
@@ -82,7 +82,7 @@ export class RPCHandlerCodec<T extends Context> implements StandardHandlerCodec<
   }
 
   encodeError(error: AnyORPCError, _procedure: AnyProcedure, _path: string[], _options: StandardHandlerHandleOptions<T>): Promisable<StandardResponse> {
-    const status = this.errorStatusMap[error.code] ?? DEFAULT_ERROR_STATUS
+    const status = getOwn(this.errorStatusMap, error.code) ?? DEFAULT_ERROR_STATUS
 
     return {
       headers: {},

--- a/packages/shared/src/object.test.ts
+++ b/packages/shared/src/object.test.ts
@@ -1,7 +1,7 @@
 import * as a from 'arktype'
 import * as v from 'valibot'
 import z from 'zod'
-import { bindMethods, clone, findDeepMatches, get, getConstructor, getConstructors, isPlainObject, isPropertyKey, mergeTwoLevels, NullProtoObj, omit, set } from './object'
+import { bindMethods, clone, findDeepMatches, get, getConstructor, getConstructors, getOwn, isPlainObject, isPropertyKey, mergeTwoLevels, NullProtoObj, omit, set } from './object'
 
 it('findDeepMatches', () => {
   const { maps, values } = findDeepMatches(v => typeof v === 'string', {
@@ -113,6 +113,13 @@ it('isPlainObject', () => {
     Object.setPrototypeOf(obj, null)
     return obj
   })()).toSatisfy(isPlainObject)
+})
+
+it('getOwn', () => {
+  expect(getOwn({ a: 1 }, 'a')).toEqual(1)
+  expect(getOwn({ a: 1 }, 'b')).toBeUndefined()
+  expect(getOwn({ a: 1 }, 'toString')).toBeUndefined()
+  expect(getOwn({ toString: 1 } as any, 'toString')).toEqual(1)
 })
 
 it('get', () => {

--- a/packages/shared/src/object.ts
+++ b/packages/shared/src/object.ts
@@ -69,6 +69,14 @@ export function isPlainObject(value: unknown): value is Record<PropertyKey, unkn
   return proto === Object.prototype || !proto || !proto.constructor
 }
 
+/**
+ * Returns `object[key]` only when it is an own property, so keys like
+ * `toString` do not resolve through the prototype chain.
+ */
+export function getOwn<T extends object>(object: T, key: PropertyKey): T[keyof T] | undefined {
+  return Object.hasOwn(object, key) ? object[key as keyof T] : undefined
+}
+
 export function get(object: unknown, path: readonly PropertyKey[]): unknown {
   let current: unknown = object
 


### PR DESCRIPTION
Error-code lookups like `map[error.code]` resolved codes such as `toString` or `constructor` through `Object.prototype`. In `reconcileORPCError` the resolved prototype method has no `.data` schema, so a crafted wire error was stamped `defined`/`inferable` with its payload never validated. This adds a `getOwn` helper to `@orpc/shared` and uses it at every error-code lookup.

## Fixes

- `reconcileORPCError` no longer promotes prototype-coded errors to defined; they downgrade like any unmapped code.
- RPC and OpenAPI `encodeError` return the default error status for prototype-coded errors instead of an invalid `status: [Function]` response.
- `catchORPCErrorCodes` (Effect) no longer invokes `Object.prototype.toString` as an error handler.
- `SmartCoercionLinkPlugin` no longer probes prototype members when looking up error data schemas.
- `createORPCErrorConstructorMap` constructors treat prototype-named codes as undefined config.

## Testing

- One regression test per changed source file (fails without the guard), plus unit tests for `getOwn`.
- `pnpm lint`, `pnpm type:check`, and affected package tests (182 files, 2070 tests) pass.