### PR TITLE
feat(server): expose not-yet-validated input fields to middleware between input schemas

### DIFF
--- a/apps/content/docs/middleware.mdx
+++ b/apps/content/docs/middleware.mdx
@@ -124,6 +124,10 @@ const adaptedCanUpdate = canUpdate.adaptInput((input: { id: number }) => input.i
 
 :::
 
+:::danger
+A middleware placed between [multiple input schemas](/docs/procedure#multiple-schemas) also receives the raw fields the remaining schemas have not validated yet. Only trust fields validated before the middleware; treat the rest as untrusted client input.
+:::
+
 ## Middleware Output
 
 Middleware can also modify the output of a handler, such as implementing caching mechanisms.

--- a/apps/content/docs/procedure.mdx
+++ b/apps/content/docs/procedure.mdx
@@ -70,7 +70,7 @@ By specifying `.output` or the handler's return type, TypeScript can infer the o
 
 `.input` and `.output` can be called multiple times. Each call adds a schema instead of replacing the previous one, and the value must pass all of them.
 
-Every `.input` object schema validates the original input, then the results are merged. This lets you extend a base procedure without repeating its fields. Fields that no schema defines are dropped. [Middleware](/docs/middleware) sees the fields validated before it, the handler sees them all.
+Every `.input` object schema validates the original input, then the results are merged. This lets you extend a base procedure without repeating its fields. Fields that no schema defines are dropped before the handler runs. [Middleware](/docs/middleware) placed between schemas sees the fields validated so far plus the raw rest of the input, so a whole-input middleware like caching works anywhere in the chain, but fields a later schema defines are not validated yet at that point.
 
 ```ts
 const base = os

--- a/packages/server/src/procedure-client.test.ts
+++ b/packages/server/src/procedure-client.test.ts
@@ -623,8 +623,42 @@ describe('createProcedureClient', () => {
         .toEqual({ parent: 'parent__PARENT', child: 'child__CHILD' })
 
       expect(rootMid).toHaveBeenCalledWith(expect.any(Object), { parent: 'PARENT', child: 'CHILD', unknown: 'UNKNOWN' }, expect.any(Function))
-      expect(parentMid).toHaveBeenCalledWith(expect.any(Object), { parent: 'parent__PARENT' }, expect.any(Function))
+      expect(parentMid).toHaveBeenCalledWith(expect.any(Object), { parent: 'parent__PARENT', child: 'CHILD', unknown: 'UNKNOWN' }, expect.any(Function))
       expect(childMid).toHaveBeenCalledWith(expect.any(Object), { parent: 'parent__PARENT', child: 'child__CHILD' }, expect.any(Function))
+    })
+
+    it('gives middleware between schemas the not-yet-validated rest of the input, validated fields win', async () => {
+      const beforeMid = vi.fn(({ next }) => next())
+      const betweenMid = vi.fn(({ next }) => next())
+      const afterMid = vi.fn(({ next }) => next())
+
+      const procedure = os
+        .use(beforeMid)
+        .input(z.object({ params: z.object({ id: z.string().transform(value => `id__${value}`) }) }))
+        .use(betweenMid)
+        .input(z.object({ params: z.object({ slug: z.string() }), page: z.coerce.number() }))
+        .use(afterMid)
+        .handler(({ input }) => input)
+
+      const client = createProcedureClient(procedure)
+
+      const rawInput: any = { params: { id: 'ID', slug: 'SLUG', unknown: 'UNKNOWN' }, page: '2', unknown: 'UNKNOWN' }
+
+      await expect(client(rawInput))
+        .resolves
+        .toEqual({ params: { id: 'id__ID', slug: 'SLUG' }, page: 2 })
+
+      expect(beforeMid.mock.calls[0]![1]).toBe(rawInput)
+      expect(betweenMid).toHaveBeenCalledWith(
+        expect.any(Object),
+        { params: { id: 'id__ID', slug: 'SLUG', unknown: 'UNKNOWN' }, page: '2', unknown: 'UNKNOWN' },
+        expect.any(Function),
+      )
+      expect(afterMid).toHaveBeenCalledWith(
+        expect.any(Object),
+        { params: { id: 'id__ID', slug: 'SLUG' }, page: 2 },
+        expect.any(Function),
+      )
     })
 
     it('composes fragments nested one level deep', async () => {

--- a/packages/server/src/procedure-client.test.ts
+++ b/packages/server/src/procedure-client.test.ts
@@ -628,7 +628,7 @@ describe('createProcedureClient', () => {
     })
 
     it('gives middleware between schemas the not-yet-validated rest of the input, validated fields win', async () => {
-      const beforeMid = vi.fn(({ next }) => next())
+      const beforeMid = vi.fn(({ next }, _input: unknown) => next())
       const betweenMid = vi.fn(({ next }) => next())
       const afterMid = vi.fn(({ next }) => next())
 

--- a/packages/server/src/procedure-client.ts
+++ b/packages/server/src/procedure-client.ts
@@ -211,6 +211,7 @@ async function executeProcedureInternal(procedure: AnyProcedure, options: Proced
     input: unknown,
   ): Promise<{ output: unknown, context: Record<any, any> }> => {
     let currentInput = input
+    let middlewareInput = input
 
     const startInputIndex = midIndex === 0
       ? 0
@@ -234,6 +235,10 @@ async function executeProcedureInternal(procedure: AnyProcedure, options: Proced
 
         currentInput = i !== 0 ? mergeTwoLevels(currentInput, validated) : validated
       }
+
+      middlewareInput = endInputIndex > 0 && endInputIndex < inputSchemas.length
+        ? mergeTwoLevels(options.input, currentInput)
+        : currentInput
     }
 
     let currentOutput: unknown
@@ -262,7 +267,7 @@ async function executeProcedureInternal(procedure: AnyProcedure, options: Proced
             },
             lastEventId: options.lastEventId,
           },
-          currentInput,
+          middlewareInput,
           middlewareDone,
         )
       })


### PR DESCRIPTION
A middleware placed between multiple `.input()` schemas previously received only the fields validated by the schemas before it, so whole-input middlewares like caching built keys from a partial input and returned wrong cached results for distinct requests. Such middlewares now receive the validated fields merged over the raw rest of the input, so they see the complete input anywhere in the chain.

## Fixes

- A cache middleware between input schemas no longer collides distinct inputs into one cache key; each request keys on the full input.
- Validated fields always win over raw ones in the merged view, and the merge applies only between schemas: middlewares before the first `.input()` still get the raw input untouched (same reference, no clone), and middlewares after the last one plus the handler still see only fully validated input, with fields no schema defines dropped.
- The raw view is presentation-only: the chain continues from the validated value, so remaining schemas still validate those fields before the handler runs.

## Docs

- `docs/procedure` (Multiple Schemas) and `docs/middleware` (Middleware Input) document the new behavior, with a danger note: only trust fields validated before the middleware and treat the rest as untrusted client input.

## Testing

- New test covers all three positions (before/between/after schemas), including raw pre-coercion values, unknown fields at top level and nested, and pass-through identity for leading middlewares; full suite (3271 tests), type check, and lint pass.