### PR TITLE
chore: build packages via prepack instead of a separate build script

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,6 +73,4 @@ jobs:
 
       - run: pnpm i
 
-      - run: pnpm --filter='./packages/*' run -r build
-
       - run: pnpm exec pkg-pr-new publish './packages/*' --pnpm --compact --template './playgrounds/*'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,6 +78,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - run: pnpm --filter='./packages/*' run -r build
-
       - run: pnpm --filter='./packages/*' publish -r --provenance --access=public --tag=${{ github.event.inputs.tag || steps.version.outputs.preid || 'latest' }} ${{ github.event.inputs.skip_git_check == 'true' && '--no-git-checks' || '' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ pnpm type:check              # tsc across all packages — this is also what run
 pnpm lint                    # eslint (also the formatter — @antfu/eslint-config)
 pnpm lint:fix
 pnpm bench                   # vitest bench
-pnpm --filter @orpc/server build   # build one package (unbuild); builds are NOT needed for dev/tests
+pnpm --filter @orpc/server prepack # build one package (unbuild, runs automatically on pack/publish); builds are NOT needed for dev/tests
 ```
 
 - Root vitest config (`vitest.config.ts`) runs all `*.test.ts` with `globals: true`, plus a jsdom project for `*.test.tsx` in `packages/next` and `packages/tanstack-query`.

--- a/packages/ai-sdk/package.json
+++ b/packages/ai-sdk/package.json
@@ -43,7 +43,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "peerDependencies": {

--- a/packages/arktype/package.json
+++ b/packages/arktype/package.json
@@ -42,7 +42,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "peerDependencies": {

--- a/packages/bun/package.json
+++ b/packages/bun/package.json
@@ -41,7 +41,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b",
     "test": "bun --env-file=../../.env test",
     "test:coverage": "bun --env-file=../../.env test --coverage"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -74,7 +74,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "dependencies": {

--- a/packages/cloudflare/package.json
+++ b/packages/cloudflare/package.json
@@ -43,7 +43,7 @@
   ],
   "scripts": {
     "prepare": "wrangler types",
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "wrangler types && tsc -b",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage"

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -50,7 +50,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "dependencies": {

--- a/packages/effect/package.json
+++ b/packages/effect/package.json
@@ -56,7 +56,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "peerDependencies": {

--- a/packages/evlog/package.json
+++ b/packages/evlog/package.json
@@ -47,7 +47,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "peerDependencies": {

--- a/packages/hibernation/package.json
+++ b/packages/hibernation/package.json
@@ -41,7 +41,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "dependencies": {

--- a/packages/json-schema/package.json
+++ b/packages/json-schema/package.json
@@ -41,7 +41,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "dependencies": {

--- a/packages/msw/package.json
+++ b/packages/msw/package.json
@@ -38,7 +38,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "peerDependencies": {

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -43,7 +43,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "peerDependencies": {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -58,7 +58,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "peerDependencies": {

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -42,7 +42,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "dependencies": {

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -95,7 +95,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "peerDependencies": {

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -41,7 +41,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "peerDependencies": {

--- a/packages/pinia-colada/package.json
+++ b/packages/pinia-colada/package.json
@@ -43,7 +43,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "peerDependencies": {

--- a/packages/pino/package.json
+++ b/packages/pino/package.json
@@ -41,7 +41,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "peerDependencies": {

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -62,7 +62,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "peerDependencies": {

--- a/packages/ratelimit/package.json
+++ b/packages/ratelimit/package.json
@@ -61,7 +61,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "peerDependencies": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -123,7 +123,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "peerDependencies": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -36,7 +36,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "peerDependencies": {

--- a/packages/swr/package.json
+++ b/packages/swr/package.json
@@ -43,7 +43,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "peerDependencies": {

--- a/packages/tanstack-query/package.json
+++ b/packages/tanstack-query/package.json
@@ -47,7 +47,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "peerDependencies": {

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -43,7 +43,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "peerDependencies": {

--- a/packages/valibot/package.json
+++ b/packages/valibot/package.json
@@ -42,7 +42,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "peerDependencies": {

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -42,7 +42,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "unbuild",
+    "prepack": "unbuild",
     "type:check": "tsc -b"
   },
   "peerDependencies": {


### PR DESCRIPTION
Every package's `build` script is renamed to `prepack`, so unbuild runs automatically whenever a package is packed or published. The explicit build steps in the CI preview and release workflows are gone, since `pnpm pack` (used by pkg-pr-new) and `pnpm publish` both trigger the hook themselves. Publishing a package without its `dist` is no longer possible by forgetting a step.

## Changes

- All 27 `packages/*/package.json`: `"build": "unbuild"` → `"prepack": "unbuild"`.
- `.github/workflows/ci.yaml`: the `publish_preview` job goes straight from `pnpm i` to pkg-pr-new.
- `.github/workflows/release.yaml`: the release job goes straight from changelog to `pnpm publish -r`.
- `CLAUDE.md`: single-package build command is now `pnpm --filter @orpc/server prepack`.

## Testing

- `pnpm pack` in `packages/shared` runs `prepack`, and the tarball contains `dist/index.mjs`, `dist/index.d.mts`, `dist/index.d.ts`.
- `pnpm publish --dry-run --no-git-checks` runs `prepack` before the upload, covering the release path.
- pkg-pr-new 0.0.88 with `--pnpm` shells out to `pnpm pack --pack-destination <dir>` per package with no `--ignore-scripts`, so the preview path builds too.
- eslint clean.

## Notes for reviewers

Builds now happen after pkg-pr-new rewrites each `package.json`'s dependencies to `pkg.pr.new` URLs rather than before. That is safe here: unbuild derives externals from dependency keys, which are untouched, and resolution still goes through the unchanged `node_modules` workspace links.

`packages/cloudflare` keeps its existing `prepare: wrangler types`, which pnpm runs after `prepack` during pack and publish. That ordering already applied before this change.