### PR TITLE
chore(content): stop the page rail from leaking below 1280px

### DIFF
--- a/apps/content/theme.css
+++ b/apps/content/theme.css
@@ -309,15 +309,22 @@ main#blume-content {
    the aside lets the card's `order-1` + `mt-auto` pin it to the bottom of the
    rail without owning RootLayout. The card's sticky wrapper owns the bottom
    spacing instead of the aside's pb-10, so the card rests at the same offset
-   whether the rail scrolls (stuck at bottom-0) or not (mt-auto). */
-aside[data-blume-toc] {
-  display: flex;
-  flex-direction: column;
-  padding-bottom: 0;
-}
+   whether the rail scrolls (stuck at bottom-0) or not (mt-auto).
 
-aside[data-blume-toc] > * {
-  flex: none;
+   Scoped to xl, the tier Blume reveals the rail at: `aside[data-blume-toc]`
+   outranks the `hidden` utility that hides it below xl, so an unscoped
+   `display` here would leak the rail onto every narrower viewport as an
+   extra grid row under the nav column. */
+@media (min-width: 80rem) {
+  aside[data-blume-toc] {
+    display: flex;
+    flex-direction: column;
+    padding-bottom: 0;
+  }
+
+  aside[data-blume-toc] > * {
+    flex: none;
+  }
 }
 
 /* Blume tints `:::tip` blocks with the accent color, which here is the brand


### PR DESCRIPTION
The on-this-page rail rendered at every viewport width instead of only from 1280px up, so below that tier it landed as an extra grid row under the nav column and its sticky positioning painted the table of contents and page actions on top of the sidebar. The rail now disappears below 1280px as intended, leaving the collapsible "On this page" disclosure as the only table of contents there.

Introduced by #1902, which added the flex context the coffee card needs but left it unscoped: `aside[data-blume-toc]` outranks the `hidden` utility Blume hides the rail with.

## Fixes

- Docs and blog pages between 1024px and 1280px no longer show the rail overlapping the sidebar, and no longer carry the 918px of dead scroll the phantom grid row added.
- Mobile and tablet widths no longer append a full-width duplicate table of contents and page-actions block, worth another 755px of dead scroll, to the bottom of every page.

## Testing

Checked on `blume dev` at 375, 1023, 1210, 1279, 1280 and 1440px on both a docs page and a blog post. Below 1280px the rail computes to `display: none` with the grid height matching the content column exactly; from 1280px up the three-column grid, the rail's flex column and the coffee card pinned flush to the viewport bottom are unchanged. No console errors, no horizontal overflow at any width. A sweep of the live DOM for other `hidden` utilities losing on specificity found none.