### PR TITLE
fix(openapi): give path params precedence over query and body in compact input

### DIFF
--- a/packages/openapi/src/adapters/standard/openapi-handler-codec.test.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler-codec.test.ts
@@ -110,6 +110,25 @@ describe('openAPIHandlerCodec', () => {
         expect(resolveBody).not.toHaveBeenCalled()
       })
 
+      it('gives path params precedence over conflicting query params', async () => {
+        const procedure = os
+          .meta(openapi({ method: 'GET', path: '/{id}' }))
+          .handler(vi.fn())
+        const codec = new OpenAPIHandlerCodec(procedure)
+
+        const result = await codec.resolveProcedure(createRequest({
+          method: 'GET',
+          url: '/42?id=99&q=hello',
+        }), options as any)
+
+        expect(result).toBeDefined()
+
+        await expect(result!.decodeInput()).resolves.toEqual({
+          id: '42',
+          q: 'hello',
+        })
+      })
+
       it('returns query directly when there are no path params', async () => {
         const procedure = os
           .meta(openapi({ method: 'GET', path: '/status' }))
@@ -233,6 +252,30 @@ describe('openAPIHandlerCodec', () => {
 
         expect(resolveBody).toHaveBeenCalledOnce()
         expect(resolveBody).toHaveBeenCalledWith('url-search-params')
+      })
+
+      it('gives path params precedence over conflicting body properties', async () => {
+        const procedure = os
+          .meta(openapi({ method: 'POST', path: '/{id}', requestBodyHint: 'url-search-params' }))
+          .handler(vi.fn())
+        const codec = new OpenAPIHandlerCodec(procedure)
+        const resolveBody = vi.fn().mockResolvedValueOnce(new URLSearchParams([
+          ['id', '99'],
+          ['title', 'hello'],
+        ]))
+
+        const result = await codec.resolveProcedure(createRequest({
+          method: 'POST',
+          url: '/24',
+          resolveBody,
+        }), options as any)
+
+        expect(result).toBeDefined()
+
+        await expect(result!.decodeInput()).resolves.toEqual({
+          id: '24',
+          title: 'hello',
+        })
       })
 
       it('returns a primitive body as-is when it cannot be merged with path params', async () => {

--- a/packages/openapi/src/adapters/standard/openapi-handler-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler-codec.ts
@@ -82,8 +82,8 @@ export class OpenAPIHandlerCodecCore<T extends Context> {
 
       if (isPlainObject(data)) {
         return {
-          ...params,
           ...data,
+          ...params,
         }
       }
 


### PR DESCRIPTION
In `compact` input structure, path params were merged into the query or body with the client-controlled data spread last, so a colliding key silently overwrote the value the router derived from the URL path. `POST /posts/24` with body `id=99` reached the handler as `{ id: '99' }`. Path params now win on collision, so a client can no longer rewrite a value taken from the URL.

## Fixes

- A request cannot substitute its own value for a path param it collides with. Any authorization or ownership check reading that key now sees the routed value, not the one the caller supplied.
- Applies to both directions of the merge: query params on bodyless methods and body properties on the rest.

## Compatibility

Round-trips through an oRPC client are unchanged. The link codec already deletes each dynamic param key from the data before serializing it as query or body, so a colliding key never leaves a real client. Only requests that deliberately shadow a path segment change behavior.

Non-mergeable bodies (Blob, streams, arrays, primitives) are untouched: they have no keys to shadow a param, so the body still becomes the full input, as documented for `compact`.

## Testing

`pnpm vitest run packages/openapi tests/` passes (859 tests). Two cases added covering the collision on each path: `GET /42?id=99&q=hello` yields `{ id: '42', q: 'hello' }`, and `POST /24` with body `id=99&title=hello` yields `{ id: '24', title: 'hello' }`.