### PR TITLE
chore(content): keep home copy button working after client-side navigation

### DIFF
--- a/apps/content/pages/_home/Hero.astro
+++ b/apps/content/pages/_home/Hero.astro
@@ -96,42 +96,54 @@ const install = 'npx skills add middleapi/orpc'
 </section>
 
 <script>
-  const status = document.querySelector<HTMLElement>('[data-copy-status]')
+  // Astro's ClientRouter swaps the page body on soft navigation but runs this
+  // module only once per full load, so listeners bound per button are lost when
+  // the home page is re-entered from another page. A single delegated listener
+  // survives the swap and resolves the button and status node at click time.
+  const resetTimers = new WeakMap<HTMLButtonElement, number>()
 
-  for (const button of document.querySelectorAll<HTMLButtonElement>('[data-copy]')) {
-    let resetTimer = 0
+  document.addEventListener('click', async (event) => {
+    if (!(event.target instanceof Element)) {
+      return
+    }
 
-    button.addEventListener('click', async () => {
-      // A second click inside the reset window would otherwise be cleared early
-      // by the first click's timer, and announce nothing.
-      clearTimeout(resetTimer)
+    const button = event.target.closest<HTMLButtonElement>('button[data-copy]')
 
-      try {
-        await navigator.clipboard.writeText(button.dataset.copy ?? '')
+    if (!button) {
+      return
+    }
+
+    const status = document.querySelector<HTMLElement>('[data-copy-status]')
+
+    // A second click inside the reset window would otherwise be cleared early
+    // by the first click's timer, and announce nothing.
+    clearTimeout(resetTimers.get(button))
+
+    try {
+      await navigator.clipboard.writeText(button.dataset.copy ?? '')
+    }
+    catch {
+      if (status) {
+        status.textContent = 'Copy failed'
       }
-      catch {
-        if (status) {
-          status.textContent = 'Copy failed'
-        }
-        return
-      }
+      return
+    }
 
-      button.classList.add('is-copied')
+    button.classList.add('is-copied')
+
+    if (status) {
+      // Cleared first so a repeat copy is announced again rather than being
+      // treated as unchanged text.
+      status.textContent = ''
+      status.textContent = 'Copied'
+    }
+
+    resetTimers.set(button, window.setTimeout(() => {
+      button.classList.remove('is-copied')
 
       if (status) {
-        // Cleared first so a repeat copy is announced again rather than being
-        // treated as unchanged text.
         status.textContent = ''
-        status.textContent = 'Copied'
       }
-
-      resetTimer = window.setTimeout(() => {
-        button.classList.remove('is-copied')
-
-        if (status) {
-          status.textContent = ''
-        }
-      }, 1600)
-    })
-  }
+    }, 1600))
+  })
 </script>


### PR DESCRIPTION
## What happens

The install command copy button on the home page does nothing if you reach the home page through a link inside the site. Open any docs page, click the logo to come back, click the button. Nothing is copied and the icon never flips to the check. Reload the page and it works again.

## Why

`Hero.astro` binds a click listener to each `[data-copy]` button from a hoisted script. Astro runs that script once per real page load. The site uses `ClientRouter`, so going from docs back to home does not reload. It fetches the new HTML and swaps the body in place. The button in that new body is a fresh element. The script that bound the old listener already ran and does not run again, so the new button has no listener.

## The change

The listener now sits on `document` instead of on each button. `document` survives the swap. When a click lands, the handler walks up from the target with `closest('button[data-copy]')` and looks up `[data-copy-status]` at that moment, so it always sees the current elements. The per-button reset timer moved into a `WeakMap` keyed by button. That keeps the double-click guard and lets swapped-out buttons be garbage collected. The copied state, the aria-live announcement, the failure text and the 1.6s reset are unchanged.

## How I checked

On orpc.dev I hooked `navigator.clipboard.writeText`, soft navigated from `/docs/getting-started` back to `/` and clicked. No write, no `is-copied`. With this branch in `blume dev` the same steps write `npx skills add middleapi/orpc` and the status reads "Copied", both on first load and after the soft navigation.

The Showcase tabs and the blog filter bind listeners the same way and probably have the same problem. I left them out to keep this small.
