### PR TITLE
fix(shared): await fn() in runWithSpan / runInSpanContext so an already-rejected promise is not observed as unhandled

### DIFF
--- a/packages/shared/src/opentelemetry.ts
+++ b/packages/shared/src/opentelemetry.ts
@@ -130,7 +130,7 @@ export async function runWithSpan<T>(
   const tracer = getOpenTelemetryConfig()?.tracer
 
   if (!tracer) {
-    return fn()
+    return await fn()
   }
 
   if (typeof options === 'string') {
@@ -165,7 +165,7 @@ export async function runInSpanContext<T>(
   const otelConfig = getOpenTelemetryConfig()
 
   if (!span || !otelConfig) {
-    return fn()
+    return await fn()
   }
 
   const ctx = otelConfig.trace.setSpan(otelConfig.context.active(), span)


### PR DESCRIPTION
## Summary

`runWithSpan` and `runInSpanContext` return `fn()` directly when no tracer / span is configured:

```ts
if (!tracer) {
  return fn()
}
```

When `fn` is an `async` handler that throws **before its first `await`** (a very common shape — e.g. an auth guard as the first statement of a procedure handler), `fn()` returns an *already-rejected* promise. Returning it from an `async` function without `await` resolves the outer promise through a `PromiseResolveThenableJob`, so the rejection handler is attached a couple of microtasks after the rejection happened.

Node ignores that gap, but **workerd (Cloudflare Workers) reports it as an unhandled rejection**. Under `@cloudflare/vitest-pool-workers` every such handler call shows up as `Unhandled Rejection` in the test summary (and fails the run on vitest 4), even though `RPCHandler.handle()` correctly turns the error into the error response.

This PR changes both no-tracer paths to `return await fn()`, which attaches the handler immediately (the same thing the tracer path already does via `return await fn(span)` inside `callback`). No behavior change otherwise.

## Reproduction

In a `@cloudflare/vitest-pool-workers` project (vitest 4, pool-workers 0.16 or 0.22):

```ts
import { ORPCError, os } from '@orpc/server'
import { RPCHandler } from '@orpc/server/fetch'

it('async handler throwing before its first await', async () => {
  const handler = new RPCHandler({
    ping: os.handler(async () => {
      throw new ORPCError('UNAUTHORIZED')
    }),
  })
  const { response } = await handler.handle(
    new Request('http://localhost/rpc/ping', {
      method: 'POST',
      headers: { 'content-type': 'application/json' },
      body: JSON.stringify({ json: {} }),
    }),
    { prefix: '/rpc', context: {} },
  )
  expect(response?.status).toBe(401) // passes …
})
// … but vitest reports: Errors 1 error — Unhandled Rejection: Error: Unauthorized
//   ❯ runWithSpan node_modules/@orpc/shared/dist/index.mjs:127:12
```

Bisect results in that environment:

| handler shape | unhandled rejection reported |
|---|---|
| synchronous `throw` | no |
| `async`, `throw` after an `await` | no |
| `async`, `throw` before the first `await` | **yes** |
| same, with this patch applied to `@orpc/shared` | no |

We currently carry this as a one-line `patch` in our repo; happy to add a test if you can suggest a way to assert it outside of workerd (Node's unhandled-rejection tracking does not observe the gap).