### PR TITLE
docs(server): restore Better Auth integration guide for v2

### DIFF
--- a/apps/content/docs/integrations/better-auth.mdx
+++ b/apps/content/docs/integrations/better-auth.mdx
@@ -8,7 +8,7 @@ sidebar:
 Use your [Better Auth](https://better-auth.com/) instance with oRPC's [context](/docs/context) and [middleware](/docs/middleware). No extra package is needed.
 
 :::tip
-To forward Better Auth's [response headers](https://better-auth.com/docs/concepts/api#getting-headers), such as a refreshed session cookie, use `returnHeaders: true` with the [Response Headers Plugin](/docs/plugins/response-headers). This does not work for [batched](/docs/plugins/batch) requests.
+You may need to forward Better Auth's [response headers](https://better-auth.com/docs/concepts/api#getting-headers), such as a refreshed session cookie. The [Response Headers Plugin](/docs/plugins/response-headers) can help unless you use the [Batch Plugin](/docs/plugins/batch).
 :::
 
 ## Resolve the Session in Middleware

--- a/apps/content/docs/integrations/better-auth.mdx
+++ b/apps/content/docs/integrations/better-auth.mdx
@@ -5,23 +5,24 @@ sidebar:
   label: "Better Auth"
 ---
 
-Use your configured [Better Auth](https://better-auth.com/) instance with oRPC's [context](/docs/context) and [middleware](/docs/middleware). No additional oRPC package is needed.
-
-The examples below import that instance from `./auth`. Keep Better Auth's authentication routes mounted through its [framework integration](https://better-auth.com/docs/installation#mount-handler), alongside your oRPC handler.
+Use your [Better Auth](https://better-auth.com/) instance with oRPC's [context](/docs/context) and [middleware](/docs/middleware). No extra package is needed.
 
 ## Resolve the Session in Middleware
 
-Pass the request headers into context and load the session only for procedures that use the authentication middleware. Public procedures can use the same base without looking up a session.
+The [Request Headers Plugin](/docs/plugins/request-headers) exposes request headers as `context.reqHeaders`. The middleware loads the session from them and rejects unauthenticated calls. Public procedures use the base directly. Each protected call performs its own lookup, including every sub-request of a [batch](/docs/plugins/batch).
 
 ```ts
+import type { RequestHeadersHandlerPluginContext } from '@orpc/server/plugins'
 import { ORPCError, os } from '@orpc/server'
-import { RPCHandler } from '@orpc/server/fetch'
-import { auth } from './auth'
 
-const base = os.$context<{ headers: Headers }>()
+interface ServerContext extends RequestHeadersHandlerPluginContext {}
+
+const base = os.$context<ServerContext>()
 
 const requireSession = base.middleware(async ({ context, next }) => {
-  const session = await auth.api.getSession({ headers: context.headers })
+  const session = await auth.api.getSession({
+    headers: context.reqHeaders ?? new Headers(),
+  })
 
   if (!session) {
     throw new ORPCError('UNAUTHORIZED')
@@ -39,52 +40,53 @@ const router = {
     name: context.session.user.name,
   })),
 }
-
-const handler = new RPCHandler(router)
-
-export async function handleRPC(request: Request): Promise<Response> {
-  const { matched, response } = await handler.handle(request, {
-    prefix: '/rpc',
-    context: { headers: request.headers },
-  })
-
-  return matched ? response : new Response('Not Found', { status: 404 })
-}
 ```
 
-Here, `context.session` holds Better Auth's complete session result, including its `user` and `session` fields. Its type is inferred from your configured auth instance, so additional fields remain available in protected handlers.
+`context.session` is Better Auth's full result with `user` and `session`. Its type is inferred from your auth instance, so additional fields stay available.
 
-Only a missing session becomes `UNAUTHORIZED`. Errors thrown by `getSession`, such as a database failure, propagate to oRPC's [error handling](/docs/error-handling).
+Only a missing session becomes `UNAUTHORIZED`. Other errors from `getSession` propagate to oRPC's [error handling](/docs/error-handling).
 
-## Reuse a Session from Context
+`reqHeaders` is `undefined` without the plugin, such as in [server-side calls](/docs/client/server-side). The empty fallback makes the session `null` there, since `getSession` rejects missing headers. Pass `reqHeaders` in the initial context to authenticate such calls.
 
-If your server already resolves the session before calling oRPC, pass that result into context. The middleware can check and narrow the existing value without another lookup.
+## Lazily Load and Share the Session
 
-This alternative also lets public procedures read an optional session. It resolves the session for every request passed to `handleRPC`, including public procedures; prefer the first approach when only protected procedures need it.
+If your server resolves the session itself, pass a lazy getter into the initial context instead of the session. The lookup runs at most once per request and only when a procedure asks for it. This includes [batch](/docs/plugins/batch) requests, where every sub-request shares the getter. The same getter can also serve the rest of your request handling.
 
 ```ts
 import { ORPCError, os } from '@orpc/server'
 import { RPCHandler } from '@orpc/server/fetch'
-import { auth } from './auth'
 
 type Session = Awaited<ReturnType<typeof auth.api.getSession>>
 
-const base = os.$context<{ session: Session }>()
+function once<T>(fn: () => Promise<T>): () => Promise<T> {
+  let promise: Promise<T> | undefined
+
+  return () => {
+    promise ??= fn()
+    return promise
+  }
+}
+
+const base = os.$context<{ getSession: () => Promise<Session> }>()
 
 const requireSession = base.middleware(async ({ context, next }) => {
-  if (!context.session) {
+  const session = await context.getSession()
+
+  if (!session) {
     throw new ORPCError('UNAUTHORIZED')
   }
 
-  return next({ context: { session: context.session } })
+  return next({ context: { session } })
 })
 
 const protectedProcedure = base.use(requireSession)
 
 const router = {
-  greeting: base.handler(({ context }) => ({
-    message: `Hello, ${context.session?.user.name ?? 'guest'}`,
-  })),
+  greeting: base.handler(async ({ context }) => {
+    const session = await context.getSession()
+
+    return { message: `Hello, ${session?.user.name ?? 'guest'}` }
+  }),
   me: protectedProcedure.handler(({ context }) => ({
     id: context.session.user.id,
     name: context.session.user.name,
@@ -93,21 +95,14 @@ const router = {
 
 const handler = new RPCHandler(router)
 
-export async function handleRPC(request: Request): Promise<Response> {
-  const session = await auth.api.getSession({ headers: request.headers })
+export async function fetch(request: Request): Promise<Response> {
+  const getSession = once(() => auth.api.getSession({ headers: request.headers }))
+
   const { matched, response } = await handler.handle(request, {
     prefix: '/rpc',
-    context: { session },
+    context: { getSession },
   })
 
   return matched ? response : new Response('Not Found', { status: 404 })
 }
 ```
-
-`Session` includes `null`. After `requireSession` runs, protected handlers receive a non-null session while public handlers must still check for it. The value passed to `next` is merged into context, preserving other context fields.
-
-In this version, session lookup happens outside the oRPC handler. Handle lookup failures at your server's error boundary.
-
-:::info
-Server-side Better Auth calls do not automatically forward response headers to the browser. If your session setup needs cookie updates from `getSession`, follow Better Auth's [response headers guidance](https://better-auth.com/docs/concepts/api#getting-headers) and your framework's cookie integration.
-:::

--- a/apps/content/docs/integrations/better-auth.mdx
+++ b/apps/content/docs/integrations/better-auth.mdx
@@ -1,0 +1,113 @@
+---
+title: "Better Auth Integration"
+description: "Use Better Auth sessions in oRPC context and protect procedures with typed middleware."
+sidebar:
+  label: "Better Auth"
+---
+
+Use your configured [Better Auth](https://better-auth.com/) instance with oRPC's [context](/docs/context) and [middleware](/docs/middleware). No additional oRPC package is needed.
+
+The examples below import that instance from `./auth`. Keep Better Auth's authentication routes mounted through its [framework integration](https://better-auth.com/docs/installation#mount-handler), alongside your oRPC handler.
+
+## Resolve the Session in Middleware
+
+Pass the request headers into context and load the session only for procedures that use the authentication middleware. Public procedures can use the same base without looking up a session.
+
+```ts
+import { ORPCError, os } from '@orpc/server'
+import { RPCHandler } from '@orpc/server/fetch'
+import { auth } from './auth'
+
+const base = os.$context<{ headers: Headers }>()
+
+const requireSession = base.middleware(async ({ context, next }) => {
+  const session = await auth.api.getSession({ headers: context.headers })
+
+  if (!session) {
+    throw new ORPCError('UNAUTHORIZED')
+  }
+
+  return next({ context: { session } })
+})
+
+const protectedProcedure = base.use(requireSession)
+
+const router = {
+  ping: base.handler(() => ({ message: 'pong' })),
+  me: protectedProcedure.handler(({ context }) => ({
+    id: context.session.user.id,
+    name: context.session.user.name,
+  })),
+}
+
+const handler = new RPCHandler(router)
+
+export async function handleRPC(request: Request): Promise<Response> {
+  const { matched, response } = await handler.handle(request, {
+    prefix: '/rpc',
+    context: { headers: request.headers },
+  })
+
+  return matched ? response : new Response('Not Found', { status: 404 })
+}
+```
+
+Here, `context.session` holds Better Auth's complete session result, including its `user` and `session` fields. Its type is inferred from your configured auth instance, so additional fields remain available in protected handlers.
+
+Only a missing session becomes `UNAUTHORIZED`. Errors thrown by `getSession`, such as a database failure, propagate to oRPC's [error handling](/docs/error-handling).
+
+## Reuse a Session from Context
+
+If your server already resolves the session before calling oRPC, pass that result into context. The middleware can check and narrow the existing value without another lookup.
+
+This alternative also lets public procedures read an optional session. It resolves the session for every request passed to `handleRPC`, including public procedures; prefer the first approach when only protected procedures need it.
+
+```ts
+import { ORPCError, os } from '@orpc/server'
+import { RPCHandler } from '@orpc/server/fetch'
+import { auth } from './auth'
+
+type Session = Awaited<ReturnType<typeof auth.api.getSession>>
+
+const base = os.$context<{ session: Session }>()
+
+const requireSession = base.middleware(async ({ context, next }) => {
+  if (!context.session) {
+    throw new ORPCError('UNAUTHORIZED')
+  }
+
+  return next({ context: { session: context.session } })
+})
+
+const protectedProcedure = base.use(requireSession)
+
+const router = {
+  greeting: base.handler(({ context }) => ({
+    message: `Hello, ${context.session?.user.name ?? 'guest'}`,
+  })),
+  me: protectedProcedure.handler(({ context }) => ({
+    id: context.session.user.id,
+    name: context.session.user.name,
+  })),
+}
+
+const handler = new RPCHandler(router)
+
+export async function handleRPC(request: Request): Promise<Response> {
+  const session = await auth.api.getSession({ headers: request.headers })
+  const { matched, response } = await handler.handle(request, {
+    prefix: '/rpc',
+    context: { session },
+  })
+
+  return matched ? response : new Response('Not Found', { status: 404 })
+}
+```
+
+`Session` includes `null`. After `requireSession` runs, protected handlers receive a non-null session while public handlers must still check for it. The value passed to `next` is merged into context, preserving other context fields.
+
+In this version, session lookup happens outside the oRPC handler. Handle lookup failures at your server's error boundary.
+
+:::info
+Server-side Better Auth calls do not automatically forward response headers to the browser. If your session setup needs cookie updates from `getSession`, follow Better Auth's [response headers guidance](https://better-auth.com/docs/concepts/api#getting-headers) and your framework's cookie integration.
+:::

--- a/apps/content/docs/integrations/better-auth.mdx
+++ b/apps/content/docs/integrations/better-auth.mdx
@@ -46,7 +46,7 @@ const router = {
 
 Only a missing session becomes `UNAUTHORIZED`. Other errors from `getSession` propagate to oRPC's [error handling](/docs/error-handling).
 
-`reqHeaders` is `undefined` without the plugin, such as in [server-side calls](/docs/client/server-side). The empty fallback makes the session `null` there, since `getSession` rejects missing headers. Pass `reqHeaders` in the initial context to authenticate such calls.
+`reqHeaders` is `undefined` without the plugin, such as in [server-side calls](/docs/client/server-side). The empty `Headers` fallback carries no session cookie, so `getSession` returns `null` and protected calls return `UNAUTHORIZED`. Pass `reqHeaders` in the initial context to authenticate such calls.
 
 ## Lazily Load and Share the Session
 
@@ -106,3 +106,5 @@ export async function fetch(request: Request): Promise<Response> {
   return matched ? response : new Response('Not Found', { status: 404 })
 }
 ```
+
+Both examples may need to forward session cookies to the browser; see Better Auth's [response headers guidance](https://better-auth.com/docs/concepts/api#getting-headers).

--- a/apps/content/docs/integrations/better-auth.mdx
+++ b/apps/content/docs/integrations/better-auth.mdx
@@ -7,6 +7,10 @@ sidebar:
 
 Use your [Better Auth](https://better-auth.com/) instance with oRPC's [context](/docs/context) and [middleware](/docs/middleware). No extra package is needed.
 
+:::warning
+`getSession` may return response headers, such as a refreshed session cookie. The examples below do not forward them. If you do not use the [Batch Plugin](/docs/plugins/batch), the [Response Headers Plugin](/docs/plugins/response-headers) can forward them: call `getSession` with `returnHeaders: true` and append the returned [headers](https://better-auth.com/docs/concepts/api#getting-headers) to `context.resHeaders`. Batched sub-requests cannot set browser cookies.
+:::
+
 ## Resolve the Session in Middleware
 
 The [Request Headers Plugin](/docs/plugins/request-headers) exposes request headers as `context.reqHeaders`. The middleware loads the session from them and rejects unauthenticated calls. Public procedures use the base directly. Each protected call performs its own lookup, including every sub-request of a [batch](/docs/plugins/batch).
@@ -106,5 +110,3 @@ export async function fetch(request: Request): Promise<Response> {
   return matched ? response : new Response('Not Found', { status: 404 })
 }
 ```
-
-Both examples may need to forward session cookies to the browser; see Better Auth's [response headers guidance](https://better-auth.com/docs/concepts/api#getting-headers).

--- a/apps/content/docs/integrations/better-auth.mdx
+++ b/apps/content/docs/integrations/better-auth.mdx
@@ -7,8 +7,8 @@ sidebar:
 
 Use your [Better Auth](https://better-auth.com/) instance with oRPC's [context](/docs/context) and [middleware](/docs/middleware). No extra package is needed.
 
-:::warning
-`getSession` may return response headers, such as a refreshed session cookie. The examples below do not forward them. If you do not use the [Batch Plugin](/docs/plugins/batch), the [Response Headers Plugin](/docs/plugins/response-headers) can forward them: call `getSession` with `returnHeaders: true` and append the returned [headers](https://better-auth.com/docs/concepts/api#getting-headers) to `context.resHeaders`. Batched sub-requests cannot set browser cookies.
+:::tip
+To forward Better Auth's [response headers](https://better-auth.com/docs/concepts/api#getting-headers), such as a refreshed session cookie, use `returnHeaders: true` with the [Response Headers Plugin](/docs/plugins/response-headers). This does not work for [batched](/docs/plugins/batch) requests.
 :::
 
 ## Resolve the Session in Middleware


### PR DESCRIPTION
Restores the Better Auth integration guide for v2 with two examples: resolving the session in protected middleware, and lazily loading a session once per request, shared across batch sub-requests. Both show public and protected procedures, inferred session types, and the lookup/error-handling tradeoffs.

Related to #1892. This is a documentation-first contribution; the dedicated package remains open for discussion.

Validation:
- `pnpm docs:validate`
- `pnpm --filter @orpc/content build`
- Both extracted examples typechecked against Better Auth 1.7.2, including an additional user field.
