### PR TITLE
docs: point agent skills at orpc.dev now that it serves the v2 docs

### DIFF
--- a/skills/orpc-contract/SKILL.md
+++ b/skills/orpc-contract/SKILL.md
@@ -146,11 +146,11 @@ Then run `npx @hey-api/openapi-ts`. It writes `orpc.gen.ts` (one procedure contr
 
 ## Full documentation
 
-If this skill and a fetched docs page disagree, trust the page: this skill is a summary and v2 is still moving. While v2 is in beta the docs are served at https://v2.orpc.dev:
+If this skill and a fetched docs page disagree, trust the page: this skill is a summary and v2 is still moving. The docs are served at https://orpc.dev (the v1 docs stay at https://v1.orpc.dev):
 
-- https://v2.orpc.dev/llms.txt : index of every page with descriptions (links inside print the orpc.dev domain; swap in v2.orpc.dev before fetching)
-- https://v2.orpc.dev/llms-full.txt : the entire docs in one file (large; prefer single pages)
-- Append `.md` to any docs URL for that page's exact source markdown (for example https://v2.orpc.dev/docs/contract/procedure.md)
+- https://orpc.dev/llms.txt : index of every page with descriptions
+- https://orpc.dev/llms-full.txt : the entire docs in one file (large; prefer single pages)
+- Append `.md` to any docs URL for that page's exact source markdown (for example https://orpc.dev/docs/contract/procedure.md)
 
 Pages to fetch when you need details beyond this skill:
 

--- a/skills/orpc-migrate/SKILL.md
+++ b/skills/orpc-migrate/SKILL.md
@@ -114,10 +114,10 @@ Verification: typecheck and unit tests after steps 1, 2, and 4; step 3 needs int
 
 ## Docs retrieval
 
-Fetch pages instead of recalling them, and if this skill and a fetched page disagree, trust the page. The v2 docs live at https://v2.orpc.dev; while v2 is in beta, https://orpc.dev still serves the v1 docs (same-looking slugs, wrong or missing content), so never fetch from it. The index of every docs page is at https://v2.orpc.dev/llms.txt (its links print the orpc.dev domain; swap in v2.orpc.dev before fetching), https://v2.orpc.dev/llms-full.txt bundles the entire docs in one large file, and appending `.md` to any page URL returns its exact source markdown.
+Fetch pages instead of recalling them, and if this skill and a fetched page disagree, trust the page. The v2 docs live at https://orpc.dev and the v1 docs at https://v1.orpc.dev; slugs look alike across both hosts, so check which host a page came from before copying anything from it. The index of every v2 docs page is at https://orpc.dev/llms.txt, https://orpc.dev/llms-full.txt bundles the entire docs in one large file, and appending `.md` to any page URL returns its exact source markdown.
 
 Authoritative pages to consult during the migration (this skill deliberately omits their full mapping tables):
 
-- https://v2.orpc.dev/docs/migrations/from-trpc : side-by-side tRPC/oRPC code for every step, including server setup per framework
-- https://v2.orpc.dev/docs/migrations/from-v1 : every v2 breaking change with v1/v2 comparisons, package rename table, and the deprecated alias cheat sheet
-- https://v2.orpc.dev/docs/integrations/trpc : `toORPCRouter` and `toTRPCMeta` reference for the incremental path
+- https://orpc.dev/docs/migrations/from-trpc : side-by-side tRPC/oRPC code for every step, including server setup per framework
+- https://orpc.dev/docs/migrations/from-v1 : every v2 breaking change with v1/v2 comparisons, package rename table, and the deprecated alias cheat sheet
+- https://orpc.dev/docs/integrations/trpc : `toORPCRouter` and `toTRPCMeta` reference for the incremental path

--- a/skills/orpc-openapi/SKILL.md
+++ b/skills/orpc-openapi/SKILL.md
@@ -139,11 +139,11 @@ Contract-first workflows belong to the `orpc-contract` skill: defining the shape
 
 ## Full documentation
 
-If this skill and a fetched docs page disagree, trust the page: this skill is a summary and v2 is still moving. While v2 is in beta the docs are served at https://v2.orpc.dev:
+If this skill and a fetched docs page disagree, trust the page: this skill is a summary and v2 is still moving. The docs are served at https://orpc.dev (the v1 docs stay at https://v1.orpc.dev):
 
-- https://v2.orpc.dev/llms.txt : index of every page with descriptions (links inside print the orpc.dev domain; swap in v2.orpc.dev before fetching)
-- https://v2.orpc.dev/llms-full.txt : the entire docs in one file (large; prefer single pages)
-- Append `.md` to any docs URL for that page's exact source markdown (for example https://v2.orpc.dev/docs/openapi/routing.md)
+- https://orpc.dev/llms.txt : index of every page with descriptions
+- https://orpc.dev/llms-full.txt : the entire docs in one file (large; prefer single pages)
+- Append `.md` to any docs URL for that page's exact source markdown (for example https://orpc.dev/docs/openapi/routing.md)
 
 Pages to fetch when you need details beyond this skill:
 

--- a/skills/orpc/SKILL.md
+++ b/skills/orpc/SKILL.md
@@ -8,9 +8,9 @@ license: MIT
 
 oRPC is a typesafe API framework: write plain TypeScript functions on the server, call them from clients like local functions. Input is validated at runtime, types flow end to end, and there is no code generation step. The same router can also be served as a REST API with an OpenAPI spec.
 
-This skill targets oRPC v2. Check what is installed before writing code: `npm ls @orpc/server` (or any `@orpc/*` package). A 1.x version means v1, where this skill's guidance does not apply; use the `orpc-migrate` skill to upgrade. v2 currently ships under the `beta` dist-tag (`npm install @orpc/server@beta @orpc/client@beta`; a plain install silently gets v1). If `npm view @orpc/server dist-tags` shows `latest` at 2.x, the beta has ended: install normally and read docs at https://orpc.dev instead of https://v2.orpc.dev.
+This skill targets oRPC v2. Check what is installed before writing code: `npm ls @orpc/server` (or any `@orpc/*` package). A 1.x version means v1, where this skill's guidance does not apply; use the `orpc-migrate` skill to upgrade. v2 currently ships under the `beta` dist-tag (`npm install @orpc/server@beta @orpc/client@beta`; a plain install silently gets v1). If `npm view @orpc/server dist-tags` shows `latest` at 2.x, the beta has ended: install normally.
 
-Pretrained oRPC knowledge describes v1 and is often wrong for v2 (routing moved to `.meta(openapi(...))`, `RPCLink` split `url` into `origin` plus a path, automatic middleware dedupe was removed). Prefer retrieval: the index of every docs page is at https://v2.orpc.dev/llms.txt; see [Full documentation](#full-documentation) for the mechanics.
+Pretrained oRPC knowledge describes v1 and is often wrong for v2 (routing moved to `.meta(openapi(...))`, `RPCLink` split `url` into `origin` plus a path, automatic middleware dedupe was removed). Prefer retrieval: the index of every docs page is at https://orpc.dev/llms.txt; see [Full documentation](#full-documentation) for the mechanics.
 
 Package map:
 
@@ -157,7 +157,7 @@ const server = createServer(async (req, res) => {
 server.listen(3000)
 ```
 
-Unmatched requests fall through to your own handling. By default `RPCHandler` accepts only `POST`, `PUT`, `PATCH`, and `DELETE`; enabling `GET` via `allowMethods` is a CSRF risk with cookie auth, see [RPC Handler](https://v2.orpc.dev/docs/rpc/handler). Handler options also include `interceptors`, `routingInterceptors`, `clientInterceptors`, `plugins`, `filter`, and `errorStatusMap`. Adapters also exist for [AWS Lambda](https://v2.orpc.dev/docs/adapters/aws-lambda), [Fastify](https://v2.orpc.dev/docs/adapters/fastify), [WebSocket](https://v2.orpc.dev/docs/adapters/websocket), [Message Port](https://v2.orpc.dev/docs/adapters/message-port), and [React Native](https://v2.orpc.dev/docs/adapters/react-native).
+Unmatched requests fall through to your own handling. By default `RPCHandler` accepts only `POST`, `PUT`, `PATCH`, and `DELETE`; enabling `GET` via `allowMethods` is a CSRF risk with cookie auth, see [RPC Handler](https://orpc.dev/docs/rpc/handler). Handler options also include `interceptors`, `routingInterceptors`, `clientInterceptors`, `plugins`, `filter`, and `errorStatusMap`. Adapters also exist for [AWS Lambda](https://orpc.dev/docs/adapters/aws-lambda), [Fastify](https://orpc.dev/docs/adapters/fastify), [WebSocket](https://orpc.dev/docs/adapters/websocket), [Message Port](https://orpc.dev/docs/adapters/message-port), and [Expo](https://orpc.dev/docs/adapters/expo).
 
 ## Call procedures
 
@@ -209,29 +209,29 @@ const safeClient = createSafeClient(orpc) // every call returns [error, data]
 
 ## Beyond the basics
 
-- Streaming / SSE: return an async generator from `.handler`, validate events with `asyncIteratorObject`, resume via `lastEventId`: [AsyncIteratorObject](https://v2.orpc.dev/docs/async-iterator-object)
-- OpenAPI: serve the same router as REST with routing metadata plus `OpenAPIHandler`, and generate a spec (covered in depth by the `orpc-openapi` skill): [OpenAPI Handler](https://v2.orpc.dev/docs/openapi/handler)
-- Contract-first: define contracts with `@orpc/contract`, implement with `implement` (covered in depth by the `orpc-contract` skill): [Contracts](https://v2.orpc.dev/docs/contract/procedure)
-- Plugins for handler and link: batch, CORS, dedupe, retry, compression, request limits, smart coercion, static files, timeout, tmp file upload, and more. Fetch a plugin's docs page before configuring it; option names are not guessable: [Plugins](https://v2.orpc.dev/docs/plugins/batch)
-- Integrations: [TanStack Query](https://v2.orpc.dev/docs/integrations/tanstack-query) (`createTanstackQueryUtils`), [SWR](https://v2.orpc.dev/docs/integrations/swr), [Pinia Colada](https://v2.orpc.dev/docs/integrations/pinia-colada), [Next.js](https://v2.orpc.dev/docs/integrations/next), [NestJS](https://v2.orpc.dev/docs/integrations/nest), [AI SDK](https://v2.orpc.dev/docs/integrations/ai-sdk), [OpenTelemetry](https://v2.orpc.dev/docs/integrations/opentelemetry)
-- Testing: `call` procedures directly; mock with `implement(router.planet.list).handler(() => [])`, and run the project's typecheck before declaring success, since end-to-end types are oRPC's first correctness signal: [Testing and Mocking](https://v2.orpc.dev/docs/recipes/testing-and-mocking)
-- Monorepos: TypeScript project references keep client types resolvable: [Monorepo Setup](https://v2.orpc.dev/docs/recipes/monorepo-setup)
+- Streaming / SSE: return an async generator from `.handler`, validate events with `asyncIteratorObject`, resume via `lastEventId`: [AsyncIteratorObject](https://orpc.dev/docs/async-iterator-object)
+- OpenAPI: serve the same router as REST with routing metadata plus `OpenAPIHandler`, and generate a spec (covered in depth by the `orpc-openapi` skill): [OpenAPI Handler](https://orpc.dev/docs/openapi/handler)
+- Contract-first: define contracts with `@orpc/contract`, implement with `implement` (covered in depth by the `orpc-contract` skill): [Contracts](https://orpc.dev/docs/contract/procedure)
+- Plugins for handler and link: batch, CORS, dedupe, retry, compression, request limits, smart coercion, static files, timeout, tmp file upload, and more. Fetch a plugin's docs page before configuring it; option names are not guessable: [Plugins](https://orpc.dev/docs/plugins/batch)
+- Integrations: [TanStack Query](https://orpc.dev/docs/integrations/tanstack-query) (`createTanstackQueryUtils`), [SWR](https://orpc.dev/docs/integrations/swr), [Pinia Colada](https://orpc.dev/docs/integrations/pinia-colada), [Next.js](https://orpc.dev/docs/integrations/next), [NestJS](https://orpc.dev/docs/integrations/nest), [AI SDK](https://orpc.dev/docs/integrations/ai-sdk), [OpenTelemetry](https://orpc.dev/docs/integrations/opentelemetry)
+- Testing: `call` procedures directly; mock with `implement(router.planet.list).handler(() => [])`, and run the project's typecheck before declaring success, since end-to-end types are oRPC's first correctness signal: [Testing and Mocking](https://orpc.dev/docs/recipes/testing-and-mocking)
+- Monorepos: TypeScript project references keep client types resolvable: [Monorepo Setup](https://orpc.dev/docs/recipes/monorepo-setup)
 - Migrating from tRPC or oRPC v1: use the `orpc-migrate` skill
 
 ## Full documentation
 
-This skill is an overview; fetch exact docs instead of guessing APIs, and if this skill and a fetched page disagree, trust the page. While v2 is in beta the docs are served at https://v2.orpc.dev:
+This skill is an overview; fetch exact docs instead of guessing APIs, and if this skill and a fetched page disagree, trust the page. The docs are served at https://orpc.dev (the v1 docs stay at https://v1.orpc.dev):
 
-- https://v2.orpc.dev/llms.txt : index of every page with descriptions (links inside print the orpc.dev domain; swap in v2.orpc.dev before fetching)
-- https://v2.orpc.dev/llms-full.txt : the entire docs in one file (large; prefer single pages)
-- Append `.md` to any docs URL for that page's exact source markdown (for example https://v2.orpc.dev/docs/procedure.md)
+- https://orpc.dev/llms.txt : index of every page with descriptions
+- https://orpc.dev/llms-full.txt : the entire docs in one file (large; prefer single pages)
+- Append `.md` to any docs URL for that page's exact source markdown (for example https://orpc.dev/docs/procedure.md)
 
-Doc map, all under `https://v2.orpc.dev/docs/`:
+Doc map, all under `https://orpc.dev/docs/`:
 
 - Top level: `procedure`, `router`, `middleware`, `context`, `error-handling`, `metadata`, plus `binary-data` (file uploads) and `async-iterator-object` (streaming/SSE)
 - `rpc/*`, `openapi/*`: protocol details, handlers, links; `contract/*`: contract-first (the `orpc-contract` skill)
 - `client/*`: server- and client-side clients, error handling, `DynamicLink`
-- `adapters/*`: per-runtime serving quirks (fetch-api, node-http, aws-lambda, fastify, websocket, message-port, react-native)
+- `adapters/*`: per-runtime serving quirks (fetch-api, node-http, aws-lambda, fastify, websocket, message-port, expo)
 - `plugins/*`: twenty handler/link plugins; `helpers/*`: cookie, encryption, form-data, publisher, ratelimit, signing, base64url
 - `integrations/*`: framework glue; `recipes/*`: guidance (testing, SSR, monorepos, validation)
 - `migrations/from-v1`, `migrations/from-trpc`: upgrades (use the `orpc-migrate` skill)


### PR DESCRIPTION
orpc.dev now serves the v2 docs, v1.orpc.dev serves v1, and v2.orpc.dev 302s to orpc.dev with the path preserved. The published agent skills were the only place in the repo still hardcoding the beta host, so agents loading them were being sent to a redirect and told to avoid the canonical domain.

Every other reference was already written against orpc.dev as v2's eventual home, so the DNS flip made them correct with no edit. The skills are the exception because they ship to agents that fetch at that moment, so they had to name the then-live host and warn readers off orpc.dev.

## Fixes

All 28 `v2.orpc.dev` URLs now point at `orpc.dev`. The caveats built around the old split are gone: the "while v2 is in beta the docs are served at" framing, the `llms.txt` "swap in v2.orpc.dev before fetching" workaround, which is now a no-op, and `orpc-migrate`'s instruction to never fetch orpc.dev because it serves v1, which had become the opposite of the truth. The v1 docs are named at v1.orpc.dev instead, keeping the hazard that actually still applies: both hosts share same-looking slugs, so it matters which one a page came from.

Two stale links to the React Native adapter page, renamed to `expo` in #1932, are corrected as well.

The `@beta` install guidance is unchanged and still accurate: `npm view @orpc/server dist-tags` shows `latest` at 1.15.0, `beta` at 2.0.0-beta.31. The docs-wide `@beta` sweep and the site's beta banner remain gated on `latest` reaching 2.x.

## Testing

`scripts/verify-docs-jsdoc.ts` reports 0 errors across 208 docs-mentioned symbols and 338 orpc.dev links. Every one of the 29 unique URLs the skills cite was curl-checked against the live site and returns 200. `pnpm exec eslint skills/` passes, and all four SKILL.md frontmatter blocks still parse through a real YAML parser with names and descriptions intact, so the discovery index at `/.well-known/agent-skills/` keeps listing all four.

No `v2.orpc.dev` reference remains anywhere in the repo.

## Note for reviewers

Unrelated gap found while verifying: `/docs/adapters/react-native` has no redirect entry in `apps/content/blume.config.ts` after #1932 renamed the page, so that indexed URL 404s. Left out of this PR as out of scope; happy to add it here or separately.