### PR TITLE
chore: upgrade effect to 4.0.0-rc.112

### DIFF
--- a/apps/content/package.json
+++ b/apps/content/package.json
@@ -32,7 +32,7 @@
     "@tanstack/vue-query": "^5.101.4",
     "@types/node": "^26.2.0",
     "blume": "^1.5.3",
-    "effect": "4.0.0-rc.109",
+    "effect": "4.0.0-rc.112",
     "pino": "^10.3.1",
     "superjson": "^2.2.6",
     "zod": "^4.4.3"

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -69,6 +69,6 @@
     "@orpc/shared": "workspace:*"
   },
   "devDependencies": {
-    "effect": "4.0.0-rc.109"
+    "effect": "4.0.0-rc.112"
   }
 }

--- a/packages/effect/src/runtime.test.ts
+++ b/packages/effect/src/runtime.test.ts
@@ -52,16 +52,16 @@ describe('runPromise & extractErrorFromCause', () => {
       await expect(runPromise(effect)).rejects.toThrow(defect)
     })
 
-    it('throws the finalizer error on sequential cause (mirrors try/finally)', async () => {
-      const finalizerError = new Error('finalizer also failed')
+    it('throws the use error when the finalizer also fails', async () => {
+      const useError = new Error('use failed')
 
       const effect = Effect.acquireUseRelease(
         Effect.succeed('resource'),
-        () => Effect.fail(new Error('use failed')),
-        () => Effect.fail(finalizerError) as Effect.Effect<never, never>,
+        () => Effect.fail(useError),
+        () => Effect.fail(new Error('finalizer also failed')) as Effect.Effect<never, never>,
       )
 
-      await expect(runPromise(effect)).rejects.toThrow(finalizerError)
+      await expect(runPromise(effect)).rejects.toThrow(useError)
     })
 
     it('throws the left error on parallel cause', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,8 +261,8 @@ importers:
         specifier: ^1.5.3
         version: 1.5.3(4f37e8c30923bacb6b6775379b0a0df7)
       effect:
-        specifier: 4.0.0-rc.109
-        version: 4.0.0-rc.109
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
       pino:
         specifier: ^10.3.1
         version: 10.3.1
@@ -430,8 +430,8 @@ importers:
         version: link:../shared
     devDependencies:
       effect:
-        specifier: 4.0.0-rc.109
-        version: 4.0.0-rc.109
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
 
   packages/evlog:
     dependencies:
@@ -7397,8 +7397,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  effect@4.0.0-rc.109:
-    resolution: {integrity: sha512-6ubcOCtfdbmFO5+vgcT2HsTw5s+n3aMUj4eAIbVpUxP7+VYCwXxxcBHgiWgizOrGO1eGmuOBFek3mM0dFcwaWA==}
+  effect@4.0.0-rc.112:
+    resolution: {integrity: sha512-wXxwuh1Ywnv4cPRM3Wfa0vDwuOHnZ1TsTgHJkG9XgzND6inhBH9n1vBxhg3iIXOia/OrpmvVmd3lrD4vq6bF3A==}
 
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
@@ -19363,9 +19363,8 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  effect@4.0.0-rc.109:
+  effect@4.0.0-rc.112:
     dependencies:
-      '@standard-schema/spec': 1.1.0
       fast-check: 4.9.0
       msgpackr: 2.0.5
 


### PR DESCRIPTION
Upgrades the `effect` devDependency in `@orpc/experimental-effect` and `apps/content` from `4.0.0-rc.109` to `4.0.0-rc.112`.

rc.112 fixes an upstream bug where a failing finalizer discarded the original failure. Running the same program against both versions shows it:

```
rc.109 → Cause([Fail(finalizer also failed)])                    squash → "finalizer also failed"
rc.112 → Cause([Fail(use failed), Fail(finalizer also failed)])  squash → "use failed"
```

Under rc.109 the actual domain error was lost entirely. rc.112 keeps both, original first (upstream added a `combineFinalizerCause` helper that runs `causeCombine(exit.cause, cause)` instead of letting the finalizer's failure replace the original).

## Fixes

`runPromise` now rejects with the real domain error rather than the cleanup error when a finalizer also fails. No source change was needed, since it already surfaces `Cause.squash`, which takes the first failure.

One test asserted the old lossy behavior and had to change. Its name also claimed to mirror `try/finally` — accurate for rc.109, where a throwing finalizer won and the original was lost, but no longer what happens.

## Dependencies

One fewer transitive dependency: rc.112 drops `@standard-schema/spec` in favor of its own `StandardSchema` module. `Schema.toStandardSchemaV1` is unchanged, so the documented Effect Schema integration still works.

## Testing

- `pnpm type:check` clean across all packages.
- `pnpm test` green: 3270 passed / 41 skipped (root), 128 (bun), 26 (cloudflare).
- The Effect integration examples in `apps/content/docs/integrations/effect.mdx` aren't covered by the root type check, so they were verified separately against rc.112 via a scratch `.test-d.ts` — clean.
- No `minimumReleaseAgeExclude` entry needed; rc.112 is past pnpm's one-day gate.

The peer range stays at `>=4.0.0-beta.90`. The finalizer change is behavioral, not an API break, so older versions still work; they just surface the finalizer error rather than the use error from the same cause.