### PR TITLE
chore(content): send PostHog through the poho.orpc.dev reverse proxy

### DIFF
--- a/apps/content/blume.config.ts
+++ b/apps/content/blume.config.ts
@@ -69,8 +69,14 @@ export default defineConfig({
   },
   analytics: {
     posthog: {
+      /** Reverse proxy on our own domain, so ad blockers don't drop events. */
+      host: 'https://poho.orpc.dev',
       key: 'phc_YHeqjC9tR604AHH45kQi63fT4aBvpsS7zAaCxntBzZm',
     },
+    scripts: [
+      /** A reverse proxy requires `ui_host`, and Blume has no option for it. */
+      { content: 'posthog.set_config({ ui_host: "https://us.posthog.com" })' },
+    ],
   },
 
   seo: {


### PR DESCRIPTION
Analytics for the docs site now goes through `poho.orpc.dev`, the PostHog-managed reverse proxy on our own domain, so events from ad-blocked visitors reach the project instead of being dropped. The proxy serves posthog-js and its lazy-loaded bundles too, so nothing on the page requests `*.i.posthog.com` anymore.

The second line pins `ui_host`. posthog-js derives it from the ingestion host by rewriting `.i.posthog.com`, which is a no-op on a custom domain, so without it every link the SDK builds client-side (toolbar, session replay URLs) points at the proxy, which serves no UI. Blume has no config option for it, so it goes in through the `analytics.scripts` escape hatch; the loader stub queues the call and replays it once the library loads.

## Testing

Checked against a production build served by `blume preview`. `api_host` is the proxy, `ui_host` and the resolved `uiHost` are `https://us.posthog.com`, and `array.js`, the remote config, web-vitals, dead-clicks, and surveys bundles all load from `poho.orpc.dev` with no console errors. Client-side navigations keep the setting and re-execute neither script.

A control run without the `set_config` line resolves `uiHost` to `https://poho.orpc.dev` and hands out replay links on that domain, which confirms the line is doing real work.
