### PR TITLE
feat(client,server): allow overriding compressible content-type detection in compression plugins

### DIFF
--- a/apps/content/docs/plugins/request-compression.mdx
+++ b/apps/content/docs/plugins/request-compression.mdx
@@ -30,7 +30,18 @@ const link = new RPCLink({
        *
        * @default 1024 (1KB)
        */
-      threshold: 1024
+      threshold: 1024,
+
+      /**
+       * Determines whether a request with the given Content-Type should be compressed.
+       * Only consulted for binary transfers (streams, files, and file form-data parts);
+       * other body types are serialized with fixed, known-compressible content types.
+       * Also receives the transport interceptor options for per-request decisions.
+       * Overrides the built-in check, which covers common text-based formats.
+       */
+      isCompressibleContentType: (contentType, { path }) => {
+        return /^application\/x-custom-format(?:[;\s]|$)/i.test(contentType ?? '') && path[0] !== 'uploads'
+      },
     }),
   ],
 })

--- a/apps/content/docs/plugins/request-compression.mdx
+++ b/apps/content/docs/plugins/request-compression.mdx
@@ -31,17 +31,6 @@ const link = new RPCLink({
        * @default 1024 (1KB)
        */
       threshold: 1024,
-
-      /**
-       * Determines whether a request with the given Content-Type should be compressed.
-       * Only consulted for binary transfers (streams, files, and file form-data parts);
-       * other body types are serialized with fixed, known-compressible content types.
-       * Also receives the transport interceptor options for per-request decisions.
-       * Overrides the built-in check, which covers common text-based formats.
-       */
-      isCompressibleContentType: (contentType, { path }) => {
-        return /^application\/x-custom-format(?:[;\s]|$)/i.test(contentType ?? '') && path[0] !== 'uploads'
-      },
     }),
   ],
 })
@@ -50,6 +39,31 @@ const link = new RPCLink({
 :::info
 The `link` can be any supported oRPC link, such as [RPCLink](/docs/rpc/link), [OpenAPILink](/docs/openapi/link), or a custom one.
 :::
+
+### Customize Compressible Content Types
+
+For binary transfers (streams, files, and file form-data parts), the plugin only compresses when the Content-Type is known to benefit from it. Other body types are serialized with fixed, known-compressible content types, so no check is needed:
+
+```ts
+import { RequestCompressionLinkPlugin } from '@orpc/client/plugins'
+
+const link = new RPCLink({
+  plugins: [
+    new RequestCompressionLinkPlugin({
+      /**
+       * Determines whether a request with the given Content-Type should be compressed.
+       * Only consulted for binary transfers (streams, files, and file form-data parts).
+       * Also receives the transport interceptor options for per-request decisions.
+       *
+       * @default isCompressibleContentType (covers common text-based formats)
+       */
+      isCompressibleContentType: (contentType, { path }) => {
+        return /^application\/x-custom-format(?:[;\s]|$)/i.test(contentType ?? '') && path[0] !== 'uploads'
+      },
+    }),
+  ],
+})
+```
 
 ## Server
 

--- a/apps/content/docs/plugins/request-compression.mdx
+++ b/apps/content/docs/plugins/request-compression.mdx
@@ -42,7 +42,7 @@ The `link` can be any supported oRPC link, such as [RPCLink](/docs/rpc/link), [O
 
 ### Customize Compressible Content Types
 
-For binary transfers (streams, files, and file form-data parts), the plugin only compresses when the Content-Type is known to benefit from it. Other body types are serialized with fixed, known-compressible content types, so no check is needed:
+For binary transfers (streams, files, and file form-data parts), the plugin only compresses content types that benefit from compression. Override the check with `isCompressibleContentType`:
 
 ```ts
 import { RequestCompressionLinkPlugin } from '@orpc/client/plugins'
@@ -51,8 +51,6 @@ const link = new RPCLink({
   plugins: [
     new RequestCompressionLinkPlugin({
       /**
-       * Determines whether a request with the given Content-Type should be compressed.
-       * Only consulted for binary transfers (streams, files, and file form-data parts).
        * Also receives the transport interceptor options for per-request decisions.
        *
        * @default isCompressibleContentType (covers common text-based formats)

--- a/apps/content/docs/plugins/response-compression.mdx
+++ b/apps/content/docs/plugins/response-compression.mdx
@@ -33,6 +33,17 @@ const handler = new RPCHandler(router, {
        * @default 1024 (1KB)
        */
       threshold: 1024,
+
+      /**
+       * Determines whether a response with the given Content-Type should be compressed.
+       * Only consulted for binary transfers (streams, files, and file form-data parts);
+       * other body types are serialized with fixed, known-compressible content types.
+       * Also receives the routing interceptor options for per-request decisions.
+       * Overrides the built-in check, which covers common text-based formats.
+       */
+      isCompressibleContentType: (contentType, { request }) => {
+        return /^application\/x-custom-format(?:[;\s]|$)/i.test(contentType ?? '') && request.headers['x-no-compression'] === undefined
+      },
     }),
   ],
 })

--- a/apps/content/docs/plugins/response-compression.mdx
+++ b/apps/content/docs/plugins/response-compression.mdx
@@ -33,17 +33,6 @@ const handler = new RPCHandler(router, {
        * @default 1024 (1KB)
        */
       threshold: 1024,
-
-      /**
-       * Determines whether a response with the given Content-Type should be compressed.
-       * Only consulted for binary transfers (streams, files, and file form-data parts);
-       * other body types are serialized with fixed, known-compressible content types.
-       * Also receives the routing interceptor options for per-request decisions.
-       * Overrides the built-in check, which covers common text-based formats.
-       */
-      isCompressibleContentType: (contentType, { request }) => {
-        return /^application\/x-custom-format(?:[;\s]|$)/i.test(contentType ?? '') && request.headers['x-no-compression'] === undefined
-      },
     }),
   ],
 })
@@ -56,6 +45,31 @@ The `handler` can be any supported oRPC handler, such as [RPCHandler](/docs/rpc/
 :::tip
 A [batch](/docs/plugins/batch) response might be left uncompressed here, depending on the shape it takes. On Node.js, add the [Batch Response Compression Plugin](/docs/plugins/batch-response-compression) to fully cover them, when you know your batch responses are all compressible.
 :::
+
+### Customize Compressible Content Types
+
+For binary transfers (streams, files, and file form-data parts), the plugin only compresses when the Content-Type is known to benefit from it. Other body types are serialized with fixed, known-compressible content types, so no check is needed:
+
+```ts handler
+import { ResponseCompressionHandlerPlugin } from '@orpc/server/plugins'
+
+const handler = new RPCHandler(router, {
+  plugins: [
+    new ResponseCompressionHandlerPlugin({
+      /**
+       * Determines whether a response with the given Content-Type should be compressed.
+       * Only consulted for binary transfers (streams, files, and file form-data parts).
+       * Also receives the routing interceptor options for per-request decisions.
+       *
+       * @default isCompressibleContentType (covers common text-based formats)
+       */
+      isCompressibleContentType: (contentType, { request }) => {
+        return /^application\/x-custom-format(?:[;\s]|$)/i.test(contentType ?? '') && request.headers['x-no-compression'] === undefined
+      },
+    }),
+  ],
+})
+```
 
 ## Client
 

--- a/apps/content/docs/plugins/response-compression.mdx
+++ b/apps/content/docs/plugins/response-compression.mdx
@@ -48,7 +48,7 @@ A [batch](/docs/plugins/batch) response might be left uncompressed here, dependi
 
 ### Customize Compressible Content Types
 
-For binary transfers (streams, files, and file form-data parts), the plugin only compresses when the Content-Type is known to benefit from it. Other body types are serialized with fixed, known-compressible content types, so no check is needed:
+For binary transfers (streams, files, and file form-data parts), the plugin only compresses content types that benefit from compression. Override the check with `isCompressibleContentType`:
 
 ```ts handler
 import { ResponseCompressionHandlerPlugin } from '@orpc/server/plugins'
@@ -57,8 +57,6 @@ const handler = new RPCHandler(router, {
   plugins: [
     new ResponseCompressionHandlerPlugin({
       /**
-       * Determines whether a response with the given Content-Type should be compressed.
-       * Only consulted for binary transfers (streams, files, and file form-data parts).
        * Also receives the routing interceptor options for per-request decisions.
        *
        * @default isCompressibleContentType (covers common text-based formats)

--- a/packages/client/src/plugins/request-compression.test.ts
+++ b/packages/client/src/plugins/request-compression.test.ts
@@ -672,4 +672,48 @@ describe('requestCompressionLinkPlugin', () => {
       ).resolves.toEqual(await largeBlob.text())
     })
   })
+
+  describe('isCompressibleContentType option', () => {
+    it('compresses a normally non-compressible content-type when the custom check allows it', async () => {
+      const { link, fetch } = createLink({
+        pluginOptions: {
+          threshold: 100,
+          isCompressibleContentType: (contentType, interceptorOptions) => {
+            expect(interceptorOptions.path).toEqual(['test'])
+            expect(interceptorOptions.request).toBeDefined()
+            return contentType === 'application/octet-stream'
+          },
+        },
+      })
+      const binaryBlob = new Blob(['large content'.repeat(100)], { type: 'application/octet-stream' })
+
+      await expect(link.call(['test'], binaryBlob, { context: {} })).resolves.toEqual('OK')
+
+      expect(fetch).toHaveBeenCalledTimes(1)
+      const [, init] = fetch.mock.calls[0]!
+      expect(init.body).toBeInstanceOf(ReadableStream)
+      expect(init.headers?.get('content-encoding')).toBe('gzip')
+
+      await expect(
+        decompressStream(init.body as ReadableStream, 'gzip'),
+      ).resolves.toEqual(await binaryBlob.text())
+    })
+
+    it('does not compress a normally compressible content-type when the custom check rejects it', async () => {
+      const { link, fetch } = createLink({
+        pluginOptions: {
+          threshold: 100,
+          isCompressibleContentType: () => false,
+        },
+      })
+      const textBlob = new Blob(['large content'.repeat(100)], { type: 'text/plain' })
+
+      await expect(link.call(['test'], textBlob, { context: {} })).resolves.toEqual('OK')
+
+      expect(fetch).toHaveBeenCalledTimes(1)
+      const [, init] = fetch.mock.calls[0]!
+      expect(init.body).toBe(textBlob)
+      expect(init.headers?.get('content-encoding')).toBeNull()
+    })
+  })
 })

--- a/packages/client/src/plugins/request-compression.ts
+++ b/packages/client/src/plugins/request-compression.ts
@@ -27,12 +27,10 @@ export interface RequestCompressionLinkPluginOptions<T extends ClientContext> {
 
   /**
    * Determines whether a request with the given Content-Type should be compressed.
-   * Only consulted for binary transfers (streams, files, and file form-data parts);
-   * other body types are serialized with fixed, known-compressible content types.
+   * Only consulted for binary transfers (streams, files, and file form-data parts).
    * Also receives the transport interceptor options for per-request decisions.
-   * Overrides the built-in check, which covers common text-based formats.
    *
-   * @default isCompressibleContentType
+   * @default isCompressibleContentType (covers common text-based formats)
    */
   isCompressibleContentType?: (contentType: string | null | undefined, options: StandardLinkTransportInterceptorOptions<T>) => boolean
 }

--- a/packages/client/src/plugins/request-compression.ts
+++ b/packages/client/src/plugins/request-compression.ts
@@ -31,6 +31,8 @@ export interface RequestCompressionLinkPluginOptions<T extends ClientContext> {
    * other body types are serialized with fixed, known-compressible content types.
    * Also receives the transport interceptor options for per-request decisions.
    * Overrides the built-in check, which covers common text-based formats.
+   *
+   * @default isCompressibleContentType
    */
   isCompressibleContentType?: (contentType: string | null | undefined, options: StandardLinkTransportInterceptorOptions<T>) => boolean
 }

--- a/packages/client/src/plugins/request-compression.ts
+++ b/packages/client/src/plugins/request-compression.ts
@@ -1,5 +1,5 @@
 import type { StandardBodyHint } from '@standardserver/core'
-import type { StandardLinkOptions, StandardLinkPlugin, StandardLinkTransportInterceptor } from '../adapters/standard'
+import type { StandardLinkOptions, StandardLinkPlugin, StandardLinkTransportInterceptor, StandardLinkTransportInterceptorOptions } from '../adapters/standard'
 import type { ClientContext } from '../types'
 import { isAsyncIteratorObject, isCompressibleContentType, stringifyJSON, toArray } from '@orpc/shared'
 import { flattenStandardHeader, generateContentDisposition } from '@standardserver/core'
@@ -8,7 +8,7 @@ import { flattenStandardHeader, generateContentDisposition } from '@standardserv
 // occasional multi-byte characters increase the average.
 const AVG_BYTES_PER_CHAR = 1.2
 
-export interface RequestCompressionLinkPluginOptions<_T extends ClientContext> {
+export interface RequestCompressionLinkPluginOptions<T extends ClientContext> {
   /**
    * The compression scheme to use for request compression.
    *
@@ -24,6 +24,15 @@ export interface RequestCompressionLinkPluginOptions<_T extends ClientContext> {
    * @default 1024 (1KB)
    */
   threshold?: number
+
+  /**
+   * Determines whether a request with the given Content-Type should be compressed.
+   * Only consulted for binary transfers (streams, files, and file form-data parts);
+   * other body types are serialized with fixed, known-compressible content types.
+   * Also receives the transport interceptor options for per-request decisions.
+   * Overrides the built-in check, which covers common text-based formats.
+   */
+  isCompressibleContentType?: (contentType: string | null | undefined, options: StandardLinkTransportInterceptorOptions<T>) => boolean
 }
 
 /**
@@ -42,10 +51,12 @@ export class RequestCompressionLinkPlugin<T extends ClientContext> implements St
 
   private readonly encoding: Exclude<RequestCompressionLinkPluginOptions<T>['encoding'], undefined>
   private readonly threshold: Exclude<RequestCompressionLinkPluginOptions<T>['threshold'], undefined>
+  private readonly isCompressibleContentType: Exclude<RequestCompressionLinkPluginOptions<T>['isCompressibleContentType'], undefined>
 
   constructor(options: RequestCompressionLinkPluginOptions<T> = {}) {
     this.encoding = options.encoding ?? 'gzip'
     this.threshold = options.threshold ?? 1024
+    this.isCompressibleContentType = options.isCompressibleContentType ?? isCompressibleContentType
   }
 
   init(options: StandardLinkOptions<T>): StandardLinkOptions<T> {
@@ -62,7 +73,7 @@ export class RequestCompressionLinkPlugin<T extends ClientContext> implements St
 
         if (
           (!Number.isFinite(contentLength) || contentLength >= this.threshold)
-          && isCompressibleContentType(flattenStandardHeader(request.headers['content-type']))
+          && this.isCompressibleContentType(flattenStandardHeader(request.headers['content-type']), interceptorOptions)
         ) {
           const compressedStream = request.body.pipeThrough(new CompressionStream(this.encoding))
 
@@ -85,7 +96,7 @@ export class RequestCompressionLinkPlugin<T extends ClientContext> implements St
       else if (request.body instanceof Blob) {
         if (
           (!Number.isFinite(request.body.size) || request.body.size >= this.threshold)
-          && isCompressibleContentType(request.body.type)
+          && this.isCompressibleContentType(request.body.type, interceptorOptions)
         ) {
           const compressedStream = request.body.stream().pipeThrough(new CompressionStream(this.encoding))
           const contentDisposition = request.headers['content-disposition'] ?? generateContentDisposition(
@@ -119,7 +130,7 @@ export class RequestCompressionLinkPlugin<T extends ClientContext> implements St
 
           if (value instanceof Blob) {
             if (!Number.isFinite(value.size)) { // Bun-s3 can use NaN for size
-              if (!isCompressibleContentType(value.type)) {
+              if (!this.isCompressibleContentType(value.type, interceptorOptions)) {
                 // Unknown non-compressible part size makes the estimate unreliable
                 contentLength = -Infinity
                 break
@@ -129,7 +140,7 @@ export class RequestCompressionLinkPlugin<T extends ClientContext> implements St
               contentLength = Infinity
             }
             else {
-              contentLength += isCompressibleContentType(value.type)
+              contentLength += this.isCompressibleContentType(value.type, interceptorOptions)
                 ? value.size
                 : -value.size
             }

--- a/packages/server/src/plugins/response-compression.test.ts
+++ b/packages/server/src/plugins/response-compression.test.ts
@@ -1229,6 +1229,65 @@ describe('responseCompressionHandlerPlugin', () => {
     })
   })
 
+  describe('isCompressibleContentType option', () => {
+    it('compresses a normally non-compressible content-type when the custom check allows it', async () => {
+      const binaryBlob = new Blob(['large content'.repeat(100)], { type: 'application/octet-stream' })
+      const handler = new RPCHandler(os.handler(() => binaryBlob), {
+        plugins: [
+          new ResponseCompressionHandlerPlugin({
+            threshold: 100,
+            isCompressibleContentType: (contentType, interceptorOptions) => {
+              expect(interceptorOptions.request).toBeDefined()
+              expect(interceptorOptions.context).toEqual({})
+              return contentType === 'application/octet-stream'
+            },
+          }),
+        ],
+      })
+
+      const { matched, response } = await handler.handle(new Request('http://localhost', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'accept-encoding': 'gzip',
+        },
+        body: JSON.stringify({ json: null }),
+      }))
+
+      expect(matched).toBe(true)
+      expect(response!.headers.get('content-encoding')).toBe('gzip')
+
+      await expect(
+        decompressStream(response!.body!, 'gzip'),
+      ).resolves.toEqual(await binaryBlob.text())
+    })
+
+    it('does not compress a normally compressible content-type when the custom check rejects it', async () => {
+      const textBlob = new Blob(['large content'.repeat(100)], { type: 'text/plain' })
+      const handler = new RPCHandler(os.handler(() => textBlob), {
+        plugins: [
+          new ResponseCompressionHandlerPlugin({
+            threshold: 100,
+            isCompressibleContentType: () => false,
+          }),
+        ],
+      })
+
+      const { matched, response } = await handler.handle(new Request('http://localhost', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'accept-encoding': 'gzip',
+        },
+        body: JSON.stringify({ json: null }),
+      }))
+
+      expect(matched).toBe(true)
+      expect(response!.headers.has('content-encoding')).toBe(false)
+      await expect(response!.text()).resolves.toBe(await textBlob.text())
+    })
+  })
+
   describe('node adapter', () => {
     it('should work with Node.js adapter', async () => {
       const largeText = 'x'.repeat(2000)

--- a/packages/server/src/plugins/response-compression.ts
+++ b/packages/server/src/plugins/response-compression.ts
@@ -29,12 +29,10 @@ export interface ResponseCompressionHandlerPluginOptions<T extends Context> {
 
   /**
    * Determines whether a response with the given Content-Type should be compressed.
-   * Only consulted for binary transfers (streams, files, and file form-data parts);
-   * other body types are serialized with fixed, known-compressible content types.
+   * Only consulted for binary transfers (streams, files, and file form-data parts).
    * Also receives the routing interceptor options for per-request decisions.
-   * Overrides the built-in check, which covers common text-based formats.
    *
-   * @default isCompressibleContentType
+   * @default isCompressibleContentType (covers common text-based formats)
    */
   isCompressibleContentType?: (contentType: string | null | undefined, options: StandardHandlerRoutingInterceptorOptions<T>) => boolean
 }

--- a/packages/server/src/plugins/response-compression.ts
+++ b/packages/server/src/plugins/response-compression.ts
@@ -33,6 +33,8 @@ export interface ResponseCompressionHandlerPluginOptions<T extends Context> {
    * other body types are serialized with fixed, known-compressible content types.
    * Also receives the routing interceptor options for per-request decisions.
    * Overrides the built-in check, which covers common text-based formats.
+   *
+   * @default isCompressibleContentType
    */
   isCompressibleContentType?: (contentType: string | null | undefined, options: StandardHandlerRoutingInterceptorOptions<T>) => boolean
 }

--- a/packages/server/src/plugins/response-compression.ts
+++ b/packages/server/src/plugins/response-compression.ts
@@ -1,5 +1,5 @@
 import type { StandardBodyHint } from '@standardserver/core'
-import type { StandardHandlerOptions, StandardHandlerPlugin, StandardHandlerRoutingInterceptor } from '../adapters/standard'
+import type { StandardHandlerOptions, StandardHandlerPlugin, StandardHandlerRoutingInterceptor, StandardHandlerRoutingInterceptorOptions } from '../adapters/standard'
 import type { Context } from '../context'
 import { isAsyncIteratorObject, isCompressibleContentType, isNoTransformCacheControl, parseAcceptEncodingQualities, stringifyJSON, toArray, varyByAcceptEncoding } from '@orpc/shared'
 import { flattenStandardHeader, generateContentDisposition } from '@standardserver/core'
@@ -8,7 +8,7 @@ import { flattenStandardHeader, generateContentDisposition } from '@standardserv
 // occasional multi-byte characters increase the average.
 const AVG_BYTES_PER_CHAR = 1.2
 
-export interface ResponseCompressionHandlerPluginOptions<_T extends Context> {
+export interface ResponseCompressionHandlerPluginOptions<T extends Context> {
   /**
    * The compression schemes to use for response compression.
    * Schemes are prioritized by their order in this array and
@@ -26,6 +26,15 @@ export interface ResponseCompressionHandlerPluginOptions<_T extends Context> {
    * @default 1024 (1KB)
    */
   threshold?: number
+
+  /**
+   * Determines whether a response with the given Content-Type should be compressed.
+   * Only consulted for binary transfers (streams, files, and file form-data parts);
+   * other body types are serialized with fixed, known-compressible content types.
+   * Also receives the routing interceptor options for per-request decisions.
+   * Overrides the built-in check, which covers common text-based formats.
+   */
+  isCompressibleContentType?: (contentType: string | null | undefined, options: StandardHandlerRoutingInterceptorOptions<T>) => boolean
 }
 
 /**
@@ -45,10 +54,12 @@ export class ResponseCompressionHandlerPlugin<T extends Context> implements Stan
 
   private readonly encodings: Exclude<ResponseCompressionHandlerPluginOptions<T>['encodings'], undefined>
   private readonly threshold: Exclude<ResponseCompressionHandlerPluginOptions<T>['threshold'], undefined>
+  private readonly isCompressibleContentType: Exclude<ResponseCompressionHandlerPluginOptions<T>['isCompressibleContentType'], undefined>
 
   constructor(options: ResponseCompressionHandlerPluginOptions<T> = {}) {
     this.encodings = options.encodings ?? ['gzip', 'deflate']
     this.threshold = options.threshold ?? 1024
+    this.isCompressibleContentType = options.isCompressibleContentType ?? isCompressibleContentType
   }
 
   init(options: StandardHandlerOptions<T>): StandardHandlerOptions<T> {
@@ -96,7 +107,7 @@ export class ResponseCompressionHandlerPlugin<T extends Context> implements Stan
 
         if (
           (!Number.isFinite(contentLength) || contentLength >= this.threshold)
-          && isCompressibleContentType(flattenStandardHeader(headers['content-type']))
+          && this.isCompressibleContentType(flattenStandardHeader(headers['content-type']), interceptorOptions)
         ) {
           return {
             ...result,
@@ -118,7 +129,7 @@ export class ResponseCompressionHandlerPlugin<T extends Context> implements Stan
       else if (body instanceof Blob) {
         if (
           (!Number.isFinite(body.size) || body.size >= this.threshold)
-          && isCompressibleContentType(body.type)
+          && this.isCompressibleContentType(body.type, interceptorOptions)
         ) {
           const contentDisposition = headers['content-disposition'] ?? generateContentDisposition(
             body instanceof File ? body.name : 'blob',
@@ -152,7 +163,7 @@ export class ResponseCompressionHandlerPlugin<T extends Context> implements Stan
 
           if (value instanceof Blob) {
             if (!Number.isFinite(value.size)) { // Bun-s3 can use NaN for size
-              if (!isCompressibleContentType(value.type)) {
+              if (!this.isCompressibleContentType(value.type, interceptorOptions)) {
                 // Unknown non-compressible part size makes the estimate unreliable
                 contentLength = -Infinity
                 break
@@ -162,7 +173,7 @@ export class ResponseCompressionHandlerPlugin<T extends Context> implements Stan
               contentLength = Infinity
             }
             else {
-              contentLength += isCompressibleContentType(value.type)
+              contentLength += this.isCompressibleContentType(value.type, interceptorOptions)
                 ? value.size
                 : -value.size
             }


### PR DESCRIPTION
The response and request compression plugins hard-code which content types count as compressible, so proprietary binary formats (e.g. a compressible `application/octet-stream`) can never be compressed and there is no per-request opt-out. Both plugins now accept an `isCompressibleContentType` option that replaces the built-in check for binary transfers (streams, files, and file form-data parts) and receives the interceptor options as a second argument for per-request decisions.

Closes #1963

## Behavior

- Custom checks can opt normally skipped content types into compression and opt normally compressed ones out; all four internal call sites in each plugin go through the option.
- The second argument exposes the routing interceptor options on the server and the transport interceptor options on the client, so decisions can depend on the request, procedure path, or context.
- Defaults are unchanged: without the option, the built-in check applies exactly as before, and non-binary bodies still use their fixed serialized content types gated only by the threshold.

## Testing

- New tests in both plugins cover allowing a normally skipped type, rejecting a normally compressed one, and that the interceptor options reach the callback.
- Docs for both plugins document the option with a regex-based example; snippets verified to compile against the workspace packages.