### PR TITLE
feat(pino,evlog): allow customizing log level for procedure errors in pino and evlog plugins

### DIFF
--- a/apps/content/docs/integrations/evlog.mdx
+++ b/apps/content/docs/integrations/evlog.mdx
@@ -40,6 +40,22 @@ const handler = new RPCHandler(router, {
 The `handler` can be any supported oRPC handler, such as [RPCHandler](/docs/rpc/handler), [OpenAPIHandler](/docs/openapi/handler), or a custom one.
 :::
 
+## Error Logging Levels
+
+Errors thrown from your procedures set the wide event's level to match their intent: `info` for abort errors, `warn` for `ORPCError` instances since they represent deliberate rejections, and `error` for everything else, including `ORPCError` with the `INTERNAL_SERVER_ERROR` code. Use the `procedureErrorLevel` option to customize this behavior:
+
+```ts
+const plugin = new EvlogHandlerPlugin({
+  procedureErrorLevel: (error, level) => {
+    if (level === 'error' && error instanceof ExpectedError) {
+      return 'warn'
+    }
+
+    return level
+  },
+})
+```
+
 ## Using the Logger in Your Code
 
 This plugin supports using [AsyncLocalStorage](https://nodejs.org/api/async_context.html#class-asynclocalstorage) to access the logger throughout a request and enrich the final [wide event](https://www.evlog.dev/learn/wide-events#uselogger-retrieving-the-request-logger). It is the most convenient way to use Evlog's full feature set. If your runtime does not support AsyncLocalStorage, you can still [access the logger from the context](#without-asynclocalstorage).

--- a/apps/content/docs/integrations/pino.mdx
+++ b/apps/content/docs/integrations/pino.mdx
@@ -53,6 +53,22 @@ npm run dev | npx pino-pretty
 
 :::
 
+## Error Logging Levels
+
+Errors thrown from your procedures are logged at a level matching their intent: `info` for abort errors, `warn` for `ORPCError` instances since they represent deliberate rejections, and `error` for everything else, including `ORPCError` with the `INTERNAL_SERVER_ERROR` code. Use the `procedureErrorLevel` option to customize this behavior:
+
+```ts
+const plugin = new PinoHandlerPlugin({
+  procedureErrorLevel: (error, level) => {
+    if (level === 'error' && error instanceof ExpectedError) {
+      return 'warn'
+    }
+
+    return level
+  },
+})
+```
+
 ## Using the Logger in Your Code
 
 You can access the logger from the context object using the `getLogger` function:

--- a/packages/evlog/src/adapters/node.test.ts
+++ b/packages/evlog/src/adapters/node.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+import { createLoggerStorage } from './node'
+
+describe('createLoggerStorage', () => {
+  it('exposes useLogger backed by the storage', () => {
+    const { storage, useLogger } = createLoggerStorage()
+    const logger = { set: () => {} } as any
+
+    storage!.run(logger, () => {
+      expect(useLogger()).toBe(logger)
+    })
+
+    expect(() => useLogger()).toThrow(
+      'please configure EvlogHandlerPlugin for your handler using the created storage',
+    )
+  })
+})

--- a/packages/evlog/src/handler-plugin.test.ts
+++ b/packages/evlog/src/handler-plugin.test.ts
@@ -497,6 +497,22 @@ describe('evlogHandlerPlugin', () => {
     expect(logger.setLevel).not.toHaveBeenCalled()
   })
 
+  it('skips procedure error logging when no logger is in the context', async () => {
+    const procedureErrorLevel = vi.fn()
+    const plugin = new EvlogHandlerPlugin({ procedureErrorLevel })
+    const { interceptor } = getPluginHooks(plugin)
+    const error = new Error('boom')
+
+    await expect(interceptor({
+      next: vi.fn().mockRejectedValue(error),
+      context: {},
+      path: ['ping'],
+      request: createRequest('/ping'),
+    })).rejects.toThrow(error)
+
+    expect(procedureErrorLevel).not.toHaveBeenCalled()
+  })
+
   it('honors the procedureErrorLevel option, passing the error and its default level', async () => {
     const logger = createLogger()
     const procedureErrorLevel = vi.fn(

--- a/packages/evlog/src/handler-plugin.test.ts
+++ b/packages/evlog/src/handler-plugin.test.ts
@@ -435,7 +435,7 @@ describe('evlogHandlerPlugin', () => {
     })
   })
 
-  it('downgrades business errors (ORPCError) to warn level and abort errors to info level, keeps unexpected errors at error level', async () => {
+  it('downgrades business errors (ORPCError) to warn level and abort errors to info level, keeps INTERNAL_SERVER_ERROR and unexpected errors at error level', async () => {
     const logger = createLogger()
     const plugin = new EvlogHandlerPlugin()
     const { interceptor } = getPluginHooks(plugin)
@@ -480,6 +480,58 @@ describe('evlogHandlerPlugin', () => {
 
     expect(logger.error).toHaveBeenCalledWith(abortError)
     expect(logger.setLevel).toHaveBeenCalledWith('info')
+
+    logger.error.mockClear()
+    logger.setLevel.mockClear()
+
+    const internalError = new ORPCError('INTERNAL_SERVER_ERROR')
+
+    await expect(interceptor({
+      next: vi.fn().mockRejectedValue(internalError),
+      context: { [LOGGER_CONTEXT_SYMBOL]: logger },
+      path: ['ping'],
+      request: createRequest('/ping'),
+    })).rejects.toThrow(internalError)
+
+    expect(logger.error).toHaveBeenCalledWith(internalError)
+    expect(logger.setLevel).not.toHaveBeenCalled()
+  })
+
+  it('honors the procedureErrorLevel option, passing the error and its default level', async () => {
+    const logger = createLogger()
+    const procedureErrorLevel = vi.fn(
+      (error: unknown, level: 'info' | 'error' | 'warn' | 'debug') =>
+        error instanceof ORPCError && error.code === 'UNAUTHORIZED' ? 'debug' as const : level,
+    )
+    const plugin = new EvlogHandlerPlugin({ procedureErrorLevel })
+    const { interceptor } = getPluginHooks(plugin)
+    const businessError = new ORPCError('UNAUTHORIZED')
+
+    await expect(interceptor({
+      next: vi.fn().mockRejectedValue(businessError),
+      context: { [LOGGER_CONTEXT_SYMBOL]: logger },
+      path: ['ping'],
+      request: createRequest('/ping'),
+    })).rejects.toThrow(businessError)
+
+    expect(procedureErrorLevel).toHaveBeenCalledWith(businessError, 'warn')
+    expect(logger.error).toHaveBeenCalledWith(businessError)
+    expect(logger.setLevel).toHaveBeenCalledWith('debug')
+
+    logger.error.mockClear()
+    logger.setLevel.mockClear()
+
+    const otherError = new ORPCError('CONFLICT')
+
+    await expect(interceptor({
+      next: vi.fn().mockRejectedValue(otherError),
+      context: { [LOGGER_CONTEXT_SYMBOL]: logger },
+      path: ['ping'],
+      request: createRequest('/ping'),
+    })).rejects.toThrow(otherError)
+
+    expect(procedureErrorLevel).toHaveBeenCalledWith(otherError, 'warn')
+    expect(logger.setLevel).toHaveBeenCalledWith('warn')
   })
 
   it('returns non-stream client outputs unchanged', async () => {

--- a/packages/evlog/src/handler-plugin.ts
+++ b/packages/evlog/src/handler-plugin.ts
@@ -1,7 +1,7 @@
 import type { Context, ErrorMap, ProcedureClientInterceptor, Schema } from '@orpc/server'
 import type { StandardHandlerInterceptor, StandardHandlerOptions, StandardHandlerPlugin, StandardHandlerRoutingInterceptor } from '@orpc/server/standard'
 import type { StandardRequest } from '@standardserver/core'
-import type { RequestLogger } from 'evlog'
+import type { LogLevel, RequestLogger } from 'evlog'
 import type { BaseEvlogOptions, FrameworkIntegrationHelpers, FrameworkIntegrationSpec } from 'evlog/toolkit'
 import { ORPCError, wrapAsyncIteratorPreservingEventMeta } from '@orpc/client'
 import { isAbortError, isAsyncIteratorObject, ORPC_NAME, override, sleep, toArray, wrapReadableStream } from '@orpc/shared'
@@ -21,6 +21,16 @@ export interface EvlogHandlerPluginOptions<_T extends Context> extends BaseEvlog
    * @default false
    */
   logAbort?: boolean
+
+  /**
+   * Customizes the log level for errors thrown from procedures;
+   * internal handler failures are always logged at error level.
+   * Receives the level applied by default; return it to keep the default behavior:
+   * 'info' for abort errors, 'warn' for ORPCError except INTERNAL_SERVER_ERROR, 'error' otherwise.
+   *
+   * @default (error, level) => level
+   */
+  procedureErrorLevel?: (error: unknown, level: LogLevel) => LogLevel
 }
 
 /**
@@ -41,14 +51,16 @@ export class EvlogHandlerPlugin<T extends Context> implements StandardHandlerPlu
   before = ['~opentelemetry', '~batch', '~hibernation']
 
   private readonly logAbort: Exclude<EvlogHandlerPluginOptions<T>['logAbort'], undefined>
+  private readonly procedureErrorLevel: Exclude<EvlogHandlerPluginOptions<T>['procedureErrorLevel'], undefined>
   private readonly integration: FrameworkIntegrationHelpers<{ request: StandardRequest }>
   private readonly evlogOptions: BaseEvlogOptions
 
   constructor(
-    { storage, logAbort, ...evlogOptions }: EvlogHandlerPluginOptions<T> = {},
+    { storage, logAbort, procedureErrorLevel, ...evlogOptions }: EvlogHandlerPluginOptions<T> = {},
   ) {
     this.evlogOptions = evlogOptions
     this.logAbort = logAbort ?? false
+    this.procedureErrorLevel = procedureErrorLevel ?? ((_, level) => level)
     this.integration = defineFrameworkIntegration({
       name: ORPC_NAME,
       storage,
@@ -193,7 +205,7 @@ export class EvlogHandlerPlugin<T extends Context> implements StandardHandlerPlu
         return await next()
       }
       catch (error) {
-        logBusinessLogicError(logger, error)
+        logProcedureError(logger, error, this.procedureErrorLevel)
         throw error
       }
     }
@@ -209,7 +221,7 @@ export class EvlogHandlerPlugin<T extends Context> implements StandardHandlerPlu
          */
         return override(output, wrapAsyncIteratorPreservingEventMeta(output, {
           onError: (error) => {
-            logBusinessLogicError(logger, error)
+            logProcedureError(logger, error, this.procedureErrorLevel)
           },
         }))
       }
@@ -221,7 +233,7 @@ export class EvlogHandlerPlugin<T extends Context> implements StandardHandlerPlu
          */
         return override(output, wrapReadableStream(output, {
           onError: (error) => {
-            logBusinessLogicError(logger, error)
+            logProcedureError(logger, error, this.procedureErrorLevel)
           },
         }))
       }
@@ -255,18 +267,35 @@ function toErrorOrString(error: unknown) {
   return String(error)
 }
 
-function logBusinessLogicError(logger: RequestLogger | undefined, error: unknown) {
+function logProcedureError(
+  logger: RequestLogger | undefined,
+  error: unknown,
+  procedureErrorLevel: Exclude<EvlogHandlerPluginOptions<any>['procedureErrorLevel'], undefined>,
+) {
   logger?.error(toErrorOrString(error))
 
+  const level = procedureErrorLevel(error, defaultErrorLevel(error))
+
+  if (level !== 'error') {
+    logger?.setLevel(level)
+  }
+}
+
+function defaultErrorLevel(error: unknown): LogLevel {
   // An abort means the client withdrew the request, not that something failed,
   // so record it as normal operation.
   if (isAbortError(error)) {
-    logger?.setLevel('info')
+    return 'info'
   }
+
   // A thrown ORPCError is a deliberate business rejection delivered to the client,
-  // so keep it reviewable without treating it as a failure.
-  // Anything else is unexpected and stays at error level.
-  else if (error instanceof ORPCError) {
-    logger?.setLevel('warn')
+  // so keep it reviewable without treating it as a failure. INTERNAL_SERVER_ERROR
+  // is the exception: it signals a server-side failure (oRPC itself throws it for
+  // failures like output validation), so it stays at error level along with
+  // anything unexpected.
+  if (error instanceof ORPCError && error.code !== 'INTERNAL_SERVER_ERROR') {
+    return 'warn'
   }
+
+  return 'error'
 }

--- a/packages/evlog/src/handler-plugin.ts
+++ b/packages/evlog/src/handler-plugin.ts
@@ -278,14 +278,14 @@ function logProcedureError(
 
   logger.error(toErrorOrString(error))
 
-  const level = procedureErrorLevel(error, defaultErrorLevel(error))
+  const level = procedureErrorLevel(error, defaultProcedureErrorLevel(error))
 
   if (level !== 'error') {
     logger.setLevel(level)
   }
 }
 
-function defaultErrorLevel(error: unknown): LogLevel {
+function defaultProcedureErrorLevel(error: unknown): LogLevel {
   // An abort means the client withdrew the request, not that something failed,
   // so record it as normal operation.
   if (isAbortError(error)) {

--- a/packages/evlog/src/handler-plugin.ts
+++ b/packages/evlog/src/handler-plugin.ts
@@ -272,12 +272,16 @@ function logProcedureError(
   error: unknown,
   procedureErrorLevel: Exclude<EvlogHandlerPluginOptions<any>['procedureErrorLevel'], undefined>,
 ) {
-  logger?.error(toErrorOrString(error))
+  if (!logger) {
+    return
+  }
+
+  logger.error(toErrorOrString(error))
 
   const level = procedureErrorLevel(error, defaultErrorLevel(error))
 
   if (level !== 'error') {
-    logger?.setLevel(level)
+    logger.setLevel(level)
   }
 }
 

--- a/packages/pino/src/handler-plugin.test.ts
+++ b/packages/pino/src/handler-plugin.test.ts
@@ -8,6 +8,7 @@ import { PinoHandlerPlugin } from './handler-plugin'
 
 const globalSpies = {
   child: vi.fn(),
+  debug: vi.fn(),
   info: vi.fn(),
   warn: vi.fn(),
   error: vi.fn(),
@@ -24,6 +25,11 @@ class FakeLogger {
   child(opts: any) {
     globalSpies.child(opts)
     return new FakeLogger({ ...this._bindings, ...opts }, this.childDepth + 1)
+  }
+
+  debug(...args: any[]) {
+    expect(this.childDepth).toBeGreaterThan(0)
+    globalSpies.debug(...args)
   }
 
   info(...args: any[]) {
@@ -148,7 +154,7 @@ describe('pinoHandlerPlugin', () => {
     expect(globalSpies.info).toHaveBeenCalledWith('request was aborted before handling (manual)')
   })
 
-  it('logs business errors (ORPCError) as warn, unexpected errors as error, and abort errors as info', async () => {
+  it('logs business errors (ORPCError) as warn except INTERNAL_SERVER_ERROR, unexpected errors as error, and abort errors as info', async () => {
     const baseLogger = new FakeLogger({ rpc: {} })
     const businessError = new ORPCError('UNAUTHORIZED')
     const handler1 = new StandardHandler(createCodec(os.handler(() => {
@@ -194,6 +200,57 @@ describe('pinoHandlerPlugin', () => {
     expect(globalSpies.info).toHaveBeenCalledWith(abortError)
     expect(globalSpies.warn).not.toHaveBeenCalled()
     expect(globalSpies.error).not.toHaveBeenCalled()
+
+    vi.clearAllMocks()
+
+    const internalError = new ORPCError('INTERNAL_SERVER_ERROR')
+    const handler4 = new StandardHandler(createCodec(os.handler(() => {
+      throw internalError
+    })) as any, {
+      plugins: [new PinoHandlerPlugin({ logger: baseLogger as any })],
+    })
+
+    const result4 = await handler4.handle(createRequest('GET', '/ping'), { prefix: undefined, context: {} })
+
+    expect(result4.matched).toBe(true)
+    expect(globalSpies.error).toHaveBeenCalledWith(internalError)
+    expect(globalSpies.warn).not.toHaveBeenCalled()
+  })
+
+  it('honors the procedureErrorLevel option, passing the error and its default level', async () => {
+    const baseLogger = new FakeLogger({ rpc: {} })
+    const businessError = new ORPCError('UNAUTHORIZED')
+    const procedureErrorLevel = vi.fn(
+      (error: unknown, level: 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace') =>
+        error instanceof ORPCError && error.code === 'UNAUTHORIZED' ? 'debug' as const : level,
+    )
+
+    const handler1 = new StandardHandler(createCodec(os.handler(() => {
+      throw businessError
+    })) as any, {
+      plugins: [new PinoHandlerPlugin({ logger: baseLogger as any, procedureErrorLevel })],
+    })
+
+    await handler1.handle(createRequest('GET', '/ping'), { prefix: undefined, context: {} })
+
+    expect(procedureErrorLevel).toHaveBeenCalledWith(businessError, 'warn')
+    expect(globalSpies.debug).toHaveBeenCalledWith(businessError)
+    expect(globalSpies.warn).not.toHaveBeenCalled()
+
+    vi.clearAllMocks()
+
+    const otherError = new ORPCError('CONFLICT')
+    const handler2 = new StandardHandler(createCodec(os.handler(() => {
+      throw otherError
+    })) as any, {
+      plugins: [new PinoHandlerPlugin({ logger: baseLogger as any, procedureErrorLevel })],
+    })
+
+    await handler2.handle(createRequest('GET', '/ping'), { prefix: undefined, context: {} })
+
+    expect(procedureErrorLevel).toHaveBeenCalledWith(otherError, 'warn')
+    expect(globalSpies.debug).not.toHaveBeenCalled()
+    expect(globalSpies.warn).toHaveBeenCalledWith(otherError)
   })
 
   it('logs internal errors', async () => {

--- a/packages/pino/src/handler-plugin.ts
+++ b/packages/pino/src/handler-plugin.ts
@@ -37,6 +37,16 @@ export interface PinoHandlerPluginOptions<T extends Context> {
    * @default false
    */
   logAbort?: boolean
+
+  /**
+   * Customizes the log level for errors thrown from procedures;
+   * internal handler failures are always logged at error level.
+   * Receives the level applied by default; return it to keep the default behavior:
+   * 'info' for abort errors, 'warn' for ORPCError except INTERNAL_SERVER_ERROR, 'error' otherwise.
+   *
+   * @default (error, level) => level
+   */
+  procedureErrorLevel?: (error: unknown, level: pino.Level) => pino.Level
 }
 
 /**
@@ -60,6 +70,7 @@ export class PinoHandlerPlugin<T extends Context> implements StandardHandlerPlug
   private readonly generateRequestId: Exclude<PinoHandlerPluginOptions<T>['generateRequestId'], undefined>
   private readonly logLifecycle: Exclude<PinoHandlerPluginOptions<T>['logLifecycle'], undefined>
   private readonly logAbort: Exclude<PinoHandlerPluginOptions<T>['logAbort'], undefined>
+  private readonly procedureErrorLevel: Exclude<PinoHandlerPluginOptions<T>['procedureErrorLevel'], undefined>
 
   constructor(
     options: PinoHandlerPluginOptions<T> = {},
@@ -69,6 +80,7 @@ export class PinoHandlerPlugin<T extends Context> implements StandardHandlerPlug
       ?? (({ request }) => flattenStandardHeader(request.headers['x-request-id']) ?? crypto.randomUUID())
     this.logLifecycle = options.logLifecycle ?? false
     this.logAbort = options.logAbort ?? false
+    this.procedureErrorLevel = options.procedureErrorLevel ?? ((_, level) => level)
   }
 
   init(options: StandardHandlerOptions<T>): StandardHandlerOptions<T> {
@@ -159,7 +171,7 @@ export class PinoHandlerPlugin<T extends Context> implements StandardHandlerPlug
         return await next()
       }
       catch (error) {
-        logBusinessLogicError(logger, error)
+        logProcedureError(logger, error, this.procedureErrorLevel)
         throw error
       }
     }
@@ -174,7 +186,7 @@ export class PinoHandlerPlugin<T extends Context> implements StandardHandlerPlug
          */
         return override(output, wrapAsyncIteratorPreservingEventMeta(output, {
           onError: (error) => {
-            logBusinessLogicError(getLogger(context), error)
+            logProcedureError(getLogger(context), error, this.procedureErrorLevel)
           },
         }))
       }
@@ -186,7 +198,7 @@ export class PinoHandlerPlugin<T extends Context> implements StandardHandlerPlug
          */
         return override(output, wrapReadableStream(output, {
           onError: (error) => {
-            logBusinessLogicError(getLogger(context), error)
+            logProcedureError(getLogger(context), error, this.procedureErrorLevel)
           },
         }))
       }
@@ -212,19 +224,29 @@ export class PinoHandlerPlugin<T extends Context> implements StandardHandlerPlug
   }
 }
 
-function logBusinessLogicError(logger: Logger | undefined, error: unknown) {
+function logProcedureError(
+  logger: Logger | undefined,
+  error: unknown,
+  procedureErrorLevel: Exclude<PinoHandlerPluginOptions<any>['procedureErrorLevel'], undefined>,
+) {
+  logger?.[procedureErrorLevel(error, defaultErrorLevel(error))](error)
+}
+
+function defaultErrorLevel(error: unknown): pino.Level {
   // An abort means the client withdrew the request, not that something failed,
   // so record it as normal operation.
   if (isAbortError(error)) {
-    logger?.info(error)
+    return 'info'
   }
+
   // A thrown ORPCError is a deliberate business rejection delivered to the client,
-  // so keep it reviewable without treating it as a failure.
-  else if (error instanceof ORPCError) {
-    logger?.warn(error)
+  // so keep it reviewable without treating it as a failure. INTERNAL_SERVER_ERROR
+  // is the exception: it signals a server-side failure (oRPC itself throws it for
+  // failures like output validation), so it stays at error level along with
+  // anything unexpected.
+  if (error instanceof ORPCError && error.code !== 'INTERNAL_SERVER_ERROR') {
+    return 'warn'
   }
-  // Anything else is unexpected and stays at error level.
-  else {
-    logger?.error(error)
-  }
+
+  return 'error'
 }

--- a/packages/pino/src/handler-plugin.ts
+++ b/packages/pino/src/handler-plugin.ts
@@ -229,10 +229,10 @@ function logProcedureError(
   error: unknown,
   procedureErrorLevel: Exclude<PinoHandlerPluginOptions<any>['procedureErrorLevel'], undefined>,
 ) {
-  logger?.[procedureErrorLevel(error, defaultErrorLevel(error))](error)
+  logger?.[procedureErrorLevel(error, defaultProcedureErrorLevel(error))](error)
 }
 
-function defaultErrorLevel(error: unknown): pino.Level {
+function defaultProcedureErrorLevel(error: unknown): pino.Level {
   // An abort means the client withdrew the request, not that something failed,
   // so record it as normal operation.
   if (isAbortError(error)) {


### PR DESCRIPTION
The pino and evlog handler plugins now log procedure errors at a level matching their intent instead of treating every failure the same, and both accept a new `procedureErrorLevel` option to customize that level per error. This lets expected business rejections stay out of error-level alerting while genuine failures keep full severity.

Resolves #1930

## Behavior

- Abort errors log as `info`, deliberately thrown `ORPCError`s as `warn`, and everything unexpected as `error` — including `ORPCError` with the `INTERNAL_SERVER_ERROR` code, since oRPC itself throws it for failures like output validation.
- `procedureErrorLevel: (error, level) => Level` receives the level applied by default and returns the level to use, so overriding one case is a single condition with `return level` as the fallback.
- The option covers everywhere procedure errors are logged (handler interceptor, event-iterator and readable-stream outputs); internal handler failures always stay at `error`.

## Docs

Both integration pages gained an "Error Logging Levels" section stating the defaults and showing a `procedureErrorLevel` example.

## Testing

Existing suites extended: `INTERNAL_SERVER_ERROR` no longer downgraded, custom resolver receives `(error, defaultLevel)` and its return value is honored, returning the incoming level preserves default behavior. All package tests, repo-wide type checks, and lint pass.