### PR TITLE
perf(server): reduce middleware pipeline overhead

### DIFF
--- a/benches/__shared__/payloads.ts
+++ b/benches/__shared__/payloads.ts
@@ -40,6 +40,25 @@ const SIZE_10KB = 10 * SIZE_1KB
 const SIZE_100KB = 100 * SIZE_1KB
 const SIZE_5MB = 5 * 1024 * 1024
 
+/** Plain JSON only: strings, numbers, booleans, arrays, plain objects. */
+function createJsonUnit(i: number) {
+  return {
+    id: i,
+    name: `item-${i}`,
+    active: true,
+    score: 0.5 + (i % 100) / 100,
+    tags: ['a', 'b', 'c'],
+    metadata: {
+      version: '2.0.0',
+      count: i,
+      nested: { depth: 2, ok: true },
+    },
+  }
+}
+
+export const PURE_JSON_1KB = createJsonUnit(0)
+export const PURE_JSON_100KB = Array.from({ length: 100 }, (_, i) => createJsonUnit(i))
+
 export const PAYLOAD_1KB = createUnit(0)
 export const PAYLOAD_10KB = Array.from({ length: 10 }, (_, i) => createUnit(i))
 export const PAYLOAD_100KB = Array.from({ length: 100 }, (_, i) => createUnit(i))

--- a/benches/openapi-link-handler.bench.ts
+++ b/benches/openapi-link-handler.bench.ts
@@ -7,11 +7,22 @@ import { os, type } from '@orpc/server'
 import { StandardHandler } from '@orpc/server/standard'
 import { bench } from 'vitest'
 import { asReadableStream, asSyncIteratorObject, BYTES_10KB, drainBody, EVENTS_10KB, handlers, PAYLOAD_10KB } from './__shared__/payloads'
+import '@orpc/openapi/extensions/route'
 
 const serializer = new OpenAPISerializer({ handlers })
 
 const router = {
   ping: os
+    .input(type<any>())
+    .output(type<any>())
+    .handler(({ input }) => input),
+  getUser: os
+    .route({ method: 'GET', path: '/users/{id}' })
+    .input(type<any>())
+    .output(type<any>())
+    .handler(({ input }) => input),
+  updatePost: os
+    .route({ method: 'POST', path: '/posts/{id}' })
     .input(type<any>())
     .output(type<any>())
     .handler(({ input }) => input),
@@ -51,5 +62,15 @@ describe('openapi link + handler', () => {
     await drainBody(
       await client.ping(asReadableStream(BYTES_10KB)),
     )
+  })
+
+  describe('dynamic paths (tiny payload)', () => {
+    bench('get dynamic path param', async () => {
+      await client.getUser({ id: 1 })
+    })
+
+    bench('post dynamic path param + body', async () => {
+      await client.updatePost({ id: 1, title: 'Hello', content: 'World' })
+    })
   })
 })

--- a/benches/procedure-call.bench.ts
+++ b/benches/procedure-call.bench.ts
@@ -41,6 +41,43 @@ const fullClient = createProcedureClient(full, {
   interceptors: [({ next }) => next()],
 })
 
+function buildMiddlewareProcedure(middlewareCount: number, addContext: boolean) {
+  let builder = os as any
+
+  for (let i = 0; i < middlewareCount; i++) {
+    builder = builder.use(addContext
+      ? os.middleware(async ({ next }) => next({ context: { [`key${i}`]: i } }))
+      : os.middleware(async ({ next }) => next()))
+  }
+
+  return builder.handler(({ input }: any) => input)
+}
+
+/**
+ * Middleware interleaved with input schemas: every level re-slices the schema
+ * stack (`inputSchemasLengthAtUse`) and runs stacked-object merging.
+ */
+function buildStackedSchemaProcedure(middlewareCount: number) {
+  let builder = os as any
+
+  for (let i = 0; i < middlewareCount; i++) {
+    builder = builder
+      .use(os.middleware(async ({ next }) => next()))
+      .input(type<any>())
+  }
+
+  return builder
+    .output(type<any>())
+    .handler(({ input }: any) => input)
+}
+
+const passthrough10Client = createProcedureClient(buildMiddlewareProcedure(10, false))
+const passthrough100Client = createProcedureClient(buildMiddlewareProcedure(100, false))
+const context10Client = createProcedureClient(buildMiddlewareProcedure(10, true))
+const context50Client = createProcedureClient(buildMiddlewareProcedure(50, true))
+const stacked10Client = createProcedureClient(buildStackedSchemaProcedure(10))
+const stacked50Client = createProcedureClient(buildStackedSchemaProcedure(50))
+
 describe('procedure call', () => {
   const input = {
     id: 1,
@@ -64,5 +101,29 @@ describe('procedure call', () => {
 
   bench('full (middlewares + validated + interceptors)', async () => {
     await fullClient(input)
+  })
+
+  bench('10 middlewares (passthrough)', async () => {
+    await passthrough10Client(input as any)
+  })
+
+  bench('100 middlewares (passthrough)', async () => {
+    await passthrough100Client(input as any)
+  })
+
+  bench('10 middlewares (context-adding)', async () => {
+    await context10Client(input as any)
+  })
+
+  bench('50 middlewares (context-adding)', async () => {
+    await context50Client(input as any)
+  })
+
+  bench('10 middlewares + 11 stacked input schemas', async () => {
+    await stacked10Client(input as any)
+  })
+
+  bench('50 middlewares + 51 stacked input schemas', async () => {
+    await stacked50Client(input as any)
   })
 })

--- a/benches/rpc-link-handler.bench.ts
+++ b/benches/rpc-link-handler.bench.ts
@@ -1,18 +1,30 @@
 import type { RouterClient } from '@orpc/server'
 import { createORPCClient, RPCSerializer } from '@orpc/client'
 import { RPCLinkCodec, StandardLink } from '@orpc/client/standard'
-import { os, type } from '@orpc/server'
+import { ORPCError, os, type } from '@orpc/server'
 import { RPCHandlerCodec, StandardHandler } from '@orpc/server/standard'
 import { bench } from 'vitest'
 import { asReadableStream, asSyncIteratorObject, BYTES_10KB, drainBody, EVENTS_10KB, handlers, PAYLOAD_10KB } from './__shared__/payloads'
 
 const serializer = new RPCSerializer({ handlers })
 
+const log = os.middleware(async ({ next }) => next())
+const auth = os.middleware(async ({ next }) => next({ context: { userId: 'user-1' } }))
+
 const router = {
   ping: os
     .input(type<any>())
     .output(type<any>())
     .handler(({ input }) => input),
+  plain: os.handler(({ input }) => input),
+  middlewares: os
+    .use(log)
+    .use(auth)
+    .use(log)
+    .handler(({ input }) => input),
+  fail: os.handler(() => {
+    throw new ORPCError('NOT_FOUND')
+  }),
 }
 
 const handler = new StandardHandler(new RPCHandlerCodec(router, { serializer }), {})
@@ -49,5 +61,25 @@ describe('rpc link + handler', () => {
     await drainBody(
       await client.ping(asReadableStream(BYTES_10KB)),
     )
+  })
+
+  describe('fixed overhead (tiny payload)', () => {
+    const input = { id: 1 }
+
+    bench('plain (no schema, no middleware)', async () => {
+      await client.plain(input as any)
+    })
+
+    bench('middlewares x3', async () => {
+      await client.middlewares(input as any)
+    })
+
+    bench('error thrown', async () => {
+      await client.fail(undefined as any).catch(() => {})
+    })
+
+    bench('not found (404)', async () => {
+      await (client as any).missing(input).catch(() => {})
+    })
   })
 })

--- a/benches/rpc-serializer.bench.ts
+++ b/benches/rpc-serializer.bench.ts
@@ -1,6 +1,6 @@
 import { RPCSerializer } from '@orpc/client'
 import { bench } from 'vitest'
-import { handlers, PAYLOAD_1KB, PAYLOAD_5MB, PAYLOAD_5MB_WITH_FILES, PAYLOAD_100KB } from './__shared__/payloads'
+import { handlers, PAYLOAD_1KB, PAYLOAD_5MB, PAYLOAD_5MB_WITH_FILES, PAYLOAD_100KB, PURE_JSON_1KB, PURE_JSON_100KB } from './__shared__/payloads'
 
 const serializer = new RPCSerializer({ handlers })
 
@@ -26,6 +26,18 @@ describe('rpc serializer', () => {
   bench('5MB payload with files', () => {
     serializer.deserialize(
       serializer.serialize(PAYLOAD_5MB_WITH_FILES),
+    )
+  })
+
+  bench('1KB payload (pure JSON)', () => {
+    serializer.deserialize(
+      serializer.serialize(PURE_JSON_1KB),
+    )
+  })
+
+  bench('100KB payload (pure JSON)', () => {
+    serializer.deserialize(
+      serializer.serialize(PURE_JSON_100KB),
     )
   })
 })

--- a/packages/server/src/procedure-client.test.ts
+++ b/packages/server/src/procedure-client.test.ts
@@ -1026,3 +1026,133 @@ describe('createProcedureClient', () => {
     })
   })
 })
+
+describe('untraced fast path and context edge cases', () => {
+  const SYMBOL_KEY = Symbol('untraced-test')
+  let previousOtelConfig: unknown
+
+  beforeEach(() => {
+    // The test setup registers a no-op tracer; disable it to exercise the
+    // untraced branches, restoring the config afterwards.
+    previousOtelConfig = SharedV2Module.getOpenTelemetryConfig()
+    SharedV2Module.setOpenTelemetryConfig(undefined)
+  })
+
+  afterEach(() => {
+    SharedV2Module.setOpenTelemetryConfig(previousOtelConfig as any)
+  })
+
+  it('propagates parent context when middleware passes an empty context object', async () => {
+    const handler = vi.fn(async ({ context }: any) => context.userId)
+    const procedure = os
+      .use(async ({ next }) => next({ context: { userId: 'user-1' } }))
+      .use(async ({ next }) => next({ context: {} }))
+      .handler(handler)
+
+    await expect(createProcedureClient(procedure)()).resolves.toBe('user-1')
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ context: { userId: 'user-1' } }), undefined)
+  })
+
+  it('treats next(undefined) the same as next()', async () => {
+    const handler = vi.fn(async ({ context }: any) => context.userId)
+    const procedure = os
+      .use(async ({ next }) => next({ context: { userId: 'user-1' } }))
+      .use(async ({ next }) => next(undefined as any))
+      .handler(handler)
+
+    await expect(createProcedureClient(procedure)()).resolves.toBe('user-1')
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ context: { userId: 'user-1' } }), undefined)
+  })
+
+  it('propagates symbol-keyed context overrides to the handler', async () => {
+    const handler = vi.fn(async ({ context }: any) => context[SYMBOL_KEY])
+    const procedure = os
+      .use(async ({ next }) => next({ context: { [SYMBOL_KEY]: 'symbol-value', visible: 'yes' } }))
+      .handler(handler)
+
+    await expect(createProcedureClient(procedure)()).resolves.toBe('symbol-value')
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ context: expect.objectContaining({ visible: 'yes' }) }),
+      undefined,
+    )
+  })
+
+  it('keeps the outer context when a middleware result omits context', async () => {
+    const first = vi.fn(async ({ next }: any) => next({ context: { userId: 'user-1' } }))
+    const second = vi.fn(async ({ next }: any) => {
+      const result = await next()
+      return { output: result.output, context: undefined } as any
+    })
+    const procedure = os
+      .use(first)
+      .use(second)
+      .handler(async () => 'ok')
+
+    await expect(createProcedureClient(procedure)()).resolves.toBe('ok')
+    expect(second).toHaveBeenCalledTimes(1)
+    expect(first).toHaveResolvedWith({
+      output: 'ok',
+      context: expect.objectContaining({ userId: 'user-1' }),
+    })
+  })
+
+  it.each([
+    ['string', 'plain-string'],
+    ['number', 42],
+    ['boolean', true],
+    ['null', null],
+    ['undefined', undefined],
+  ])('returns a primitive %s output untouched', async (_kind, output) => {
+    const procedure = os.handler(async () => output)
+    await expect(createProcedureClient(procedure)()).resolves.toBe(output)
+  })
+})
+
+describe('traced path span names', () => {
+  it('emits the expected span names through a full procedure call', async () => {
+    const spans: string[] = []
+    const span = {
+      setAttribute: vi.fn(),
+      recordException: vi.fn(),
+      setStatus: vi.fn(),
+      addEvent: vi.fn(),
+      end: vi.fn(),
+    }
+    const tracer = {
+      startActiveSpan(name: string, _options: unknown, argA?: unknown, argB?: unknown) {
+        spans.push(name)
+        const callback = typeof argA === 'function' ? argA : argB
+        return (callback as (span: unknown) => unknown)(span)
+      },
+    }
+
+    const previousOtelConfig = SharedV2Module.getOpenTelemetryConfig()
+    SharedV2Module.setOpenTelemetryConfig({
+      tracer,
+      trace: { getActiveSpan: () => undefined, setSpan: (context: unknown, _span: unknown) => context },
+      context: { active: () => ({}) },
+    } as any)
+
+    try {
+      const namedMiddleware = async ({ next }: any) => next()
+      const procedure = os
+        .use(namedMiddleware)
+        .input(z.any())
+        .output(z.any())
+        .handler(async () => 'ok')
+
+      await expect(createProcedureClient(procedure)()).resolves.toBe('ok')
+    }
+    finally {
+      SharedV2Module.setOpenTelemetryConfig(previousOtelConfig as any)
+    }
+
+    expect(spans).toEqual([
+      'call_procedure',
+      'middleware.namedMiddleware',
+      'validate_input.0',
+      'handler',
+      'validate_output.0',
+    ])
+  })
+})

--- a/packages/server/src/procedure-client.test.ts
+++ b/packages/server/src/procedure-client.test.ts
@@ -1042,6 +1042,15 @@ describe('untraced fast path and context edge cases', () => {
     SharedV2Module.setOpenTelemetryConfig(previousOtelConfig as any)
   })
 
+  it('validates input and output without tracing', async () => {
+    const procedure = os
+      .input(z.string().transform(value => `input:${value}`))
+      .output(z.string().transform(value => `output:${value}`))
+      .handler(async ({ input }) => input)
+
+    await expect(createProcedureClient(procedure)('value')).resolves.toBe('output:input:value')
+  })
+
   it('propagates parent context when middleware passes an empty context object', async () => {
     const handler = vi.fn(async ({ context }: any) => context.userId)
     const procedure = os

--- a/packages/server/src/procedure-client.ts
+++ b/packages/server/src/procedure-client.ts
@@ -323,11 +323,7 @@ function getExecutionPlan(procedure: AnyProcedure): ProcedureExecutionPlan {
  * skipping the spread entirely beats copying an empty override into the context.
  * The `hasOwnProperty` guard mirrors what `{ ...context, ...next }` would copy.
  */
-function hasEnumerableProperties(context: Context | undefined): boolean {
-  if (context === undefined) {
-    return false
-  }
-
+function hasEnumerableProperties(context: Context): boolean {
   for (const key in context) {
     if (Object.hasOwn(context, key)) {
       return true

--- a/packages/server/src/procedure-client.ts
+++ b/packages/server/src/procedure-client.ts
@@ -4,11 +4,11 @@ import type { Interceptor, MaybeOptionalOptions, Promisable, PromiseWithError, T
 import type { Context } from './context'
 import type { Lazyable } from './lazy'
 import type { MiddlewareDone } from './middleware'
-import type { AnyProcedure, Procedure, ProcedureHandlerOptions } from './procedure'
+import type { AnyProcedure, OrderedMiddleware, Procedure, ProcedureHandlerOptions } from './procedure'
 import { cloneORPCError, ORPCError, wrapAsyncIteratorPreservingEventMeta } from '@orpc/client'
 import { createORPCErrorConstructorMap, reconcileORPCError, ValidationError } from '@orpc/contract'
-import { intercept, isAsyncIteratorObject, isPlainObject, mergeTwoLevels, override, resolveMaybeOptionalOptions, runWithSpan, toArray, traceAsyncIterator, traceReadableStream, value } from '@orpc/shared'
-import { unlazy } from './lazy'
+import { getOpenTelemetryConfig, intercept, isAsyncIteratorObject, isPlainObject, mergeTwoLevels, override, resolveMaybeOptionalOptions, runWithSpan, toArray, traceAsyncIterator, traceReadableStream, value } from '@orpc/shared'
+import { Lazy, unlazy } from './lazy'
 
 export type ProcedureClient<
   TClientContext extends ClientContext,
@@ -42,10 +42,43 @@ export type ProcedureClientOptions<
     interceptors?: ProcedureClientInterceptor<TInitialContext, TOutputSchema, TErrorMap, TReturnedError>[]
   }
   & (
-    object extends TInitialContext
-      ? { context?: Value<Promisable<TInitialContext>, [clientContext: TClientContext]> }
-      : { context: Value<Promisable<TInitialContext>, [clientContext: TClientContext]> }
-  )
+      object extends TInitialContext
+        ? { context?: Value<Promisable<TInitialContext>, [clientContext: TClientContext]> }
+        : { context: Value<Promisable<TInitialContext>, [clientContext: TClientContext]> }
+    )
+
+interface ProcedureCallArtifacts {
+  readonly errors: ORPCErrorConstructorMap<any>
+  readonly reconcileError: (e: ThrowableError) => Promise<ThrowableError>
+}
+
+/**
+ * Per-procedure artifacts that never change between calls, so each request
+ * stops re-allocating them (the error constructor map allocates a `Proxy`).
+ */
+const procedureCallArtifacts = new WeakMap<AnyProcedure, ProcedureCallArtifacts>()
+
+function getProcedureCallArtifacts(procedure: AnyProcedure): ProcedureCallArtifacts {
+  const cached = procedureCallArtifacts.get(procedure)
+
+  if (cached) {
+    return cached
+  }
+
+  const artifacts: ProcedureCallArtifacts = {
+    errors: createORPCErrorConstructorMap(procedure['~orpc'].errorMap),
+    reconcileError: async (e: ThrowableError) => {
+      if (e instanceof ORPCError) {
+        return await reconcileORPCError(procedure['~orpc'].errorMap, e)
+      }
+
+      return e
+    },
+  }
+
+  procedureCallArtifacts.set(procedure, artifacts)
+  return artifacts
+}
 
 export function createProcedureClient<
   TInitialContext extends Context,
@@ -67,24 +100,19 @@ export function createProcedureClient<
   >
 ): ProcedureClient<TClientContext, TInputSchema, TOutputSchema, TErrorMap, TReturnedError> {
   const options = resolveMaybeOptionalOptions(rest)
+  const path = toArray(options.path)
 
   return async (...[input, callerOptions]) => {
-    const path = toArray(options.path)
-    const { default: procedure } = await unlazy(lazyableProcedure)
+    // `unlazy` allocates and awaits a resolved promise for the common non-lazy case.
+    const procedure = lazyableProcedure instanceof Lazy
+      ? (await unlazy(lazyableProcedure)).default
+      : lazyableProcedure
 
     // callerOptions.context can be undefined when all field is optional
     const clientContext = callerOptions?.context ?? {} as TClientContext
     // options.context can be undefined when all field is optional
     const context = await value(options.context, clientContext) as TInitialContext | undefined ?? {} as TInitialContext
-    const errors = createORPCErrorConstructorMap(procedure['~orpc'].errorMap)
-
-    const reconcileError = async (e: ThrowableError) => {
-      if (e instanceof ORPCError) {
-        return await reconcileORPCError(procedure['~orpc'].errorMap, e)
-      }
-
-      return e
-    }
+    const { errors, reconcileError } = getProcedureCallArtifacts(procedure)
 
     try {
       const output = await runWithSpan('call_procedure', (span) => {
@@ -145,48 +173,62 @@ export function createProcedureClient<
   }
 }
 
-async function validateInput(i: number, schema: AnySchema, input: unknown): Promise<any> {
+type SchemaValidateResult = Awaited<ReturnType<AnySchema['~standard']['validate']>>
+
+function unwrapInput(result: SchemaValidateResult, input: unknown): any {
+  if (result.issues) {
+    throw new ORPCError('BAD_REQUEST', {
+      message: 'Input validation failed',
+      data: {
+        issues: result.issues,
+      },
+      cause: new ValidationError({
+        message: 'Input validation failed',
+        issues: result.issues,
+        invalidData: input,
+      }),
+    })
+  }
+
+  return result.value
+}
+
+function unwrapOutput(result: SchemaValidateResult, output: unknown): any {
+  if (result.issues) {
+    throw new ORPCError('INTERNAL_SERVER_ERROR', {
+      message: 'Output validation failed',
+      cause: new ValidationError({
+        message: 'Output validation failed',
+        issues: result.issues,
+        invalidData: output,
+      }),
+    })
+  }
+
+  return result.value
+}
+
+async function validateInput(traced: boolean, i: number, schema: AnySchema, input: unknown): Promise<any> {
+  if (!traced) {
+    return unwrapInput(await schema['~standard'].validate(input), input)
+  }
+
   return runWithSpan(`validate_input.${i}`, async (span) => {
     span?.setAttribute('input_schema.index', i)
 
-    const result = await schema['~standard'].validate(input)
-
-    if (result.issues) {
-      throw new ORPCError('BAD_REQUEST', {
-        message: 'Input validation failed',
-        data: {
-          issues: result.issues,
-        },
-        cause: new ValidationError({
-          message: 'Input validation failed',
-          issues: result.issues,
-          invalidData: input,
-        }),
-      })
-    }
-
-    return result.value
+    return unwrapInput(await schema['~standard'].validate(input), input)
   })
 }
 
-async function validateOutput(i: number, schema: AnySchema, output: unknown): Promise<any> {
+async function validateOutput(traced: boolean, i: number, schema: AnySchema, output: unknown): Promise<any> {
+  if (!traced) {
+    return unwrapOutput(await schema['~standard'].validate(output), output)
+  }
+
   return runWithSpan(`validate_output.${i}`, async (span) => {
     span?.setAttribute('output_schema.index', i)
 
-    const result = await schema['~standard'].validate(output)
-
-    if (result.issues) {
-      throw new ORPCError('INTERNAL_SERVER_ERROR', {
-        message: 'Output validation failed',
-        cause: new ValidationError({
-          message: 'Output validation failed',
-          issues: result.issues,
-          invalidData: output,
-        }),
-      })
-    }
-
-    return result.value
+    return unwrapOutput(await schema['~standard'].validate(output), output)
   })
 }
 
@@ -200,10 +242,106 @@ const middlewareDone: MiddlewareDone<any> = (...rest) => {
   }
 }
 
+interface ProcedureExecutionPlan {
+  readonly orderedMiddlewares: OrderedMiddleware[]
+  readonly inputSchemas: AnySchema[]
+  readonly outputSchemas: AnySchema[]
+  /**
+   * Per-level input/output schema slice boundaries (`length` = middleware count + 1,
+   * the last entry being the handler level), precomputed from the snapshots
+   * taken when each middleware was used.
+   */
+  readonly inputStarts: number[]
+  readonly inputEnds: number[]
+  readonly outputStarts: number[]
+  readonly outputEnds: number[]
+  readonly validateInputs: boolean
+  readonly validateOutputs: boolean
+  readonly stackedObjectInputs: boolean
+}
+
+const executionPlans = new WeakMap<AnyProcedure, ProcedureExecutionPlan>()
+
+function getExecutionPlan(procedure: AnyProcedure): ProcedureExecutionPlan {
+  const cached = executionPlans.get(procedure)
+
+  if (cached) {
+    return cached
+  }
+
+  const def = procedure['~orpc']
+  const inputSchemas = toArray(def.inputSchemas)
+  const outputSchemas = toArray(def.outputSchemas)
+  const orderedMiddlewares = def.orderedMiddlewares
+
+  const levels = orderedMiddlewares.length + 1
+  const inputStarts: number[] = []
+  const inputEnds: number[] = []
+  const outputStarts: number[] = []
+  const outputEnds: number[] = []
+
+  let hasInputs = false
+  let hasOutputs = false
+
+  for (let level = 0; level < levels; level++) {
+    const isHandler = level === orderedMiddlewares.length
+    const prev = level === 0 ? undefined : orderedMiddlewares[level - 1]!
+    const curr = isHandler ? undefined : orderedMiddlewares[level]!
+
+    const inputStart = prev?.inputSchemasLengthAtUse ?? 0
+    const inputEnd = isHandler ? inputSchemas.length : curr!.inputSchemasLengthAtUse ?? 0
+    const outputStart = prev?.outputSchemasLengthAtUse ?? 0
+    const outputEnd = isHandler ? outputSchemas.length : curr!.outputSchemasLengthAtUse ?? 0
+
+    inputStarts.push(inputStart)
+    inputEnds.push(inputEnd)
+    outputStarts.push(outputStart)
+    outputEnds.push(outputEnd)
+    hasInputs ||= inputEnd > inputStart
+    hasOutputs ||= outputEnd > outputStart
+  }
+
+  const plan: ProcedureExecutionPlan = {
+    orderedMiddlewares,
+    inputSchemas,
+    outputSchemas,
+    inputStarts,
+    inputEnds,
+    outputStarts,
+    outputEnds,
+    validateInputs: hasInputs && !def.disableInputValidation,
+    validateOutputs: hasOutputs && !def.disableOutputValidation,
+    stackedObjectInputs: inputSchemas.length > 1,
+  }
+
+  executionPlans.set(procedure, plan)
+  return plan
+}
+
+/**
+ * `for...in` with an early exit is the cheapest "has own enumerable keys" check;
+ * skipping the spread entirely beats copying an empty override into the context.
+ * The `hasOwnProperty` guard mirrors what `{ ...context, ...next }` would copy.
+ */
+function hasEnumerableProperties(context: Context | undefined): boolean {
+  if (context === undefined) {
+    return false
+  }
+
+  for (const key in context) {
+    if (Object.hasOwn(context, key)) {
+      return true
+    }
+  }
+
+  // `for...in` misses symbol keys, which object spread does copy
+  // (e.g. rate limit bookkeeping passed through middleware context).
+  return Object.getOwnPropertySymbols(context).length > 0
+}
+
 async function executeProcedureInternal(procedure: AnyProcedure, options: ProcedureHandlerOptions<any, any, any>): Promise<any> {
-  const inputSchemas = toArray(procedure['~orpc'].inputSchemas)
-  const outputSchemas = toArray(procedure['~orpc'].outputSchemas)
-  const orderedMiddlewares = procedure['~orpc'].orderedMiddlewares
+  const plan = getExecutionPlan(procedure)
+  const traced = getOpenTelemetryConfig()?.tracer !== undefined
 
   const next = async (
     midIndex: number,
@@ -212,24 +350,16 @@ async function executeProcedureInternal(procedure: AnyProcedure, options: Proced
   ): Promise<{ output: unknown, context: Record<any, any> }> => {
     let currentInput = input
 
-    const startInputIndex = midIndex === 0
-      ? 0
-      : orderedMiddlewares[midIndex - 1]!.inputSchemasLengthAtUse ?? 0
-    const endInputIndex = midIndex === orderedMiddlewares.length
-      ? inputSchemas.length
-      : orderedMiddlewares[midIndex]!.inputSchemasLengthAtUse ?? 0
+    if (plan.validateInputs) {
+      const inputSchemas = plan.inputSchemas
+      const stackedObjectInputs = plan.stackedObjectInputs
 
-    /**
-     * Stacked object schemas each validate the original input and are merged afterwards, so every
-     * schema can declare its own fragment without the previous ones stripping or rejecting it.
-     * Anything else stays piped, which keeps schemas like `asyncIteratorObject` wrapping each other.
-     */
-    if (!procedure['~orpc'].disableInputValidation) {
-      for (let i = startInputIndex; i < endInputIndex; i++) {
+      for (let i = plan.inputStarts[midIndex]!; i < plan.inputEnds[midIndex]!; i++) {
         const validated = await validateInput(
+          traced,
           i,
           inputSchemas[i]!,
-          inputSchemas.length > 1 && isPlainObject(currentInput) ? options.input : currentInput,
+          stackedObjectInputs && isPlainObject(currentInput) ? options.input : currentInput,
         )
 
         currentInput = i !== 0 ? mergeTwoLevels(currentInput, validated) : validated
@@ -239,44 +369,60 @@ async function executeProcedureInternal(procedure: AnyProcedure, options: Proced
     let currentOutput: unknown
     let currentContext = context
 
-    if (midIndex < orderedMiddlewares.length) {
-      const { middleware } = orderedMiddlewares[midIndex]!
+    if (midIndex < plan.orderedMiddlewares.length) {
+      const { middleware } = plan.orderedMiddlewares[midIndex]!
 
-      const result = await runWithSpan(`middleware.${middleware.name}`, async (span) => {
-        span?.setAttribute('middleware.index', midIndex)
+      const invoke = () => middleware(
+        {
+          ...options,
+          context,
+          next: (...rest) => {
+            const nextContext = rest.length === 0 ? undefined : rest[0]?.context
 
-        return await middleware(
-          {
-            ...options,
-            context,
-            next: (...rest) => {
-              const nextOptions = resolveMaybeOptionalOptions(rest)
-              // context can be undefined when all field is optional
-              const nextContext = nextOptions.context ?? {} as any
-
-              return next(
-                midIndex + 1,
-                { ...context, ...nextContext },
-                currentInput,
-              )
-            },
-            lastEventId: options.lastEventId,
+            return next(
+              midIndex + 1,
+              nextContext !== undefined && hasEnumerableProperties(nextContext)
+                ? { ...context, ...nextContext }
+                : context,
+              currentInput,
+            )
           },
-          currentInput,
-          middlewareDone,
-        )
-      })
-
-      currentOutput = result.output
-      currentContext = { ...context, ...result.context }
-    }
-    else {
-      currentOutput = await runWithSpan(
-        'handler',
-        () => procedure['~orpc'].handler({ ...options, context, input: currentInput }, currentInput),
+          lastEventId: options.lastEventId,
+        },
+        currentInput,
+        middlewareDone,
       )
 
-      if (currentOutput instanceof ORPCError) {
+      const result = traced
+        ? await runWithSpan(`middleware.${middleware.name}`, async (span) => {
+            span?.setAttribute('middleware.index', midIndex)
+
+            return await invoke()
+          })
+        : await invoke()
+
+      currentOutput = result.output
+
+      const resultContext = result.context
+      currentContext = resultContext !== undefined && hasEnumerableProperties(resultContext)
+        ? { ...context, ...resultContext }
+        : context
+    }
+    else {
+      const handler = procedure['~orpc'].handler
+
+      currentOutput = traced
+        ? await runWithSpan(
+            'handler',
+            () => handler({ ...options, context, input: currentInput }, currentInput),
+          )
+        : await handler({ ...options, context, input: currentInput }, currentInput)
+
+      /**
+       * `ORPCError` is always an object, so primitives skip the
+       * prototype-chain-walking `Symbol.hasInstance` on the happy path.
+       */
+      if (typeof currentOutput === 'object' && currentOutput !== null && currentOutput instanceof ORPCError) {
         if (procedure['~orpc'].opaqueReturnedErrors) {
           throw currentOutput
         }
@@ -294,16 +440,11 @@ async function executeProcedureInternal(procedure: AnyProcedure, options: Proced
       }
     }
 
-    const startOutputIndex = midIndex === 0
-      ? 0
-      : orderedMiddlewares[midIndex - 1]!.outputSchemasLengthAtUse ?? 0
-    const endOutputIndex = midIndex === orderedMiddlewares.length
-      ? outputSchemas.length
-      : orderedMiddlewares[midIndex]!.outputSchemasLengthAtUse ?? 0
+    if (plan.validateOutputs) {
+      const outputSchemas = plan.outputSchemas
 
-    if (!procedure['~orpc'].disableOutputValidation) {
-      for (let i = endOutputIndex - 1; i >= startOutputIndex; i--) {
-        currentOutput = await validateOutput(i, outputSchemas[i]!, currentOutput)
+      for (let i = plan.outputEnds[midIndex]! - 1; i >= plan.outputStarts[midIndex]!; i--) {
+        currentOutput = await validateOutput(traced, i, outputSchemas[i]!, currentOutput)
       }
     }
 


### PR DESCRIPTION
## What this PR does

The middleware pipeline does less work per request. The API does not change. Runtime code changes are limited to `packages/server/src/procedure-client.ts`.

## What changed

1. The execution plan is computed one time per procedure. A `WeakMap` holds it. Before, the code computed it again for each request.
2. The OpenTelemetry config is read one time per call. When no tracer is set, the code calls the middleware, the handler, and the validators directly. This skips the async `runWithSpan` wrapper. It also skips the span name strings. Span names and attributes do not change when a tracer is set.
3. The code does not copy the context when the middleware passes no new data. The check sees string keys and symbol keys. The rate limit middleware passes its data through a symbol key. A test covers this case.
4. Small changes:
   - Primitive outputs skip the `instanceof ORPCError` check.
   - Non-lazy procedures skip the `unlazy` promise.
   - The error constructor map and the error reconcile function are cached per procedure.

## How much faster

Test setup: Apple M4, Node v25.9.0, Vitest v4.1.11, tracing off. The base is current `main`.

| Test | Before | After | Change |
|---|---:|---:|---|
| Procedure call, 10 middlewares | 2.84µs | 1.97µs | 1.44x faster |
| Procedure call, 100 middlewares | 26.61µs | 15.58µs | 1.71x faster |
| Procedure call, 50 middlewares + 51 input schemas | 29.35µs | 19.66µs | 1.49x faster |
| Procedure call, validated | 0.97µs | 0.75µs | 1.29x faster |
| Procedure call, full stack | 1.77µs | 1.33µs | 1.33x faster |
| OpenAPI e2e, POST with path param and body | 6.07µs | 5.43µs | 1.12x faster |

The largest gain is on deep pass-through middleware chains.

## Benchmark scenarios

The PR adds scenarios to the existing benchmark files. It adds no new files.

- `procedure-call.bench.ts`: middleware counts 10 and 100 (passthrough), 10 and 50 (context-adding), 10 and 50 with stacked input schemas.
- `rpc-link-handler.bench.ts`: small payloads. The scenarios cover plain, middleware x3, error, and 404.
- `openapi-link-handler.bench.ts`: small payloads with GET and POST on a dynamic path.
- `rpc-serializer.bench.ts`: payloads with plain JSON only.

The old scenario names stay the same. CodSpeed history stays comparable.

## Behavior notes

- Spans do not change when tracing is on.
- When a middleware passes no context, the next level gets the same context object. It does not get a copy. The old code made a copy. No test sees this difference.
- The OpenTelemetry config is read one time per procedure call. Before, the code read it one time per span.

## Tests

- Focused server tests: 45 passed.
- Bun 1.4.0 coverage suite: 97 passed and 31 skipped.
- Node 24 coverage run: 3266 passed and 41 skipped. `procedure-client.ts` has 100 percent line coverage.
- The full coverage command then reported the pre-existing Node upload cancellation defect isolated in #1952.
- New tests cover untraced validation, empty context objects, `next(undefined)`, symbol keys, primitive outputs, and the span name sequence with a mock tracer.
- `eslint` and package diagnostics pass with no errors.

A second PR is stacked on this one. It speeds up the client codecs. I will link it here.
