### PR TITLE
chore(content): deepen the dark theme to a near-black canvas

### DIFF
--- a/apps/content/blume.config.ts
+++ b/apps/content/blume.config.ts
@@ -29,8 +29,10 @@ export default defineConfig({
     // Light mode darkens it so white accent text keeps AA contrast; dark
     // mode uses the true brand pink (its text flips dark in theme.css).
     accent: { light: 'oklch(0.58 0.19 359)', dark: '#ff6ca5' },
-    // Zed One Dark editor background; the rest of the palette lives in theme.css.
-    background: { dark: '#282c33' },
+    // Deep near-black canvas (tanstack.com-style layering; a whisper of blue so
+    // the github-dark Shiki palette and the brand pink sit naturally on it).
+    // The rest of the dark palette lives in theme.css.
+    background: { dark: '#111114' },
     fonts: {
       display: 'inter',
       body: 'inter',

--- a/apps/content/sponsors/ads.ts
+++ b/apps/content/sponsors/ads.ts
@@ -25,7 +25,7 @@ export interface AdSponsor {
   /**
    * Optional brand tint behind the card. Both modes are required together so a
    * sponsor never ships a colour that only works in one theme. Aim for the
-   * lightness of Blume's muted surface (#f6f6f7 light, #2f343e dark) carrying
+   * lightness of Blume's muted surface (#f6f6f7 light, #1e2026 dark) carrying
    * a hint of the brand hue — roughly the brand mixed 6% into the page in
    * light mode and 10% in dark — so the card reads as a surface rather than a
    * banner and --blume-muted-foreground still clears AA on top. Omit for none.

--- a/apps/content/theme.css
+++ b/apps/content/theme.css
@@ -24,18 +24,20 @@
 }
 
 :root[data-theme='dark'] {
-  /* Palette — dark (Zed One Dark values; page background lives in
-     blume.config.ts `theme`). Surfaces sit above the page, code blocks
-     recess below it like Zed's editor pane. */
-  --blume-foreground: #dce0e5;
+  /* Palette — dark (tanstack.com-style layering; page background lives in
+     blume.config.ts `theme`). A near-black canvas with low-contrast borders:
+     hover fills and the search box sit just above the page, code blocks
+     recess just below it, close to github-dark's native ground so the Shiki
+     tokens read as designed. */
+  --blume-foreground: #e3e5ea;
   /* Blume forces white accent text in dark mode; our accent there is the
      light brand pink (#ff6ca5), where white text fails contrast (2.6:1).
      Flip the text dark instead (7.5:1). */
   --blume-accent-foreground: oklch(0.145 0 0);
-  --blume-muted: #2f343e;
-  --blume-muted-foreground: #a9afbc;
-  --blume-border: #363c46;
-  --blume-code-background: #21252b;
+  --blume-muted: #1e2026;
+  --blume-muted-foreground: #9da3ae;
+  --blume-border: #26282f;
+  --blume-code-background: #0c0d10;
 }
 
 /* ---------------------------------------------------------------- */
@@ -137,6 +139,13 @@
 .prose :where(h3) {
   font-weight: 600;
   letter-spacing: -0.0125em;
+}
+
+/* On the near-black canvas the headings step up to near-white while body
+   text stays on the softer foreground, so the hierarchy reads at a glance
+   (the tanstack.com pattern). Light mode keeps one ink for both. */
+:root[data-theme='dark'] .prose :where(h1, h2, h3, h4) {
+  color: #f6f7f9;
 }
 
 /* Filled code blocks like the reference (not Blume's outline style) */


### PR DESCRIPTION
The docs site's dark theme moves from the Zed One Dark gray-blue canvas to a deep near-black one with quieter borders and near-white headings, the surface layering tanstack.com's docs use. The palette was derived from TanStack's live design tokens and tuned so the brand pink and the existing github-dark Shiki palette sit on a ground they were designed for.

## Changes

- Page background goes from `#282c33` to `#111114`; foreground, muted surface, and border tokens follow, and code blocks recess to `#0c0d10`, close to github-dark's native ground.
- Headings step up to near-white in dark mode while body text stays on the softer foreground, so the hierarchy reads at a glance. Light mode is untouched.
- The sponsor-tint guidance comment now names the new dark muted value.

## Testing

- Verified against the running dev server in both themes: docs pages, a code-heavy page (RPC Link, including the warning callout with nested code), and the landing page (hero, showcase tabs, feature grid, stats).
- Light mode confirmed unchanged; eslint passes on the changed files.