### PR TITLE
perf: memoize URL and route resolution in link codecs

### DIFF
--- a/benches/openapi-link-handler.bench.ts
+++ b/benches/openapi-link-handler.bench.ts
@@ -1,12 +1,14 @@
 import type { RouterClient } from '@orpc/server'
 import { createORPCClient } from '@orpc/client'
 import { StandardLink } from '@orpc/client/standard'
-import { OpenAPISerializer } from '@orpc/openapi'
+import { oc } from '@orpc/contract'
+import { openapi, OpenAPISerializer } from '@orpc/openapi'
 import { OpenAPIHandlerCodec, OpenAPILinkCodec } from '@orpc/openapi/standard'
 import { os, type } from '@orpc/server'
 import { StandardHandler } from '@orpc/server/standard'
 import { bench } from 'vitest'
 import { asReadableStream, asSyncIteratorObject, BYTES_10KB, drainBody, EVENTS_10KB, handlers, PAYLOAD_10KB } from './__shared__/payloads'
+import '@orpc/openapi/extensions/route'
 
 const serializer = new OpenAPISerializer({ handlers })
 
@@ -51,5 +53,68 @@ describe('openapi link + handler', () => {
     await drainBody(
       await client.ping(asReadableStream(BYTES_10KB)),
     )
+  })
+})
+
+describe('openapi link codec route resolution depth', () => {
+  function buildDeepContract(depth: number) {
+    let node: Record<string, any> = { leaf: oc.meta(openapi({})) }
+
+    for (let i = 0; i < depth; i++) {
+      node = { [`level${i}`]: node }
+    }
+
+    return node
+  }
+
+  const codecOptions = { context: {} } as any
+  const codecDepth10 = new OpenAPILinkCodec(buildDeepContract(9), {})
+  const codecDepth20 = new OpenAPILinkCodec(buildDeepContract(19), {})
+
+  const wideRouter: Record<string, any> = {}
+  for (let i = 0; i < 1000; i++) {
+    wideRouter[`proc${i}`] = oc.meta(openapi({}))
+  }
+  const codecWide1000 = new OpenAPILinkCodec(wideRouter, {})
+
+  const pathDepth10 = Array.from({ length: 9 }, (_, i) => `level${i}`).reverse().concat('leaf')
+  const pathDepth20 = Array.from({ length: 19 }, (_, i) => `level${i}`).reverse().concat('leaf')
+
+  bench('encodeInput at path depth 10', async () => {
+    await codecDepth10.encodeInput(undefined, pathDepth10, codecOptions)
+  })
+
+  bench('encodeInput at path depth 20', async () => {
+    await codecDepth20.encodeInput(undefined, pathDepth20, codecOptions)
+  })
+
+  bench('encodeInput on a 1000-procedure router', async () => {
+    await codecWide1000.encodeInput(undefined, ['proc500'], codecOptions)
+  })
+})
+
+describe('openapi link codec param and query stress', () => {
+  const contract = {
+    search: oc
+      .route({ method: 'GET', path: '/a/{p1}/b/{p2}/c/{p3}/d/{p4}/e/{p5}' })
+      .input(type<any>())
+      .output(type<any>()),
+  }
+  const codec = new OpenAPILinkCodec(contract as any, {})
+  const options = { context: {} } as any
+
+  const multiParamInput = { p1: 1, p2: 2, p3: 3, p4: 4, p5: 5, extra: 'x' }
+
+  const queryInput: Record<string, string | number> = { p1: 1, p2: 2, p3: 3, p4: 4, p5: 5 }
+  for (let i = 0; i < 45; i++) {
+    queryInput[`q${i}`] = i
+  }
+
+  bench('encodeInput with 5 dynamic path params', async () => {
+    await codec.encodeInput(multiParamInput, ['search'], options)
+  })
+
+  bench('encodeInput GET with 50 query params', async () => {
+    await codec.encodeInput(queryInput, ['search'], options)
   })
 })

--- a/benches/rpc-link-handler.bench.ts
+++ b/benches/rpc-link-handler.bench.ts
@@ -51,3 +51,28 @@ describe('rpc link + handler', () => {
     )
   })
 })
+
+describe('rpc link codec path encoding depth', () => {
+  const codec = new RPCLinkCodec({ serializer })
+  const options = { context: {} } as any
+
+  // Memoized paths, matching how createORPCClient caches per-procedure paths.
+  const pathDepth10 = Array.from({ length: 10 }, (_, i) => `level${i}`)
+  const pathDepth20 = Array.from({ length: 20 }, (_, i) => `level${i}`)
+
+  bench('encodeInput at path depth 10', async () => {
+    await codec.encodeInput(undefined, pathDepth10, options)
+  })
+
+  bench('encodeInput at path depth 20', async () => {
+    await codec.encodeInput(undefined, pathDepth20, options)
+  })
+
+  /**
+   * Worst case: a fresh array per call never hits the identity-keyed
+   * path cache and pays the WeakMap lookup on top of encoding.
+   */
+  bench('encodeInput at path depth 20 (fresh array per call)', async () => {
+    await codec.encodeInput(undefined, Array.from({ length: 20 }, (_, i) => `level${i}`), options)
+  })
+})

--- a/packages/client/src/adapters/standard/link.test.ts
+++ b/packages/client/src/adapters/standard/link.test.ts
@@ -1,7 +1,7 @@
 import type { StandardLazyResponse, StandardRequest } from '@standardserver/core'
 import type { StandardLinkCodec } from './codec'
 import type { StandardLinkTransport } from './transport'
-import { isAsyncIteratorObject } from '@orpc/shared'
+import { getOpenTelemetryConfig, isAsyncIteratorObject, setOpenTelemetryConfig } from '@orpc/shared'
 import { ORPCError } from '../../error'
 import { StandardLink } from './link'
 
@@ -172,5 +172,78 @@ describe('standardLink', () => {
     })
 
     await expect(link.call(['test'], 'input', { context: {} })).resolves.toBe('__INTERCEPTED__')
+  })
+})
+
+describe('standardLink with OpenTelemetry disabled', () => {
+  function makeCodec(): StandardLinkCodec<any> {
+    return {
+      encodeInput: vi.fn(),
+      decodeResponse: vi.fn(),
+    }
+  }
+
+  function makeTransport(): StandardLinkTransport<any> {
+    return {
+      send: vi.fn(),
+    }
+  }
+
+  it('round-trips a call without tracing configured', async () => {
+    const previousOtelConfig = getOpenTelemetryConfig()
+    setOpenTelemetryConfig(undefined)
+
+    try {
+      const codec = makeCodec()
+      const transport = makeTransport()
+
+      const link = new StandardLink(codec, transport)
+
+      vi.mocked(codec.encodeInput).mockResolvedValueOnce({
+        method: 'POST',
+        url: '/ping',
+        headers: {},
+        body: 'input',
+      })
+      vi.mocked(transport.send).mockResolvedValueOnce({
+        status: 200,
+        headers: {},
+        resolveBody: () => Promise.resolve('body'),
+      })
+      vi.mocked(codec.decodeResponse).mockResolvedValueOnce({ kind: 'output', output: 'output' })
+
+      await expect(link.call(['ping'], 'input', { context: {} })).resolves.toBe('output')
+
+      expect(codec.encodeInput).toHaveBeenCalledTimes(1)
+      expect(transport.send).toHaveBeenCalledTimes(1)
+      expect(codec.decodeResponse).toHaveBeenCalledTimes(1)
+    }
+    finally {
+      setOpenTelemetryConfig(previousOtelConfig as any)
+    }
+  })
+
+  it('propagates transport errors without tracing configured', async () => {
+    const previousOtelConfig = getOpenTelemetryConfig()
+    setOpenTelemetryConfig(undefined)
+
+    try {
+      const codec = makeCodec()
+      const transport = makeTransport()
+      const link = new StandardLink(codec, transport)
+
+      vi.mocked(codec.encodeInput).mockResolvedValueOnce({
+        method: 'POST',
+        url: '/ping',
+        headers: {},
+        body: 'input',
+      })
+      vi.mocked(transport.send).mockRejectedValueOnce(new Error('network down'))
+
+      await expect(link.call(['ping'], 'input', { context: {} })).rejects.toThrow('network down')
+    }
+    finally {
+      setOpenTelemetryConfig(previousOtelConfig as any)
+    }
   })
 })

--- a/packages/client/src/adapters/standard/link.test.ts
+++ b/packages/client/src/adapters/standard/link.test.ts
@@ -246,4 +246,26 @@ describe('standardLink with OpenTelemetry disabled', () => {
       setOpenTelemetryConfig(previousOtelConfig as any)
     }
   })
+
+  it('returns a rejected promise when an interceptor throws synchronously', async () => {
+    const previousOtelConfig = getOpenTelemetryConfig()
+    setOpenTelemetryConfig(undefined)
+
+    try {
+      const error = new Error('interceptor failed')
+      const link = new StandardLink(makeCodec(), makeTransport(), {
+        interceptors: [() => {
+          throw error
+        }],
+      })
+
+      const result = link.call(['ping'], 'input', { context: {} })
+
+      expect(result).toBeInstanceOf(Promise)
+      await expect(result).rejects.toBe(error)
+    }
+    finally {
+      setOpenTelemetryConfig(previousOtelConfig as any)
+    }
+  })
 })

--- a/packages/client/src/adapters/standard/link.ts
+++ b/packages/client/src/adapters/standard/link.ts
@@ -79,7 +79,12 @@ export class StandardLink<T extends ClientContext> implements ClientLink<T> {
       })
     }
 
-    return this.callInterceptors(path, input, options, undefined, traced)
+    try {
+      return Promise.resolve(this.callInterceptors(path, input, options, undefined, traced))
+    }
+    catch (error) {
+      return Promise.reject(error)
+    }
   }
 
   private callInterceptors(

--- a/packages/client/src/adapters/standard/link.ts
+++ b/packages/client/src/adapters/standard/link.ts
@@ -35,6 +35,9 @@ export interface StandardLinkOptions<T extends ClientContext> {
   plugins?: StandardLinkPlugin<T>[]
 }
 
+/** The optional span argument that `runWithSpan` passes to its callback. */
+type MaybeSpan = Parameters<Parameters<typeof runWithSpan>[1]>[0]
+
 export class StandardLink<T extends ClientContext> implements ClientLink<T> {
   private readonly interceptors: StandardLinkOptions<T>['interceptors']
   private readonly transportInterceptors: StandardLinkOptions<T>['transportInterceptors']
@@ -54,88 +57,110 @@ export class StandardLink<T extends ClientContext> implements ClientLink<T> {
    * @throws ORPCError, transport-level errors (network failures, timeouts, etc.)
    */
   call(path: string[], input: unknown, options: ClientOptions<T>): Promise<unknown> {
-    return runWithSpan(`${ORPC_NAME}.${path.join('/')}`, (span) => {
-      /**
-       * [Semantic conventions for RPC spans](https://opentelemetry.io/docs/specs/semconv/rpc/rpc-spans/)
-       */
-      span?.setAttribute('rpc.system', ORPC_NAME)
-      span?.setAttribute('rpc.method', path.join('.'))
+    const traced = getOpenTelemetryConfig()?.tracer !== undefined
 
-      if (isAsyncIteratorObject(input)) {
+    if (traced) {
+      return runWithSpan(`${ORPC_NAME}.${path.join('/')}`, (span) => {
         /**
-         * @warning
-         * Remember use `override` for AsyncIteratorObject to remain other special properties
+         * [Semantic conventions for RPC spans](https://opentelemetry.io/docs/specs/semconv/rpc/rpc-spans/)
          */
-        input = override(input, traceAsyncIterator('consume_async_iterator_object_input', input))
-      }
+        span?.setAttribute('rpc.system', ORPC_NAME)
+        span?.setAttribute('rpc.method', path.join('.'))
 
-      return intercept(this.interceptors, { ...options, path, input }, async ({ path, input, ...options }) => {
-        /**
-         * In browsers, the OpenTelemetry context manager may not work reliably with async functions,
-         * so we should manually manage the context here.
-         */
-        const otel = getOpenTelemetryConfig()
-        let activeContext: ReturnType<Exclude<typeof otel, undefined>['context']['active']> | undefined
-        const activeSpan = otel?.trace.getActiveSpan() ?? span
-        if (activeSpan && otel) {
-          activeContext = otel.trace.setSpan(otel.context.active(), activeSpan)
-        }
-
-        let request = await runWithSpan(
-          { name: 'encode_input', context: activeContext },
-          () => this.codec.encodeInput(input, path, options),
-        )
-
-        if (activeContext && otel?.propagation) {
-          const headers = { ...request.headers }
-          otel.propagation.inject(activeContext, headers)
-          request = { ...request, headers }
-        }
-
-        const response = await intercept(
-          this.transportInterceptors,
-          { ...options, path, request },
-          ({ path, request, ...options }) => {
-            /**
-             * In browsers, the OpenTelemetry context manager may not work reliably with async functions,
-             * so we should manually manage the context here.
-             */
-            let activeTransportContext: ReturnType<Exclude<typeof otel, undefined>['context']['active']> | undefined
-            const activeTransportSpan = otel?.trace.getActiveSpan() ?? activeSpan
-            if (activeTransportSpan && otel) {
-              activeTransportContext = otel.trace.setSpan(otel.context.active(), activeTransportSpan)
-            }
-
-            return runWithSpan(
-              { name: 'send_request', context: activeTransportContext },
-              () => this.transport.send(request, path, options),
-            )
-          },
-        )
-
-        const decodedResult = await runWithSpan(
-          { name: 'decode_response', context: activeContext },
-          () => this.codec.decodeResponse(response, path, options),
-        )
-
-        if (decodedResult.kind === 'error') {
-          throw decodedResult.error
-        }
-
-        const output = decodedResult.output
-
-        if (isAsyncIteratorObject(output)) {
+        if (isAsyncIteratorObject(input)) {
           /**
-           * Do not use otelContext here, as it is a lazy span.
-           *
            * @warning
            * Remember use `override` for AsyncIteratorObject to remain other special properties
            */
-          return override(output, traceAsyncIterator('consume_async_iterator_object_output', output))
+          input = override(input, traceAsyncIterator('consume_async_iterator_object_input', input))
         }
 
-        return output
+        return this.callInterceptors(path, input, options, span, traced)
       })
+    }
+
+    return this.callInterceptors(path, input, options, undefined, traced)
+  }
+
+  private callInterceptors(
+    path: string[],
+    input: unknown,
+    options: ClientOptions<T>,
+    span: MaybeSpan,
+    traced: boolean,
+  ): Promise<unknown> {
+    return intercept(this.interceptors, { ...options, path, input }, async ({ path, input, ...options }) => {
+      /**
+       * In browsers, the OpenTelemetry context manager may not work reliably with async functions,
+       * so we should manually manage the context here.
+       */
+      const otel = getOpenTelemetryConfig()
+      let activeContext: ReturnType<Exclude<typeof otel, undefined>['context']['active']> | undefined
+      const activeSpan = otel?.trace.getActiveSpan() ?? span
+      if (activeSpan && otel) {
+        activeContext = otel.trace.setSpan(otel.context.active(), activeSpan)
+      }
+
+      let request = traced
+        ? await runWithSpan(
+            { name: 'encode_input', context: activeContext },
+            () => this.codec.encodeInput(input, path, options),
+          )
+        : await this.codec.encodeInput(input, path, options)
+
+      if (activeContext && otel?.propagation) {
+        const headers = { ...request.headers }
+        otel.propagation.inject(activeContext, headers)
+        request = { ...request, headers }
+      }
+
+      const response = await intercept(
+        this.transportInterceptors,
+        { ...options, path, request },
+        ({ path, request, ...options }) => {
+          /**
+           * In browsers, the OpenTelemetry context manager may not work reliably with async functions,
+           * so we should manually manage the context here.
+           */
+          let activeTransportContext: ReturnType<Exclude<typeof otel, undefined>['context']['active']> | undefined
+          const activeTransportSpan = otel?.trace.getActiveSpan() ?? activeSpan
+          if (activeTransportSpan && otel) {
+            activeTransportContext = otel.trace.setSpan(otel.context.active(), activeTransportSpan)
+          }
+
+          return traced
+            ? runWithSpan(
+                { name: 'send_request', context: activeTransportContext },
+                () => this.transport.send(request, path, options),
+              )
+            : this.transport.send(request, path, options)
+        },
+      )
+
+      const decodedResult = traced
+        ? await runWithSpan(
+            { name: 'decode_response', context: activeContext },
+            () => this.codec.decodeResponse(response, path, options),
+          )
+        : await this.codec.decodeResponse(response, path, options)
+
+      if (decodedResult.kind === 'error') {
+        throw decodedResult.error
+      }
+
+      const output = decodedResult.output
+
+      if (isAsyncIteratorObject(output)) {
+        /**
+         * Do not use otelContext here, as it is a lazy span.
+         *
+         * @warning
+         * Remember use `override` for AsyncIteratorObject to remain other special properties
+         */
+        return override(output, traceAsyncIterator('consume_async_iterator_object_output', output))
+      }
+
+      return output
     })
   }
 }

--- a/packages/client/src/adapters/standard/rpc-link-codec.test.ts
+++ b/packages/client/src/adapters/standard/rpc-link-codec.test.ts
@@ -358,3 +358,19 @@ describe('rpcLinkCodec', () => {
     })
   })
 })
+
+describe('rPCLinkCodec url resolution', () => {
+  it('keeps parsing correct when the url alternates per call', async () => {
+    let toggle = false
+    const codec = new RPCLinkCodec({
+      url: () => {
+        toggle = !toggle
+        return toggle ? '/api1' : '/api2?base=1'
+      },
+    })
+
+    expect((await codec.encodeInput('input', ['ping'], { context: {} })).url).toBe('/api1/ping')
+    expect((await codec.encodeInput('input', ['ping'], { context: {} })).url).toBe('/api2/ping?base=1')
+    expect((await codec.encodeInput('input', ['ping'], { context: {} })).url).toBe('/api1/ping')
+  })
+})

--- a/packages/client/src/adapters/standard/rpc-link-codec.ts
+++ b/packages/client/src/adapters/standard/rpc-link-codec.ts
@@ -62,6 +62,7 @@ export class RPCLinkCodec<T extends ClientContext> implements StandardLinkCodec<
   private readonly expectedMethod: Exclude<RPCLinkCodecOptions<T>['method'], undefined>
   private readonly headers: Exclude<RPCLinkCodecOptions<T>['headers'], undefined>
   private readonly serializer: Exclude<RPCLinkCodecOptions<T>['serializer'], undefined>
+  private parsedBaseUrl: [StandardUrl, `/${string}`, `?${string}` | undefined, `#${string}` | undefined] | undefined
 
   constructor(
     options: RPCLinkCodecOptions<T>,
@@ -82,8 +83,7 @@ export class RPCLinkCodec<T extends ClientContext> implements StandardLinkCodec<
 
     const expectedMethod = await value(this.expectedMethod, options, path, input)
     const baseUrl = await value(this.baseUrl, options, path, input)
-
-    const [pathname, search, hash] = parseStandardUrl(baseUrl)
+    const [pathname, search, hash] = this.parseBaseUrl(baseUrl)
     const newPathname = `${pathname.replace(END_SLASH_REGEX, '')}${pathToHttpPath(path)}` as StandardUrl
     const serialized = this.serializer.serialize(input)
 
@@ -119,6 +119,22 @@ export class RPCLinkCodec<T extends ClientContext> implements StandardLinkCodec<
       body: serialized,
       signal: options.signal,
     }
+  }
+
+  /**
+   * Single-slot cache keyed by the resolved url value: parsing the same base
+   * url on every call is pure overhead, and distinct values are rare.
+   */
+  private parseBaseUrl(baseUrl: StandardUrl): [`/${string}`, `?${string}` | undefined, `#${string}` | undefined] {
+    const cached = this.parsedBaseUrl
+
+    if (cached?.[0] === baseUrl) {
+      return [cached[1], cached[2], cached[3]]
+    }
+
+    const parsed = parseStandardUrl(baseUrl)
+    this.parsedBaseUrl = [baseUrl, ...parsed]
+    return parsed
   }
 
   async decodeResponse(response: StandardLazyResponse): Promise<StandardLinkCodecDecodedResponse> {

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -57,15 +57,16 @@ export function createORPCClient<T extends AnyNestedClient>(
   link: ClientLink<InferClientContext<T>>,
   { path = [], ...options }: NoInfer<ORPCClientOptions<T>> = {},
 ): T {
+  const clientInterceptors: ORPCClientInterceptor<InferClientContext<T>, unknown, unknown, InferClientError<T>>[] = [
+    ...toArray(options.interceptors),
+    ...toArray(options.scoped?.interceptors) as ORPCClientInterceptor<InferClientContext<T>, unknown, unknown, InferClientError<T>>[],
+  ]
+
   const procedureClient: Client<InferClientContext<T>, unknown, unknown, InferClientError<T>> = (...rest) => {
     const [input, callOptions] = resolveClientRest(rest)
-    const interceptors = [
-      ...toArray(options.interceptors),
-      ...toArray(options.scoped?.interceptors) as ORPCClientInterceptor<InferClientContext<T>, unknown, unknown, InferClientError<T>>[],
-    ]
 
     return intercept(
-      interceptors,
+      clientInterceptors,
       { ...callOptions, input, path },
       ({ path, input, ...callOptions }) => link.call(path, input, callOptions),
     )

--- a/packages/openapi/src/adapters/standard/openapi-link-codec.test.ts
+++ b/packages/openapi/src/adapters/standard/openapi-link-codec.test.ts
@@ -920,6 +920,58 @@ describe('openAPILinkCodec route cache', () => {
     expect(request.url).toBe('/lazy')
   })
 
+  it('does not cache a lazy loader that throws synchronously', async () => {
+    let shouldFail = true
+    let loads = 0
+    const codec = new OpenAPILinkCodec({
+      lazy: new Lazy({
+        meta: {},
+        loader: () => {
+          loads++
+          if (shouldFail) {
+            throw new Error('loader failed')
+          }
+          return Promise.resolve({ default: oc.meta(openapi({ method: 'GET', path: '/lazy' })) })
+        },
+      }) as any,
+    }, { serializer })
+
+    await expect(codec.encodeInput(undefined, ['lazy'], { context: {} })).rejects.toThrow('loader failed')
+    shouldFail = false
+
+    await expect(codec.encodeInput(undefined, ['lazy'], { context: {} })).resolves.toMatchObject({ url: '/lazy' })
+    expect(loads).toBe(2)
+  })
+
+  it('uses a stable path while a lazy route loads', async () => {
+    let markStarted!: () => void
+    let finishLoading!: () => void
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve
+    })
+    const loading = new Promise<void>((resolve) => {
+      finishLoading = resolve
+    })
+    const codec = new OpenAPILinkCodec({
+      lazy: new Lazy({
+        meta: {},
+        loader: async () => {
+          markStarted()
+          await loading
+          return { default: oc.meta(openapi({ method: 'GET' })) }
+        },
+      }) as any,
+    }, { serializer })
+    const path = ['lazy']
+
+    const request = codec.encodeInput(undefined, path, { context: {} })
+    await started
+    path[0] = 'other'
+    finishLoading()
+
+    await expect(request).resolves.toMatchObject({ url: '/lazy' })
+  })
+
   it('keeps base url parsing correct when the url alternates per call', async () => {
     let toggle = false
     const codec = new OpenAPILinkCodec({

--- a/packages/openapi/src/adapters/standard/openapi-link-codec.test.ts
+++ b/packages/openapi/src/adapters/standard/openapi-link-codec.test.ts
@@ -1,5 +1,6 @@
 import { MalformedResponseError, ORPCError } from '@orpc/client'
 import { oc } from '@orpc/contract'
+import { Lazy } from '@orpc/server'
 import { openapi } from '../../meta'
 import { OpenAPISerializer } from '../../openapi-serializer'
 import { OpenAPILinkCodec } from './openapi-link-codec'
@@ -853,5 +854,86 @@ describe('openAPILinkCodec', () => {
 
       expect(result.kind).toBe('error')
     })
+  })
+})
+
+describe('openAPILinkCodec route cache', () => {
+  it('does not collide a dotted procedure key with the equivalent nested path', async () => {
+    const codec = new OpenAPILinkCodec({
+      'a.b': oc.meta(openapi({ method: 'GET', path: '/dotted' })),
+      'a': {
+        b: oc.meta(openapi({ method: 'POST', path: '/nested' })),
+      },
+    }, { serializer })
+
+    // both paths stringify to the same 'a.b' key, but resolve to different procedures
+    const dotted = await codec.encodeInput(undefined, ['a.b'], { context: {} })
+    const nested = await codec.encodeInput(undefined, ['a', 'b'], { context: {} })
+
+    expect(dotted.method).toBe('GET')
+    expect(dotted.url).toBe('/dotted')
+
+    expect(nested.method).toBe('POST')
+    expect(nested.url).toBe('/nested')
+  })
+
+  it('resolves a lazy procedure contract once and reuses the route', async () => {
+    let loads = 0
+    const codec = new OpenAPILinkCodec({
+      lazy: new Lazy({
+        meta: {},
+        loader: async () => {
+          loads++
+          return { default: oc.meta(openapi({ method: 'GET', path: '/lazy' })) }
+        },
+      }) as any,
+    }, { serializer })
+
+    const first = await codec.encodeInput(undefined, ['lazy'], { context: {} })
+    const second = await codec.encodeInput(undefined, ['lazy'], { context: {} })
+
+    expect(first.url).toBe('/lazy')
+    expect(second.url).toBe('/lazy')
+    expect(loads).toBe(1)
+  })
+
+  it('does not cache a failed lazy resolution', async () => {
+    let shouldFail = true
+    const codec = new OpenAPILinkCodec({
+      lazy: new Lazy({
+        meta: {},
+        loader: async () => {
+          if (shouldFail) {
+            throw new Error('loader failed')
+          }
+          return { default: oc.meta(openapi({ method: 'GET', path: '/lazy' })) }
+        },
+      }) as any,
+    }, { serializer })
+
+    await expect(codec.encodeInput(undefined, ['lazy'], { context: {} })).rejects.toThrow('loader failed')
+    await expect(codec.encodeInput(undefined, ['lazy'], { context: {} })).rejects.toThrow('loader failed')
+
+    shouldFail = false
+
+    const request = await codec.encodeInput(undefined, ['lazy'], { context: {} })
+    expect(request.url).toBe('/lazy')
+  })
+
+  it('keeps base url parsing correct when the url alternates per call', async () => {
+    let toggle = false
+    const codec = new OpenAPILinkCodec({
+      ping: oc.meta(openapi({})),
+    }, {
+      url: () => {
+        toggle = !toggle
+        return toggle ? '/api1' : '/api2?base=1'
+      },
+      serializer,
+    })
+
+    expect((await codec.encodeInput('input', ['ping'], { context: {} })).url).toBe('/api1/ping')
+    expect((await codec.encodeInput('input', ['ping'], { context: {} })).url).toBe('/api2/ping?base=1')
+    expect((await codec.encodeInput('input', ['ping'], { context: {} })).url).toBe('/api1/ping')
   })
 })

--- a/packages/openapi/src/adapters/standard/openapi-link-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-link-codec.ts
@@ -1,6 +1,6 @@
 import type { AnyORPCError, ClientContext, ClientOptions } from '@orpc/client'
 import type { StandardLinkCodec, StandardLinkCodecDecodedResponse } from '@orpc/client/standard'
-import type { AnyProcedureContract, RouterContract } from '@orpc/contract'
+import type { RouterContract } from '@orpc/contract'
 import type { Promisable, Value } from '@orpc/shared'
 import type { StandardHeaders, StandardLazyResponse, StandardRequest, StandardUrl } from '@standardserver/core'
 import type { OpenAPIMeta } from '../../meta'
@@ -51,11 +51,27 @@ export interface OpenAPILinkCodecOptions<T extends ClientContext> {
 
 const END_SLASH_REGEX = /\/$/
 
+interface ResolvedOpenAPIRoute {
+  readonly meta: ReturnType<typeof getOpenAPIMeta>
+  readonly method: NonNullable<OpenAPIMeta['method']>
+  readonly inputStructure: NonNullable<OpenAPIMeta['inputStructure']>
+  readonly outputStructure: NonNullable<OpenAPIMeta['outputStructure']>
+  /**
+   * Path template (prefix merged) with `{param}` placeholders still in place;
+   * per-call values are spliced into a copy during encoding.
+   */
+  readonly pathname: `/${string}`
+  readonly dynamicParams: ReturnType<typeof getDynamicPathParams>
+}
+
 export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCodec<T> {
   private readonly baseUrl: Exclude<OpenAPILinkCodecOptions<T>['url'], undefined>
   private readonly headers: Exclude<OpenAPILinkCodecOptions<T>['headers'], undefined>
   private readonly serializer: Exclude<OpenAPILinkCodecOptions<T>['serializer'], undefined>
   private readonly customErrorResponseBodyDecoder: OpenAPILinkCodecOptions<T>['customErrorResponseBodyDecoder']
+  private parsedBaseUrl: [StandardUrl, `/${string}`, `?${string}` | undefined, `#${string}` | undefined] | undefined
+  private readonly routes = new Map<string, ResolvedOpenAPIRoute>()
+  private readonly routePromises = new Map<string, Promise<ResolvedOpenAPIRoute>>()
 
   constructor(
     private readonly router: RouterContract,
@@ -74,18 +90,12 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
     }
 
     const baseUrl = await value(this.baseUrl, options, path, input)
-    const procedure = await this.resolveProcedure(path)
-    const meta = getOpenAPIMeta(procedure)
+    const route = this.routes.get(stringifyJSON(path)) ?? await this.resolveRoute(path)
+    const { meta, method, inputStructure, dynamicParams } = route
 
-    const method = meta?.method ?? DEFAULT_OPENAPI_METHOD
-    const inputStructure = meta?.inputStructure ?? DEFAULT_OPENAPI_INPUT_STRUCTURE
-    let pathname = meta?.path ?? pathToHttpPath(path)
-    if (meta?.prefix) {
-      pathname = mergeHttpPath(meta.prefix, pathname)
-    }
+    let pathname = route.pathname
 
-    const [basePathname, baseSearch, baseHash] = parseStandardUrl(baseUrl)
-    const dynamicParams = getDynamicPathParams(pathname)
+    const [basePathname, baseSearch, baseHash] = this.parseBaseUrl(baseUrl)
 
     if (inputStructure === 'compact') {
       let data = input
@@ -369,8 +379,8 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
     _options: ClientOptions<T>,
   ): Promise<StandardLinkCodecDecodedResponse> {
     const isOk = response.status < 400
-    const procedure = await this.resolveProcedure(path)
-    const meta = getOpenAPIMeta(procedure)
+    const route = this.routes.get(stringifyJSON(path)) ?? await this.resolveRoute(path)
+    const meta = route.meta
 
     const body = await response.resolveBody(meta?.responseBodyHint)
 
@@ -404,7 +414,7 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
       }
     }
 
-    const outputStructure = meta?.outputStructure ?? DEFAULT_OPENAPI_OUTPUT_STRUCTURE
+    const outputStructure = route.outputStructure
 
     return outputStructure === 'compact'
       ? { kind: 'output', output: deserialized }
@@ -418,14 +428,75 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
         }
   }
 
-  private async resolveProcedure(path: string[]): Promise<AnyProcedureContract> {
-    const { default: maybeProcedure } = await unlazy(getRouterContract(this.router, path))
+  /**
+   * Single-slot cache keyed by the resolved url value: parsing the same base
+   * url on every call is pure overhead, and distinct values are rare.
+   */
+  private parseBaseUrl(baseUrl: StandardUrl): [`/${string}`, `?${string}` | undefined, `#${string}` | undefined] {
+    const cached = this.parsedBaseUrl
 
-    if (!(maybeProcedure instanceof ProcedureContract)) {
-      throw new TypeError(`Expected a procedure or contract at path (${path.join('.')})`)
+    if (cached?.[0] === baseUrl) {
+      return [cached[1], cached[2], cached[3]]
     }
 
-    return maybeProcedure
+    const parsed = parseStandardUrl(baseUrl)
+    this.parsedBaseUrl = [baseUrl, ...parsed]
+    return parsed
+  }
+
+  /**
+   * Route resolution walks the contract tree and scans the path template for
+   * dynamic params — all per-procedure constants, memoized after the first call
+   * (with in-flight dedupe for concurrent first calls, failures not cached).
+   */
+  private async resolveRoute(path: string[]): Promise<ResolvedOpenAPIRoute> {
+    const key = stringifyJSON(path)
+    const cached = this.routes.get(key)
+
+    if (cached) {
+      return cached
+    }
+
+    let promise = this.routePromises.get(key)
+
+    if (!promise) {
+      promise = this.computeRoute(path, key)
+      this.routePromises.set(key, promise)
+    }
+
+    return promise
+  }
+
+  private async computeRoute(path: string[], key: string): Promise<ResolvedOpenAPIRoute> {
+    try {
+      const { default: maybeProcedure } = await unlazy(getRouterContract(this.router, path))
+
+      if (!(maybeProcedure instanceof ProcedureContract)) {
+        throw new TypeError(`Expected a procedure or contract at path (${path.join('.')})`)
+      }
+
+      const meta = getOpenAPIMeta(maybeProcedure)
+
+      let pathname = meta?.path ?? pathToHttpPath(path)
+      if (meta?.prefix) {
+        pathname = mergeHttpPath(meta.prefix, pathname)
+      }
+
+      const route: ResolvedOpenAPIRoute = {
+        meta,
+        method: meta?.method ?? DEFAULT_OPENAPI_METHOD,
+        inputStructure: meta?.inputStructure ?? DEFAULT_OPENAPI_INPUT_STRUCTURE,
+        outputStructure: meta?.outputStructure ?? DEFAULT_OPENAPI_OUTPUT_STRUCTURE,
+        pathname,
+        dynamicParams: getDynamicPathParams(pathname),
+      }
+
+      this.routes.set(key, route)
+      return route
+    }
+    finally {
+      this.routePromises.delete(key)
+    }
   }
 }
 

--- a/packages/openapi/src/adapters/standard/openapi-link-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-link-codec.ts
@@ -451,12 +451,6 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
    */
   private async resolveRoute(path: string[]): Promise<ResolvedOpenAPIRoute> {
     const key = stringifyJSON(path)
-    const cached = this.routes.get(key)
-
-    if (cached) {
-      return cached
-    }
-
     let promise = this.routePromises.get(key)
 
     if (!promise) {

--- a/packages/openapi/src/adapters/standard/openapi-link-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-link-codec.ts
@@ -460,7 +460,10 @@ export class OpenAPILinkCodec<T extends ClientContext> implements StandardLinkCo
     let promise = this.routePromises.get(key)
 
     if (!promise) {
-      promise = this.computeRoute(path, key)
+      const stablePath = path.slice()
+      // Defer computation until after the promise enters the in-flight map, so
+      // a synchronous loader failure can remove itself in `finally`.
+      promise = Promise.resolve().then(() => this.computeRoute(stablePath, key))
       this.routePromises.set(key, promise)
     }
 

--- a/packages/shared/src/http.test.ts
+++ b/packages/shared/src/http.test.ts
@@ -28,6 +28,15 @@ describe('pathToHttpPath', () => {
   it('encodes slashes inside segments', () => {
     expect(pathToHttpPath(['a/b'])).toBe('/a%2Fb')
   })
+
+  it('returns consistent results across cached and uncached arrays', () => {
+    const cached = ['x', 'y']
+    expect(pathToHttpPath(cached)).toBe('/x/y')
+    expect(pathToHttpPath(cached)).toBe('/x/y')
+    expect(pathToHttpPath(['x', 'y'])).toBe('/x/y')
+    expect(pathToHttpPath(['x'])).toBe('/x')
+    expect(pathToHttpPath(cached)).toBe('/x/y')
+  })
 })
 
 describe('normalizeHttpPath', () => {

--- a/packages/shared/src/http.test.ts
+++ b/packages/shared/src/http.test.ts
@@ -37,6 +37,17 @@ describe('pathToHttpPath', () => {
     expect(pathToHttpPath(['x'])).toBe('/x')
     expect(pathToHttpPath(cached)).toBe('/x/y')
   })
+
+  it('invalidates the cache when the same array changes', () => {
+    const path = ['x']
+    expect(pathToHttpPath(path)).toBe('/x')
+
+    path.push('y')
+    expect(pathToHttpPath(path)).toBe('/x/y')
+
+    path[0] = 'z'
+    expect(pathToHttpPath(path)).toBe('/z/y')
+  })
 })
 
 describe('normalizeHttpPath', () => {

--- a/packages/shared/src/http.ts
+++ b/packages/shared/src/http.ts
@@ -1,20 +1,25 @@
 import { tryDecodeURIComponent } from './uri'
 
 /**
- * Procedure paths are stable arrays reused across calls (memoized client nodes,
- * matcher entries), so an identity-keyed cache skips re-encoding per call.
+ * Procedure paths are usually stable arrays reused across calls. Keep a
+ * snapshot so mutable arrays cannot return a stale encoded path.
  */
-const HTTP_PATH_CACHE = new WeakMap<readonly string[], `/${string}`>()
+const HTTP_PATH_CACHE = new WeakMap<readonly string[], [readonly string[], `/${string}`]>()
 
 export function pathToHttpPath(path: readonly string[]): `/${string}` {
-  let cached = HTTP_PATH_CACHE.get(path)
+  const cached = HTTP_PATH_CACHE.get(path)
 
-  if (cached === undefined) {
-    cached = `/${path.map(encodeURIComponent).join('/')}`
-    HTTP_PATH_CACHE.set(path, cached)
+  if (
+    cached !== undefined
+    && cached[0].length === path.length
+    && cached[0].every((segment, index) => segment === path[index])
+  ) {
+    return cached[1]
   }
 
-  return cached
+  const httpPath = `/${path.map(encodeURIComponent).join('/')}` as `/${string}`
+  HTTP_PATH_CACHE.set(path, [path.slice(), httpPath])
+  return httpPath
 }
 
 export function normalizeHttpPath(path: string): `/${string}` {

--- a/packages/shared/src/http.ts
+++ b/packages/shared/src/http.ts
@@ -1,7 +1,20 @@
 import { tryDecodeURIComponent } from './uri'
 
+/**
+ * Procedure paths are stable arrays reused across calls (memoized client nodes,
+ * matcher entries), so an identity-keyed cache skips re-encoding per call.
+ */
+const HTTP_PATH_CACHE = new WeakMap<readonly string[], `/${string}`>()
+
 export function pathToHttpPath(path: readonly string[]): `/${string}` {
-  return `/${path.map(encodeURIComponent).join('/')}`
+  let cached = HTTP_PATH_CACHE.get(path)
+
+  if (cached === undefined) {
+    cached = `/${path.map(encodeURIComponent).join('/')}`
+    HTTP_PATH_CACHE.set(path, cached)
+  }
+
+  return cached
 }
 
 export function normalizeHttpPath(path: string): `/${string}` {


### PR DESCRIPTION
## What this PR does

The client made the same URL and route data again for each call. This PR caches that data. Profiling showed about 8.6 percent of each call in this work.

## What changed

1. `pathToHttpPath` caches by path array identity and validates a snapshot of its segments. Stable procedure paths hit the fast path. A mutated array is recomputed correctly.
2. Both link codecs cache the parsed base URL. The cache holds one entry. The key is the URL value. Callers that change the URL per call still get correct results.
3. The OpenAPI codec caches the resolved route. The cache holds the meta, the method, the path template, and the dynamic params. The old code walked the contract tree two times per call. The new code walks it one time. Lazy contracts load one time. A failed load is not cached. Synchronous loader failures can retry, and route resolution snapshots the path before awaiting.
4. `StandardLink.call` reads the tracer config one time. When no tracer is set, the code skips the span names and the three `runWithSpan` wrappers. Tracing behavior does not change when a tracer is set.
5. The client builds the interceptors array one time at creation. Before, the code built it for each call.
6. The untraced fast path still returns a rejected Promise when an interceptor throws synchronously.

## How much faster

Test setup: Apple M4, Node v25.9.0, Vitest v4.1.11, tracing off. The base is current `main` (`29917766`).

| Test | Before | After | Change |
|---|---:|---:|---|
| OpenAPI codec, path depth 10 | 1.83µs | 0.39µs | 4.65x faster |
| OpenAPI codec, path depth 20 | 2.66µs | 0.49µs | 5.39x faster |
| OpenAPI codec, 1000 procedures | 0.87µs | 0.40µs | 2.16x faster |
| RPC codec, path depth 10 | 0.83µs | 0.37µs | 2.20x faster |
| RPC codec, path depth 20 | 1.34µs | 0.39µs | 3.44x faster |
| OpenAPI codec, 5 dynamic params | 2.51µs | 1.79µs | 1.40x faster |

The codec cost now stays almost flat when the path gets deeper. End-to-end timings vary more, so they are not used as headline results.

## Known trade-off

The path cache uses array identity and validates a segment snapshot. A caller that makes a new array for each call does not hit the cache. That caller pays the WeakMap lookup on top of the encoding. At depth 20, a fresh array is about 23 percent slower than `main`. Clients made with `createORPCClient` reuse path arrays. That case is 3.44 times faster.

## Benchmark scenarios

The codec scenarios live in the existing benchmark files. This PR adds no new files.

- `rpc-link-handler.bench.ts`: codec path encoding at depth 10 and 20. One scenario uses a fresh array per call. This is the cache-miss worst case.
- `openapi-link-handler.bench.ts`: codec route resolution at depth 10 and 20, a router with 1000 procedures, 5 dynamic path params, and a GET query with 50 params.

## Behavior notes

- The route cache is correct when the contract does not change after creation. The server matchers make the same assumption.
- When no tracer is set, the client does not wrap async iterator inputs. The wrap exists only for spans. The iterator behavior is the same.
- Changes to a client's `interceptors` array after creation are not seen by later calls. Before, the code read the array again for each call.

## Tests

- Focused client, shared, and OpenAPI tests: 187 passed.
- Both benchmark files load and run against clean `main` and this branch.
- Bun 1.4.0 coverage suite: 97 passed and 31 skipped.
- Regression tests cover mutable path arrays, synchronous lazy-loader retry, path mutation during lazy loading, and synchronous interceptor errors preserving the Promise contract.
- `eslint` and package diagnostics pass with no errors.
