### PR TITLE
fix(json-schema): keep sibling union branches that share a $defs entry

### DIFF
--- a/packages/json-schema/src/composition-utils.test.ts
+++ b/packages/json-schema/src/composition-utils.test.ts
@@ -839,6 +839,38 @@ describe('flattenJsonUnionSchema', () => {
     ])
   })
 
+  it('flattens every sibling branch that references the same $defs entry', () => {
+    const schema = {
+      $defs: { Shared: { type: 'string' } },
+      anyOf: [
+        { $ref: '#/$defs/Shared', minLength: 2 },
+        { $ref: '#/$defs/Shared', maxLength: 5 },
+      ],
+    } satisfies JsonSchema
+
+    expect(flattenJsonUnionSchema(schema)).toEqual([
+      { $defs: schema.$defs, $ref: '#/$defs/Shared', minLength: 2 },
+      { $defs: schema.$defs, $ref: '#/$defs/Shared', maxLength: 5 },
+    ])
+  })
+
+  it('flattens every sibling branch that references the same union $defs entry', () => {
+    const schema = {
+      $defs: { Shared: { anyOf: [{ type: 'number' }, { type: 'boolean' }] } },
+      anyOf: [
+        { $ref: '#/$defs/Shared', description: 'first' },
+        { $ref: '#/$defs/Shared', description: 'second' },
+      ],
+    } satisfies JsonSchema
+
+    expect(flattenJsonUnionSchema(schema)).toEqual([
+      { $defs: schema.$defs, description: 'first', type: 'number' },
+      { $defs: schema.$defs, description: 'first', type: 'boolean' },
+      { $defs: schema.$defs, description: 'second', type: 'number' },
+      { $defs: schema.$defs, description: 'second', type: 'boolean' },
+    ])
+  })
+
   it('flattens transitive local $ref union branches', () => {
     const schema = {
       $defs: {
@@ -879,6 +911,23 @@ describe('flattenJsonUnionSchema', () => {
       { $defs: schema.$defs, type: 'number' },
       { $defs: schema.$defs, type: 'boolean' },
       { $defs: schema.$defs, type: 'string' },
+    ])
+  })
+
+  it('flattening mutually recursive union $ref branches', () => {
+    const schema = {
+      $defs: {
+        A: { anyOf: [{ $ref: '#/$defs/B' }, { type: 'string' }] },
+        B: { anyOf: [{ $ref: '#/$defs/A' }, { type: 'number' }] },
+      },
+      anyOf: [{ $ref: '#/$defs/A' }, { $ref: '#/$defs/B' }],
+    } satisfies JsonSchema
+
+    expect(flattenJsonUnionSchema(schema)).toEqual([
+      { $defs: schema.$defs, $ref: '#/$defs/B' },
+      { $defs: schema.$defs, type: 'string' },
+      { $defs: schema.$defs, $ref: '#/$defs/A' },
+      { $defs: schema.$defs, type: 'number' },
     ])
   })
 

--- a/packages/json-schema/src/composition-utils.ts
+++ b/packages/json-schema/src/composition-utils.ts
@@ -380,7 +380,7 @@ function flattenJsonUnionSchemaInternal(
     const resolved = resolveJsonSchemaRootLocalRef(schema)
 
     if (resolved !== schema) {
-      const result = flattenJsonUnionSchemaInternal(resolved, resolvingRefs.add(schema.$ref))
+      const result = flattenJsonUnionSchemaInternal(resolved, new Set(resolvingRefs).add(schema.$ref))
       if (result.length > 1) {
         return result
       }


### PR DESCRIPTION
Sibling `anyOf`/`oneOf` branches that reference the same `$defs` entry no longer collapse into one when a union is flattened. `flattenJsonUnionSchemaInternal` tracked in-progress `$ref`s in a Set it mutated in place, and since `Set.prototype.add` returns the same set, a `$ref` being resolved leaked out of its own recursion path and persisted into later sibling branches. Any branch pointing at an entry an earlier sibling had already touched hit the cycle guard and was silently dropped.

Copying the set per recursion path scopes the guard to the path actually being walked, matching what the sibling function `extractJsonObjectSchemaEntriesInternal` already does.

## Fixes

The reported case now keeps both branches with their own keywords instead of returning only the first:

```ts
flattenJsonUnionSchema({
  $defs: { Shared: { type: 'string' } },
  anyOf: [
    { $ref: '#/$defs/Shared', minLength: 2 },
    { $ref: '#/$defs/Shared', maxLength: 5 },
  ],
})
```

Downstream, OpenAPI documents generated from unions whose members share a `$ref` no longer lose members: detailed output schemas keep every response status, and request/response bodies keep every variant. Cycle detection stays intact and still terminates, including on mutually recursive `$defs`.

## Performance

The in-place mutation was acting as accidental global memoization, so flattening is now exponential in union nesting depth in the worst case. This only bites on shapes far outside normal contracts, because flattening recurses through `anyOf`/`oneOf` and top-level `$ref` only, never into `properties` or `items`. A union nested 7 deep with 3 branches per level measures ~20 ms; a synthetic depth-20 chain of unions-of-unions takes seconds. Generation happens at build/startup on developer-authored schemas, and the previous cost was paid in silently wrong output, so the trade seemed worth making rather than keeping a faster incorrect traversal.

Worth noting for anyone who revisits this: a memo would have to be keyed on the resolved definition *plus* the path-relevant ref set. Keying on schema identity alone would collapse legitimately distinct branches and reintroduce exactly this bug.

## Testing

Three regression tests, each confirmed to fail before the change and pass after: the reported repro, a shared `$defs` entry that is itself a union (2 branches to 4), and mutual `A` to `B` recursion, which also pins that cycle detection stays path-scoped and terminating.

Full suite (3251 tests), `pnpm type:check` and `pnpm lint` pass.

Closes #1926
