### PR TITLE
chore(content): add Browser to the "Runs on" list on the home page

### DIFF
--- a/apps/content/pages/_home/Runtimes.astro
+++ b/apps/content/pages/_home/Runtimes.astro
@@ -15,6 +15,7 @@ const rows = [
       { name: 'Fetch API', href: '/docs/adapters/fetch-api' },
       { name: 'WebSocket', href: '/docs/adapters/websocket' },
       { name: 'MessagePort', href: '/docs/adapters/message-port' },
+      { name: 'Browser', href: '/docs/adapters/browser' },
       { name: 'Expo', href: '/docs/adapters/expo' },
     ],
   },


### PR DESCRIPTION
The home page "Runs on" strip listed every adapter except the browser one, so visitors scanning the landing page had no path to the Browser Adapter docs. Adding it makes the strip a complete jump list again.

The entry sits right after MessagePort, since the browser adapter is built on the Message Port Adapter, and keeps Expo last as the mobile entry.

## Testing

Link target verified: `apps/content/docs/adapters/browser.mdx` exists and is registered in the adapters `meta.ts`. The docs site was not built locally.