### PR TITLE
chore: fix stale nest test guidance in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ pnpm --filter @orpc/server prepack # build one package (unbuild, runs automatica
 ```
 
 - Root vitest config (`vitest.config.ts`) runs all `*.test.ts` with `globals: true`, plus a jsdom project for `*.test.tsx` in `packages/next` and `packages/tanstack-query`.
-- Exceptions: `packages/bun` runs with `bun test`, `packages/cloudflare` with its own vitest (workerd) — both are excluded from the root vitest and root tsconfig, as is `packages/nest`. Run their tests via `pnpm --filter <pkg> test`.
+- Exceptions: `packages/bun` runs with `bun test`, `packages/cloudflare` with its own vitest (workerd) — both are excluded from the root vitest and root tsconfig. Run their tests via `pnpm --filter <pkg> test`. `packages/nest` is excluded only from the root tsconfig (type-check it with `pnpm --filter @orpc/nest type:check`); its tests run in the root vitest.
 - Docs site (Blume): `cd apps/content && pnpm dev` (`blume dev`); `pnpm build` runs `blume build`. Content lives in `.mdx` files; custom pages in `apps/content/pages/`. The dev server caches content-collection frontmatter for custom pages — restart it after editing blog-post frontmatter. `pnpm docs:validate` (root) runs the JSDoc backlink checker plus `blume validate --strict` (links, anchors, assets); CI runs it too.
 - PR titles follow Conventional Commits. Scope rules:
   - Use the package name (e.g. `feat(server): ...`), or `rpc`/`openapi` for changes tied to a protocol rather than a single package, such as its serializers, handlers, links, or dedicated plugins.


### PR DESCRIPTION
CLAUDE.md said `packages/nest` is excluded from the root vitest and that its tests run via `pnpm --filter <pkg> test`. Neither is true anymore: the root vitest collects and runs `packages/nest/src/*.test.ts`, and `@orpc/nest` has no `test` script, so that command silently runs nothing. The sentence now says nest is excluded only from the root tsconfig and points to its `type:check` script instead.

## Verification

- `vitest.config.ts` excludes only `packages/bun` and `packages/cloudflare`; `pnpm vitest list packages/nest` shows the nest test files.
- Root `tsconfig.json` still excludes `packages/nest/**`.
- The bun and cloudflare guidance is unchanged.
