### PR TITLE
fix(server): judge GET CSRF protection after routing so unmatched requests fall through

### DIFF
--- a/apps/content/docs/plugins/get-method-csrf-protection.mdx
+++ b/apps/content/docs/plugins/get-method-csrf-protection.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 ## How It Works
 
-Cross-site, browsers withhold explicitly marked [`SameSite=Lax`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value) cookies from unsafe methods such as `POST`, but still attach them to [safe methods](https://developer.mozilla.org/en-US/docs/Glossary/Safe/HTTP) like `GET` on top-level navigations, per [RFC 6265bis](https://datatracker.ietf.org/doc/draft-ietf-httpbis-rfc6265bis/). The plugin closes that gap by rejecting exactly those navigations with a `403` before routing:
+Cross-site, browsers withhold explicitly marked [`SameSite=Lax`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Set-Cookie#samesitesamesite-value) cookies from unsafe methods such as `POST`, but still attach them to [safe methods](https://developer.mozilla.org/en-US/docs/Glossary/Safe/HTTP) like `GET` on top-level navigations, per [RFC 6265bis](https://datatracker.ietf.org/doc/draft-ietf-httpbis-rfc6265bis/). The plugin closes that gap by rejecting exactly those navigations with a `403`:
 
 | Request from another site | Sends `SameSite=Lax` cookies | |
 | --- | --- | --- |
@@ -21,6 +21,8 @@ Cross-site, browsers withhold explicitly marked [`SameSite=Lax`](https://develop
 The verdict comes from [Fetch Metadata](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers#fetch_metadata_request_headers): a `GET` request is rejected when [`Sec-Fetch-Site`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Sec-Fetch-Site) reports `cross-site` or `none` on a top-level navigation (`Sec-Fetch-Mode: navigate` targeting `Sec-Fetch-Dest: document`). A guarded request stripped of either header is rejected. Only `GET` needs guarding, since [navigations use no method](https://html.spec.whatwg.org/multipage/browsing-the-web.html) besides `GET` and the unsafe `POST`. The result resembles upgrading your cookies to `SameSite=Strict` for safe methods, and also covers links opened from outside the browser, where browsers attach even `Strict` cookies.
 
 Cookie-less cross-site requests pass, which makes the plugin the natural safeguard for [enabling the `GET` method](/docs/rpc/handler#enabling-the-get-method). Requests from your own site always pass, including sibling subdomains, since the `SameSite` cookie model makes the site the trust boundary. Host untrusted content on a separate site, not a subdomain.
+
+Only requests that match a procedure are judged. The rest stay unmatched, so a handler that falls through to a static site or SPA keeps serving visitors arriving from links on other sites.
 
 ## Setup
 

--- a/packages/server/src/plugins/get-method-csrf-protection.test.ts
+++ b/packages/server/src/plugins/get-method-csrf-protection.test.ts
@@ -1,14 +1,9 @@
+import { ORPCError } from '@orpc/client'
 import { RPCHandler } from '../adapters/fetch/rpc-handler'
 import { RPC_DEFAULT_ALLOW_METHODS } from '../adapters/standard'
 import { os } from '../builder'
 import { BatchHandlerPlugin } from './batch'
 import { GetMethodCsrfProtectionHandlerPlugin } from './get-method-csrf-protection'
-
-const BLOCKED_RESPONSE = {
-  status: 403,
-  headers: {},
-  body: 'Request blocked by CSRF protection.',
-}
 
 function makeRequest(headers: Record<string, unknown>, method: string) {
   return {
@@ -20,25 +15,25 @@ function makeRequest(headers: Record<string, unknown>, method: string) {
 }
 
 function getPlugin() {
-  const existingRoutingInterceptor = vi.fn()
+  const existingInterceptor = vi.fn()
 
   const handlerOptions = new GetMethodCsrfProtectionHandlerPlugin<any>().init({
-    routingInterceptors: [existingRoutingInterceptor],
+    interceptors: [existingInterceptor],
   } as any)
 
   return {
-    routingInterceptor: handlerOptions.routingInterceptors![0]!,
-    existingRoutingInterceptor,
+    interceptor: handlerOptions.interceptors![0]!,
+    existingInterceptor,
     handlerOptions,
   }
 }
 
 function invokeInterceptor(headers: Record<string, unknown>, method = 'GET') {
-  const nextResult = { matched: true, response: 'ok' as const }
+  const nextResult = { status: 200, headers: {}, body: 'ok' }
   const next = vi.fn().mockResolvedValue(nextResult)
-  const { routingInterceptor } = getPlugin()
+  const { interceptor } = getPlugin()
 
-  const result = routingInterceptor({ context: {}, request: makeRequest(headers, method), next } as any)
+  const result = (async () => interceptor({ context: {}, request: makeRequest(headers, method), next } as any))()
 
   return { result, next, nextResult }
 }
@@ -53,7 +48,10 @@ async function expectAllowed(headers: Record<string, unknown>, method = 'GET') {
 async function expectBlocked(headers: Record<string, unknown>, method = 'GET') {
   const { result, next } = invokeInterceptor(headers, method)
 
-  await expect(result).resolves.toEqual({ matched: true, response: BLOCKED_RESPONSE })
+  await expect(result).rejects.toSatisfy(error =>
+    error instanceof ORPCError
+    && error.code === 'FORBIDDEN'
+    && error.message === 'Request blocked by CSRF protection.')
   expect(next).not.toHaveBeenCalled()
 }
 
@@ -70,15 +68,11 @@ describe('getMethodCsrfProtectionHandlerPlugin', () => {
   })
 
   describe('registration', () => {
-    it('prepends its routing interceptor so it runs before existing ones', () => {
-      const { handlerOptions, existingRoutingInterceptor } = getPlugin()
+    it('prepends its interceptor so it runs before existing ones', () => {
+      const { handlerOptions, existingInterceptor } = getPlugin()
 
-      expect(handlerOptions.routingInterceptors).toHaveLength(2)
-      expect(handlerOptions.routingInterceptors![1]).toBe(existingRoutingInterceptor)
-    })
-
-    it('runs after the batch plugin so it judges the original request', () => {
-      expect(new GetMethodCsrfProtectionHandlerPlugin().after).toContain('~batch')
+      expect(handlerOptions.interceptors).toHaveLength(2)
+      expect(handlerOptions.interceptors![1]).toBe(existingInterceptor)
     })
   })
 
@@ -168,11 +162,14 @@ describe('getMethodCsrfProtectionHandlerPlugin', () => {
       return new Request('https://api.example.com/deletePlanet', { headers })
     }
 
-    it('blocks a cross-site link or redirect', async () => {
+    it('blocks a cross-site link or redirect with a parseable FORBIDDEN error', async () => {
       const { matched, response } = await createHandler().handle(createGetRequest(CROSS_SITE_NAVIGATION))
 
       expect(matched).toBe(true)
       expect(response!.status).toBe(403)
+      await expect(response!.json()).resolves.toMatchObject({
+        json: expect.objectContaining({ code: 'FORBIDDEN' }),
+      })
       expect(deletePlanet).not.toHaveBeenCalled()
     })
 
@@ -201,17 +198,17 @@ describe('getMethodCsrfProtectionHandlerPlugin', () => {
       expect(deletePlanet).toHaveBeenCalledOnce()
     })
 
-    it('rejects before routing, so a request matching no procedure never reaches the router', async () => {
+    it('leaves a request matching no procedure unmatched, so a static site can serve it', async () => {
       const { matched, response } = await createHandler().handle(
         new Request('https://api.example.com/unknown', { headers: CROSS_SITE_NAVIGATION }),
       )
 
-      expect(matched).toBe(true)
-      expect(response!.status).toBe(403)
+      expect(matched).toBe(false)
+      expect(response).toBeUndefined()
     })
 
     describe('batch sub-requests', () => {
-      function createBatchAttack(handler: RPCHandler<any>) {
+      function createBatchRequest(handler: RPCHandler<any>, transportHeaders: Record<string, string>) {
         const data = encodeURIComponent(JSON.stringify([{
           kind: 'request',
           id: 0,
@@ -225,23 +222,28 @@ describe('getMethodCsrfProtectionHandlerPlugin', () => {
         }]))
 
         return handler.handle(new Request(`https://api.example.com/__batch__?data=${data}`, {
-          headers: { 'orpc-batch': 'buffered', ...CROSS_SITE_NAVIGATION },
+          headers: { 'orpc-batch': 'buffered', ...transportHeaders },
         }))
       }
 
-      it('blocks the whole batch before it is split into sub-requests', async () => {
-        const { response } = await createBatchAttack(createHandler([new BatchHandlerPlugin()]))
+      it('judges sub-requests by the transport headers, which override the client-authored ones', async () => {
+        const { response } = await createBatchRequest(createHandler([new BatchHandlerPlugin()]), CROSS_SITE_NAVIGATION)
 
-        expect(response!.status).toBe(403)
+        const body = await response!.json() as any
+        expect(body[0]).toMatchObject({ kind: 'response', id: 0 })
+        expect(body[0].json.status).toBe(403)
         expect(deletePlanet).not.toHaveBeenCalled()
       })
 
-      it('blocks it even when mapSubrequest forwards the spoofed headers verbatim', async () => {
-        const batch = new BatchHandlerPlugin({ mapSubrequest: subRequest => subRequest })
-        const { response } = await createBatchAttack(createHandler([batch]))
+      it('allows sub-requests of a cross-site fetch batch, which carries no SameSite=Lax cookie', async () => {
+        const { response } = await createBatchRequest(
+          createHandler([new BatchHandlerPlugin()]),
+          { 'sec-fetch-site': 'cross-site', 'sec-fetch-mode': 'cors', 'sec-fetch-dest': 'empty' },
+        )
 
-        expect(response!.status).toBe(403)
-        expect(deletePlanet).not.toHaveBeenCalled()
+        const body = await response!.json() as any
+        expect(body[0].json.status ?? 200).toBe(200)
+        expect(deletePlanet).toHaveBeenCalledOnce()
       })
     })
   })

--- a/packages/server/src/plugins/get-method-csrf-protection.test.ts
+++ b/packages/server/src/plugins/get-method-csrf-protection.test.ts
@@ -235,7 +235,7 @@ describe('getMethodCsrfProtectionHandlerPlugin', () => {
         expect(deletePlanet).not.toHaveBeenCalled()
       })
 
-      it('allows sub-requests of a cross-site fetch batch, where browsers withhold SameSite=Lax cookies', async () => {
+      it('allows sub-requests of a cross-site fetch batch', async () => {
         const { response } = await createBatchRequest(
           createHandler([new BatchHandlerPlugin()]),
           { 'sec-fetch-site': 'cross-site', 'sec-fetch-mode': 'cors', 'sec-fetch-dest': 'empty' },

--- a/packages/server/src/plugins/get-method-csrf-protection.test.ts
+++ b/packages/server/src/plugins/get-method-csrf-protection.test.ts
@@ -242,7 +242,7 @@ describe('getMethodCsrfProtectionHandlerPlugin', () => {
         )
 
         const body = await response!.json() as any
-        expect(body[0].json.status ?? 200).toBe(200)
+        expect(body[0].json.status).not.toBe(403)
         expect(deletePlanet).toHaveBeenCalledOnce()
       })
     })

--- a/packages/server/src/plugins/get-method-csrf-protection.test.ts
+++ b/packages/server/src/plugins/get-method-csrf-protection.test.ts
@@ -174,7 +174,7 @@ describe('getMethodCsrfProtectionHandlerPlugin', () => {
     })
 
     it.each([
-      ['a cross-site fetch, which carries no SameSite=Lax cookie', { 'sec-fetch-site': 'cross-site', 'sec-fetch-mode': 'cors', 'sec-fetch-dest': 'empty' }],
+      ['a cross-site fetch, where browsers withhold SameSite=Lax cookies', { 'sec-fetch-site': 'cross-site', 'sec-fetch-mode': 'cors', 'sec-fetch-dest': 'empty' }],
       ['a same-site fetch from a sibling subdomain', { 'sec-fetch-site': 'same-site', 'sec-fetch-mode': 'cors', 'sec-fetch-dest': 'empty' }],
       ['a same-origin navigation', { 'sec-fetch-site': 'same-origin', 'sec-fetch-mode': 'navigate', 'sec-fetch-dest': 'document' }],
       ['a non-browser client', {}],
@@ -235,7 +235,7 @@ describe('getMethodCsrfProtectionHandlerPlugin', () => {
         expect(deletePlanet).not.toHaveBeenCalled()
       })
 
-      it('allows sub-requests of a cross-site fetch batch, which carries no SameSite=Lax cookie', async () => {
+      it('allows sub-requests of a cross-site fetch batch, where browsers withhold SameSite=Lax cookies', async () => {
         const { response } = await createBatchRequest(
           createHandler([new BatchHandlerPlugin()]),
           { 'sec-fetch-site': 'cross-site', 'sec-fetch-mode': 'cors', 'sec-fetch-dest': 'empty' },

--- a/packages/server/src/plugins/get-method-csrf-protection.ts
+++ b/packages/server/src/plugins/get-method-csrf-protection.ts
@@ -1,5 +1,6 @@
-import type { StandardHandlerOptions, StandardHandlerPlugin, StandardHandlerRoutingInterceptor, StandardHandlerRoutingInterceptorOptions } from '../adapters/standard'
+import type { StandardHandlerInterceptor, StandardHandlerInterceptorOptions, StandardHandlerOptions, StandardHandlerPlugin } from '../adapters/standard'
 import type { Context } from '../context'
+import { ORPCError } from '@orpc/client'
 import { toArray } from '@orpc/shared'
 import { flattenStandardHeader } from '@standardserver/core'
 
@@ -8,6 +9,8 @@ import { flattenStandardHeader } from '@standardserver/core'
  * secure as unsafe ones such as `POST`. It rejects `GET` requests arriving as top-level
  * navigations initiated cross-site or from outside the browser, the only context where
  * another site can make a browser attach `SameSite=Lax` cookies to a safe-method request.
+ * Requests matching no procedure stay unmatched, so they can fall through to whatever
+ * serves the rest of the site.
  *
  * @remarks
  * **Note**: Requests browsers send without `SameSite=Lax` cookies, such as cross-site `fetch`
@@ -20,28 +23,27 @@ import { flattenStandardHeader } from '@standardserver/core'
 export class GetMethodCsrfProtectionHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
   name = '~get-method-csrf-protection'
 
-  /** Judge the real request, before batch splits it into client-authored sub-requests. */
-  after = ['~batch']
-
   init(options: StandardHandlerOptions<T>): StandardHandlerOptions<T> {
-    const routingInterceptor: StandardHandlerRoutingInterceptor<T> = (interceptorOptions) => {
+    /**
+     * Batch sub-requests are judged individually here, which is safe: navigations cannot
+     * carry the custom `orpc-batch` header, and the batch plugin's default `mapSubrequest`
+     * keeps the transport headers authoritative over client-authored sub-request headers.
+     */
+    const interceptor: StandardHandlerInterceptor<T> = (interceptorOptions) => {
       if (this.isAllowed(interceptorOptions)) {
         return interceptorOptions.next()
       }
 
-      return Promise.resolve({
-        matched: true,
-        response: { status: 403, headers: {}, body: 'Request blocked by CSRF protection.' },
-      })
+      throw new ORPCError('FORBIDDEN', { message: 'Request blocked by CSRF protection.' })
     }
 
     return {
       ...options,
-      routingInterceptors: [routingInterceptor, ...toArray(options.routingInterceptors)],
+      interceptors: [interceptor, ...toArray(options.interceptors)],
     }
   }
 
-  private isAllowed({ request }: StandardHandlerRoutingInterceptorOptions<T>): boolean {
+  private isAllowed({ request }: StandardHandlerInterceptorOptions<T>): boolean {
     // Navigations can only use `GET` or `POST` per the HTML spec, and `POST` is unsafe, so
     // `GET` is the only method `SameSite=Lax` cookies ride cross-site.
     if (request.method !== 'GET') {


### PR DESCRIPTION
The GET Method CSRF Protection plugin blocked cross-site GET navigations before routing, so every path under the handler's mount point returned 403, including ones matching no procedure. A handler mounted with a static-site or SPA fallthrough rejected every visitor arriving from an external link (search results, chat, email). The check now runs at the post-routing interceptor stage, so it only judges requests that would actually reach a procedure.

## Fixes

- Requests matching no procedure stay unmatched and fall through to whatever serves the rest of the site; blocked navigations to nonexistent paths now 404 like any other unmatched request instead of 403.
- A blocked matched request now surfaces as a thrown `ORPCError('FORBIDDEN')` encoded by the handler codec, so oRPC clients receive a parseable error, which matters when an SSR layer forwards incoming browser headers to an internal client call.

## Security

- Batch handling stays safe without the previous `after = ['~batch']` ordering: a navigation can never carry the custom `orpc-batch` header, and the batch plugin's default `mapSubrequest` keeps transport headers authoritative, so client-authored sub-request headers cannot fabricate a trusted verdict. Tests assert a spoofed `same-origin` sub-request header inside a cross-site-navigation transport is still rejected and the procedure never runs.

## Testing

- Unit tests exercise the post-routing interceptor directly; integration tests cover the unmatched fallthrough, the RPC-encoded `FORBIDDEN` body, and batch sub-request verdicts in both directions. Full `@orpc/server` suite (506 tests), cross-plugin integration suite, `tsc -b`, and eslint pass.
