### PR TITLE
chore: fix broken links on the home page and the OpenAPI specification page

### DIFF
--- a/apps/content/docs/openapi/specification.mdx
+++ b/apps/content/docs/openapi/specification.mdx
@@ -61,7 +61,7 @@ When `openapi` is applied multiple times, most fields, such as `method`, `path`,
 - `paramsStyles` and `queryStyles` are merged per parameter. The most recent style defined for a parameter wins.
 - `spec` values are combined: two functions are chained so the most recent one receives the result of the previous one, a function combined with an object is applied to that object, and between two objects the most recent one wins.
 
-For implementation details, see the [source code](https://github.com/orpc/orpc/blob/main/packages/openapi/src/meta.ts).
+For implementation details, see the [source code](https://github.com/middleapi/orpc/blob/main/packages/openapi/src/meta.ts).
 
 ```ts
 const router = os

--- a/apps/content/pages/_home/Runtimes.astro
+++ b/apps/content/pages/_home/Runtimes.astro
@@ -15,7 +15,7 @@ const rows = [
       { name: 'Fetch API', href: '/docs/adapters/fetch-api' },
       { name: 'WebSocket', href: '/docs/adapters/websocket' },
       { name: 'MessagePort', href: '/docs/adapters/message-port' },
-      { name: 'React Native', href: '/docs/adapters/react-native' },
+      { name: 'Expo', href: '/docs/adapters/expo' },
     ],
   },
   {


### PR DESCRIPTION
Two links in the docs site returned 404. The home page "Runs on" strip still pointed at the React Native adapter page, which was removed in 6a7f785 when it became the Expo adapter page, and the OpenAPI specification page linked its source code under `github.com/orpc/orpc` instead of `middleapi/orpc`.

## Fixes

- The home page "Runs on" strip now lists **Expo** and links `/docs/adapters/expo`, matching the doc's sidebar label.
- The OpenAPI specification source link resolves again (verified 200).

Note that the live orpc.dev deploy predates the Expo rename and still serves the dead link, so this takes effect on the next deploy.

## Testing

- `blume validate --strict` reports no broken links.
- A full sweep of all 1,362 links in `apps/content` (943 internal, 419 external) found no other broken page, anchor, or asset. All 45 config redirect targets resolve and none shadow a real page. The checker was itself validated against injected failures of each kind.
- Every external URL resolves. The npmjs.com/opencollective 403s and npmx.dev 429s are bot-blocking rather than dead links, cross-checked via `registry.npmjs.org`.

## For the reviewer

One dead link is deliberately left untouched: `blog/v1-announcement.mdx:133` links `github.com/Stijn-Timmer`, whose account no longer exists (404 on both the page and the API, with no rename redirect). It's a sponsor thank-you credit for a real person, so it seemed better to leave the attribution than to guess a new handle. Happy to keep the name and drop the link if preferred.