### PR TITLE
fix(json-schema): rewrite refs inside promoted $defs when combining schemas

### DIFF
--- a/packages/json-schema/src/composition-utils.test.ts
+++ b/packages/json-schema/src/composition-utils.test.ts
@@ -765,6 +765,87 @@ describe('combineJsonObjectSchemaEntries', () => {
       },
     })
   })
+
+  it('promotes def bodies per property, renaming only what the rebase makes distinct', () => {
+    // the exact same schema object for both entries: Self and Sibling rebase onto their own
+    // property and must not dedupe, Wrapper follows them, while Leaf and Dangling stay shared
+    const entry: JsonSchema = {
+      type: 'object',
+      properties: {
+        value: { type: 'string' },
+      },
+      allOf: [{ $ref: '#/$defs/Wrapper' }],
+      $defs: {
+        Self: { $ref: '#' },
+        Sibling: { $ref: '#/properties/value' },
+        Dangling: { $ref: '#/nonExists' },
+        Leaf: { type: 'string' },
+        Wrapper: { allOf: [{ $ref: '#/$defs/Leaf' }, { $ref: '#/$defs/Self' }, { $ref: '#/$defs/Sibling' }] },
+      },
+    }
+
+    expect(combineJsonObjectSchemaEntries([
+      ['left', entry, false],
+      ['right', entry, true],
+    ])).toEqual({
+      type: 'object',
+      properties: {
+        left: {
+          type: 'object',
+          properties: { value: { type: 'string' } },
+          allOf: [{ $ref: '#/$defs/Wrapper' }],
+        },
+        right: {
+          type: 'object',
+          properties: { value: { type: 'string' } },
+          allOf: [{ $ref: '#/$defs/Wrapper2' }],
+        },
+      },
+      required: ['left'],
+      $defs: {
+        Self: { $ref: '#/properties/left' },
+        Sibling: { $ref: '#/properties/left/properties/value' },
+        Dangling: { $ref: '#/nonExists' },
+        Leaf: { type: 'string' },
+        Wrapper: { allOf: [{ $ref: '#/$defs/Leaf' }, { $ref: '#/$defs/Self' }, { $ref: '#/$defs/Sibling' }] },
+        Self2: { $ref: '#/properties/right' },
+        Sibling2: { $ref: '#/properties/right/properties/value' },
+        Wrapper2: { allOf: [{ $ref: '#/$defs/Leaf' }, { $ref: '#/$defs/Self2' }, { $ref: '#/$defs/Sibling2' }] },
+      },
+    })
+  })
+
+  it('encodes the property name when rebasing entry root pointers', () => {
+    expect(combineJsonObjectSchemaEntries([
+      ['a/b', {
+        type: 'object',
+        properties: {
+          self: { $ref: '#' },
+          deep: { $ref: '#/properties/self' },
+        },
+      }, false],
+    ])).toEqual({
+      type: 'object',
+      properties: {
+        'a/b': {
+          type: 'object',
+          properties: {
+            self: { $ref: '#/properties/a~1b' },
+            deep: { $ref: '#/properties/a~1b/properties/self' },
+          },
+        },
+      },
+      required: ['a/b'],
+    })
+  })
+
+  it('keeps a property named __proto__ as an own key', () => {
+    // an own __proto__ key can neither be written as an object literal nor compared with toEqual
+    expect(JSON.stringify(combineJsonObjectSchemaEntries([
+      ['__proto__', { type: 'string' }, false],
+      ['safe', { type: 'number' }, true],
+    ]))).toBe('{"type":"object","properties":{"__proto__":{"type":"string"},"safe":{"type":"number"}},"required":["__proto__"]}')
+  })
 })
 
 describe('flattenJsonUnionSchema', () => {
@@ -1268,6 +1349,258 @@ describe('combineJsonSchemasWithComposition', () => {
     })
   })
 
+  it('only dedupes against the def sharing its name', () => {
+    // the renamed body is byte-identical to `B`, but `B` is not a dedupe candidate for `A`
+    expect(combineJsonSchemasWithComposition('anyOf', [
+      {
+        allOf: [{ $ref: '#/$defs/A' }, { $ref: '#/$defs/B' }],
+        $defs: {
+          A: { type: 'string' },
+          B: { type: 'number' },
+        },
+      },
+      {
+        $ref: '#/$defs/A',
+        $defs: {
+          A: { type: 'number' },
+        },
+      },
+    ])).toEqual({
+      anyOf: [
+        { allOf: [{ $ref: '#/$defs/A' }, { $ref: '#/$defs/B' }] },
+        { $ref: '#/$defs/A2' },
+      ],
+      $defs: {
+        A: { type: 'string' },
+        B: { type: 'number' },
+        A2: { type: 'number' },
+      },
+    })
+  })
+
+  it('rewrites refs inside promoted def bodies so renamed defs stay reachable', () => {
+    expect(combineJsonSchemasWithComposition('anyOf', [
+      {
+        $ref: '#/$defs/Wrapper',
+        $defs: {
+          Leaf: { type: 'string' },
+          Wrapper: { type: 'array', items: { $ref: '#/$defs/Leaf' } },
+        },
+      },
+      {
+        $ref: '#/$defs/Wrapper',
+        $defs: {
+          Leaf: { type: 'number' },
+          Wrapper: { type: 'array', items: { $ref: '#/$defs/Leaf' } },
+        },
+      },
+    ])).toEqual({
+      anyOf: [
+        { $ref: '#/$defs/Wrapper' },
+        { $ref: '#/$defs/Wrapper2' },
+      ],
+      $defs: {
+        Leaf: { type: 'string' },
+        Wrapper: { type: 'array', items: { $ref: '#/$defs/Leaf' } },
+        Leaf2: { type: 'number' },
+        Wrapper2: { type: 'array', items: { $ref: '#/$defs/Leaf2' } },
+      },
+    })
+
+    // referencing defs still dedupe when everything they point at dedupes too
+    expect(combineJsonSchemasWithComposition('anyOf', [
+      {
+        $ref: '#/$defs/Wrapper',
+        $defs: {
+          Leaf: { type: 'string' },
+          Wrapper: { type: 'array', items: { $ref: '#/$defs/Leaf' } },
+        },
+      },
+      {
+        $ref: '#/$defs/Wrapper',
+        $defs: {
+          Leaf: { type: 'string' },
+          Wrapper: { type: 'array', items: { $ref: '#/$defs/Leaf' } },
+        },
+      },
+    ])).toEqual({
+      anyOf: [
+        { $ref: '#/$defs/Wrapper' },
+        { $ref: '#/$defs/Wrapper' },
+      ],
+      $defs: {
+        Leaf: { type: 'string' },
+        Wrapper: { type: 'array', items: { $ref: '#/$defs/Leaf' } },
+      },
+    })
+  })
+
+  it('cascades def renames through a chain declared before its dependencies', () => {
+    // Outer and Middle both compare equal until the def they reach has been renamed, so this
+    // only settles after three passes
+    const chain = (leaf: JsonSchema): JsonSchema => ({
+      $ref: '#/$defs/Outer',
+      $defs: {
+        Outer: { type: 'object', properties: { value: { $ref: '#/$defs/Middle' } } },
+        Middle: { type: 'array', items: { $ref: '#/$defs/Inner' } },
+        Inner: leaf,
+      },
+    })
+
+    expect(combineJsonSchemasWithComposition('anyOf', [
+      chain({ type: 'string' }),
+      chain({ type: 'number' }),
+    ])).toEqual({
+      anyOf: [
+        { $ref: '#/$defs/Outer' },
+        { $ref: '#/$defs/Outer2' },
+      ],
+      $defs: {
+        Outer: { type: 'object', properties: { value: { $ref: '#/$defs/Middle' } } },
+        Middle: { type: 'array', items: { $ref: '#/$defs/Inner' } },
+        Inner: { type: 'string' },
+        Outer2: { type: 'object', properties: { value: { $ref: '#/$defs/Middle2' } } },
+        Middle2: { type: 'array', items: { $ref: '#/$defs/Inner2' } },
+        Inner2: { type: 'number' },
+      },
+    })
+  })
+
+  it('never renames a def onto a name another def in the same branch already claims', () => {
+    expect(combineJsonSchemasWithComposition('anyOf', [
+      {
+        $ref: '#/$defs/Shared',
+        $defs: {
+          Shared: { type: 'string' },
+        },
+      },
+      {
+        allOf: [{ $ref: '#/$defs/Shared' }, { $ref: '#/$defs/Shared2' }],
+        $defs: {
+          Shared: { type: 'number' },
+          Shared2: { type: 'boolean' },
+        },
+      },
+    ])).toEqual({
+      anyOf: [
+        { $ref: '#/$defs/Shared' },
+        { allOf: [{ $ref: '#/$defs/Shared3' }, { $ref: '#/$defs/Shared2' }] },
+      ],
+      $defs: {
+        Shared: { type: 'string' },
+        Shared3: { type: 'number' },
+        Shared2: { type: 'boolean' },
+      },
+    })
+  })
+
+  it('promotes def names that shadow Object.prototype members', () => {
+    expect(combineJsonSchemasWithComposition('anyOf', [
+      {
+        allOf: [{ $ref: '#/$defs/toString' }, { $ref: '#/$defs/valueOf' }],
+        $defs: {
+          toString: { type: 'string' },
+          constructor: { type: 'boolean' },
+        },
+      },
+      {
+        $ref: '#/$defs/toString',
+        $defs: {
+          toString: { type: 'number' },
+          constructor: { type: 'boolean' },
+        },
+      },
+    ])).toEqual({
+      anyOf: [
+        { allOf: [{ $ref: '#/$defs/toString' }, { $ref: '#/$defs/valueOf' }] },
+        { $ref: '#/$defs/toString2' },
+      ],
+      $defs: {
+        toString: { type: 'string' },
+        constructor: { type: 'boolean' },
+        toString2: { type: 'number' },
+      },
+    })
+
+    // a def literally named __proto__ has to survive as an own key
+    expect(JSON.stringify(combineJsonSchemasWithComposition('anyOf', [
+      JSON.parse('{"$ref":"#/$defs/__proto__","$defs":{"__proto__":{"type":"string"}}}'),
+      { type: 'object' },
+    ]))).toBe('{"anyOf":[{"$ref":"#/$defs/__proto__"},{"type":"object"}],"$defs":{"__proto__":{"type":"string"}}}')
+  })
+
+  it('never lets two renames in the same branch land on the same target', () => {
+    // A skips the taken A2..A11 and lands on A12, which A1 would otherwise take as its own first choice
+    const taken = Object.fromEntries(
+      ['A', 'A1', 'A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8', 'A9', 'A10', 'A11'].map(name => [name, { type: 'string' }]),
+    )
+
+    expect(combineJsonSchemasWithComposition('anyOf', [
+      {
+        allOf: [{ $ref: '#/$defs/A' }, { $ref: '#/$defs/A1' }],
+        $defs: taken,
+      },
+      {
+        allOf: [{ $ref: '#/$defs/A' }, { $ref: '#/$defs/A1' }],
+        $defs: {
+          A: { type: 'number' },
+          A1: { type: 'boolean' },
+        },
+      },
+    ])).toEqual({
+      anyOf: [
+        { allOf: [{ $ref: '#/$defs/A' }, { $ref: '#/$defs/A1' }] },
+        { allOf: [{ $ref: '#/$defs/A12' }, { $ref: '#/$defs/A13' }] },
+      ],
+      $defs: {
+        ...taken,
+        A12: { type: 'number' },
+        A13: { type: 'boolean' },
+      },
+    })
+  })
+
+  it('rebases root pointers inside promoted def bodies and never dedupes them across branches', () => {
+    // the exact same schema object on both sides: Self and Sibling are only distinguishable
+    // once rebased, while Dangling and Relative resolve nowhere and dedupe
+    const branch: JsonSchema = {
+      type: 'object',
+      properties: {
+        value: { type: 'string' },
+      },
+      allOf: [{ $ref: '#/$defs/Self' }, { $ref: '#/$defs/Sibling' }],
+      $defs: {
+        Self: { $ref: '#' },
+        Sibling: { $ref: '#/properties/value' },
+        Dangling: { $ref: '#/nonExists' },
+        Relative: { $ref: '../External' },
+      },
+    }
+
+    expect(combineJsonSchemasWithComposition('anyOf', [branch, branch])).toEqual({
+      anyOf: [
+        {
+          type: 'object',
+          properties: { value: { type: 'string' } },
+          allOf: [{ $ref: '#/$defs/Self' }, { $ref: '#/$defs/Sibling' }],
+        },
+        {
+          type: 'object',
+          properties: { value: { type: 'string' } },
+          allOf: [{ $ref: '#/$defs/Self2' }, { $ref: '#/$defs/Sibling2' }],
+        },
+      ],
+      $defs: {
+        Self: { $ref: '#/anyOf/0' },
+        Sibling: { $ref: '#/anyOf/0/properties/value' },
+        Dangling: { $ref: '#/nonExists' },
+        Relative: { $ref: '../External' },
+        Self2: { $ref: '#/anyOf/1' },
+        Sibling2: { $ref: '#/anyOf/1/properties/value' },
+      },
+    })
+  })
+
   it('ignore relative refs unchanged', () => {
     expect(combineJsonSchemasWithComposition('allOf', [
       {
@@ -1332,6 +1665,30 @@ describe('combineJsonSchemasWithComposition', () => {
     })
   })
 
+  it('decodes encoded segments when rebasing root pointers', () => {
+    expect(combineJsonSchemasWithComposition('anyOf', [
+      {
+        type: 'object',
+        properties: {
+          'a/b': { type: 'string' },
+          'ref': { $ref: '#/properties/a~1b' },
+        },
+      },
+      { type: 'object' },
+    ])).toEqual({
+      anyOf: [
+        {
+          type: 'object',
+          properties: {
+            'a/b': { type: 'string' },
+            'ref': { $ref: '#/anyOf/0/properties/a~1b' },
+          },
+        },
+        { type: 'object' },
+      ],
+    })
+  })
+
   it('preserves encoded pointer refs', () => {
     expect(combineJsonSchemasWithComposition('allOf', [
       {
@@ -1370,6 +1727,32 @@ describe('combineJsonSchemasWithComposition', () => {
     })
   })
 
+  it('renames encoded def names and re-encodes the rewritten refs', () => {
+    expect(combineJsonSchemasWithComposition('anyOf', [
+      {
+        allOf: [{ $ref: '#/$defs/path~1name' }, { $ref: '#/$defs/path~1name/properties/x' }],
+        $defs: {
+          'path/name': { type: 'object', properties: { x: { type: 'string' } } },
+        },
+      },
+      {
+        allOf: [{ $ref: '#/$defs/path~1name' }, { $ref: '#/$defs/path~1name/properties/x' }],
+        $defs: {
+          'path/name': { type: 'object', properties: { x: { type: 'number' } } },
+        },
+      },
+    ])).toEqual({
+      anyOf: [
+        { allOf: [{ $ref: '#/$defs/path~1name' }, { $ref: '#/$defs/path~1name/properties/x' }] },
+        { allOf: [{ $ref: '#/$defs/path~1name2' }, { $ref: '#/$defs/path~1name2/properties/x' }] },
+      ],
+      $defs: {
+        'path/name': { type: 'object', properties: { x: { type: 'string' } } },
+        'path/name2': { type: 'object', properties: { x: { type: 'number' } } },
+      },
+    })
+  })
+
   it('ignores undefined defs entries while promoting valid defs', () => {
     expect(combineJsonSchemasWithComposition('allOf', [
       {
@@ -1383,7 +1766,8 @@ describe('combineJsonSchemasWithComposition', () => {
         },
       },
       { type: 'object' },
-    ])).toEqual({
+    // toEqual would treat a `Missing: undefined` key as absent, so this has to be strict
+    ])).toStrictEqual({
       allOf: [
         {
           type: 'object',

--- a/packages/json-schema/src/composition-utils.ts
+++ b/packages/json-schema/src/composition-utils.ts
@@ -11,6 +11,87 @@ import { decodeJsonPointerSegment, encodeJsonPointerSegment, hoistRecursiveRefTo
 import { ensureJsonSchemaObject, isJsonArraySchema } from './utils'
 
 /**
+ * Moves a schema's `$defs` into the shared root map, renaming only the names whose bodies
+ * conflict with an already promoted def, and returns the schema body rebased onto `basePath`.
+ *
+ * Refs inside the promoted def bodies are rewritten too: they share the schema's namespace, so
+ * a rename left unapplied there would silently bind the body to another schema's defs.
+ */
+function promoteJsonSchemaDefs(
+  schema: Exclude<JsonSchema, boolean>,
+  mergedDefs: Map<string, JsonSchema>,
+  basePath: string,
+): JsonSchema {
+  const { $defs, ...rootBody } = schema
+  const renameMap = new Map<string, string>()
+
+  /**
+   * `basePath` is where `rootBody` lands in the combined document, so pointers resolved against
+   * the original root are rebased onto it, while `#/$defs/` pointers follow the promoted defs.
+   */
+  const mapRef = (ref: string): string => {
+    if (ref === '#') {
+      return basePath
+    }
+
+    if (ref.startsWith('#/$defs/')) {
+      const [encodedName, ...segments] = ref.slice('#/$defs/'.length).split('/')
+      const newName = renameMap.get(decodeJsonPointerSegment(encodedName!))
+
+      return newName === undefined
+        ? ref
+        : ['#/$defs', encodeJsonPointerSegment(newName), ...segments].join('/')
+    }
+
+    if (ref.startsWith('#/') && get(rootBody, ref.slice(2).split('/').map(decodeJsonPointerSegment)) !== undefined) {
+      return `${basePath}/${ref.slice(2)}`
+    }
+
+    return ref
+  }
+
+  const defs = Object.entries($defs ?? {}).filter(([, def]) => def !== undefined)
+
+  if (defs.length > 0) {
+    const promoted = new Map<string, JsonSchema>()
+    const reserved = new Set([...mergedDefs.keys(), ...defs.map(([name]) => name)])
+
+    /**
+     * A def body must be rewritten into the merged namespace before it can be compared for
+     * deduplication, and each rename invalidates every body pointing at the renamed def, so
+     * keep rewriting until a full pass renames nothing.
+     */
+    for (let changed = true; changed;) {
+      changed = false
+
+      for (const [name, def] of defs) {
+        const body = mapJsonSchemaRefs(def, mapRef)
+        promoted.set(name, body)
+
+        if (renameMap.has(name) || !mergedDefs.has(name) || isDeepEqual(mergedDefs.get(name), body)) {
+          continue
+        }
+
+        let counter = 2
+        while (reserved.has(`${name}${counter}`)) {
+          counter++
+        }
+
+        reserved.add(`${name}${counter}`)
+        renameMap.set(name, `${name}${counter}`)
+        changed = true
+      }
+    }
+
+    for (const [name, body] of promoted) {
+      mergedDefs.set(renameMap.get(name) ?? name, body)
+    }
+  }
+
+  return mapJsonSchemaRefs(rootBody, mapRef)
+}
+
+/**
  * Combines multiple schemas under the requested composition keyword, promoting branch `$defs` to the root.
  */
 export function combineJsonSchemasWithComposition(
@@ -21,84 +102,20 @@ export function combineJsonSchemasWithComposition(
     return schemas[0] ?? true
   }
 
-  const mergedDefs: Record<string, JsonSchema> = {}
+  const mergedDefs = new Map<string, JsonSchema>()
   const compositionBranches: JsonSchema[] = []
 
   for (let i = 0; i < schemas.length; i++) {
     const schema = schemas[i]!
 
-    if (typeof schema === 'boolean') {
-      compositionBranches.push(schema)
-      continue
-    }
-
-    const { $defs, ...rest } = schema
-    const renameMap: Record<string, string> = {}
-    const promotedNames = new Set<string>()
-
-    if ($defs) {
-      for (const [name, def] of Object.entries($defs)) {
-        if (def === undefined)
-          continue
-        promotedNames.add(name)
-
-        if (name in mergedDefs) {
-          if (isDeepEqual(mergedDefs[name], def)) {
-            continue
-          }
-
-          let counter = 2
-          let newName = `${name}${counter}`
-          while (newName in mergedDefs) {
-            counter++
-            newName = `${name}${counter}`
-          }
-          mergedDefs[newName] = def
-          renameMap[name] = newName
-        }
-        else {
-          mergedDefs[name] = def
-        }
-      }
-    }
-
-    compositionBranches.push(mapJsonSchemaRefs(
-      rest,
-      (ref) => {
-        if (ref === '#') {
-          return `#/${keyword}/${i}`
-        }
-
-        if (ref.startsWith('#/$defs/')) {
-          const afterPrefix = ref.slice('#/$defs/'.length)
-          const slashIdx = afterPrefix.indexOf('/')
-          const encodedSegment = slashIdx === -1 ? afterPrefix : afterPrefix.slice(0, slashIdx)
-          const rest = slashIdx === -1 ? '' : afterPrefix.slice(slashIdx)
-          const defName = decodeJsonPointerSegment(encodedSegment)
-
-          if (!promotedNames.has(defName)) {
-            return ref
-          }
-
-          if (defName in renameMap) {
-            return `#/$defs/${encodeJsonPointerSegment(renameMap[defName]!)}${rest}`
-          }
-
-          return ref
-        }
-
-        if (ref.startsWith('#/') && get(rest, ref.slice(2).split('/').map(decodeJsonPointerSegment)) !== undefined) {
-          return `#/${keyword}/${i}/${ref.slice(2)}`
-        }
-
-        return ref
-      },
-    ))
+    compositionBranches.push(typeof schema === 'boolean'
+      ? schema
+      : promoteJsonSchemaDefs(schema, mergedDefs, `#/${keyword}/${i}`))
   }
 
   const result: Exclude<JsonSchema, boolean> = { [keyword]: compositionBranches }
-  if (Object.keys(mergedDefs).length > 0) {
-    result.$defs = mergedDefs
+  if (mergedDefs.size > 0) {
+    result.$defs = Object.fromEntries(mergedDefs)
   }
 
   return result
@@ -110,96 +127,31 @@ export type JsonObjectSchemaEntry = [name: string, schema: JsonSchema, optional:
  * Combines object property entries back into a single object schema.
  */
 export function combineJsonObjectSchemaEntries(entries: JsonObjectSchemaEntry[]): JsonObjectSchema {
-  const properties: Record<string, JsonSchema> = {}
+  const properties = new Map<string, JsonSchema>()
   const required: string[] = []
-  const mergedDefs: Record<string, JsonSchema> = {}
+  const mergedDefs = new Map<string, JsonSchema>()
 
   for (const [name, propertySchema, optional] of entries) {
     if (!optional) {
       required.push(name)
     }
 
-    if (typeof propertySchema === 'boolean') {
-      properties[name] = propertySchema
-      continue
-    }
-
-    const { $defs, ...rest } = propertySchema
-    const renameMap: Record<string, string> = {}
-    const promotedNames = new Set<string>()
-
-    if ($defs) {
-      for (const [defName, def] of Object.entries($defs)) {
-        if (def === undefined) {
-          continue
-        }
-
-        promotedNames.add(defName)
-
-        if (defName in mergedDefs) {
-          if (isDeepEqual(mergedDefs[defName], def)) {
-            continue
-          }
-
-          let counter = 2
-          let newName = `${defName}${counter}`
-          while (newName in mergedDefs) {
-            counter++
-            newName = `${defName}${counter}`
-          }
-
-          mergedDefs[newName] = def
-          renameMap[defName] = newName
-        }
-        else {
-          mergedDefs[defName] = def
-        }
-      }
-    }
-
-    const propertyPathPrefix = `#/properties/${encodeJsonPointerSegment(name)}`
-    properties[name] = mapJsonSchemaRefs(rest, (ref) => {
-      if (ref.startsWith('#/$defs/')) {
-        const afterPrefix = ref.slice('#/$defs/'.length)
-        const slashIdx = afterPrefix.indexOf('/')
-        const encodedSegment = slashIdx === -1 ? afterPrefix : afterPrefix.slice(0, slashIdx)
-        const refRest = slashIdx === -1 ? '' : afterPrefix.slice(slashIdx)
-        const defName = decodeJsonPointerSegment(encodedSegment)
-
-        if (!promotedNames.has(defName)) {
-          return ref
-        }
-
-        if (defName in renameMap) {
-          return `#/$defs/${encodeJsonPointerSegment(renameMap[defName]!)}${refRest}`
-        }
-
-        return ref
-      }
-
-      if (ref === '#') {
-        return propertyPathPrefix
-      }
-
-      if (ref.startsWith('#/') && get(rest, ref.slice(2).split('/').map(decodeJsonPointerSegment)) !== undefined) {
-        return `${propertyPathPrefix}/${ref.slice(2)}`
-      }
-
-      return ref
-    })
+    properties.set(name, typeof propertySchema === 'boolean'
+      ? propertySchema
+      : promoteJsonSchemaDefs(propertySchema, mergedDefs, `#/properties/${encodeJsonPointerSegment(name)}`))
   }
 
   const schema: JsonObjectSchema = {
     type: 'object',
-    properties,
+    properties: Object.fromEntries(properties),
   }
 
   if (required.length > 0) {
     schema.required = required
   }
 
-  if (Object.keys(mergedDefs).length > 0) {
-    schema.$defs = mergedDefs
+  if (mergedDefs.size > 0) {
+    schema.$defs = Object.fromEntries(mergedDefs)
   }
 
   return schema


### PR DESCRIPTION
`combineJsonSchemasWithComposition` and `combineJsonObjectSchemaEntries` promote each sibling schema's `$defs` into one shared root map, renaming names that collide with a differing body. Refs *inside* a promoted def body were never rewritten into that merged namespace, so a body that deep-equalled an already promoted def deduped even though its refs resolved against a different sibling's defs. The losing branch was silently bound to the wrong def, dropping a union alternative, and the output depended on the order the schemas were combined in.

Reachable from the OpenAPI generator whenever a procedure declares more than one `.input()`/`.output()` schema, and from `@orpc/ai-sdk`. Confirmed with real Zod v4 schemas, not just synthetic input.

## Fixes

- A union alternative is no longer silently dropped when two siblings share a def name whose body references another def, and the result no longer depends on sibling order.
- `$ref: '#'` and `#/properties/...` inside a promoted def body now resolve to the branch that body came from, instead of the combined root or nothing at all.
- Def and property names colliding with `Object.prototype` members (`toString`, `constructor`, …) no longer throw, and a def or property literally named `__proto__` is kept as a real key instead of vanishing while still being listed in `required`.

The two helpers no longer carry near-identical inlined copies of the promotion logic, which is where the divergence hid.

## Testing

- 100% statement, branch, function and line coverage on the changed file.
- A 39-mutant sweep over the changed code; every mutant is caught, including one that reproduces the original bug exactly.
- Differentially fuzzed against the previous behaviour over 18,000 generated schemas (plain names, rename-target collisions, RFC 6901 encoded names) — byte-identical output apart from the fixes above.

## Known limitations, unchanged here

Deduplication still only compares the entry sharing a def's name, so a body identical to an already-renamed def gets a fresh name rather than reusing it. Nested `$id` boundaries and the `$anchor` namespace are not accounted for, and `mapJsonSchemaRefs` still has no cycle guard. All pre-existing; happy to pick any of them up separately.