### PR TITLE
feat(pino): allow customizing error logging

### DIFF
--- a/apps/content/docs/integrations/pino.md
+++ b/apps/content/docs/integrations/pino.md
@@ -52,6 +52,7 @@ const handler = new RPCHandler(router, {
     new LoggingHandlerPlugin({
       logger, // Custom logger instance
       generateId: ({ request }) => crypto.randomUUID(), // Custom ID generator
+      logError: (logger, error) => logger.warn(error), // Custom error level or payload
       logRequestResponse: true, // Log request start/end (disabled by default)
       logRequestAbort: true, // Log when requests are aborted (disabled by default)
     }),
@@ -62,6 +63,10 @@ const handler = new RPCHandler(router, {
 ::: info
 The `handler` can be any supported oRPC handler, such as [RPCHandler](/docs/rpc-handler), [OpenAPIHandler](/docs/openapi/openapi-handler), or another custom handler.
 :::
+
+By default, handler errors are logged with `logger.error(error)`. Use `logError`
+to choose a different level, enrich the payload, or forward the error to another
+destination. Request aborts remain informational and do not invoke `logError`.
 
 ::: tip
 For improved log readability during development, consider using [pino-pretty](https://github.com/pinojs/pino-pretty) to format your logs in a human-friendly way.

--- a/packages/pino/src/handler-plugin.test.ts
+++ b/packages/pino/src/handler-plugin.test.ts
@@ -1,4 +1,5 @@
 import type { StandardLazyRequest } from '@orpc/standard-server'
+import type { Logger } from 'pino'
 import { StandardRPCJsonSerializer, StandardRPCSerializer } from '@orpc/client/standard'
 import { os } from '@orpc/server'
 import { StandardHandler, StandardRPCCodec, StandardRPCMatcher } from '@orpc/server/standard'
@@ -11,6 +12,7 @@ const globalSpies = {
   child: vi.fn(),
   info: vi.fn(),
   error: vi.fn(),
+  warn: vi.fn(),
   setBindings: vi.fn(),
 }
 
@@ -35,6 +37,11 @@ class FakeLogger {
   error(...args: any[]) {
     expect(this.childDeep).toBeGreaterThan(0) // Ensure child logger is used
     globalSpies.error(...args)
+  }
+
+  warn(...args: any[]) {
+    expect(this.childDeep).toBeGreaterThan(0) // Ensure child logger is used
+    globalSpies.warn(...args)
   }
 
   setBindings(bindings: any) {
@@ -161,6 +168,7 @@ describe('loggingHandlerPlugin', () => {
     vi.clearAllMocks()
     const controller = new AbortController()
     const abortError = new Error('abort-reason')
+    const logError = vi.fn()
     controller.abort(abortError)
 
     const handler2 = new StandardHandler(
@@ -172,7 +180,7 @@ describe('loggingHandlerPlugin', () => {
       new StandardRPCMatcher(),
       codec,
       {
-        plugins: [new LoggingHandlerPlugin({ logger: baseLogger as any })],
+        plugins: [new LoggingHandlerPlugin({ logger: baseLogger as any, logError })],
       },
     )
 
@@ -180,6 +188,7 @@ describe('loggingHandlerPlugin', () => {
     const result2 = await handler2.handle(request2, { prefix: undefined, context: {} })
     expect(result2.matched).toBe(true)
     expect(globalSpies.info).toHaveBeenCalledWith(abortError)
+    expect(logError).not.toHaveBeenCalled()
   })
 
   it('logs internal errors', async () => {
@@ -205,6 +214,99 @@ describe('loggingHandlerPlugin', () => {
     // Root interceptor errors are thrown, not encoded in response
     await expect(handler.handle(request, { prefix: undefined, context: {} })).rejects.toThrow(error)
     expect(globalSpies.error).toHaveBeenCalledWith(error)
+  })
+
+  it('customizes internal error logging', async () => {
+    const error = new Error('internal-error')
+    const baseLogger = new FakeLogger({ orpc: {} })
+    const logError = vi.fn((logger: Logger, caught: unknown) => {
+      logger.warn({ caught }, 'custom internal error')
+    })
+    const handler = new StandardHandler(
+      {
+        ping: os.handler(() => 'pong'),
+      },
+      new StandardRPCMatcher(),
+      codec,
+      {
+        plugins: [new LoggingHandlerPlugin({ logger: baseLogger as any, logError })],
+        rootInterceptors: [
+          async () => {
+            throw error
+          },
+        ],
+      },
+    )
+
+    const request = createRequest('GET', 'http://localhost/ping')
+    await expect(handler.handle(request, { prefix: undefined, context: {} })).rejects.toThrow(error)
+
+    expect(logError).toHaveBeenCalledWith(expect.any(FakeLogger), error)
+    expect(globalSpies.warn).toHaveBeenCalledWith({ caught: error }, 'custom internal error')
+    expect(globalSpies.error).not.toHaveBeenCalled()
+  })
+
+  it('customizes business error logging', async () => {
+    const error = new Error('business-error')
+    const baseLogger = new FakeLogger({ orpc: {} })
+    const logError = vi.fn((logger: Logger, caught: unknown) => {
+      logger.warn({ caught }, 'custom business error')
+    })
+    const handler = new StandardHandler(
+      {
+        ping: os.handler(() => {
+          throw error
+        }),
+      },
+      new StandardRPCMatcher(),
+      codec,
+      {
+        plugins: [new LoggingHandlerPlugin({ logger: baseLogger as any, logError })],
+      },
+    )
+
+    const request = createRequest('GET', 'http://localhost/ping')
+    const result = await handler.handle(request, { prefix: undefined, context: {} })
+
+    expect(result.matched).toBe(true)
+    expect(result.response?.status).toBe(500)
+    expect(logError).toHaveBeenCalledWith(expect.any(FakeLogger), error)
+    expect(globalSpies.warn).toHaveBeenCalledWith({ caught: error }, 'custom business error')
+    expect(globalSpies.error).not.toHaveBeenCalled()
+  })
+
+  it('customizes stream error logging', async () => {
+    const error = new Error('stream-error')
+    const baseLogger = new FakeLogger({ orpc: {} })
+    const logError = vi.fn((logger: Logger, caught: unknown) => {
+      logger.warn({ caught }, 'custom stream error')
+    })
+    const handler = new StandardHandler(
+      {
+        ping: os.handler(async function* () {
+          yield 1
+          throw error
+        }),
+      },
+      new StandardRPCMatcher(),
+      codec,
+      {
+        plugins: [new LoggingHandlerPlugin({ logger: baseLogger as any, logError })],
+      },
+    )
+
+    const request = createRequest('GET', 'http://localhost/ping')
+    const result = await handler.handle(request, { prefix: undefined, context: {} })
+
+    try {
+      for await (const _ of result.response?.body as AsyncIterable<unknown>) {
+        // consume the stream
+      }
+    }
+    catch {}
+    expect(logError).toHaveBeenCalledWith(expect.any(FakeLogger), error)
+    expect(globalSpies.warn).toHaveBeenCalledWith({ caught: error }, 'custom stream error')
+    expect(globalSpies.error).not.toHaveBeenCalled()
   })
 
   it('sets path on client interceptor and handles non-stream output', async () => {
@@ -272,6 +374,7 @@ describe('loggingHandlerPlugin', () => {
     vi.clearAllMocks()
     const controller = new AbortController()
     const abortedError = new Error('aborted-stream')
+    const logError = vi.fn()
     controller.abort(abortedError)
 
     const handler2 = new StandardHandler(
@@ -283,7 +386,7 @@ describe('loggingHandlerPlugin', () => {
       new StandardRPCMatcher(),
       codec,
       {
-        plugins: [new LoggingHandlerPlugin({ logger: baseLogger as any })],
+        plugins: [new LoggingHandlerPlugin({ logger: baseLogger as any, logError })],
       },
     )
 
@@ -300,6 +403,7 @@ describe('loggingHandlerPlugin', () => {
     expect(globalSpies.error).toHaveBeenCalledTimes(0)
     expect(globalSpies.info).toHaveBeenCalledTimes(1)
     expect(globalSpies.info).toHaveBeenCalledWith(abortedError)
+    expect(logError).not.toHaveBeenCalled()
   })
 
   describe('edge cases', () => {

--- a/packages/pino/src/handler-plugin.ts
+++ b/packages/pino/src/handler-plugin.ts
@@ -23,6 +23,16 @@ export interface LoggingHandlerPluginOptions<T extends Context> {
   generateId?: (options: StandardHandlerInterceptorOptions<T>) => string
 
   /**
+   * Logs errors raised while handling a request.
+   *
+   * Use this callback to customize the error payload or log level. Abort errors
+   * remain informational and are not passed to this callback.
+   *
+   * @default (logger, error) => logger.error(error)
+   */
+  logError?: (logger: Logger, error: unknown) => void
+
+  /**
    * Enables logging for request/response events.
    *
    * @example
@@ -50,6 +60,7 @@ export interface LoggingHandlerPluginOptions<T extends Context> {
 export class LoggingHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   private readonly logger: Exclude<LoggingHandlerPluginOptions<T>['logger'], undefined>
   private readonly generateId: Exclude<LoggingHandlerPluginOptions<T>['generateId'], undefined>
+  private readonly logError: Exclude<LoggingHandlerPluginOptions<T>['logError'], undefined>
   private readonly logRequestResponse: Exclude<LoggingHandlerPluginOptions<T>['logRequestResponse'], undefined>
   private readonly logRequestAbort: Exclude<LoggingHandlerPluginOptions<T>['logRequestAbort'], undefined>
 
@@ -58,6 +69,7 @@ export class LoggingHandlerPlugin<T extends Context> implements StandardHandlerP
   ) {
     this.logger = options.logger ?? pino()
     this.generateId = options.generateId ?? (() => crypto.randomUUID())
+    this.logError = options.logError ?? ((logger, error) => logger.error(error))
     this.logRequestResponse = options.logRequestResponse ?? false
     this.logRequestAbort = options.logRequestAbort ?? false
   }
@@ -138,7 +150,7 @@ export class LoggingHandlerPlugin<T extends Context> implements StandardHandlerP
          * Any error here is internal (interceptor/framework), not business logic.
          * Indicates unexpected handler failure.
          */
-        logger.error(error)
+        this.logError(logger, error)
         throw error
       }
     })
@@ -156,8 +168,8 @@ export class LoggingHandlerPlugin<T extends Context> implements StandardHandlerP
         if (request.signal?.aborted && request.signal.reason === error) {
           logger?.info(error)
         }
-        else {
-          logger?.error(error)
+        else if (logger) {
+          this.logError(logger, error)
         }
         throw error
       }
@@ -182,8 +194,8 @@ export class LoggingHandlerPlugin<T extends Context> implements StandardHandlerP
               if (signal?.aborted && signal.reason === error) {
                 logger?.info(error)
               }
-              else {
-                logger?.error(error)
+              else if (logger) {
+                this.logError(logger, error)
               }
               return error
             },


### PR DESCRIPTION
## Summary

- add a `logError(logger, error)` option for customizing error payloads and log levels
- apply it consistently to internal, business-logic, and stream failures while preserving `logger.error(error)` as the default
- keep request aborts informational and document the callback semantics

## Testing

- `pnpm vitest run packages/pino/src` (14 passed)
- `pnpm --filter @orpc/experimental-pino type:check`
- `pnpm --filter @orpc/experimental-pino build`
- ESLint on the changed source, tests, and documentation
- `git diff --check`

Fixes #1930