### PR TITLE
fix(shared): do not require the AbortSignal global

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -71,7 +71,15 @@ export default antfu({
 }, {
   files: ['packages/*/src/**'],
   rules: {
+    // a scoped block replaces the base rule rather than extending it,
+    // so the first two names repeat what @antfu/eslint-config already bans
     'no-restricted-globals': ['error', {
+      name: 'global',
+      message: 'Use `globalThis` instead.',
+    }, {
+      name: 'self',
+      message: 'Use `globalThis` instead.',
+    }, {
       name: 'AbortSignal',
       message: 'AbortSignal is not a global in every runtime, read it only behind a typeof guard',
     }],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -69,12 +69,21 @@ export default antfu({
     'pnpm/json-enforce-catalog': 'off',
   },
 }, {
+  files: ['packages/*/src/**'],
+  rules: {
+    'no-restricted-globals': ['error', {
+      name: 'AbortSignal',
+      message: 'AbortSignal is not a global in every runtime, read it only behind a typeof guard',
+    }],
+  },
+}, {
   files: ['**/*.test.ts', '**/*.test.tsx', '**/*.test-d.ts', '**/*.test-d.tsx', 'apps/content/shared/**', 'playgrounds/**', 'packages/*/playground/**'],
   rules: {
     'unused-imports/no-unused-vars': 'off',
     'antfu/no-top-level-await': 'off',
     'no-alert': 'off',
     'ban/ban': 'off',
+    'no-restricted-globals': 'off',
   },
 }, {
   files: [

--- a/packages/shared/src/signal.test.ts
+++ b/packages/shared/src/signal.test.ts
@@ -71,19 +71,26 @@ describe('anyAbortSignal', () => {
   })
 
   describe.each([
-    { native: true, description: 'built-in AbortSignal.any' },
-    { native: false, description: 'fallback implementation' },
-  ])('with $description', ({ native }) => {
+    { mode: 'native', description: 'built-in AbortSignal.any' },
+    { mode: 'without-any', description: 'fallback implementation' },
+    { mode: 'without-global', description: 'fallback implementation without the AbortSignal global' },
+  ] as const)('with $description', ({ mode }) => {
     const originalAny = AbortSignal.any
 
     beforeEach(() => {
-      if (!native) {
+      if (mode === 'without-any') {
         // @ts-expect-error simulate runtimes without AbortSignal.any support
         AbortSignal.any = undefined
+      }
+
+      if (mode === 'without-global') {
+        // simulate runtimes without the AbortSignal global, such as bare React Native
+        vi.stubGlobal('AbortSignal', undefined)
       }
     })
 
     afterEach(() => {
+      vi.unstubAllGlobals()
       AbortSignal.any = originalAny
     })
 

--- a/packages/shared/src/signal.ts
+++ b/packages/shared/src/signal.ts
@@ -35,6 +35,9 @@ export function allAbortSignal(signals: readonly (AbortSignal | undefined)[]): A
 /**
  * Returns a signal that aborts as soon as any of the provided signals aborts,
  * with the same abort reason.
+ *
+ * Prefers the native `AbortSignal.any` when available, and falls back to a manual
+ * implementation otherwise, including in runtimes without the `AbortSignal` global.
  */
 export function anyAbortSignal(signals: readonly (AbortSignal | undefined)[]): AbortSignal | undefined {
   const realSignals = signals.filter(signal => signal !== undefined)
@@ -47,8 +50,9 @@ export function anyAbortSignal(signals: readonly (AbortSignal | undefined)[]): A
     return realSignals[0]
   }
 
-  if (typeof AbortSignal.any === 'function') {
-    // eslint-disable-next-line ban/ban
+  // eslint-disable-next-line no-restricted-globals
+  if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.any === 'function') {
+    // eslint-disable-next-line ban/ban, no-restricted-globals
     return AbortSignal.any(realSignals)
   }
 


### PR DESCRIPTION
`anyAbortSignal` read the `AbortSignal` global unguarded to feature-detect `AbortSignal.any`, which made the bare global a hard requirement. Runtimes without it threw `ReferenceError: AbortSignal is not defined` whenever two signals had to be merged, and that happens on every call that passes a caller signal through the client or server Timeout plugin. The global is now read behind a `typeof` guard, and a lint rule keeps it that way.

## Fixes

Passing a `signal` through the Timeout plugins no longer crashes in runtimes that lack the `AbortSignal` global. Creating a merged signal still needs `AbortController`, which is unchanged and already documented as a per-adapter and per-plugin requirement. This clears the way to drop the `AbortSignal` row from the Runtime Requirements page.

## Testing

The root suite ran twice against a scratch config that deletes `globalThis.AbortSignal`, diffed against a control run:

- With the fix, every remaining failure originates in a `*.test.ts` file that reads the global itself (`AbortSignal.timeout`, `expect.any(AbortSignal)`, `toBeInstanceOf(AbortSignal)`). None originate in `packages/*/src`.
- Without the fix, 15 more tests fail, including both Timeout plugin suites and the `tests/plugins/all-plugins.test.ts` end-to-end case, so the guard is load-bearing rather than defensive.

`pnpm vitest run` green at 3253 passed, `pnpm type:check` clean, `pnpm lint` clean apart from 4 pre-existing style errors in the untracked, gitignored `playgrounds/next/next-env.d.ts`, which fail identically with these changes stashed.

## For the reviewer

The new `no-restricted-globals` entry is scoped to `packages/*/src/**`. It flags only value reads, so the many `signal?: AbortSignal` type annotations stay clean, and it is off for tests and playgrounds, which run where the global exists. One docs-site file, `apps/content/pages/_home/stats.ts`, uses `AbortSignal.timeout` at build time and is outside that scope.
