### PR TITLE
feat(openapi): resolve parameter styles dynamically

### DIFF
--- a/apps/content/docs/openapi/input-and-output-mapping.mdx
+++ b/apps/content/docs/openapi/input-and-output-mapping.mdx
@@ -145,6 +145,34 @@ Supported query styles:
 When using delimited styles, do not use delimiter characters like `,`, ` `, or `|` in keys or values. They can make the parameter ambiguous.
 :::
 
+### Dynamic Parameter Style Resolvers
+
+For reusable style rules, `paramsStyles` and `queryStyles` also accept a resolver. The resolver receives the current parameter name and the procedure's complete input schema stack, and returns a style or `undefined` to keep the default behavior.
+
+```ts
+const searchPlanets = os
+  .meta(openapi({
+    method: 'GET',
+    path: '/planets',
+    queryStyles: (name, inputSchemas) => {
+      const usesZod = inputSchemas?.some(
+        schema => schema['~standard'].vendor === 'zod',
+      )
+
+      return usesZod && name.endsWith('Ids')
+        ? 'comma-delimited-array'
+        : undefined
+    },
+  }))
+  .input(z.object({
+    regionIds: z.array(z.string()),
+    q: z.string().optional(),
+  }))
+  .handler(async () => [])
+```
+
+The schema argument is the original `readonly AnySchema[]` stack, in input-definition order, or `undefined` when the procedure has no input schema. oRPC provides the complete stack instead of a field schema because Standard Schema has no vendor-independent way to extract fields, and a procedure can compose multiple input schemas. A resolver can apply library-specific inspection when needed.
+
 ## Output Mapping
 
 By default, oRPC uses `compact` mode. The procedure's return value becomes the response body, and the status code comes from `successStatus`, which defaults to `200` (should be in the `2xx` range and must be less than `400`).
@@ -237,7 +265,7 @@ Learn more about body hints in the [Standard Server documentation](https://githu
 
 ## Metadata Merging
 
-When `openapi` is applied multiple times, `paramsStyles` and `queryStyles` are merged per parameter, and the most recent style defined for a parameter wins. `inputStructure`, `outputStructure`, `responseBodyHint`, and `requestBodyHint` are overridden by the most recent call. For the full merge behavior of every field, see [Metadata Merging](/docs/openapi/specification#metadata-merging).
+When `openapi` is applied multiple times, two `paramsStyles` or `queryStyles` records are merged per parameter, and the most recent style defined for a parameter wins. A later resolver replaces the previous record or resolver, and a later record replaces a previous resolver. `inputStructure`, `outputStructure`, `responseBodyHint`, and `requestBodyHint` are overridden by the most recent call. For the full merge behavior of every field, see [Metadata Merging](/docs/openapi/specification#metadata-merging).
 
 ```ts
 const router = os

--- a/apps/content/docs/openapi/specification.mdx
+++ b/apps/content/docs/openapi/specification.mdx
@@ -58,7 +58,7 @@ const getPlanet = oc
 When `openapi` is applied multiple times, most fields, such as `method`, `path`, `operationId`, `summary`, and `description`, are overridden by the most recent call. Only the following fields are merged:
 
 - `tags` and `prefix` values are concatenated in definition order.
-- `paramsStyles` and `queryStyles` are merged per parameter. The most recent style defined for a parameter wins.
+- Two `paramsStyles` or `queryStyles` records are merged per parameter. The most recent style defined for a parameter wins. A resolver replaces the previous record or resolver, and a record replaces a previous resolver.
 - `spec` values are combined: two functions are chained so the most recent one receives the result of the previous one, a function combined with an object is applied to that object, and between two objects the most recent one wins.
 
 For implementation details, see the [source code](https://github.com/orpc/orpc/blob/main/packages/openapi/src/meta.ts).

--- a/packages/openapi/src/adapters/standard/openapi-handler-codec.test.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler-codec.test.ts
@@ -1,3 +1,4 @@
+import type { AnySchema } from '@orpc/contract'
 import type { StandardLazyRequest } from '@standardserver/core'
 import { ORPCError } from '@orpc/client'
 import { DEFAULT_ERROR_STATUS, os } from '@orpc/server'
@@ -176,6 +177,41 @@ describe('openAPIHandlerCodec', () => {
           filters: { size: 'large', brand: 'nike' },
           page: '2',
         })
+      })
+
+      it('resolves path and query styles with the procedure input schemas', async () => {
+        const inputSchema1 = { id: 1 } as unknown as AnySchema
+        const inputSchema2 = { id: 2 } as unknown as AnySchema
+        const inputSchemas = [inputSchema1, inputSchema2]
+        const paramsStyles = vi.fn((name: string, _schemas: readonly AnySchema[] | undefined) => (
+          name === 'ids' ? 'comma-delimited-array' as const : undefined
+        ))
+        const queryStyles = vi.fn((name: string, _schemas: readonly AnySchema[] | undefined) => (
+          name === 'tags' ? 'array' as const : name === 'meta' ? 'json' as const : undefined
+        ))
+        const procedure = os
+          .input(inputSchema1)
+          .input(inputSchema2)
+          .meta(openapi({ method: 'GET', path: '/{ids}', paramsStyles, queryStyles }))
+          .handler(vi.fn())
+        const codec = new OpenAPIHandlerCodec(procedure)
+
+        const result = await codec.resolveProcedure(createRequest({
+          method: 'GET',
+          url: '/red,blue?tags=one&tags=two&meta=%7B%22active%22%3Atrue%7D&plain=value',
+        }), options as any)
+
+        expect(result).toBeDefined()
+        await expect(result!.decodeInput()).resolves.toEqual({
+          ids: ['red', 'blue'],
+          tags: ['one', 'two'],
+          meta: { active: true },
+          plain: 'value',
+        })
+        expect(paramsStyles).toHaveBeenCalledWith('ids', inputSchemas)
+        expect(queryStyles).toHaveBeenCalledWith('tags', inputSchemas)
+        expect(queryStyles).toHaveBeenCalledWith('meta', inputSchemas)
+        expect(queryStyles).toHaveBeenCalledWith('plain', inputSchemas)
       })
     })
 

--- a/packages/openapi/src/adapters/standard/openapi-handler-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler-codec.ts
@@ -1,4 +1,5 @@
 import type { AnyORPCError } from '@orpc/client'
+import type { AnySchema } from '@orpc/contract'
 import type { AnyProcedure, AnyRouter, Context } from '@orpc/server'
 import type { StandardHandlerCodec, StandardHandlerCodecResolvedProcedure, StandardHandlerHandleOptions } from '@orpc/server/standard'
 import type { Promisable } from '@orpc/shared'
@@ -15,6 +16,7 @@ import {
 } from '../../constants'
 import { getOpenAPIMeta } from '../../meta'
 import { OpenAPISerializer } from '../../openapi-serializer'
+import { resolveOpenAPIParameterStyle } from '../../parameter-styles'
 import { isBodylessMethod } from '../../utils'
 import { OpenAPIMatcher } from './openapi-matcher'
 import { serializeHeaders } from './utils'
@@ -63,9 +65,10 @@ export class OpenAPIHandlerCodecCore<T extends Context> {
     const [_, search] = parseStandardUrl(request.url)
 
     const meta = getOpenAPIMeta(matched.procedure)
+    const inputSchemas = matched.procedure['~orpc'].inputSchemas
     const inputStructure = meta?.inputStructure ?? DEFAULT_OPENAPI_INPUT_STRUCTURE
-    const params = this.deserializeParams(matched.params, meta?.paramsStyles)
-    const query = this.deserializeQuery(search, meta?.queryStyles)
+    const params = this.deserializeParams(matched.params, meta?.paramsStyles, inputSchemas)
+    const query = this.deserializeQuery(search, meta?.queryStyles, inputSchemas)
 
     if (inputStructure === 'compact') {
       const data = isBodylessMethod(request.method)
@@ -149,6 +152,7 @@ export class OpenAPIHandlerCodecCore<T extends Context> {
   private deserializeQuery(
     search: `?${string}` | undefined,
     styles: OpenAPIMeta['queryStyles'],
+    inputSchemas: AnySchema[] | undefined,
   ): unknown {
     const searchParams = new URLSearchParams(search)
     const parsed = this.serializer.deserialize(searchParams)
@@ -157,7 +161,11 @@ export class OpenAPIHandlerCodecCore<T extends Context> {
       return parsed
     }
 
-    Object.entries(styles).forEach(([key, hint]) => {
+    const keys = typeof styles === 'function' ? Object.keys(parsed) : Object.keys(styles)
+
+    keys.forEach((key) => {
+      const hint = resolveOpenAPIParameterStyle(styles, key, inputSchemas)
+
       if (hint === undefined) {
         return
       }
@@ -219,6 +227,7 @@ export class OpenAPIHandlerCodecCore<T extends Context> {
   private deserializeParams(
     params: Record<string, string> | undefined,
     styles: OpenAPIMeta['paramsStyles'],
+    inputSchemas: AnySchema[] | undefined,
   ): Record<string, unknown> | undefined {
     if (!params || !styles) {
       return params
@@ -226,7 +235,11 @@ export class OpenAPIHandlerCodecCore<T extends Context> {
 
     const parsed: Record<string, unknown> = { ...params }
 
-    Object.entries(styles).forEach(([key, hint]) => {
+    const keys = typeof styles === 'function' ? Object.keys(params) : Object.keys(styles)
+
+    keys.forEach((key) => {
+      const hint = resolveOpenAPIParameterStyle(styles, key, inputSchemas)
+
       if (hint === undefined || hint === 'primitive') {
         return
       }

--- a/packages/openapi/src/adapters/standard/openapi-link-codec.test.ts
+++ b/packages/openapi/src/adapters/standard/openapi-link-codec.test.ts
@@ -1,3 +1,4 @@
+import type { AnySchema } from '@orpc/contract'
 import { MalformedResponseError, ORPCError } from '@orpc/client'
 import { oc } from '@orpc/contract'
 import { openapi } from '../../meta'
@@ -119,6 +120,43 @@ describe('openAPILinkCodec', () => {
         expect(url.searchParams.get('file')).toBe('[object File]')
       })
 
+      it('resolves path and query styles with the contract input schemas', async () => {
+        const inputSchema1 = { id: 1 } as unknown as AnySchema
+        const inputSchema2 = { id: 2 } as unknown as AnySchema
+        const inputSchemas = [inputSchema1, inputSchema2]
+        const paramsStyles = vi.fn((name: string, _schemas: readonly AnySchema[] | undefined) => (
+          name === 'ids' ? 'comma-delimited-array' as const : undefined
+        ))
+        const queryStyles = vi.fn((name: string, _schemas: readonly AnySchema[] | undefined) => (
+          name === 'filter' ? 'json' as const : undefined
+        ))
+        const codec = new OpenAPILinkCodec({
+          item: oc
+            .input(inputSchema1)
+            .input(inputSchema2)
+            .meta(openapi({
+              method: 'GET',
+              path: '/items/{ids}',
+              paramsStyles,
+              queryStyles,
+            })),
+        }, { url: '/api', serializer })
+
+        const request = await codec.encodeInput({
+          ids: ['first', 'second'],
+          filter: { active: true },
+          search: 'value',
+        }, ['item'], { context: {} })
+
+        const url = new URL(request.url, 'http://localhost')
+        expect(url.pathname).toBe('/api/items/first,second')
+        expect(url.searchParams.get('filter')).toBe('{"active":true}')
+        expect(url.searchParams.get('search')).toBe('value')
+        expect(paramsStyles).toHaveBeenCalledWith('ids', inputSchemas)
+        expect(queryStyles).toHaveBeenCalledWith('filter', inputSchemas)
+        expect(queryStyles).toHaveBeenCalledWith('search', inputSchemas)
+      })
+
       it('rejects non-object input when dynamic path params must be resolved', async () => {
         const codec = new OpenAPILinkCodec({
           ping: oc.meta(openapi({ path: '/items/{id}' })),
@@ -164,6 +202,41 @@ describe('openAPILinkCodec', () => {
           body: { title: 'Hello' },
           signal: undefined,
         })
+      })
+
+      it('resolves detailed path and query styles with the contract input schemas', async () => {
+        const inputSchema1 = { id: 1 } as unknown as AnySchema
+        const inputSchema2 = { id: 2 } as unknown as AnySchema
+        const inputSchemas = [inputSchema1, inputSchema2]
+        const paramsStyles = vi.fn((name: string, _schemas: readonly AnySchema[] | undefined) => (
+          name === 'tags' ? 'comma-delimited-array' as const : undefined
+        ))
+        const queryStyles = vi.fn((name: string, _schemas: readonly AnySchema[] | undefined) => (
+          name === 'meta' ? 'json' as const : undefined
+        ))
+        const codec = new OpenAPILinkCodec({
+          search: oc
+            .input(inputSchema1)
+            .input(inputSchema2)
+            .meta(openapi({
+              method: 'POST',
+              path: '/search/{tags}',
+              inputStructure: 'detailed',
+              paramsStyles,
+              queryStyles,
+            })),
+        }, { url: '/api', serializer })
+
+        const request = await codec.encodeInput({
+          params: { tags: ['alpha', 'beta'] },
+          query: { meta: { enabled: true }, plain: 'value' },
+          body: { title: 'Hello' },
+        }, ['search'], { context: {} })
+
+        expect(request.url).toBe('/api/search/alpha,beta?plain=value&meta=%7B%22enabled%22%3Atrue%7D')
+        expect(paramsStyles).toHaveBeenCalledWith('tags', inputSchemas)
+        expect(queryStyles).toHaveBeenCalledWith('meta', inputSchemas)
+        expect(queryStyles).toHaveBeenCalledWith('plain', inputSchemas)
       })
 
       it('uses base headers when detailed input omits the headers field', async () => {

--- a/packages/openapi/src/adapters/standard/openapi-link-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-link-codec.ts
@@ -4,6 +4,7 @@ import type { AnyProcedureContract, RouterContract } from '@orpc/contract'
 import type { Promisable, Value } from '@orpc/shared'
 import type { StandardHeaders, StandardLazyResponse, StandardRequest, StandardUrl } from '@standardserver/core'
 import type { OpenAPIMeta } from '../../meta'
+import type { OpenAPIParamsStyle } from '../../parameter-styles'
 import { createORPCErrorFromJson, createORPCErrorFromMalformedResponse, isORPCErrorJson } from '@orpc/client'
 import { getRouterContract, ProcedureContract } from '@orpc/contract'
 import { unlazy } from '@orpc/server'
@@ -17,6 +18,7 @@ import {
 } from '../../constants'
 import { getOpenAPIMeta } from '../../meta'
 import { OpenAPISerializer } from '../../openapi-serializer'
+import { resolveOpenAPIParameterStyle } from '../../parameter-styles'
 import { getDynamicPathParams, isBodylessMethod } from '../../utils'
 import { serializeHeaders } from './utils'
 
@@ -76,6 +78,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
     const baseUrl = await value(this.baseUrl, options, path, input)
     const procedure = await this.resolveProcedure(path)
     const meta = getOpenAPIMeta(procedure)
+    const inputSchemas = procedure['~orpc'].inputSchemas
 
     const method = meta?.method ?? DEFAULT_OPENAPI_METHOD
     const inputStructure = meta?.inputStructure ?? DEFAULT_OPENAPI_INPUT_STRUCTURE
@@ -101,7 +104,8 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
 
         for (let i = dynamicParams.length - 1; i >= 0; i--) {
           const param = dynamicParams[i]!
-          const encoded = this.encodePathParam(input[param.parameterName], param, meta?.paramsStyles?.[param.parameterName], path)
+          const style = resolveOpenAPIParameterStyle(meta?.paramsStyles, param.parameterName, inputSchemas)
+          const encoded = this.encodePathParam(input[param.parameterName], param, style, path)
           pathname = `${pathname.slice(0, param.startIndex)}${encoded}${pathname.slice(param.startIndex + param.segment.length)}` as `/${string}`
           delete remaining[param.parameterName]
         }
@@ -112,7 +116,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
       pathname = `${basePathname.replace(END_SLASH_REGEX, '')}${pathname}` as `/${string}`
 
       if (isBodylessMethod(method)) {
-        const queryString = this.serializeQueryString(data, meta?.queryStyles)
+        const queryString = this.serializeQueryString(data, meta?.queryStyles, inputSchemas)
         const search = combineSearch(baseSearch, queryString)
         const url = `${pathname}${search ?? ''}${baseHash ?? ''}` as StandardUrl
 
@@ -160,7 +164,8 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
       for (let i = dynamicParams.length - 1; i >= 0; i--) {
         const param = dynamicParams[i]!
         const val = input.params[param.parameterName]
-        const encoded = this.encodePathParam(val, param, meta?.paramsStyles?.[param.parameterName], path)
+        const style = resolveOpenAPIParameterStyle(meta?.paramsStyles, param.parameterName, inputSchemas)
+        const encoded = this.encodePathParam(val, param, style, path)
         pathname = `${pathname.slice(0, param.startIndex)}${encoded}${pathname.slice(param.startIndex + param.segment.length)}` as `/${string}`
       }
     }
@@ -170,7 +175,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
     }
 
     pathname = `${basePathname.replace(END_SLASH_REGEX, '')}${pathname}` as `/${string}`
-    const queryString = this.serializeQueryString(input?.query, meta?.queryStyles)
+    const queryString = this.serializeQueryString(input?.query, meta?.queryStyles, inputSchemas)
     const search = combineSearch(baseSearch, queryString)
     const url = `${pathname}${search ?? ''}${baseHash ?? ''}` as StandardUrl
 
@@ -196,7 +201,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
   private encodePathParam(
     val: unknown,
     param: { parameterName: string, allowsSlash: boolean, segment: string },
-    style: Exclude<OpenAPIMeta['paramsStyles'], undefined>[string],
+    style: OpenAPIParamsStyle | undefined,
     path: string[],
   ): string {
     let encoded: string | undefined
@@ -235,7 +240,11 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
     return encoded
   }
 
-  private serializeQueryString(data: unknown, queryStyles: OpenAPIMeta['queryStyles']): string | undefined {
+  private serializeQueryString(
+    data: unknown,
+    queryStyles: OpenAPIMeta['queryStyles'],
+    inputSchemas: AnyProcedureContract['~orpc']['inputSchemas'],
+  ): string | undefined {
     if (!queryStyles || !isTypescriptObject(data)) {
       return toURLSearchParams(
         this.serializer.serialize(data, { asFormData: true }) as FormData,
@@ -245,7 +254,11 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
     const remaining = { ...data }
     let query = ''
 
-    Object.entries(queryStyles).forEach(([key, style]) => {
+    const keys = typeof queryStyles === 'function' ? Object.keys(data) : Object.keys(queryStyles)
+
+    keys.forEach((key) => {
+      const style = resolveOpenAPIParameterStyle(queryStyles, key, inputSchemas)
+
       if (style === undefined) {
         return
       }

--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -5,6 +5,12 @@ export * from './meta'
 export * from './openapi-generator'
 export * from './openapi-json-serializer'
 export * from './openapi-serializer'
+export type {
+  OpenAPIParameterStyleResolver,
+  OpenAPIParameterStyles,
+  OpenAPIParamsStyle,
+  OpenAPIQueryStyle,
+} from './parameter-styles'
 export * from './router-utils'
 export * from './types'
 export * from './utils'

--- a/packages/openapi/src/meta.test-d.ts
+++ b/packages/openapi/src/meta.test-d.ts
@@ -1,0 +1,40 @@
+import type { AnySchema } from '@orpc/contract'
+import type {
+  OpenAPIMeta,
+  OpenAPIParameterStyleResolver,
+  OpenAPIParameterStyles,
+  OpenAPIParamsStyle,
+  OpenAPIQueryStyle,
+} from '.'
+
+describe('OpenAPIMeta parameter styles', () => {
+  it('accepts resolvers with the parameter name and input schema stack', () => {
+    const paramsStyles: OpenAPIMeta['paramsStyles'] = (name, inputSchemas) => {
+      expectTypeOf(name).toEqualTypeOf<string>()
+      expectTypeOf(inputSchemas).toEqualTypeOf<readonly AnySchema[] | undefined>()
+
+      return name === 'ids' ? 'comma-delimited-array' : undefined
+    }
+    const queryStyles: OpenAPIMeta['queryStyles'] = (name, inputSchemas) => {
+      expectTypeOf(name).toEqualTypeOf<string>()
+      expectTypeOf(inputSchemas).toEqualTypeOf<readonly AnySchema[] | undefined>()
+
+      return name === 'filter' ? 'json' : undefined
+    }
+
+    expectTypeOf(paramsStyles).toMatchTypeOf<NonNullable<OpenAPIMeta['paramsStyles']>>()
+    expectTypeOf(queryStyles).toMatchTypeOf<NonNullable<OpenAPIMeta['queryStyles']>>()
+  })
+
+  it('exports reusable style and resolver types', () => {
+    const paramsResolver: OpenAPIParameterStyleResolver<OpenAPIParamsStyle> = name => (
+      name === 'ids' ? 'comma-delimited-array' : undefined
+    )
+    const queryStyles: OpenAPIParameterStyles<OpenAPIQueryStyle> = {
+      filter: 'json',
+    }
+
+    expectTypeOf(paramsResolver).toMatchTypeOf<NonNullable<OpenAPIMeta['paramsStyles']>>()
+    expectTypeOf(queryStyles).toMatchTypeOf<NonNullable<OpenAPIMeta['queryStyles']>>()
+  })
+})

--- a/packages/openapi/src/meta.test.ts
+++ b/packages/openapi/src/meta.test.ts
@@ -88,6 +88,23 @@ describe('openapi meta', () => {
           tags: 'array',
         })
       })
+
+      it('replaces a record with the latest resolver', () => {
+        const resolver = vi.fn(() => 'array' as const)
+        const procedure = oc
+          .meta(openapi({ queryStyles: { keyword: 'primitive' } }))
+          .meta(openapi({ queryStyles: resolver }))
+
+        expect(getOpenAPIMeta(procedure)?.queryStyles).toBe(resolver)
+      })
+
+      it('replaces a resolver with the latest record', () => {
+        const procedure = oc
+          .meta(openapi({ queryStyles: () => 'primitive' }))
+          .meta(openapi({ queryStyles: { tags: 'array' } }))
+
+        expect(getOpenAPIMeta(procedure)?.queryStyles).toEqual({ tags: 'array' })
+      })
     })
 
     describe('paramsStyles merging', () => {
@@ -120,6 +137,24 @@ describe('openapi meta', () => {
         expect(getOpenAPIMeta(procedure)?.paramsStyles).toEqual({
           tags: 'comma-delimited-array',
         })
+      })
+
+      it('replaces a resolver with the latest resolver', () => {
+        const latest = vi.fn(() => 'comma-delimited-array' as const)
+        const procedure = oc
+          .meta(openapi({ paramsStyles: () => 'primitive' }))
+          .meta(openapi({ paramsStyles: latest }))
+
+        expect(getOpenAPIMeta(procedure)?.paramsStyles).toBe(latest)
+      })
+
+      it('keeps a resolver when a later call omits paramsStyles', () => {
+        const resolver = vi.fn(() => 'primitive' as const)
+        const procedure = oc
+          .meta(openapi({ paramsStyles: resolver }))
+          .meta(openapi({}))
+
+        expect(getOpenAPIMeta(procedure)?.paramsStyles).toBe(resolver)
       })
     })
 

--- a/packages/openapi/src/meta.ts
+++ b/packages/openapi/src/meta.ts
@@ -2,6 +2,7 @@ import type { AnyProcedureContract, AnySchema, ErrorMap, MetaPlugin } from '@orp
 import type { Lazy } from '@orpc/server'
 import type { Value } from '@orpc/shared'
 import type { StandardBodyHint } from '@standardserver/core'
+import type { OpenAPIParameterStyles, OpenAPIParamsStyle, OpenAPIQueryStyle } from './parameter-styles'
 import type { OpenAPIOperationObject } from './types'
 import { mergeHttpPath } from '@orpc/shared'
 
@@ -70,8 +71,12 @@ export interface OpenAPIMeta {
   /**
    * Controls how individual path parameters are decoded.
    *
-   * **Merging**: When defined multiple times, styles are merged per parameter.
-   * The most recent style defined for a parameter wins.
+   * Pass either a record or a resolver that receives the parameter name and the procedure's
+   * complete input schema stack. The full stack is provided because Standard Schema does not
+   * define a vendor-agnostic way to extract a schema for an individual field.
+   *
+   * **Merging**: Two records are merged per parameter, with the most recent style winning.
+   * A resolver replaces the previous record or resolver, and a record replaces a previous resolver.
    * Explicitly setting `undefined` resets the styles instead of merging.
    *
    * Each key maps a path parameter name to one of the following strategies:
@@ -113,16 +118,17 @@ export interface OpenAPIMeta {
    *
    * @default `primitive` for all parameters
    */
-  paramsStyles?: Record<
-    string,
-    'primitive' | 'comma-delimited-array' | 'comma-delimited-object' | undefined
-  > | undefined
+  paramsStyles?: OpenAPIParameterStyles<OpenAPIParamsStyle> | undefined
 
   /**
    * Controls how individual query parameters are encoding/decoding.
    *
-   * **Merging**: When defined multiple times, styles are merged per parameter.
-   * The most recent style defined for a parameter wins.
+   * Pass either a record or a resolver that receives the parameter name and the procedure's
+   * complete input schema stack. The full stack is provided because Standard Schema does not
+   * define a vendor-agnostic way to extract a schema for an individual field.
+   *
+   * **Merging**: Two records are merged per parameter, with the most recent style winning.
+   * A resolver replaces the previous record or resolver, and a record replaces a previous resolver.
    * Explicitly setting `undefined` resets the styles instead of merging.
    *
    * Each key maps a query parameter name to one of the following strategies:
@@ -169,10 +175,7 @@ export interface OpenAPIMeta {
    *
    * @default `undefined` for all parameters (bracket-notation decoding)
    */
-  queryStyles?: Record<
-    string,
-    'primitive' | 'array' | 'comma-delimited-array' | 'comma-delimited-object' | 'space-delimited-array' | 'space-delimited-object' | 'pipe-delimited-array' | 'pipe-delimited-object' | 'json' | undefined
-  > | undefined
+  queryStyles?: OpenAPIParameterStyles<OpenAPIQueryStyle> | undefined
 
   /**
    * Hint for how to parse the incoming request body.
@@ -356,6 +359,27 @@ export interface OpenAPIFunction {
   prefix(method: OpenAPIMeta['prefix']): OpenAPIPrefixMetaPlugin<any, any, any>
 }
 
+function mergeParameterStyles<TStyle>(
+  existing: OpenAPIParameterStyles<TStyle> | undefined,
+  incoming: OpenAPIParameterStyles<TStyle> | undefined,
+  hasIncoming: boolean,
+): OpenAPIParameterStyles<TStyle> | undefined {
+  if (!hasIncoming) {
+    return existing
+  }
+
+  if (
+    typeof existing === 'object'
+    && existing !== null
+    && typeof incoming === 'object'
+    && incoming !== null
+  ) {
+    return { ...existing, ...incoming }
+  }
+
+  return incoming
+}
+
 /**
  * Creates OpenAPI meta plugins that control how a procedure is exposed over HTTP,
  * such as its method, path, prefix, and OpenAPI operation spec.
@@ -372,13 +396,17 @@ export const openapi: OpenAPIFunction = incoming => ({
       ? [...existing.tags, ...incoming.tags]
       : 'tags' in incoming ? incoming.tags : existing?.tags
 
-    const queryStyles = existing?.queryStyles && incoming.queryStyles
-      ? { ...existing.queryStyles, ...incoming.queryStyles }
-      : 'queryStyles' in incoming ? incoming.queryStyles : existing?.queryStyles
+    const queryStyles = mergeParameterStyles(
+      existing?.queryStyles,
+      incoming.queryStyles,
+      'queryStyles' in incoming,
+    )
 
-    const paramsStyles = existing?.paramsStyles && incoming.paramsStyles
-      ? { ...existing.paramsStyles, ...incoming.paramsStyles }
-      : 'paramsStyles' in incoming ? incoming.paramsStyles : existing?.paramsStyles
+    const paramsStyles = mergeParameterStyles(
+      existing?.paramsStyles,
+      incoming.paramsStyles,
+      'paramsStyles' in incoming,
+    )
 
     const existingSpec = existing?.spec
     const incomingSpec = incoming.spec

--- a/packages/openapi/src/openapi-generator-operation.test.ts
+++ b/packages/openapi/src/openapi-generator-operation.test.ts
@@ -179,6 +179,48 @@ describe('openAPIGenerator operation builders', () => {
       ])
     })
 
+    it('resolves parameter styles by name with the original input schemas', () => {
+      const { ctx, operation } = createContext()
+      const path = '/planets/{ids}' as const
+      const inputSchemas = [
+        testSchema({
+          type: 'object',
+          properties: {
+            ids: { type: 'array' },
+            filter: { type: 'object' },
+          },
+          required: ['ids', 'filter'],
+        }),
+        testSchema({
+          type: 'object',
+          properties: { search: { type: 'string' } },
+          required: ['search'],
+        }),
+      ]
+      const paramsStyles = vi.fn((name: string, _schemas: readonly AnySchema[] | undefined) => (
+        name === 'ids' ? 'comma-delimited-array' as const : undefined
+      ))
+      const queryStyles = vi.fn((name: string, _schemas: readonly AnySchema[] | undefined) => (
+        name === 'filter' ? 'json' as const : undefined
+      ))
+
+      buildRequest(ctx, operation, testDef({ inputs: inputSchemas }), {
+        method: 'GET',
+        path,
+        paramsStyles,
+        queryStyles,
+      }, getDynamicPathParams(path))
+
+      expect(paramsStyles).toHaveBeenCalledWith('ids', inputSchemas)
+      expect(queryStyles).toHaveBeenCalledWith('filter', inputSchemas)
+      expect(queryStyles).toHaveBeenCalledWith('search', inputSchemas)
+      expect(operation.parameters).toEqual([
+        { in: 'path', required: true, name: 'ids', style: 'simple', explode: false, schema: { type: 'array' } },
+        { in: 'query', name: 'filter', required: true, allowEmptyValue: true, allowReserved: true, content: { 'application/json': { schema: { type: 'object' } } } },
+        { in: 'query', name: 'search', required: true, allowEmptyValue: true, allowReserved: true, schema: { type: 'string' } },
+      ])
+    })
+
     it('marks the request body optional when every non-param field is optional', () => {
       const { ctx, operation } = createContext()
       const path = '/planets/{id}' as const

--- a/packages/openapi/src/openapi-generator-operation.ts
+++ b/packages/openapi/src/openapi-generator-operation.ts
@@ -26,6 +26,7 @@ import {
   DEFAULT_OPENAPI_OUTPUT_STRUCTURE,
   DEFAULT_OPENAPI_SUCCESS_DESCRIPTION,
 } from './constants'
+import { resolveOpenAPIParameterStyle } from './parameter-styles'
 import { isBodylessMethod } from './utils'
 
 export type DynamicPathParam = NonNullable<ReturnType<typeof getDynamicPathParams>>[number]
@@ -121,8 +122,8 @@ export function buildRequest(
     ? extractCompactRequestParts(schema, optional, method, dynamicParams)
     : extractDetailedRequestParts(schema)
 
-  renderPathParameters(ctx, operation, dynamicParams, parts.paramsEntries, meta?.paramsStyles)
-  renderQueryParameters(ctx, operation, parts.queryEntries, meta?.queryStyles)
+  renderPathParameters(ctx, operation, dynamicParams, parts.paramsEntries, meta?.paramsStyles, def.inputSchemas)
+  renderQueryParameters(ctx, operation, parts.queryEntries, meta?.queryStyles, def.inputSchemas)
   renderHeaderParameters(ctx, operation, parts.headersEntries)
 
   if (parts.bodySchema !== undefined) {
@@ -197,6 +198,7 @@ function renderPathParameters(
   dynamicParams: string[] | undefined,
   paramsEntries: JsonObjectSchemaEntry[] | undefined,
   paramsStyles: OpenAPIMeta['paramsStyles'],
+  inputSchemas: AnySchema[] | undefined,
 ): void {
   if (!dynamicParams?.length) {
     return
@@ -228,7 +230,7 @@ function renderPathParameters(
       )
     }
 
-    const style = paramsStyles?.[name]
+    const style = resolveOpenAPIParameterStyle(paramsStyles, name, inputSchemas)
     const parameter: Exclude<OpenAPIOperationObject['parameters'], undefined>[number] = {
       in: 'path',
       required: true,
@@ -254,9 +256,10 @@ function renderQueryParameters(
   operation: OpenAPIOperationObject,
   queryEntries: JsonObjectSchemaEntry[] | undefined,
   queryStyles: OpenAPIMeta['queryStyles'],
+  inputSchemas: AnySchema[] | undefined,
 ): void {
   for (const [name, schema, optional] of queryEntries ?? []) {
-    const style = queryStyles?.[name]
+    const style = resolveOpenAPIParameterStyle(queryStyles, name, inputSchemas)
     const parameter: Exclude<OpenAPIOperationObject['parameters'], undefined>[number] = {
       in: 'query',
       name,

--- a/packages/openapi/src/parameter-styles.ts
+++ b/packages/openapi/src/parameter-styles.ts
@@ -1,0 +1,56 @@
+import type { AnySchema } from '@orpc/contract'
+
+/**
+ * Encoding and decoding strategies for OpenAPI path parameters.
+ *
+ * @see {@link https://orpc.dev/docs/openapi/input-and-output-mapping#dynamic-parameter-style-resolvers | OpenAPI Input and Output Mapping - Dynamic Parameter Style Resolvers}
+ */
+export type OpenAPIParamsStyle
+  = | 'primitive'
+    | 'comma-delimited-array'
+    | 'comma-delimited-object'
+
+/**
+ * Encoding and decoding strategies for OpenAPI query parameters.
+ *
+ * @see {@link https://orpc.dev/docs/openapi/input-and-output-mapping#dynamic-parameter-style-resolvers | OpenAPI Input and Output Mapping - Dynamic Parameter Style Resolvers}
+ */
+export type OpenAPIQueryStyle
+  = | 'primitive'
+    | 'array'
+    | 'comma-delimited-array'
+    | 'comma-delimited-object'
+    | 'space-delimited-array'
+    | 'space-delimited-object'
+    | 'pipe-delimited-array'
+    | 'pipe-delimited-object'
+    | 'json'
+
+/**
+ * Resolves a parameter style from its name and the procedure's ordered input schema stack.
+ *
+ * @see {@link https://orpc.dev/docs/openapi/input-and-output-mapping#dynamic-parameter-style-resolvers | OpenAPI Input and Output Mapping - Dynamic Parameter Style Resolvers}
+ */
+export type OpenAPIParameterStyleResolver<TStyle> = (
+  name: string,
+  inputSchemas: readonly AnySchema[] | undefined,
+) => TStyle | undefined
+
+/**
+ * Parameter styles defined per name or resolved dynamically.
+ *
+ * @see {@link https://orpc.dev/docs/openapi/input-and-output-mapping#dynamic-parameter-style-resolvers | OpenAPI Input and Output Mapping - Dynamic Parameter Style Resolvers}
+ */
+export type OpenAPIParameterStyles<TStyle>
+  = | Record<string, TStyle | undefined>
+    | OpenAPIParameterStyleResolver<TStyle>
+
+export function resolveOpenAPIParameterStyle<TStyle>(
+  styles: OpenAPIParameterStyles<TStyle> | undefined,
+  name: string,
+  inputSchemas: readonly AnySchema[] | undefined,
+): TStyle | undefined {
+  return typeof styles === 'function'
+    ? styles(name, inputSchemas)
+    : styles?.[name]
+}


### PR DESCRIPTION
## Summary

- allow `paramsStyles` and `queryStyles` to be resolver functions as well as records
- pass the parameter name and ordered input-schema stack through generation, request decoding, and client encoding
- document resolver behavior and export reusable public style types

## Testing

- `pnpm --filter @orpc/openapi vitest run --config vitest.config.ts`
- `pnpm --filter @orpc/openapi tsc --noEmit`
- `pnpm tsc --noEmit`
- `pnpm --filter @orpc/openapi build`
- targeted ESLint and documentation validation

Fixes #1689
