### PR TITLE
chore(content): tighten the docs sidebar rail's vertical padding

### DIFF
--- a/apps/content/theme.css
+++ b/apps/content/theme.css
@@ -75,7 +75,7 @@
     top: var(--docs-header-height);
     height: calc(100dvh - var(--docs-header-height));
     border-inline-end: 1px solid var(--blume-border);
-    padding: 2rem 1.5rem 2.5rem 1.25rem;
+    padding: 1.5rem 1.5rem 2rem 1.25rem;
   }
 
   /* Docs content column only — PageLayout pages (blog, custom landings)


### PR DESCRIPTION
The docs sidebar rail carried 32px of top padding and 40px of bottom padding, leaving a noticeably large dead zone between the header and the first nav item, and below the last item at the end of the scroll. This reduces the rail to 24px top / 32px bottom, one step tighter while keeping the original bottom-heavier ratio so the list doesn't sit against the viewport edge at the scroll boundary.

## Testing

- Applied the exact new padding to the live orpc.dev DOM and re-measured: the header-to-first-item gap drops from 32px to 24px.
- Desktop only: the rule is scoped to the lg breakpoint, so the mobile drawer keeps Blume's defaults.