### PR TITLE
feat(server): add PrototypePollutionProtectionHandlerPlugin

### DIFF
--- a/apps/content/docs/plugins/prototype-pollution-protection.mdx
+++ b/apps/content/docs/plugins/prototype-pollution-protection.mdx
@@ -14,7 +14,7 @@ The plugin closes that gap by inspecting the decoded input of every matched requ
 - an own `__proto__` key on an object
 - an own `constructor` key holding a `prototype` key, the same rule [secure-json-parse](https://github.com/fastify/secure-json-parse) enforces for Fastify
 
-The walk covers everything the built-in codecs can decode: plain objects, arrays, and `Map`/`Set` keys and values, at any depth. A lone `constructor` or `prototype` key stays allowed, since either alone cannot pollute and both are common in real data. Because the check runs on the decoded input, it applies to any handler and content type: JSON and query data in [RPCHandler](/docs/rpc/handler), plus form data and [bracket notation](/docs/openapi/bracket-notation) in [OpenAPIHandler](/docs/openapi/handler).
+The walk covers everything the built-in codecs can decode: plain objects, arrays, and `Map`/`Set` keys and values, at any depth. An [AsyncIteratorObject](/docs/async-iterator-object) input is checked value by value as it arrives, and a polluting value fails that iteration with the same error. A lone `constructor` or `prototype` key stays allowed, since either alone cannot pollute and both are common in real data. Because the check runs on the decoded input, it applies to any handler and content type: JSON and query data in [RPCHandler](/docs/rpc/handler), plus form data and [bracket notation](/docs/openapi/bracket-notation) in [OpenAPIHandler](/docs/openapi/handler).
 
 ## Setup
 
@@ -37,7 +37,6 @@ The `handler` can be any supported oRPC handler, such as [RPCHandler](/docs/rpc/
 
 ## Limitations
 
-- Only the decoded request input is inspected. Values yielded later by an [event iterator](/docs/async-iterator-object) input arrive after the check runs, so they pass through uninspected.
 - The plugin is defense in depth, not a substitute for safe code: prefer `Object.create(null)` or `Map` for attacker-keyed lookups, and keep merge/clone utilities patched, per the [OWASP guidance](https://cheatsheetseries.owasp.org/cheatsheets/Prototype_Pollution_Prevention_Cheat_Sheet.html).
 - Rejection is all-or-nothing with a generic `BAD_REQUEST`. If a procedure must accept these keys as data, drop the plugin for that handler and validate the field with your schema instead.
 

--- a/apps/content/docs/plugins/prototype-pollution-protection.mdx
+++ b/apps/content/docs/plugins/prototype-pollution-protection.mdx
@@ -1,0 +1,46 @@
+---
+title: "Prototype Pollution Protection Plugin"
+description: "Use PrototypePollutionProtectionHandlerPlugin to reject request input carrying __proto__ or constructor.prototype keys before it reaches your procedures."
+sidebar:
+  label: "Prototype Pollution Protection"
+---
+
+## How It Works
+
+Prototype pollution happens when attacker-controlled keys such as `__proto__` end up assigned onto `Object.prototype`, changing the behavior of every object in the process. oRPC's own decoding never assigns through the prototype chain, so the risk appears later, when your code passes the decoded input to something that merges, clones, or path-sets it, such as a vulnerable `merge` or `set` utility.
+
+The plugin closes that gap by inspecting the decoded input of every matched request and rejecting it with a `400` when either appears:
+
+- an own `__proto__` key on an object
+- an own `constructor` key holding a `prototype` key, the same rule [secure-json-parse](https://github.com/fastify/secure-json-parse) enforces for Fastify
+
+The walk covers everything the built-in codecs can decode: plain objects, arrays, and `Map`/`Set` keys and values, at any depth. A lone `constructor` or `prototype` key stays allowed, since either alone cannot pollute and both are common in real data. Because the check runs on the decoded input, it applies to any handler and content type: JSON and query data in [RPCHandler](/docs/rpc/handler), plus form data and [bracket notation](/docs/openapi/bracket-notation) in [OpenAPIHandler](/docs/openapi/handler).
+
+## Setup
+
+```ts twoslash
+import { RPCHandler } from '@orpc/server/fetch'
+import { router } from './shared/planet'
+// ---cut---
+import { PrototypePollutionProtectionHandlerPlugin } from '@orpc/server/plugins'
+
+const handler = new RPCHandler(router, {
+  plugins: [
+    new PrototypePollutionProtectionHandlerPlugin(),
+  ],
+})
+```
+
+:::info
+The `handler` can be any supported oRPC handler, such as [RPCHandler](/docs/rpc/handler), [OpenAPIHandler](/docs/openapi/handler), or a custom one.
+:::
+
+## Limitations
+
+- Only the decoded request input is inspected. Values yielded later by an [event iterator](/docs/async-iterator-object) input arrive after the check runs, so they pass through uninspected.
+- The plugin is defense in depth, not a substitute for safe code: prefer `Object.create(null)` or `Map` for attacker-keyed lookups, and keep merge/clone utilities patched, per the [OWASP guidance](https://cheatsheetseries.owasp.org/cheatsheets/Prototype_Pollution_Prevention_Cheat_Sheet.html).
+- Rejection is all-or-nothing with a generic `BAD_REQUEST`. If a procedure must accept these keys as data, drop the plugin for that handler and validate the field with your schema instead.
+
+## Learn More
+
+Learn more about the attack this plugin prevents on [MDN](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/Prototype_pollution) and in the [OWASP Prototype Pollution Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Prototype_Pollution_Prevention_Cheat_Sheet.html). For implementation details, see the [source code](https://github.com/middleapi/orpc/blob/main/packages/server/src/plugins/prototype-pollution-protection.ts).

--- a/apps/content/docs/plugins/prototype-pollution-protection.mdx
+++ b/apps/content/docs/plugins/prototype-pollution-protection.mdx
@@ -35,11 +35,6 @@ const handler = new RPCHandler(router, {
 The `handler` can be any supported oRPC handler, such as [RPCHandler](/docs/rpc/handler), [OpenAPIHandler](/docs/openapi/handler), or a custom one.
 :::
 
-## Limitations
-
-- The plugin is defense in depth, not a substitute for safe code: prefer `Object.create(null)` or `Map` for attacker-keyed lookups, and keep merge/clone utilities patched, per the [OWASP guidance](https://cheatsheetseries.owasp.org/cheatsheets/Prototype_Pollution_Prevention_Cheat_Sheet.html).
-- Rejection is all-or-nothing with a generic `BAD_REQUEST`. If a procedure must accept these keys as data, drop the plugin for that handler and validate the field with your schema instead.
-
 ## Learn More
 
 Learn more about the attack this plugin prevents on [MDN](https://developer.mozilla.org/en-US/docs/Web/Security/Attacks/Prototype_pollution) and in the [OWASP Prototype Pollution Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Prototype_Pollution_Prevention_Cheat_Sheet.html). For implementation details, see the [source code](https://github.com/middleapi/orpc/blob/main/packages/server/src/plugins/prototype-pollution-protection.ts).

--- a/packages/server/src/plugins/index.ts
+++ b/packages/server/src/plugins/index.ts
@@ -8,6 +8,7 @@ export {
 } from './cors'
 export * from './get-method-csrf-protection'
 export * from './method-override'
+export * from './prototype-pollution-protection'
 export * from './request-compression'
 export * from './request-headers'
 export {

--- a/packages/server/src/plugins/prototype-pollution-protection.test.ts
+++ b/packages/server/src/plugins/prototype-pollution-protection.test.ts
@@ -102,6 +102,24 @@ describe('prototypePollutionProtectionHandlerPlugin', () => {
     })
   })
 
+  describe('deeply nested inputs, beyond call stack limits', () => {
+    function nest(leaf: unknown, depth: number) {
+      let value = leaf
+      for (let i = 0; i < depth; i++) {
+        value = { nested: value, list: [value] }
+      }
+      return value
+    }
+
+    it('allows a benign one instead of overflowing the stack', async () => {
+      await expectAllowed(nest({ name: 'Earth' }, 100_000))
+    })
+
+    it('blocks one polluted at the bottom', async () => {
+      await expectBlocked(nest(JSON.parse('{"__proto__": {"isAdmin": true}}'), 100_000))
+    })
+  })
+
   describe('asyncIteratorObject inputs', () => {
     function invokeWithIterator(input: AsyncIterator<unknown>) {
       const next = vi.fn(async (options: any) => options.input)

--- a/packages/server/src/plugins/prototype-pollution-protection.test.ts
+++ b/packages/server/src/plugins/prototype-pollution-protection.test.ts
@@ -1,3 +1,4 @@
+import type { AsyncIteratorClass } from '@orpc/shared'
 import { ORPCError } from '@orpc/client'
 import { RPCHandler } from '../adapters/fetch/rpc-handler'
 import { os } from '../builder'
@@ -98,6 +99,60 @@ describe('prototypePollutionProtectionHandlerPlugin', () => {
       input.self = input
 
       await expectAllowed(input)
+    })
+  })
+
+  describe('asyncIteratorObject inputs', () => {
+    function invokeWithIterator(input: AsyncIterator<unknown>) {
+      const next = vi.fn(async (options: any) => options.input)
+      const { interceptor } = getPlugin()
+
+      return (async () => interceptor({ context: {}, input, next } as any))() as Promise<AsyncIteratorClass<unknown, unknown>>
+    }
+
+    it('forwards a guarded iterator and passes benign values through', async () => {
+      async function* input() {
+        yield { name: 'Earth' }
+        yield { name: 'Mars' }
+      }
+
+      const original = input()
+      const guarded = await invokeWithIterator(original)
+
+      expect(guarded).not.toBe(original)
+
+      const values = []
+      for await (const value of guarded) {
+        values.push(value)
+      }
+
+      expect(values).toEqual([{ name: 'Earth' }, { name: 'Mars' }])
+    })
+
+    it('fails the iteration when a yielded value pollutes', async () => {
+      async function* input() {
+        yield { name: 'Earth' }
+        yield JSON.parse('{"__proto__": {"isAdmin": true}}')
+      }
+
+      const guarded = await invokeWithIterator(input())
+
+      await expect(guarded.next()).resolves.toEqual({ done: false, value: { name: 'Earth' } })
+      await expect(guarded.next()).rejects.toSatisfy(error =>
+        error instanceof ORPCError
+        && error.code === 'BAD_REQUEST'
+        && error.message === 'Request blocked by prototype pollution protection.')
+    })
+
+    it('checks the return value too', async () => {
+      async function* input() {
+        return JSON.parse('{"constructor": {"prototype": {}}}')
+      }
+
+      const guarded = await invokeWithIterator(input())
+
+      await expect(guarded.next()).rejects.toSatisfy(error =>
+        error instanceof ORPCError && error.code === 'BAD_REQUEST')
     })
   })
 

--- a/packages/server/src/plugins/prototype-pollution-protection.test.ts
+++ b/packages/server/src/plugins/prototype-pollution-protection.test.ts
@@ -1,0 +1,155 @@
+import { ORPCError } from '@orpc/client'
+import { RPCHandler } from '../adapters/fetch/rpc-handler'
+import { os } from '../builder'
+import { PrototypePollutionProtectionHandlerPlugin } from './prototype-pollution-protection'
+
+function getPlugin() {
+  const existingInterceptor = vi.fn()
+
+  const handlerOptions = new PrototypePollutionProtectionHandlerPlugin<any>().init({
+    clientInterceptors: [existingInterceptor],
+  } as any)
+
+  return {
+    interceptor: handlerOptions.clientInterceptors![0]!,
+    existingInterceptor,
+    handlerOptions,
+  }
+}
+
+function invokeInterceptor(input: unknown) {
+  const nextResult = { output: 'ok' }
+  const next = vi.fn().mockResolvedValue(nextResult)
+  const { interceptor } = getPlugin()
+
+  const result = (async () => interceptor({ context: {}, input, next } as any))()
+
+  return { result, next, nextResult }
+}
+
+async function expectAllowed(input: unknown) {
+  const { result, next, nextResult } = invokeInterceptor(input)
+
+  await expect(result).resolves.toBe(nextResult)
+  expect(next).toHaveBeenCalledOnce()
+}
+
+async function expectBlocked(input: unknown) {
+  const { result, next } = invokeInterceptor(input)
+
+  await expect(result).rejects.toSatisfy(error =>
+    error instanceof ORPCError
+    && error.code === 'BAD_REQUEST'
+    && error.message === 'Request blocked by prototype pollution protection.')
+  expect(next).not.toHaveBeenCalled()
+}
+
+describe('prototypePollutionProtectionHandlerPlugin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('registration', () => {
+    it('prepends its client interceptor so it runs before existing ones', () => {
+      const { handlerOptions, existingInterceptor } = getPlugin()
+
+      expect(handlerOptions.clientInterceptors).toHaveLength(2)
+      expect(handlerOptions.clientInterceptors![1]).toBe(existingInterceptor)
+    })
+  })
+
+  describe('polluting inputs', () => {
+    it.each([
+      ['an own __proto__ key at the top level', () => JSON.parse('{"__proto__": {"isAdmin": true}}')],
+      ['an own __proto__ key in a nested object', () => JSON.parse('{"user": {"settings": {"__proto__": {"isAdmin": true}}}}')],
+      ['an own __proto__ key inside an array element', () => JSON.parse('[{"__proto__": {"isAdmin": true}}]')],
+      ['an own __proto__ key on a null-prototype object', () => {
+        const value = Object.create(null)
+        Object.defineProperty(value, '__proto__', { value: { isAdmin: true }, enumerable: true, configurable: true, writable: true })
+        return { value }
+      }],
+      ['a constructor key holding a prototype key', () => JSON.parse('{"constructor": {"prototype": {"isAdmin": true}}}')],
+      ['a nested constructor.prototype pair', () => JSON.parse('{"user": {"constructor": {"prototype": {"isAdmin": true}}}}')],
+      ['a polluting object used as a Map key', () => new Map([[JSON.parse('{"__proto__": {}}'), 'value']])],
+      ['a polluting object used as a Map value', () => new Map([['key', JSON.parse('{"__proto__": {}}')]])],
+      ['a polluting object inside a Set', () => new Set([JSON.parse('{"constructor": {"prototype": {}}}')])],
+      ['a polluting object behind a benign constructor key', () => JSON.parse('{"constructor": {"nested": {"__proto__": {}}}}')],
+    ])('blocks %s', async (_, createInput) => {
+      await expectBlocked(createInput())
+    })
+  })
+
+  describe('benign inputs', () => {
+    it.each([
+      ['undefined input', () => undefined],
+      ['primitive input', () => 'constructor'],
+      ['a plain object without special keys', () => ({ user: { name: '__proto__', tags: ['constructor'] } })],
+      ['a constructor key holding a string', () => JSON.parse('{"constructor": "Ford"}')],
+      ['a constructor key holding an object without a prototype key', () => JSON.parse('{"constructor": {"year": 1913}}')],
+      ['a prototype key alone', () => JSON.parse('{"prototype": {"isAdmin": true}}')],
+      ['non-plain objects such as dates and files', () => ({ at: new Date(), file: new File(['hi'], 'hi.txt') })],
+      ['a benign Map and Set', () => ({ map: new Map([['a', 1]]), set: new Set(['a']) })],
+    ])('allows %s', async (_, createInput) => {
+      await expectAllowed(createInput())
+    })
+
+    it('tolerates cyclic input without hanging', async () => {
+      const input: Record<string, unknown> = { name: 'cycle' }
+      input.self = input
+
+      await expectAllowed(input)
+    })
+  })
+
+  describe('with an RPCHandler', () => {
+    const createPlanet = vi.fn(() => 'created')
+
+    function createHandler() {
+      return new RPCHandler({ createPlanet: os.handler(createPlanet) }, {
+        plugins: [new PrototypePollutionProtectionHandlerPlugin()],
+      })
+    }
+
+    function createRequest(body: string) {
+      return new Request('https://api.example.com/createPlanet', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body,
+      })
+    }
+
+    it('blocks a polluting body with a parseable BAD_REQUEST error', async () => {
+      const { matched, response } = await createHandler().handle(
+        createRequest('{"json": {"name": "Earth", "__proto__": {"isAdmin": true}}}'),
+      )
+
+      expect(matched).toBe(true)
+      expect(response!.status).toBe(400)
+      await expect(response!.json()).resolves.toMatchObject({
+        json: expect.objectContaining({
+          code: 'BAD_REQUEST',
+          message: 'Request blocked by prototype pollution protection.',
+        }),
+      })
+      expect(createPlanet).not.toHaveBeenCalled()
+    })
+
+    it('blocks a constructor.prototype pair nested in the body', async () => {
+      const { response } = await createHandler().handle(
+        createRequest('{"json": {"settings": {"constructor": {"prototype": {"isAdmin": true}}}}}'),
+      )
+
+      expect(response!.status).toBe(400)
+      expect(createPlanet).not.toHaveBeenCalled()
+    })
+
+    it('allows a benign body', async () => {
+      const { response } = await createHandler().handle(
+        createRequest('{"json": {"name": "Earth", "constructor": "Ford"}}'),
+      )
+
+      expect(response!.status).toBe(200)
+      expect(createPlanet).toHaveBeenCalledOnce()
+    })
+  })
+})

--- a/packages/server/src/plugins/prototype-pollution-protection.ts
+++ b/packages/server/src/plugins/prototype-pollution-protection.ts
@@ -57,48 +57,63 @@ export class PrototypePollutionProtectionHandlerPlugin<T extends Context> implem
   /**
    * Walks the containers the built-in codecs can produce: arrays, maps, sets, and plain
    * objects, including null-prototype ones. Other objects, such as files and dates, carry
-   * no attacker-authored keys and are left alone.
+   * no attacker-authored keys and are left alone. The walk is iterative, so input nested
+   * deeper than the call stack allows still gets the intended verdict instead of a
+   * `RangeError`.
    */
-  private containsPollutingKey(value: unknown, visited = new WeakSet<object>()): boolean {
-    if (typeof value !== 'object' || value === null || visited.has(value)) {
-      return false
-    }
+  private containsPollutingKey(root: unknown): boolean {
+    const visited = new WeakSet<object>()
+    const stack = [root]
 
-    visited.add(value)
+    while (stack.length !== 0) {
+      const value = stack.pop()
 
-    if (Array.isArray(value)) {
-      return value.some(item => this.containsPollutingKey(item, visited))
-    }
-
-    // A map yields `[key, item]` entry arrays, so recursing covers both keys and values.
-    if (value instanceof Map || value instanceof Set) {
-      for (const entry of value) {
-        if (this.containsPollutingKey(entry, visited)) {
-          return true
-        }
+      if (typeof value !== 'object' || value === null || visited.has(value)) {
+        continue
       }
 
-      return false
+      visited.add(value)
+
+      if (Array.isArray(value)) {
+        for (const item of value) {
+          stack.push(item)
+        }
+
+        continue
+      }
+
+      // A map yields `[key, item]` entry arrays, so walking them covers both keys and values.
+      if (value instanceof Map || value instanceof Set) {
+        for (const entry of value) {
+          stack.push(entry)
+        }
+
+        continue
+      }
+
+      if (!isPlainObject(value)) {
+        continue
+      }
+
+      if (Object.hasOwn(value, '__proto__')) {
+        return true
+      }
+
+      // A lone `constructor` key is harmless and common, such as user text. Pollution
+      // requires reaching `constructor.prototype`, mirroring secure-json-parse.
+      if (
+        Object.hasOwn(value, 'constructor')
+        && isTypescriptObject(value.constructor)
+        && Object.hasOwn(value.constructor, 'prototype')
+      ) {
+        return true
+      }
+
+      for (const key of Object.keys(value)) {
+        stack.push(value[key])
+      }
     }
 
-    if (!isPlainObject(value)) {
-      return false
-    }
-
-    if (Object.hasOwn(value, '__proto__')) {
-      return true
-    }
-
-    // A lone `constructor` key is harmless and common, such as user text. Pollution
-    // requires reaching `constructor.prototype`, mirroring secure-json-parse.
-    if (
-      Object.hasOwn(value, 'constructor')
-      && isTypescriptObject(value.constructor)
-      && Object.hasOwn(value.constructor, 'prototype')
-    ) {
-      return true
-    }
-
-    return Object.keys(value).some(key => this.containsPollutingKey(value[key], visited))
+    return false
   }
 }

--- a/packages/server/src/plugins/prototype-pollution-protection.ts
+++ b/packages/server/src/plugins/prototype-pollution-protection.ts
@@ -3,19 +3,15 @@ import type { StandardHandlerOptions, StandardHandlerPlugin } from '../adapters/
 import type { Context } from '../context'
 import type { ProcedureClientInterceptor } from '../procedure-client'
 import { ORPCError } from '@orpc/client'
-import { isPlainObject, isTypescriptObject, toArray } from '@orpc/shared'
+import { isAsyncIteratorObject, isPlainObject, isTypescriptObject, override, toArray, wrapAsyncIterator } from '@orpc/shared'
 
 /**
  * Rejects requests whose decoded input contains prototype-polluting keys: an own
  * `__proto__` key, or an own `constructor` key holding a `prototype` key. oRPC's own
  * decoding never assigns through the prototype chain, so this plugin exists to stop such
  * keys from reaching application code that merges, clones, or path-sets input with a
- * library vulnerable to prototype pollution.
- *
- * @remarks
- * **Note**: Only the decoded request input is inspected. Values yielded later by an
- * [event iterator](https://orpc.dev/docs/async-iterator-object) input arrive after this
- * check runs, so they pass through uninspected.
+ * library vulnerable to prototype pollution. An `AsyncIteratorObject` input is checked
+ * value by value as it arrives, and a polluting value fails that iteration instead.
  *
  * @see {@link https://orpc.dev/docs/plugins/prototype-pollution-protection | Prototype Pollution Protection Plugin}
  */
@@ -24,9 +20,24 @@ export class PrototypePollutionProtectionHandlerPlugin<T extends Context> implem
 
   init(options: StandardHandlerOptions<T>): StandardHandlerOptions<T> {
     const interceptor: ProcedureClientInterceptor<T, Schema<unknown>, ErrorMap, any> = (interceptorOptions) => {
-      if (this.containsPollutingKey(interceptorOptions.input)) {
-        throw new ORPCError('BAD_REQUEST', { message: 'Request blocked by prototype pollution protection.' })
+      const input = interceptorOptions.input
+
+      if (isAsyncIteratorObject(input)) {
+        /**
+         * @warning
+         * Remember use `override` for AsyncIteratorObject to remain other special properties
+         */
+        const guardedInput = override(input, wrapAsyncIterator(input, {
+          mapResult: (result) => {
+            this.rejectPollutingInput(result.value)
+            return result
+          },
+        }))
+
+        return interceptorOptions.next({ ...interceptorOptions, input: guardedInput })
       }
+
+      this.rejectPollutingInput(input)
 
       return interceptorOptions.next()
     }
@@ -34,6 +45,12 @@ export class PrototypePollutionProtectionHandlerPlugin<T extends Context> implem
     return {
       ...options,
       clientInterceptors: [interceptor, ...toArray(options.clientInterceptors)],
+    }
+  }
+
+  private rejectPollutingInput(input: unknown): void {
+    if (this.containsPollutingKey(input)) {
+      throw new ORPCError('BAD_REQUEST', { message: 'Request blocked by prototype pollution protection.' })
     }
   }
 

--- a/packages/server/src/plugins/prototype-pollution-protection.ts
+++ b/packages/server/src/plugins/prototype-pollution-protection.ts
@@ -1,0 +1,87 @@
+import type { ErrorMap, Schema } from '@orpc/contract'
+import type { StandardHandlerOptions, StandardHandlerPlugin } from '../adapters/standard'
+import type { Context } from '../context'
+import type { ProcedureClientInterceptor } from '../procedure-client'
+import { ORPCError } from '@orpc/client'
+import { isPlainObject, isTypescriptObject, toArray } from '@orpc/shared'
+
+/**
+ * Rejects requests whose decoded input contains prototype-polluting keys: an own
+ * `__proto__` key, or an own `constructor` key holding a `prototype` key. oRPC's own
+ * decoding never assigns through the prototype chain, so this plugin exists to stop such
+ * keys from reaching application code that merges, clones, or path-sets input with a
+ * library vulnerable to prototype pollution.
+ *
+ * @remarks
+ * **Note**: Only the decoded request input is inspected. Values yielded later by an
+ * [event iterator](https://orpc.dev/docs/async-iterator-object) input arrive after this
+ * check runs, so they pass through uninspected.
+ *
+ * @see {@link https://orpc.dev/docs/plugins/prototype-pollution-protection | Prototype Pollution Protection Plugin}
+ */
+export class PrototypePollutionProtectionHandlerPlugin<T extends Context> implements StandardHandlerPlugin<T> {
+  name = '~prototype-pollution-protection'
+
+  init(options: StandardHandlerOptions<T>): StandardHandlerOptions<T> {
+    const interceptor: ProcedureClientInterceptor<T, Schema<unknown>, ErrorMap, any> = (interceptorOptions) => {
+      if (this.containsPollutingKey(interceptorOptions.input)) {
+        throw new ORPCError('BAD_REQUEST', { message: 'Request blocked by prototype pollution protection.' })
+      }
+
+      return interceptorOptions.next()
+    }
+
+    return {
+      ...options,
+      clientInterceptors: [interceptor, ...toArray(options.clientInterceptors)],
+    }
+  }
+
+  /**
+   * Walks the containers the built-in codecs can produce: arrays, maps, sets, and plain
+   * objects, including null-prototype ones. Other objects, such as files and dates, carry
+   * no attacker-authored keys and are left alone.
+   */
+  private containsPollutingKey(value: unknown, visited = new WeakSet<object>()): boolean {
+    if (typeof value !== 'object' || value === null || visited.has(value)) {
+      return false
+    }
+
+    visited.add(value)
+
+    if (Array.isArray(value)) {
+      return value.some(item => this.containsPollutingKey(item, visited))
+    }
+
+    // A map yields `[key, item]` entry arrays, so recursing covers both keys and values.
+    if (value instanceof Map || value instanceof Set) {
+      for (const entry of value) {
+        if (this.containsPollutingKey(entry, visited)) {
+          return true
+        }
+      }
+
+      return false
+    }
+
+    if (!isPlainObject(value)) {
+      return false
+    }
+
+    if (Object.hasOwn(value, '__proto__')) {
+      return true
+    }
+
+    // A lone `constructor` key is harmless and common, such as user text. Pollution
+    // requires reaching `constructor.prototype`, mirroring secure-json-parse.
+    if (
+      Object.hasOwn(value, 'constructor')
+      && isTypescriptObject(value.constructor)
+      && Object.hasOwn(value.constructor, 'prototype')
+    ) {
+      return true
+    }
+
+    return Object.keys(value).some(key => this.containsPollutingKey(value[key], visited))
+  }
+}


### PR DESCRIPTION
Adds `PrototypePollutionProtectionHandlerPlugin` to `@orpc/server/plugins`. It rejects any request whose decoded input contains an own `__proto__` key, or a `constructor` key holding a `prototype` key, with a `400 BAD_REQUEST` before the procedure runs — the same rule [secure-json-parse](https://github.com/fastify/secure-json-parse) enforces for Fastify. oRPC's own decoding is already pollution-safe; the plugin stops these keys from reaching application code that merges, clones, or path-sets input with a vulnerable utility.

### Behavior

- Runs as a client interceptor, so every matched request on any handler is checked: JSON and query data in `RPCHandler`, form data and bracket notation in `OpenAPIHandler`.
- Walks plain and null-prototype objects, arrays, and `Map`/`Set` keys and values at any depth, iteratively with a cycle guard, so nesting deeper than the call stack still gets a `400` instead of a `RangeError`; non-container objects such as `File` and `Date` pass untouched.
- An `AsyncIteratorObject` input is checked value by value as it arrives; a polluting value fails that iteration with the same error.
- Lone `constructor` or `prototype` keys stay allowed; neither alone can pollute.

### Testing

- 28 new tests cover block/allow cases at the interceptor level, `AsyncIteratorObject` inputs, and `RPCHandler` integration with raw JSON bodies; the full server suite (532 tests) passes.
- `pnpm type:check`, eslint, and the docs JSDoc backlink checker all pass.

### Docs

- New page `/docs/plugins/prototype-pollution-protection` documents how the check works and setup.

