### PR TITLE
chore: remove `--max-warnings=0` from eslint commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; ./node_modules/.bin/eslint --no-warn-ignored --max-warnings=0 --fix \"$f\"; } 2>/dev/null || true",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; ./node_modules/.bin/eslint --no-warn-ignored --fix \"$f\"; } 2>/dev/null || true",
             "timeout": 30,
             "statusMessage": "Running eslint --fix"
           }

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
     "bench": "vitest bench --run",
     "test": "pnpm run -r test && vitest run",
     "test:coverage": "pnpm run -r test:coverage && vitest run --coverage",
-    "lint": "eslint --max-warnings=0 .",
-    "lint:fix": "eslint --max-warnings=0 --fix .",
+    "lint": "eslint .",
+    "lint:fix": "eslint --fix .",
     "repo:fix": "sherif --fix",
     "docs:validate": "node scripts/verify-docs-jsdoc.ts && pnpm run -r docs:validate",
-    "sponsors:sync": "node scripts/sync-sponsors.ts && eslint --max-warnings=0 --fix **/README.md"
+    "sponsors:sync": "node scripts/sync-sponsors.ts && eslint --fix **/README.md"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^9.2.0",
@@ -82,6 +82,6 @@
     "pre-commit": "pnpm lint-staged"
   },
   "lint-staged": {
-    "*": "eslint --no-warn-ignored --max-warnings=0 --fix"
+    "*": "eslint --no-warn-ignored --fix"
   }
 }


### PR DESCRIPTION
Drops `--max-warnings=0` from every eslint invocation so lint warnings no longer fail the check; only errors do.

Applies to the `lint`, `lint:fix`, and `sponsors:sync` scripts, the lint-staged pre-commit command, and the Claude Code post-edit hook. Same change is being applied to middleapi/openapi-spec and middleapi/standardserver.