### PR TITLE
chore(content): darken the dark theme to Zed's editor ground

### DIFF
--- a/apps/content/blume.config.ts
+++ b/apps/content/blume.config.ts
@@ -29,8 +29,9 @@ export default defineConfig({
     // Light mode darkens it so white accent text keeps AA contrast; dark
     // mode uses the true brand pink (its text flips dark in theme.css).
     accent: { light: 'oklch(0.58 0.19 359)', dark: '#ff6ca5' },
-    // Zed One Dark editor background; the rest of the palette lives in theme.css.
-    background: { dark: '#282c33' },
+    // Zed's dark editor/content ground (#282c33 is only its sidebar color);
+    // the rest of the palette lives in theme.css.
+    background: { dark: '#0d1016' },
     fonts: {
       display: 'inter',
       body: 'inter',

--- a/apps/content/sponsors/ads.ts
+++ b/apps/content/sponsors/ads.ts
@@ -25,7 +25,7 @@ export interface AdSponsor {
   /**
    * Optional brand tint behind the card. Both modes are required together so a
    * sponsor never ships a colour that only works in one theme. Aim for the
-   * lightness of Blume's muted surface (#f6f6f7 light, #2f343e dark) carrying
+   * lightness of Blume's muted surface (#f6f6f7 light, #1a202a dark) carrying
    * a hint of the brand hue — roughly the brand mixed 6% into the page in
    * light mode and 10% in dark — so the card reads as a surface rather than a
    * banner and --blume-muted-foreground still clears AA on top. Omit for none.

--- a/apps/content/theme.css
+++ b/apps/content/theme.css
@@ -24,7 +24,7 @@
 }
 
 :root[data-theme='dark'] {
-  /* Palette — dark (Zed One Dark values; page background lives in
+  /* Palette — dark (Zed-style; the #0d1016 page background lives in
      blume.config.ts `theme`). Surfaces sit above the page, code blocks
      recess below it like Zed's editor pane. */
   --blume-foreground: #dce0e5;
@@ -32,10 +32,10 @@
      light brand pink (#ff6ca5), where white text fails contrast (2.6:1).
      Flip the text dark instead (7.5:1). */
   --blume-accent-foreground: oklch(0.145 0 0);
-  --blume-muted: #2f343e;
+  --blume-muted: #1a202a;
   --blume-muted-foreground: #a9afbc;
-  --blume-border: #363c46;
-  --blume-code-background: #21252b;
+  --blume-border: #2a303c;
+  --blume-code-background: #0a0d12;
 }
 
 /* ---------------------------------------------------------------- */


### PR DESCRIPTION
The docs dark theme read too bright: its page background borrowed #282c33, which in Zed is the sidebar/panel color, not the editor ground the theme was meant to mirror (community feedback on Discord, with #0d1016 as Zed's actual content/code color). The dark palette is now rebased on #0d1016.

## Changes

- Page/content background is #0d1016; the sidebar shares it, keeping the site uniform.
- The rest of the palette keeps its layering on the darker ground: muted surfaces sit above the page (#1a202a), borders #2a303c, and code blocks still recess below it (#0a0d12).
- Text colors are unchanged; contrast only improves on the darker background.

## Testing

- Verified on the dev server in dark mode via computed styles: docs pages and the landing page (showcase frame, tab bar, install pill, search box) all pick up the new steps, with no console errors.