### PR TITLE
chore(content): move LLM context to Resources and even out the footer columns

### DIFF
--- a/apps/content/pages/_home/Footer.astro
+++ b/apps/content/pages/_home/Footer.astro
@@ -15,6 +15,7 @@ const columns: { title: string, links: FooterLink[] }[] = [
     title: 'Documentation',
     links: [
       { label: 'Getting started', href: '/docs/getting-started' },
+      { label: 'Contract-first', href: '/docs/contract-first' },
       { label: 'OpenAPI', href: '/docs/openapi/handler' },
       { label: 'Error handling', href: '/docs/error-handling' },
       { label: 'Migrate from tRPC', href: '/docs/migrations/from-trpc' },
@@ -25,6 +26,7 @@ const columns: { title: string, links: FooterLink[] }[] = [
     title: 'Ecosystem',
     links: [
       { label: 'TanStack Query', href: '/docs/integrations/tanstack-query' },
+      { label: 'AI SDK', href: '/docs/integrations/ai-sdk' },
       { label: 'NestJS', href: '/docs/integrations/nest' },
       { label: 'Adapters', href: '/docs/adapters/fetch-api' },
       { label: 'Plugins', href: '/docs/plugins/cors' },
@@ -37,6 +39,7 @@ const columns: { title: string, links: FooterLink[] }[] = [
       { label: 'Playgrounds', href: '/docs/playgrounds' },
       { label: 'Comparison', href: '/docs/comparison' },
       { label: 'Blog', href: '/blog' },
+      { label: 'LLM context', href: '/llms.txt', external: true },
       { label: 'Releases', href: 'https://github.com/middleapi/orpc/releases' },
       { label: 'V1 documentation', href: 'https://v1.orpc.dev' },
     ],
@@ -45,13 +48,11 @@ const columns: { title: string, links: FooterLink[] }[] = [
     title: 'Community',
     links: [
       { label: 'GitHub', href: 'https://github.com/middleapi/orpc' },
-      { label: 'Discord', href: 'https://discord.gg/TXEbwRBvQn' },
       { label: 'Discussions', href: 'https://github.com/middleapi/orpc/discussions' },
+      { label: 'Discord', href: 'https://discord.gg/TXEbwRBvQn' },
+      { label: 'X', href: 'https://x.com/middleapi' },
       { label: 'GitHub Sponsors', href: 'https://github.com/sponsors/dinwwwh' },
       { label: 'Open Collective', href: 'https://opencollective.com/middleapi' },
-      // Same-origin but not a page: leaving the site for a raw text dump in the
-      // current tab is a dead end, so it opens in a new one like the rest.
-      { label: 'LLM context', href: '/llms.txt', external: true },
     ],
   },
 ]


### PR DESCRIPTION
LLM context sat in the home page footer's Community column, which is otherwise entirely places where people are: GitHub, Discord, Discussions, Sponsors, Open Collective. It is a raw artifact you feed to a model, so it belongs alongside Playgrounds, Comparison, and Blog. Moving it left Community at five entries and Resources at six, so the other two columns gain an entry each and all four now line up at six.

The "it's already in the header's More dropdown" case for deleting it instead doesn't single it out: 9 of the footer's 21 links are also reachable from the header, including Blog, Comparison, Releases, V1 documentation, Discussions, Sponsors, and Open Collective. Duplication is the footer's normal condition, and llms.txt is worth advertising to humans, since copying it into a model is a person's action.

## Changes

| Documentation | Ecosystem | Resources | Community |
|---|---|---|---|
| Getting started | TanStack Query | Playgrounds | GitHub |
| **Contract-first** | **AI SDK** | Comparison | Discussions |
| OpenAPI | NestJS | Blog | Discord |
| Error handling | Adapters | **LLM context** | **X** |
| Migrate from tRPC | Plugins | Releases | GitHub Sponsors |
| Migrate from v1 | Community packages | V1 documentation | Open Collective |

Contract-first and AI SDK are the highest-traffic pages not already reachable from the footer or the header nav. Contract-first also lands in slot 2, mirroring `docs/meta.ts`, where it sits directly after getting-started. It is spelled hyphenated to match the page's own `title` and the footer's sentence case.

Ordering in the two changed columns groups by destination. Resources keeps everything hosted on orpc.dev together and closes with the two links that leave the domain. Community pairs the repo links, then the two places to talk, then the two funding links, which moves Discussions up next to GitHub instead of leaving Discord between them.

## Testing

All 24 footer links checked live: every one returns 200 except Discord, a normal `discord.gg` invite 301, and Open Collective, which 403s to automated requests. Both are untouched by this PR.

eslint has no configuration covering `.astro`, so it reports the file as ignored rather than checking it. Compile-checked through `@astrojs/compiler-rs` instead: 0 diagnostics, with every new label and href present in the emitted output.

## Note for reviewers

The comment explaining why a same-origin `/llms.txt` link opens in a new tab moved with the link, so it still sits with the code it describes.

Unrelated gap, not addressed here: `/docs/adapters/react-native` has no redirect in `apps/content/blume.config.ts` after #1932 renamed the page to `expo`, so that indexed URL 404s.