### PR TITLE
chore: remove leftover .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "integrations/nest"]
-	path = integrations/nest
-	url = https://github.com/middleapi/orpc-nest


### PR DESCRIPTION
Removes the stale `.gitmodules` file left behind when the `integrations/nest` submodule was merged back into this repo (25cfa7c0f). No gitlink entries remain in the index, so the file no longer references anything.

## Testing
- `git ls-files -s` confirms no submodule (160000) entries exist in the tree.