### PR TITLE
fix(openapi): prefer path params over unmergeable compact body

### DIFF
--- a/apps/content/docs/openapi/input-and-output-mapping.mdx
+++ b/apps/content/docs/openapi/input-and-output-mapping.mdx
@@ -31,7 +31,7 @@ For `GET /planets/earth?q=life`, the procedure receives:
 ```
 
 :::info
-Some requests cannot be merged into a single object. For example, `POST /planets/earth` with a non-object body cannot be merged. In that case, the full input becomes the body. Use [detailed input structure](#detailed-input-structure) if you also need path params.
+Some requests cannot be merged into a single object. For example, `POST /planets/earth` with a non-object body cannot be merged. In that case, the input contains only the path params and the body is ignored, matching the generated OpenAPI specification, which never describes a body for such routes. Use [detailed input structure](#detailed-input-structure) if you also need the body.
 :::
 
 ### Detailed Input Structure

--- a/apps/content/docs/openapi/input-and-output-mapping.mdx
+++ b/apps/content/docs/openapi/input-and-output-mapping.mdx
@@ -31,7 +31,7 @@ For `GET /planets/earth?q=life`, the procedure receives:
 ```
 
 :::info
-Some requests cannot be merged into a single object. For example, `POST /planets/earth` with a non-object body cannot be merged. In that case, the input contains only the path params and the body is ignored, matching the generated OpenAPI specification, which never describes a body for such routes. Use [detailed input structure](#detailed-input-structure) if you also need the body.
+Some requests cannot be merged into a single object. For example, `POST /planets/earth` with a non-object body cannot be merged. In that case, the input contains only the path params and the body is ignored. Use [detailed input structure](#detailed-input-structure) if you also need the body.
 :::
 
 ### Detailed Input Structure

--- a/packages/openapi/src/adapters/standard/openapi-handler-codec.test.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler-codec.test.ts
@@ -278,7 +278,7 @@ describe('openAPIHandlerCodec', () => {
         })
       })
 
-      it('returns a primitive body as-is when it cannot be merged with path params', async () => {
+      it('returns only path params when a primitive body cannot be merged', async () => {
         const serializer = {
           serialize: vi.fn(),
           deserialize: vi.fn()
@@ -300,7 +300,7 @@ describe('openAPIHandlerCodec', () => {
 
         expect(result).toBeDefined()
 
-        await expect(result!.decodeInput()).resolves.toBe('raw-body')
+        await expect(result!.decodeInput()).resolves.toEqual({ id: '24' })
         expect(serializer.deserialize).toHaveBeenNthCalledWith(1, expect.any(URLSearchParams))
         expect(serializer.deserialize).toHaveBeenCalledWith('__body__')
       })
@@ -332,7 +332,7 @@ describe('openAPIHandlerCodec', () => {
         expect(resolveBody).toHaveBeenCalledWith(undefined)
       })
 
-      it('returns an array body as-is even when path params exist', async () => {
+      it('returns only path params when an array body cannot be merged', async () => {
         const serializer = {
           serialize: vi.fn(),
           deserialize: vi.fn()
@@ -355,7 +355,59 @@ describe('openAPIHandlerCodec', () => {
         expect(result).toBeDefined()
         expect(result!.procedure).toBe(procedure)
 
-        await expect(result!.decodeInput()).resolves.toEqual(['first', 'second'])
+        await expect(result!.decodeInput()).resolves.toEqual({ id: '24' })
+      })
+
+      it('returns only path params when a binary body cannot be merged', async () => {
+        const blob = new Blob(['raw-bytes'])
+        const serializer = {
+          serialize: vi.fn(),
+          deserialize: vi.fn()
+            .mockReturnValueOnce(undefined)
+            .mockReturnValueOnce(blob),
+        } as any
+
+        const codec = new OpenAPIHandlerCodec(
+          os.meta(openapi({ method: 'POST', path: '/{id}' })).handler(vi.fn()),
+          { serializer },
+        )
+        const resolveBody = vi.fn().mockResolvedValueOnce(blob)
+
+        const result = await codec.resolveProcedure(createRequest({
+          method: 'POST',
+          url: '/24',
+          resolveBody,
+        }), options as any)
+
+        expect(result).toBeDefined()
+
+        await expect(result!.decodeInput()).resolves.toEqual({ id: '24' })
+      })
+
+      it('returns a binary body as-is when there are no path params', async () => {
+        const blob = new Blob(['raw-bytes'])
+        const serializer = {
+          serialize: vi.fn(),
+          deserialize: vi.fn()
+            .mockReturnValueOnce(undefined)
+            .mockReturnValueOnce(blob),
+        } as any
+
+        const codec = new OpenAPIHandlerCodec(
+          os.meta(openapi({ method: 'POST', path: '/submit' })).handler(vi.fn()),
+          { serializer },
+        )
+        const resolveBody = vi.fn().mockResolvedValueOnce(blob)
+
+        const result = await codec.resolveProcedure(createRequest({
+          method: 'POST',
+          url: '/submit',
+          resolveBody,
+        }), options as any)
+
+        expect(result).toBeDefined()
+
+        await expect(result!.decodeInput()).resolves.toBe(blob)
       })
     })
 

--- a/packages/openapi/src/adapters/standard/openapi-handler-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler-codec.ts
@@ -80,15 +80,16 @@ export class OpenAPIHandlerCodecCore<T extends Context> {
         return data
       }
 
-      if (isPlainObject(data)) {
-        return {
-          ...data,
-          ...params,
-        }
+      // Non-object data (primitive, array, Blob, ReadableStream, ...) cannot be merged with params.
+      // Prefer params to stay consistent with the OpenAPI generator, which only describes path params here.
+      if (!isPlainObject(data)) {
+        return params
       }
 
-      // data can be Blob, AsyncIteratorObject, ReadableStream, ...
-      return data
+      return {
+        ...data,
+        ...params,
+      }
     }
 
     return {


### PR DESCRIPTION
In compact input mode, a non-object body (primitive, array, Blob, ReadableStream, ...) can not be merged with path params. The handler used to drop the params and pass the body through as-is. It now returns the path params and ignores the body, which matches the OpenAPI generator: it only describes path params for such routes and never a body.

Supersedes #1977. Procedures that need both the body and the path params should use the `detailed` input structure.

## Fixes

- `POST /items/{id}` with a binary, primitive, or array body no longer loses `id`.
- Behavior without path params is unchanged: the body is still returned as-is.

## Docs

- The input mapping page now states that only path params are used when the body can not be merged.

## Testing

```bash
pnpm vitest run packages/openapi tests
```