### PR TITLE
docs: add Cloudflare Workers adapter page

### DIFF
--- a/apps/content/docs/adapters/cloudflare-workers.mdx
+++ b/apps/content/docs/adapters/cloudflare-workers.mdx
@@ -1,0 +1,91 @@
+---
+title: "Cloudflare Workers Adapter"
+description: "Use oRPC on Cloudflare Workers through the Fetch API Adapter, with the compatibility flags that make request cancellation and unhandled rejections behave."
+sidebar:
+  label: "Cloudflare Workers"
+---
+
+[Cloudflare Workers](https://developers.cloudflare.com/workers/) follow the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API), so oRPC integrates through the [Fetch API Adapter](/docs/adapters/fetch-api).
+
+## Basic
+
+<CodeGroup>
+
+```ts RPC
+import { onError } from '@orpc/server'
+import { RPCHandler } from '@orpc/server/fetch'
+import { CORSHandlerPlugin } from '@orpc/server/plugins'
+
+const handler = new RPCHandler(router, {
+  plugins: [
+    new CORSHandlerPlugin()
+  ],
+  interceptors: [
+    onError((error) => {
+      console.error(error)
+    }),
+  ],
+})
+
+export default {
+  async fetch(request, env, ctx) {
+    const { matched, response } = await handler.handle(request, {
+      prefix: '/rpc',
+      context: { env, ctx } // Provide initial context if needed
+    })
+
+    if (matched) {
+      return response
+    }
+
+    return new Response('Not found', { status: 404 })
+  },
+} satisfies ExportedHandler<Env>
+```
+
+```ts OpenAPI
+import { OpenAPIHandler } from '@orpc/openapi/fetch'
+import { onError } from '@orpc/server'
+import { CORSHandlerPlugin } from '@orpc/server/plugins'
+
+const handler = new OpenAPIHandler(router, {
+  plugins: [
+    new CORSHandlerPlugin()
+  ],
+  interceptors: [
+    onError((error) => {
+      console.error(error)
+    }),
+  ],
+})
+
+export default {
+  async fetch(request, env, ctx) {
+    const { matched, response } = await handler.handle(request, {
+      prefix: '/api',
+      context: { env, ctx } // Provide initial context if needed
+    })
+
+    if (matched) {
+      return response
+    }
+
+    return new Response('Not found', { status: 404 })
+  },
+} satisfies ExportedHandler<Env>
+```
+
+</CodeGroup>
+
+## Compatibility Flags
+
+oRPC forwards `request.signal` to every procedure call so handlers can stop work when the client disconnects. Workers only abort that signal when the [`enable_request_signal`](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#enable-requestsignal-for-incoming-requests) flag is set, so add it to your Wrangler configuration:
+
+```jsonc title="wrangler.jsonc"
+{
+  "compatibility_date": "2026-07-01",
+  "compatibility_flags": ["enable_request_signal"]
+}
+```
+
+If your `compatibility_date` is before `2026-03-03`, also add [`unhandled_rejection_after_microtask_checkpoint`](https://developers.cloudflare.com/workers/configuration/compatibility-flags/#defer-unhandled-rejection-processing-to-after-microtask-checkpoint). Without it, Workers can report false `unhandledrejection` errors for promises that are handled a microtask later.

--- a/apps/content/docs/adapters/fetch-api.mdx
+++ b/apps/content/docs/adapters/fetch-api.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Fetch API Adapter"
-description: "Use oRPC with the Fetch API on both servers and clients, in runtimes such as Bun, Deno, and Cloudflare Workers."
+description: "Use oRPC with the Fetch API on both servers and clients, in runtimes such as Bun and Deno."
 sidebar:
   label: "Fetch API"
 ---
@@ -80,12 +80,6 @@ The actual usage of `fetch` depends on the runtime environment or library you us
 Bun.serve({
   fetch,
 })
-```
-
-```ts title="Cloudflare Workers"
-export default {
-  fetch,
-}
 ```
 
 ```ts Deno

--- a/apps/content/docs/adapters/meta.ts
+++ b/apps/content/docs/adapters/meta.ts
@@ -11,6 +11,7 @@ export default defineMeta({
     'message-port',
     'astro',
     'browser',
+    'cloudflare-workers',
     'electron',
     'elysia',
     'expo',

--- a/apps/content/docs/getting-started.mdx
+++ b/apps/content/docs/getting-started.mdx
@@ -73,7 +73,7 @@ A few things to notice:
 
 ## Create a Server
 
-Clients reach your router through an HTTP server. `RPCHandler` does the translation: it matches each incoming request to a procedure, validates the input, runs your handler, and sends the result back. This example uses [Node's built-in HTTP module](/docs/adapters/node-http). The same router also runs on Bun, Deno, and Cloudflare Workers through the [Fetch API adapter](/docs/adapters/fetch-api).
+Clients reach your router through an HTTP server. `RPCHandler` does the translation: it matches each incoming request to a procedure, validates the input, runs your handler, and sends the result back. This example uses [Node's built-in HTTP module](/docs/adapters/node-http). The same router also runs on Bun and Deno through the [Fetch API adapter](/docs/adapters/fetch-api), and on [Cloudflare Workers](/docs/adapters/cloudflare-workers).
 
 ```ts twoslash
 /// <reference types="node" />

--- a/apps/content/docs/requirements.mdx
+++ b/apps/content/docs/requirements.mdx
@@ -22,7 +22,7 @@ oRPC's core abstractions are written against the JavaScript language and standar
 | Android WebView | 94 | — |
 | iOS WebView (WKWebView) | 16.4 | — |
 
-Browsers update themselves, so there is nothing to recommend beyond the minimum. Edge and Chrome on Android match Chrome, Samsung Internet needs 17.0, and Safari on iOS matches iOS WebView. Cloudflare Workers tracks current V8 and ships every Web API oRPC uses; use the [Fetch Adapter](/docs/adapters/fetch-api) there. [React Native](#react-native) is not a web view and needs a polyfill.
+Browsers update themselves, so there is nothing to recommend beyond the minimum. Edge and Chrome on Android match Chrome, Samsung Internet needs 17.0, and Safari on iOS matches iOS WebView. Cloudflare Workers tracks current V8 and ships every Web API oRPC uses; use the [Cloudflare Workers Adapter](/docs/adapters/cloudflare-workers) there. [React Native](#react-native) is not a web view and needs a polyfill.
 
 Some optional features need more: compression needs Deno 1.19, Bun 1.3.3, and Firefox 113; [AsyncIteratorObject](/docs/async-iterator-object) needs Firefox 105 and Bun 1.1.23; `Blob` or `File` payloads need Node.js 20; and the [Encryption](/docs/helpers/encryption), [Signing](/docs/helpers/signing), and [Pino](/docs/integrations/pino) integrations need Node.js 19 for a bare `crypto` global.
 

--- a/playgrounds/cloudflare/wrangler.jsonc
+++ b/playgrounds/cloudflare/wrangler.jsonc
@@ -3,7 +3,7 @@
   "name": "orpc-cloudflare-playground",
   "main": "worker/index.ts",
   "compatibility_date": "2026-07-01",
-  "compatibility_flags": ["nodejs_compat"],
+  "compatibility_flags": ["nodejs_compat", "enable_request_signal"],
   "assets": { "not_found_handling": "single-page-application" },
   "observability": {
     "enabled": true


### PR DESCRIPTION
Adds a dedicated Cloudflare Workers adapter page and moves the Workers-specific bits out of the Fetch API adapter page. The new page shows the `export default { fetch }` entry with `env` and `ctx` passed as context, and recommends the compatibility flags oRPC relies on: `enable_request_signal`, so `request.signal` actually aborts when the client disconnects, and `unhandled_rejection_after_microtask_checkpoint` on compatibility dates before 2026-03-03, so Workers stop reporting false `unhandledrejection` errors.

## Docs

- New `/docs/adapters/cloudflare-workers` page, listed in the adapters sidebar after Browser.
- The Fetch API adapter page no longer mentions Cloudflare Workers; its runtime tabs are Bun and Deno only.
- Requirements and Getting Started link to the new page instead of the Fetch API adapter.

## Playground

- `playgrounds/cloudflare` enables `enable_request_signal`, so its `EvlogHandlerPlugin({ logAbort: true })` can observe client aborts.

## Testing

- `pnpm docs:validate` passes (JSDoc backlinks and `blume validate --strict`), eslint is clean, and every external Cloudflare and MDN link returns 200.
