### PR TITLE
fix(openapi): keep path params when compact body is binary

### DIFF
--- a/packages/openapi/src/adapters/fetch/openapi-handler.test.ts
+++ b/packages/openapi/src/adapters/fetch/openapi-handler.test.ts
@@ -70,4 +70,30 @@ describe('openapiHandler', () => {
     expect(response!.status).toBe(200)
     return expect(response!.text()).resolves.toBe('intercepted')
   })
+
+  it('keeps path params when the request body is a binary stream', async () => {
+    const handler = new OpenAPIHandler({
+      upload: os
+        .meta(openapi({ method: 'POST', path: '/items/{id}' }))
+        .handler(({ input }) => ({
+          id: (input as { id: string }).id,
+          hasBody: Boolean((input as { body: unknown }).body),
+        })),
+    })
+
+    const { matched, response } = await handler.handle(
+      new Request('https://example.com/items/42', {
+        method: 'POST',
+        headers: { 'content-type': 'application/octet-stream' },
+        body: new Blob(['raw-bytes'], { type: 'application/octet-stream' }),
+      }),
+    )
+
+    expect(matched).toBe(true)
+    expect(response!.status).toBe(200)
+    await expect(response!.json()).resolves.toEqual({
+      id: '42',
+      hasBody: true,
+    })
+  })
 })

--- a/packages/openapi/src/adapters/standard/openapi-handler-codec.test.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler-codec.test.ts
@@ -357,6 +357,90 @@ describe('openAPIHandlerCodec', () => {
 
         await expect(result!.decodeInput()).resolves.toEqual(['first', 'second'])
       })
+
+      it('merges path params when the body is a Blob', async () => {
+        const blob = new Blob(['raw-bytes'])
+        const serializer = {
+          serialize: vi.fn(),
+          deserialize: vi.fn()
+            .mockReturnValueOnce(undefined)
+            .mockReturnValueOnce(blob),
+        } as any
+
+        const codec = new OpenAPIHandlerCodec(
+          os.meta(openapi({ method: 'POST', path: '/{id}' })).handler(vi.fn()),
+          { serializer },
+        )
+        const resolveBody = vi.fn().mockResolvedValueOnce(blob)
+
+        const result = await codec.resolveProcedure(createRequest({
+          method: 'POST',
+          url: '/24',
+          resolveBody,
+        }), options as any)
+
+        expect(result).toBeDefined()
+
+        await expect(result!.decodeInput()).resolves.toEqual({
+          id: '24',
+          body: blob,
+        })
+      })
+
+      it('returns a Blob body as-is when there are no path params', async () => {
+        const blob = new Blob(['raw-bytes'])
+        const serializer = {
+          serialize: vi.fn(),
+          deserialize: vi.fn()
+            .mockReturnValueOnce(undefined)
+            .mockReturnValueOnce(blob),
+        } as any
+
+        const codec = new OpenAPIHandlerCodec(
+          os.meta(openapi({ method: 'POST', path: '/submit' })).handler(vi.fn()),
+          { serializer },
+        )
+        const resolveBody = vi.fn().mockResolvedValueOnce(blob)
+
+        const result = await codec.resolveProcedure(createRequest({
+          method: 'POST',
+          url: '/submit',
+          resolveBody,
+        }), options as any)
+
+        expect(result).toBeDefined()
+
+        await expect(result!.decodeInput()).resolves.toBe(blob)
+      })
+
+      it('merges path params when the body is a ReadableStream', async () => {
+        const stream = new ReadableStream()
+        const serializer = {
+          serialize: vi.fn(),
+          deserialize: vi.fn()
+            .mockReturnValueOnce(undefined)
+            .mockReturnValueOnce(stream),
+        } as any
+
+        const codec = new OpenAPIHandlerCodec(
+          os.meta(openapi({ method: 'POST', path: '/{id}' })).handler(vi.fn()),
+          { serializer },
+        )
+        const resolveBody = vi.fn().mockResolvedValueOnce(stream)
+
+        const result = await codec.resolveProcedure(createRequest({
+          method: 'POST',
+          url: '/24',
+          resolveBody,
+        }), options as any)
+
+        expect(result).toBeDefined()
+
+        await expect(result!.decodeInput()).resolves.toEqual({
+          id: '24',
+          body: stream,
+        })
+      })
     })
 
     describe('detailed input', () => {

--- a/packages/openapi/src/adapters/standard/openapi-handler-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler-codec.ts
@@ -87,7 +87,14 @@ export class OpenAPIHandlerCodecCore<T extends Context> {
         }
       }
 
-      // data can be Blob, AsyncIteratorObject, ReadableStream, ...
+      if (isBinaryRequestBody(data)) {
+        return {
+          body: data,
+          ...params,
+        }
+      }
+
+      // primitives and arrays stay as-is (cannot field-merge)
       return data
     }
 
@@ -273,6 +280,11 @@ export class OpenAPIHandlerCodec<T extends Context> extends OpenAPIHandlerCodecC
       decodeInput: () => this.decodeInput(matched, request),
     }
   }
+}
+
+function isBinaryRequestBody(data: unknown): boolean {
+  return (typeof Blob === 'function' && data instanceof Blob)
+    || (typeof ReadableStream === 'function' && data instanceof ReadableStream)
 }
 
 function isValidDetailedOutput(output: unknown): output is { status?: number, body?: unknown, headers?: object } {


### PR DESCRIPTION
## Problem

Compact OpenAPI input merges path params into object bodies, and returns only path params when the body is empty. A binary body (`Blob`, `File`, `ReadableStream`) took the remaining branch and was returned as-is, so `POST /items/{id}` with `application/octet-stream` dropped `id`.

Object merge and empty-body behavior were already covered. Primitive and array bodies stay as-is; those cases have existing tests.

## Fix

When the compact body is binary and the path has params, decode to `{ body, ...params }` so `id` is still available. Path params still win if a key collides with `body`.

A binary body with no path params is unchanged.

## Testing

```bash
vitest run packages/openapi/src/adapters/standard/openapi-handler-codec.test.ts packages/openapi/src/adapters/fetch/openapi-handler.test.ts
```
