### PR TITLE
chore(content): keep home showcase tabs and blog filter working after client-side navigation

### DIFF
--- a/apps/content/pages/_home/Showcase.astro
+++ b/apps/content/pages/_home/Showcase.astro
@@ -440,11 +440,15 @@ it('finds a planet', async () => {
 </div>
 
 <script>
+  // Astro's ClientRouter swaps the page body on soft navigation but runs this
+  // module only once per full load, so everything bound to the showcase's own
+  // elements is re-resolved in `init`, which runs again after every swap.
+  let tabs: HTMLButtonElement[] = []
+  let panels: HTMLElement[] = []
+  let tablist: HTMLElement | null = null
+
   // WAI-ARIA tabs pattern: one tab stop for the whole list, arrows move between
   // tabs and select as they go (https://www.w3.org/WAI/ARIA/apg/patterns/tabs/).
-  const tabs = [...document.querySelectorAll<HTMLButtonElement>('[data-tab]')]
-  const panels = [...document.querySelectorAll<HTMLElement>('[data-panel]')]
-
   function select(tab: HTMLButtonElement): void {
     for (const other of tabs) {
       const isActive = other === tab
@@ -460,8 +464,6 @@ it('finds a planet', async () => {
   // The strip hides its scrollbar, so a fade marks the edge that still has tabs
   // behind it. Flagging each side separately keeps the hint honest: it clears
   // once you reach that end, and never shows at all when everything fits.
-  const tablist = document.querySelector<HTMLElement>('.orpc-tablist')
-
   function syncOverflowHints(): void {
     if (!tablist) {
       return
@@ -475,62 +477,78 @@ it('finds a planet', async () => {
     tablist.dataset.overflowEnd = String(tablist.scrollLeft < max - slack)
   }
 
-  if (tablist) {
-    syncOverflowHints()
-    tablist.addEventListener('scroll', syncOverflowHints, { passive: true })
-    new ResizeObserver(syncOverflowHints).observe(tablist)
+  const overflowObserver = new ResizeObserver(syncOverflowHints)
 
-    // A trackpad swipes sideways and a touchscreen drags, but a plain mouse has
-    // no way to reach the tabs past the fold. Translate a vertical wheel into
-    // horizontal scroll, and only while the strip can still move that way — at
-    // either end the event is left alone so the page scrolls as usual.
-    tablist.addEventListener('wheel', (event) => {
-      if (event.deltaY === 0 || Math.abs(event.deltaX) > Math.abs(event.deltaY)) {
-        return
-      }
+  function init(): void {
+    tabs = [...document.querySelectorAll<HTMLButtonElement>('[data-tab]')]
+    panels = [...document.querySelectorAll<HTMLElement>('[data-panel]')]
+    tablist = document.querySelector<HTMLElement>('.orpc-tablist')
 
-      const max = tablist.scrollWidth - tablist.clientWidth
-      const next = Math.min(Math.max(tablist.scrollLeft + event.deltaY, 0), max)
+    // The previous strip left with the old body; watch the current one only.
+    overflowObserver.disconnect()
 
-      if (next === tablist.scrollLeft) {
-        return
-      }
+    if (tablist) {
+      syncOverflowHints()
+      tablist.addEventListener('scroll', syncOverflowHints, { passive: true })
+      overflowObserver.observe(tablist)
 
-      event.preventDefault()
-      tablist.scrollLeft = next
-    })
-  }
+      // A trackpad swipes sideways and a touchscreen drags, but a plain mouse has
+      // no way to reach the tabs past the fold. Translate a vertical wheel into
+      // horizontal scroll, and only while the strip can still move that way — at
+      // either end the event is left alone so the page scrolls as usual.
+      tablist.addEventListener('wheel', (event) => {
+        if (!tablist || event.deltaY === 0 || Math.abs(event.deltaX) > Math.abs(event.deltaY)) {
+          return
+        }
 
-  for (const [index, tab] of tabs.entries()) {
-    tab.addEventListener('click', () => {
-      select(tab)
-      // Keeps the active pill in view when the strip scrolls on narrow screens.
-      tab.scrollIntoView({
-        behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth',
-        block: 'nearest',
-        inline: 'nearest',
+        const max = tablist.scrollWidth - tablist.clientWidth
+        const next = Math.min(Math.max(tablist.scrollLeft + event.deltaY, 0), max)
+
+        if (next === tablist.scrollLeft) {
+          return
+        }
+
+        event.preventDefault()
+        tablist.scrollLeft = next
       })
-    })
+    }
 
-    tab.addEventListener('keydown', (event) => {
-      // Horizontal only: the strip lays out as a row at every width, so
-      // ArrowUp/ArrowDown must stay with the page for scrolling.
-      const offset = { ArrowRight: 1, ArrowLeft: -1 }[event.key]
-      const next = offset !== undefined
-        ? tabs[(index + offset + tabs.length) % tabs.length]
-        : event.key === 'Home'
-          ? tabs[0]
-          : event.key === 'End'
-            ? tabs.at(-1)
-            : undefined
+    for (const [index, tab] of tabs.entries()) {
+      tab.addEventListener('click', () => {
+        select(tab)
+        // Keeps the active pill in view when the strip scrolls on narrow screens.
+        tab.scrollIntoView({
+          behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth',
+          block: 'nearest',
+          inline: 'nearest',
+        })
+      })
 
-      if (!next) {
-        return
-      }
+      tab.addEventListener('keydown', (event) => {
+        // Horizontal only: the strip lays out as a row at every width, so
+        // ArrowUp/ArrowDown must stay with the page for scrolling.
+        const offset = { ArrowRight: 1, ArrowLeft: -1 }[event.key]
+        const next = offset !== undefined
+          ? tabs[(index + offset + tabs.length) % tabs.length]
+          : event.key === 'Home'
+            ? tabs[0]
+            : event.key === 'End'
+              ? tabs.at(-1)
+              : undefined
 
-      event.preventDefault()
-      select(next)
-      next.focus()
-    })
+        if (!next) {
+          return
+        }
+
+        event.preventDefault()
+        select(next)
+        next.focus()
+      })
+    }
   }
+
+  init()
+  // Fires once the new body is in place and before any page scripts, so it
+  // covers every re-entry; on pages without the showcase `init` finds nothing.
+  document.addEventListener('astro:after-swap', init)
 </script>

--- a/apps/content/pages/blog/index.astro
+++ b/apps/content/pages/blog/index.astro
@@ -213,27 +213,37 @@ const blogJsonLd = {
 </PageLayout>
 
 <script>
-  const buttons = document.querySelectorAll<HTMLButtonElement>('[data-blog-filter]')
-  const cards = document.querySelectorAll<HTMLElement>('[data-blog-card]')
+  // Astro's ClientRouter swaps the page body on soft navigation but runs this
+  // module only once per full load, so the buttons are re-resolved in `init`,
+  // which runs again after every swap.
+  function init(): void {
+    const buttons = document.querySelectorAll<HTMLButtonElement>('[data-blog-filter]')
+    const cards = document.querySelectorAll<HTMLElement>('[data-blog-card]')
 
-  for (const button of buttons) {
-    button.addEventListener('click', () => {
-      const active = button.dataset.blogFilter ?? ''
+    for (const button of buttons) {
+      button.addEventListener('click', () => {
+        const active = button.dataset.blogFilter ?? ''
 
-      for (const other of buttons) {
-        const isActive = other === button
-        other.classList.toggle('border-foreground', isActive)
-        other.classList.toggle('font-medium', isActive)
-        other.classList.toggle('text-foreground', isActive)
-        other.classList.toggle('border-transparent', !isActive)
-        other.classList.toggle('text-muted-foreground', !isActive)
-      }
+        for (const other of buttons) {
+          const isActive = other === button
+          other.classList.toggle('border-foreground', isActive)
+          other.classList.toggle('font-medium', isActive)
+          other.classList.toggle('text-foreground', isActive)
+          other.classList.toggle('border-transparent', !isActive)
+          other.classList.toggle('text-muted-foreground', !isActive)
+        }
 
-      for (const card of cards) {
-        const cardTags = (card.dataset.tags ?? '').split('|')
-        const visible = !active || cardTags.includes(active)
-        card.style.display = visible ? '' : 'none'
-      }
-    })
+        for (const card of cards) {
+          const cardTags = (card.dataset.tags ?? '').split('|')
+          const visible = !active || cardTags.includes(active)
+          card.style.display = visible ? '' : 'none'
+        }
+      })
+    }
   }
+
+  init()
+  // Fires once the new body is in place and before any page scripts, so it
+  // covers every re-entry; on pages without the filter `init` finds nothing.
+  document.addEventListener('astro:after-swap', init)
 </script>


### PR DESCRIPTION
The code example tabs on the home page stopped responding after navigating to another page and coming back through the header logo. The blog index tag filter had the same problem. Both scripts bound their listeners once per full page load, but Astro's ClientRouter replaces the page body on every soft navigation, so the fresh markup came back without any handlers. Each script now re-resolves its elements in an `init` that runs at load and again on `astro:after-swap`, matching how Blume's own components handle re-entry.

## Fixes

- Home showcase: tab clicks, ArrowLeft/ArrowRight/Home/End, the overflow fade hints, and the wheel-to-horizontal scroll all work after re-entering the home page.
- Blog index: tag filter buttons work after re-entering `/blog`.
- A single ResizeObserver re-targets the current tab strip after each swap instead of leaving a new observer per visit.

## Testing

- Dev server, all soft navigations (confirmed by a window global surviving every hop): home → docs → home, home → blog → home → blog, and a second round trip.
- Tab click, ArrowRight, ArrowLeft, and End switch the selected tab and panel after re-entry; blog tags filter the cards after re-entry; the copy button from #1975 still fires.
- No server errors, no new console errors.