### PR TITLE
fix(evlog): do not log ErrorEvent from event stream response bodies

### DIFF
--- a/packages/evlog/src/handler-plugin.test.ts
+++ b/packages/evlog/src/handler-plugin.test.ts
@@ -1,5 +1,6 @@
-import { ORPCError } from '@orpc/client'
+import { ORPCError, RPCSerializer } from '@orpc/client'
 import { AbortError, ORPC_NAME, sleep } from '@orpc/shared'
+import { ErrorEvent } from '@standardserver/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { LOGGER_CONTEXT_SYMBOL } from './context'
 import { EvlogHandlerPlugin } from './handler-plugin'
@@ -297,6 +298,32 @@ describe('evlogHandlerPlugin', () => {
     expect(logger.error).toHaveBeenCalledWith('iterator-failure')
     expect(finish).toHaveBeenCalledWith({ status: 200 })
     expect(logger.error).toHaveBeenCalledBefore(finish)
+  })
+
+  it('does not log ErrorEvent from response body iterators', async () => {
+    const plugin = new EvlogHandlerPlugin()
+    const { routing } = getPluginHooks(plugin)
+    const { finish, logger } = mockIntegration()
+
+    async function* source() {
+      throw new ORPCError('UNAUTHORIZED')
+    }
+
+    const result = await routing({
+      next: vi.fn().mockResolvedValue({
+        matched: true,
+        response: {
+          status: 200,
+          body: new RPCSerializer().serialize(source()),
+        },
+      }),
+      context: {},
+      request: createRequest('/iterable-error-event'),
+    })
+
+    await expect(collectIterator(result.response.body as AsyncIterable<unknown>)).rejects.toBeInstanceOf(ErrorEvent)
+    expect(logger.error).not.toHaveBeenCalled()
+    expect(finish).toHaveBeenCalledWith({ status: 200 })
   })
 
   it('wraps matched readable streams and finishes after they close', async () => {

--- a/packages/evlog/src/handler-plugin.ts
+++ b/packages/evlog/src/handler-plugin.ts
@@ -5,7 +5,7 @@ import type { RequestLogger } from 'evlog'
 import type { BaseEvlogOptions, FrameworkIntegrationHelpers, FrameworkIntegrationSpec } from 'evlog/toolkit'
 import { ORPCError, wrapAsyncIteratorPreservingEventMeta } from '@orpc/client'
 import { isAbortError, isAsyncIteratorObject, ORPC_NAME, override, sleep, toArray, wrapReadableStream } from '@orpc/shared'
-import { flattenStandardHeader, parseStandardUrl } from '@standardserver/core'
+import { ErrorEvent, flattenStandardHeader, parseStandardUrl } from '@standardserver/core'
 import { defineFrameworkIntegration } from 'evlog/toolkit'
 import { getLogger, LOGGER_CONTEXT_SYMBOL } from './context'
 
@@ -99,10 +99,13 @@ export class EvlogHandlerPlugin<T extends Context> implements StandardHandlerPlu
                   runWith,
                   onError: (error) => {
                     /**
-                     * Any error here is internal (interceptor/framework), not business logic.
-                     * Indicates unexpected handler failure.
+                     * Errors here are internal (interceptor/framework) failures,
+                     * except `ErrorEvent`: a business error the protocol delivers
+                     * inside the event stream, already logged by the client interceptor.
                      */
-                    logger.error(toErrorOrString(error))
+                    if (!(error instanceof ErrorEvent)) {
+                      logger.error(toErrorOrString(error))
+                    }
                   },
                   onFinish: async () => {
                     await sleep(0) // dealing with "log.error() called after the wide event was emitted"


### PR DESCRIPTION
Business errors thrown from event iterator procedures were logged twice by `EvlogHandlerPlugin`: once correctly by the client interceptor, and again at error level by the routing interceptor's response body wrapper, because the codec encodes them as `ErrorEvent` for the wire and the wrapper treated every body error as an internal failure.

### Fixes

- Streamed business errors no longer produce a spurious internal-failure log at error level; the client interceptor's log (warn for `ORPCError`, info for aborts) is now the only record.
- Genuine internal failures while streaming, `ReadableStream` body errors, and all pre-codec error paths are logged exactly as before.

### Testing

- New test throws `ORPCError` from an event iterator, encodes it through the real `RPCSerializer`, and asserts nothing is logged while the wide event still finishes with the response status.