### PR TITLE
chore(content): add a v2 beta banner linking to the v1 docs

### DIFF
--- a/apps/content/blume.config.ts
+++ b/apps/content/blume.config.ts
@@ -7,6 +7,11 @@ export default defineConfig({
   title: 'oRPC',
   description: 'Build APIs that are typesafe end to end, with OpenAPI included',
   logo: '/logo.svg',
+  banner: {
+    content: 'You are reading the v2 docs, currently in beta.',
+    link: { href: 'https://v1.orpc.dev', text: 'V1 docs' },
+    dismissible: true,
+  },
   content: {
     sources: [
       {


### PR DESCRIPTION
Every docs page now opens with a bar saying the reader is on the v2 docs and that v2 is still in beta, with a link across to v1.orpc.dev. Readers who arrive from a search result no longer have to work out which major version they landed on, and v1 users have a visible way back.

The bar is closable, and the choice is remembered per visitor.

## Notes

Uses Blume's built-in `banner`, so the bar covers docs pages, the landing page, and the blog: the custom pages already pass `config.banner` through to `PageLayout`. The close button works with this site's forked header, which carries the dismiss handler and re-measures the mobile drawer offset afterwards.

Dismissal is keyed on the message text, so editing the copy later re-shows the bar to everyone who closed it. Add an `id` if that ever becomes unwanted.

## Testing

Config validated through Blume's own schema loader, which normalizes the banner as expected. eslint and `tsc -p apps/content` report nothing on the changed file. The docs site was not built or served.
