### PR TITLE
feat(server)!: default CORS origin to "*" and support async origin options

### DIFF
--- a/apps/content/docs/migrations/from-v1.mdx
+++ b/apps/content/docs/migrations/from-v1.mdx
@@ -718,6 +718,35 @@ const handler = new RPCHandler(router, {
 When serving binary data cross-origin, allow and expose both the `Content-Disposition` and the new `Standard-Server` headers in your CORS configuration. See [Binary Data](/docs/binary-data).
 :::
 
+### CORS allows any origin by default
+
+In v1, `CORSPlugin` reflected the request origin by default. In v2, `CORSHandlerPlugin` defaults `origin` to `*`, which browsers reject for [credentialed requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS#requests_with_credentials). If you rely on `credentials`, restore the v1 behavior or list your allowed origins explicitly. The `origin` and `timingOrigin` functions can now also be async. See [CORS](/docs/plugins/cors).
+
+<CodeGroup>
+
+```ts v2
+const handler = new RPCHandler(router, {
+  plugins: [
+    new CORSHandlerPlugin({
+      origin: origin => origin, // restore the v1 default
+      credentials: true,
+    }),
+  ],
+})
+```
+
+```ts v1
+const handler = new RPCHandler(router, {
+  plugins: [
+    new CORSPlugin({
+      credentials: true,
+    }),
+  ],
+})
+```
+
+</CodeGroup>
+
 ## Client
 
 ### `RPCLink` splits `url` into `origin` and `url`

--- a/apps/content/docs/plugins/cors.mdx
+++ b/apps/content/docs/plugins/cors.mdx
@@ -16,7 +16,7 @@ import { CORSHandlerPlugin } from '@orpc/server/plugins'
 const handler = new RPCHandler(router, {
   plugins: [
     new CORSHandlerPlugin({
-      origin: (origin, options) => origin,
+      origin: ['https://app.example.com', 'https://admin.example.com'],
       allowMethods: ['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH', 'QUERY'],
       // ...
     }),
@@ -27,6 +27,27 @@ const handler = new RPCHandler(router, {
 :::info
 The `handler` can be any supported oRPC handler, such as [RPCHandler](/docs/rpc/handler), [OpenAPIHandler](/docs/openapi/handler), or a custom one.
 :::
+
+:::warning
+By default, `origin` is `*`, which allows any origin. The wildcard is rejected by browsers for [credentialed requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS#requests_with_credentials), so list your allowed origins explicitly when you enable `credentials`.
+:::
+
+## Dynamic Origin
+
+The `origin` and `timingOrigin` options also accept a function (optionally async) that receives the request origin and the interceptor options, including the [handler context](/docs/context). This lets you resolve the allowed origin per request:
+
+```ts
+const handler = new RPCHandler(router, {
+  plugins: [
+    new CORSHandlerPlugin({
+      origin: async (origin, { context }) => {
+        const tenant = await context.getTenant()
+        return tenant ? origin : null
+      },
+    }),
+  ],
+})
+```
 
 :::warning
 To better support `Blob`, `File`, and `ReadableStream<Uint8Array>` at the root level in cross-origin scenarios,

--- a/apps/content/docs/plugins/cors.mdx
+++ b/apps/content/docs/plugins/cors.mdx
@@ -40,10 +40,7 @@ The `origin` and `timingOrigin` options also accept a function (optionally async
 const handler = new RPCHandler(router, {
   plugins: [
     new CORSHandlerPlugin({
-      origin: async (origin, { context }) => {
-        const tenant = await context.getTenant()
-        return tenant ? origin : null
-      },
+      origin: async (origin, { context }) => await context.tenant ? origin : null,
     }),
   ],
 })

--- a/apps/content/docs/plugins/cors.mdx
+++ b/apps/content/docs/plugins/cors.mdx
@@ -40,7 +40,7 @@ The `origin` and `timingOrigin` options also accept a function (optionally async
 const handler = new RPCHandler(router, {
   plugins: [
     new CORSHandlerPlugin({
-      origin: async (origin, { context }) => await context.tenant ? origin : null,
+      origin: async (origin, { context }) => context.tenant ? origin : null,
     }),
   ],
 })

--- a/packages/server/src/plugins/cors.test.ts
+++ b/packages/server/src/plugins/cors.test.ts
@@ -26,8 +26,8 @@ describe('corsHandlerPlugin', () => {
 
     expect(handlerFn).toHaveBeenCalledTimes(0)
     expect(response!.status).toBe(204)
-    expect(response!.headers.get('access-control-allow-origin')).toBe('https://example.com')
-    expect(response!.headers.get('vary')).toBe('Origin')
+    expect(response!.headers.get('access-control-allow-origin')).toBe('*')
+    expect(response!.headers.get('vary')).toBeNull()
     expect(response!.headers.get('access-control-allow-methods')).toBe('GET, HEAD, PUT, POST, DELETE, PATCH, QUERY')
     expect(response!.headers.get('access-control-max-age')).toBeNull()
   })
@@ -232,9 +232,9 @@ describe('corsHandlerPlugin', () => {
     expect(response!.headers.get('access-control-allow-headers')).toBe('X-Requested-With, Content-Type')
   })
 
-  it('does not set access-control-allow-origin when request has no origin header', async () => {
+  it('does not set access-control-allow-origin when reflecting and request has no origin header', async () => {
     const handler = new RPCHandler(router, {
-      plugins: [new CORSHandlerPlugin()],
+      plugins: [new CORSHandlerPlugin({ origin: origin => origin })],
     })
 
     const { response } = await handler.handle(new Request('https://example.com/ping', {
@@ -245,14 +245,62 @@ describe('corsHandlerPlugin', () => {
       body: JSON.stringify({ json: null }),
     }))
 
-    // the default origin function receives undefined, so there is no origin to reflect
+    // the reflect origin function receives undefined, so there is no origin to reflect
     expect(response!.headers.get('access-control-allow-origin')).toBeNull()
     expect(response!.headers.get('vary')).toBe('Origin')
   })
 
+  it('supports an async origin function resolved per request', async () => {
+    const plugin = new CORSHandlerPlugin({
+      origin: async origin => origin === 'https://allowed.com' ? origin : null,
+    })
+    const handler = new RPCHandler(router, {
+      plugins: [plugin],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/ping', {
+      method: 'POST',
+      headers: {
+        'origin': 'https://allowed.com',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ json: null }),
+    }))
+    expect(response!.headers.get('access-control-allow-origin')).toBe('https://allowed.com')
+
+    const { response: response2 } = await handler.handle(new Request('https://example.com/ping', {
+      method: 'POST',
+      headers: {
+        'origin': 'https://disallowed.com',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ json: null }),
+    }))
+    expect(response2!.headers.get('access-control-allow-origin')).toBeNull()
+  })
+
+  it('supports an async timingOrigin function resolved per request', async () => {
+    const plugin = new CORSHandlerPlugin({
+      timingOrigin: async origin => origin === 'https://timing.com' ? origin : null,
+    })
+    const handler = new RPCHandler(router, {
+      plugins: [plugin],
+    })
+
+    const { response } = await handler.handle(new Request('https://example.com/ping', {
+      method: 'POST',
+      headers: {
+        'origin': 'https://timing.com',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({ json: null }),
+    }))
+    expect(response!.headers.get('timing-allow-origin')).toBe('https://timing.com')
+  })
+
   it('does not copy Vary from the request', async () => {
     const handler = new RPCHandler(router, {
-      plugins: [new CORSHandlerPlugin()],
+      plugins: [new CORSHandlerPlugin({ origin: origin => origin })],
     })
 
     const { response } = await handler.handle(new Request('https://example.com', {
@@ -297,7 +345,7 @@ describe('corsHandlerPlugin', () => {
             }
           },
         },
-        new CORSHandlerPlugin(),
+        new CORSHandlerPlugin({ origin: origin => origin }),
       ],
     })
 
@@ -343,7 +391,7 @@ describe('corsHandlerPlugin', () => {
             }
           },
         },
-        new CORSHandlerPlugin(),
+        new CORSHandlerPlugin({ origin: origin => origin }),
       ],
     })
 

--- a/packages/server/src/plugins/cors.ts
+++ b/packages/server/src/plugins/cors.ts
@@ -1,4 +1,4 @@
-import type { Value } from '@orpc/shared'
+import type { Promisable, Value } from '@orpc/shared'
 import type { StandardHeaders } from '@standardserver/core'
 import type { StandardHandlerOptions, StandardHandlerPlugin, StandardHandlerRoutingInterceptor, StandardHandlerRoutingInterceptorOptions } from '../adapters/standard'
 import type { Context } from '../context'
@@ -8,19 +8,19 @@ import { flattenStandardHeader } from '@standardserver/core'
 export interface CORSHandlerPluginOptions<T extends Context> {
   /**
    * Configures the `Access-Control-Allow-Origin` header.
-   * Can be a string, an array of allowed origins, or a function that returns the allowed origin(s).
+   * Can be a string, an array of allowed origins, or a function (optionally async) that returns the allowed origin(s).
    *
-   * @default (origin) => origin
+   * @default '*'
    */
-  origin?: Value<string | readonly string[] | null | undefined, [origin: string | undefined, options: StandardHandlerRoutingInterceptorOptions<T>]>
+  origin?: Value<Promisable<string | readonly string[] | null | undefined>, [origin: string | undefined, options: StandardHandlerRoutingInterceptorOptions<T>]>
 
   /**
    * Configures the `Timing-Allow-Origin` header.
-   * Can be a string, an array of allowed origins, or a function that returns the allowed origin(s).
+   * Can be a string, an array of allowed origins, or a function (optionally async) that returns the allowed origin(s).
    *
    * @default undefined
    */
-  timingOrigin?: Value<string | readonly string[] | null | undefined, [origin: string | undefined, options: StandardHandlerRoutingInterceptorOptions<T>]>
+  timingOrigin?: Value<Promisable<string | readonly string[] | null | undefined>, [origin: string | undefined, options: StandardHandlerRoutingInterceptorOptions<T>]>
 
   /**
    * Configures the `Access-Control-Allow-Methods` header for preflight requests.
@@ -79,7 +79,7 @@ export class CORSHandlerPlugin<T extends Context> implements StandardHandlerPlug
 
   constructor(options: CORSHandlerPluginOptions<T> = {}) {
     const defaults: CORSHandlerPluginOptions<T> = {
-      origin: origin => origin,
+      origin: '*',
       allowMethods: ['GET', 'HEAD', 'PUT', 'POST', 'DELETE', 'PATCH', 'QUERY'],
     }
 
@@ -101,7 +101,7 @@ export class CORSHandlerPlugin<T extends Context> implements StandardHandlerPlug
 
       const origin = flattenStandardHeader(interceptorOptions.request.headers.origin)
 
-      const allowedOrigins = toArray(value(this.options.origin, origin, interceptorOptions))
+      const allowedOrigins = toArray(await value(this.options.origin, origin, interceptorOptions))
 
       if (allowedOrigins.includes('*')) {
         resHeaders['access-control-allow-origin'] = '*'
@@ -117,7 +117,7 @@ export class CORSHandlerPlugin<T extends Context> implements StandardHandlerPlug
         }
       }
 
-      const allowedTimingOrigins = toArray(value(this.options.timingOrigin, origin, interceptorOptions))
+      const allowedTimingOrigins = toArray(await value(this.options.timingOrigin, origin, interceptorOptions))
 
       if (allowedTimingOrigins.includes('*')) {
         resHeaders['timing-allow-origin'] = '*'

--- a/packages/server/src/plugins/cors.ts
+++ b/packages/server/src/plugins/cors.ts
@@ -17,8 +17,6 @@ export interface CORSHandlerPluginOptions<T extends Context> {
   /**
    * Configures the `Timing-Allow-Origin` header.
    * Can be a string, an array of allowed origins, or a function (optionally async) that returns the allowed origin(s).
-   *
-   * @default undefined
    */
   timingOrigin?: Value<Promisable<string | readonly string[] | null | undefined>, [origin: string | undefined, options: StandardHandlerRoutingInterceptorOptions<T>]>
 
@@ -32,29 +30,21 @@ export interface CORSHandlerPluginOptions<T extends Context> {
   /**
    * Configures the `Access-Control-Allow-Headers` header for preflight requests.
    * Falls back to the request's `Access-Control-Request-Headers` if not set.
-   *
-   * @default undefined
    */
   allowHeaders?: readonly string[]
 
   /**
    * Configures the `Access-Control-Max-Age` header (in seconds) for preflight requests.
-   *
-   * @default undefined
    */
   maxAge?: number
 
   /**
    * Configures the `Access-Control-Allow-Credentials` header.
-   *
-   * @default undefined
    */
   credentials?: boolean
 
   /**
    * Configures the `Access-Control-Expose-Headers` header.
-   *
-   * @default undefined
    */
   exposeHeaders?: readonly string[]
 }


### PR DESCRIPTION
CORSHandlerPlugin now defaults `origin` to `*` instead of reflecting the request origin, and the `origin` and `timingOrigin` options accept async functions so the allowed origin can be resolved per request from the handler context.

## Breaking

- The default response now carries `Access-Control-Allow-Origin: *` with no `Vary: Origin` header; setups relying on `credentials` must configure `origin` explicitly (e.g. `origin: origin => origin` restores the v1 behavior). Documented in the v1 migration guide.

## Docs

- CORS plugin page shows an explicit allowlist in the basic example, warns that the `*` default is rejected by browsers for credentialed requests, and adds a Dynamic Origin section with an async `origin` resolved from context.

## Testing

- Default-behavior expectations updated, async `origin`/`timingOrigin` covered by new tests; full server suite (505 tests), type check, lint, and docs validation pass.