### PR TITLE
fix(nest): honor routed request during input decoding

### DIFF
--- a/packages/nest/src/implement.test.ts
+++ b/packages/nest/src/implement.test.ts
@@ -114,50 +114,6 @@ describe('requirements', () => {
   })
 })
 
-describe('request limit plugin', () => {
-  const contract = oc
-    .meta(openapi({ method: 'POST', path: '/request-limit' }))
-    .input(z.object({ value: z.string() }))
-
-  @Controller()
-  class ImplController {
-    @Implement(contract)
-    requestLimit() {
-      return implement(contract).handler(({ input }) => input.value)
-    }
-  }
-
-  describe.each([
-    ['express adapter', undefined],
-    ['fastify adapter', new FastifyAdapter()],
-  ] as const)('with %s', async (_, adapter) => {
-    const moduleRef = await Test.createTestingModule({
-      controllers: [ImplController],
-      imports: [
-        ORPCModule.forRoot({
-          plugins: [new RequestLimitHandlerPlugin({ maxBodySize: 10 })],
-        }),
-      ],
-    }).compile()
-
-    const app = moduleRef.createNestApplication(adapter as any)
-    await app.init()
-
-    if (adapter) {
-      await app.getHttpAdapter().getInstance().ready()
-    }
-
-    it('rejects a request whose content length exceeds the limit', async () => {
-      const res = await supertest(app.getHttpServer())
-        .post('/request-limit')
-        .send({ value: 'over limit' })
-
-      expect(res.statusCode).toEqual(413)
-      expect(res.body).toMatchObject({ code: 'PAYLOAD_TOO_LARGE' })
-    })
-  })
-})
-
 describe('routing', () => {
   const contract = {
     staticPath: oc.meta(openapi({
@@ -1517,5 +1473,49 @@ describe('compatibility', () => {
     expect(res.headers['x-input-cookie']).toBe('test')
 
     await app.close()
+  })
+
+  describe('handler plugins from ORPCModule take effect during input decoding', () => {
+    const contract = oc
+      .meta(openapi({ method: 'POST', path: '/request-limit' }))
+      .input(z.object({ value: z.string() }))
+
+    @Controller()
+    class ImplController {
+      @Implement(contract)
+      requestLimit() {
+        return implement(contract).handler(({ input }) => input.value)
+      }
+    }
+
+    describe.each([
+      ['express adapter', undefined],
+      ['fastify adapter', new FastifyAdapter()],
+    ] as const)('with %s', async (_, adapter) => {
+      const moduleRef = await Test.createTestingModule({
+        controllers: [ImplController],
+        imports: [
+          ORPCModule.forRoot({
+            plugins: [new RequestLimitHandlerPlugin({ maxBodySize: 10 })],
+          }),
+        ],
+      }).compile()
+
+      const app = moduleRef.createNestApplication(adapter as any)
+      await app.init()
+
+      if (adapter) {
+        await app.getHttpAdapter().getInstance().ready()
+      }
+
+      it('rejects a request whose content length exceeds the limit', async () => {
+        const res = await supertest(app.getHttpServer())
+          .post('/request-limit')
+          .send({ value: 'over limit' })
+
+        expect(res.statusCode).toEqual(413)
+        expect(res.body).toMatchObject({ code: 'PAYLOAD_TOO_LARGE' })
+      })
+    })
   })
 })

--- a/packages/nest/src/implement.test.ts
+++ b/packages/nest/src/implement.test.ts
@@ -11,6 +11,7 @@ import { Test } from '@nestjs/testing'
 import { meta, oc } from '@orpc/contract'
 import { openapi } from '@orpc/openapi'
 import { implement, ORPCError, os, Procedure } from '@orpc/server'
+import { RequestLimitHandlerPlugin } from '@orpc/server/plugins'
 import { getOrBind } from '@orpc/shared'
 import { catchError, tap } from 'rxjs'
 import supertest from 'supertest'
@@ -110,6 +111,50 @@ describe('requirements', () => {
     routingInterceptor.mockResolvedValueOnce({ matched: false })
     const res = await supertest(app.getHttpServer()).post('/procedure')
     expect(res.status).toBe(500)
+  })
+})
+
+describe('request limit plugin', () => {
+  const contract = oc
+    .meta(openapi({ method: 'POST', path: '/request-limit' }))
+    .input(z.object({ value: z.string() }))
+
+  @Controller()
+  class ImplController {
+    @Implement(contract)
+    requestLimit() {
+      return implement(contract).handler(({ input }) => input.value)
+    }
+  }
+
+  describe.each([
+    ['express adapter', undefined],
+    ['fastify adapter', new FastifyAdapter()],
+  ] as const)('with %s', async (_, adapter) => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [ImplController],
+      imports: [
+        ORPCModule.forRoot({
+          plugins: [new RequestLimitHandlerPlugin({ maxBodySize: 10 })],
+        }),
+      ],
+    }).compile()
+
+    const app = moduleRef.createNestApplication(adapter as any)
+    await app.init()
+
+    if (adapter) {
+      await app.getHttpAdapter().getInstance().ready()
+    }
+
+    it('rejects a request whose content length exceeds the limit', async () => {
+      const res = await supertest(app.getHttpServer())
+        .post('/request-limit')
+        .send({ value: 'over limit' })
+
+      expect(res.statusCode).toEqual(413)
+      expect(res.body).toMatchObject({ code: 'PAYLOAD_TOO_LARGE' })
+    })
   })
 })
 

--- a/packages/nest/src/implement.ts
+++ b/packages/nest/src/implement.ts
@@ -194,13 +194,13 @@ export class ImplementInterceptor implements NestInterceptor {
         const standardRequest = this.toNestStandardLazyRequest(req, res)
 
         const handler = new StandardHandler({
-          resolveProcedure: () => Promise.resolve({
+          resolveProcedure: request => Promise.resolve({
             path: getPathMeta(procedure) ?? [],
             procedure,
             decodeInput: () => this.codec.decodeInput({
               procedure,
               params: toORPCOpenAPIParams(procedure, standardRequest.params),
-            }, standardRequest),
+            }, request),
           }),
           encodeError: this.codec.encodeError.bind(this.codec),
           encodeOutput: this.codec.encodeOutput.bind(this.codec),


### PR DESCRIPTION
`ImplementInterceptor` currently decodes procedure input from the initial `standardRequest`, even when a routing interceptor passes a replacement request to `StandardHandler`. This prevents request wrappers such as `RequestLimitHandlerPlugin` from taking effect during Nest input decoding.

## Fixes

- Decode procedure input from the request passed to `resolveProcedure` after routing interceptors have run.
- Restore `RequestLimitHandlerPlugin` enforcement for `@orpc/nest` without changing the public API.
- Keep the existing Nest route parameter extraction behavior unchanged.

## Testing

- Added an integration regression test for both Express and Fastify adapters.
- Before the fix, both cases returned `200` for a request above the configured limit.
- After the fix, both cases return `413 PAYLOAD_TOO_LARGE`.
- `pnpm exec vitest run packages/nest/src/implement.test.ts` — 90 tests passed.
- `pnpm lint`
- `pnpm type:check`
- `pnpm docs:validate`

Fixes #1921
