### PR TITLE
docs(openapi): note that prefixes now apply to every procedure

### DIFF
--- a/apps/content/docs/migrations/from-v1.mdx
+++ b/apps/content/docs/migrations/from-v1.mdx
@@ -12,6 +12,7 @@ Most of your code keeps working: many v1 names still compile through deprecated 
 - The RPC serializer format and the error response format changed, so v1 [RPC Link](/docs/rpc/link) and [OpenAPI Link](/docs/openapi/link) clients cannot talk to a v2 server. Deploy the upgraded server and client together. See [Wire Format Changes](#wire-format-changes).
 - Automatic middleware deduplication was removed. Middleware applied at both router and procedure level now runs twice. See [Middleware](#middleware).
 - The Batch Plugin replaced `exclude` with `filter`, which has the opposite meaning. In most cases you can simply remove `exclude`. See [Batch Plugin](#batch-plugin).
+- A prefix now applies to every procedure, not only the ones that define a `path`, so procedures relying on the router-derived path move under the prefix. See [Routing Moved to OpenAPI Metadata](#routing-moved-to-openapi-metadata).
 
 :::
 
@@ -107,6 +108,32 @@ const listPlanet = os
   .handler(async () => [])
 ```
 
+:::
+
+:::warning[Prefixes now apply to every procedure]
+In v1, `.prefix` only applied to procedures that defined a `path` and left the rest untouched. In v2, `prefix` applies to every procedure, including those that fall back to the [router-derived path](/docs/openapi/routing#basic-routing), so those endpoints move under the prefix:
+
+<CodeGroup>
+
+```ts v2
+const router = os.meta(openapi({ prefix: '/api/v2' })).router({
+  planet: {
+    // POST /api/v2/planet/create
+    create: os.handler(async () => ({})),
+  },
+})
+```
+
+```ts v1
+const router = os.prefix('/api/v2').router({
+  planet: {
+    // POST /planet/create
+    create: os.handler(async () => ({})),
+  },
+})
+```
+
+</CodeGroup>
 :::
 
 The same applies to lazy routers with a prefix:


### PR DESCRIPTION
In v1, `.prefix` was a no-op for procedures that did not define a `path`, so those endpoints kept the bare router-derived path. In v2 the prefix is merged onto the derived path as well, which silently moves every such endpoint. Nothing in the migration guide said so, and the change is invisible until a client 404s.

## Docs

The "Routing Moved to OpenAPI Metadata" section now carries a warning with a side-by-side example: the same pathless `planet.create` is `POST /planet/create` under a v1 `.prefix('/api/v2')` and `POST /api/v2/planet/create` in v2. The change is also listed in the "Read these first" callout at the top of the page, next to the other upgrades that break at runtime rather than at compile time.

## Verification

Confirmed against both versions rather than from memory: v1's `prefixRoute` returns the route untouched when `path` is unset, while v2 computes `meta.path ?? pathToHttpPath(path)` first and merges the prefix onto the result. A scratch test against `OpenAPIGenerator` produced `POST /api/v2/planet/create` for the documented example.