### PR TITLE
fix(effect): default middlewareGen type parameters so standalone middleware works on concrete procedures

### DIFF
--- a/packages/effect/src/middleware.test-d.ts
+++ b/packages/effect/src/middleware.test-d.ts
@@ -105,6 +105,34 @@ describe('middlewareGen', () => {
     void procedure
   })
 
+  it('infers everything without type arguments when created via os.middleware', () => {
+    interface ServerContext extends WithEffectContext<Service1> {
+      auth: boolean
+    }
+
+    const requireAuth = os
+      .$context<ServerContext>()
+      .middleware(middlewareGen(function* ({ context, next }) {
+        expectTypeOf(context.auth).toEqualTypeOf<boolean>()
+        yield* Service1
+
+        return yield* next({ context: { user: 'user' as const } })
+      }))
+
+    const procedure = os
+      .$context<ServerContext>()
+      .input(z.object({ id: z.string() }))
+      .output(z.string())
+      .use(requireAuth)
+      .handler(({ context }) => {
+        expectTypeOf(context.user).toEqualTypeOf<'user'>()
+
+        return 'output'
+      })
+
+    void procedure
+  })
+
   it('supports standalone middleware on procedures with concrete input/output', () => {
     interface ServerContext extends WithEffectContext<Service1> {
       auth: boolean

--- a/packages/effect/src/middleware.test-d.ts
+++ b/packages/effect/src/middleware.test-d.ts
@@ -105,6 +105,47 @@ describe('middlewareGen', () => {
     void procedure
   })
 
+  it('supports standalone middleware on procedures with concrete input/output', () => {
+    interface ServerContext extends WithEffectContext<Service1> {
+      auth: boolean
+    }
+
+    const requireAuth = middlewareGen<ServerContext, { user: 'user' }>(
+      function* ({ context, next }) {
+        expectTypeOf(context.auth).toEqualTypeOf<boolean>()
+        yield* Service1
+
+        return yield* next({ context: { user: 'user' as const } })
+      },
+    )
+
+    const procedure = os
+      .$context<ServerContext>()
+      .input(z.object({ id: z.string() }))
+      .output(z.string())
+      .use(requireAuth)
+      .handler(({ context }) => {
+        expectTypeOf(context.user).toEqualTypeOf<'user'>()
+
+        return 'output'
+      })
+
+    void procedure
+
+    const decorated = os
+      .$context<ServerContext>()
+      .middleware(requireAuth)
+
+    const decoratedProcedure = os
+      .$context<ServerContext>()
+      .input(z.object({ id: z.string() }))
+      .output(z.string())
+      .use(decorated)
+      .handler(() => 'output')
+
+    void decoratedProcedure
+  })
+
   it('can infer typed errors through os.middleware', () => {
     // Unlike `.use`, `os.middleware` types `errors` from the builder's error map
     // because its middleware parameter references the error map non-generically.

--- a/packages/effect/src/middleware.ts
+++ b/packages/effect/src/middleware.ts
@@ -50,11 +50,11 @@ export type AnyMiddlewareGen = MiddlewareGen<any, any, any, any, any, any>
  */
 export function middlewareGen<
   TInContext extends Context,
-  TInput,
-  TOutput,
-  TErrorMap extends ErrorMap,
-  TYield extends Effect.Effect<any, any, InferEffectServices<TInContext>>,
   TOutContext extends Context = object,
+  TInput = unknown,
+  TOutput = any, // TOutput = any by default is important to make middleware can be used in any output by default
+  TErrorMap extends ErrorMap = Record<never, never>,
+  TYield extends Effect.Effect<any, any, InferEffectServices<TInContext>> = Effect.Effect<any, any, InferEffectServices<TInContext>>,
 >(
   middleware: MiddlewareGen<TInContext, TOutContext, TInput, TOutput, TYield, ORPCErrorConstructorMap<TErrorMap>>,
 ): Middleware<TInContext, TOutContext, TInput, TOutput, TErrorMap> {


### PR DESCRIPTION
A standalone middleware created with `middlewareGen` cannot be attached to any procedure that has a concrete output:

```ts
const requireAuth = middlewareGen(function* ({ context, next }) { /* … */ })

os.$context<ServerContext>()
  .input(z.object({ id: z.string() }))
  .output(z.string())
  .use(requireAuth)
// ^ TOutput infers `unknown`, but procedure-level `.use()` requires the
//   procedure's output type — does not compile
```

Before this change, the only way to make it compile was to spell out all six type arguments, including a hand-written `any`:

```ts
const requireAuth = middlewareGen<
  ServerContext,
  unknown,
  any, // required just so `.use()` accepts the middleware on any output
  Record<never, never>,
  Effect.Effect<unknown, unknown, InferEffectServices<ServerContext>>,
  { user: User }
>(function* ({ context, next }) {
  if (!context.auth)
    return yield* Effect.fail(new ORPCError('UNAUTHORIZED'))

  return yield* next({ context: { user: context.auth.user } })
})
```

Core already solves this for vanilla middleware: `Builder.middleware` declares `$Output = any` with the comment *"$Output = any by default is important to make middleware can be used in any output by default"* (`packages/server/src/builder.ts`). `middlewareGen` has no defaults, so inference falls back to `unknown` and the middleware is only usable inline or on builders without input/output schemas — which is exactly what the existing standalone type test covered, so this went unnoticed.

This mirrors the core defaults (`TInput = unknown`, `TOutput = any`, `TErrorMap = Record<never, never>`, `TYield` defaulted) and moves `TOutContext` to the second position, so the same middleware becomes:

```ts
const requireAuth = middlewareGen<ServerContext, { user: User }>(
  function* ({ context, next }) {
    if (!context.auth)
      return yield* Effect.fail(new ORPCError('UNAUTHORIZED'))

    return yield* next({ context: { user: context.auth.user } })
  },
)
```

And when the middleware is created through a builder's `.middleware()`, no type arguments are needed at all — the in-context arrives contextually and the narrowed out-context is inferred from `next({ context: … })`:

```ts
const requireAuth = os
  .$context<ServerContext>()
  .middleware(middlewareGen(function* ({ context, next }) {
    if (!context.auth)
      return yield* Effect.fail(new ORPCError('UNAUTHORIZED'))

    return yield* next({ context: { user: context.auth.user } })
  }))
```

(The zero-argument form compiles under `tsc` even without the defaults thanks to context-sensitive inference threading `$Output = any` into the inner call, but the TypeScript 7 native compiler resolves the inner call to `unknown` on the current signature — with the defaults it works there too. Both forms are covered by the added type tests.)

Note the reorder is breaking for callers passing explicit type arguments — but passing all six explicitly was previously the only way to make standalone middleware compile, so the affected code is the code this fixes. If you'd rather avoid the reorder, adding only the defaults (keeping the current order) also fixes compilation; the reorder is what makes the explicit form pleasant.

Adds type tests attaching a standalone generator middleware to a procedure with concrete input/output — via `.use()` with explicit type arguments, and via `.middleware()` with none.

Validated against a real consumer (an Effect 4 + `@orpc/experimental-effect` API on TypeScript 7): the auth-guard middleware in the six-argument form above reduces to the zero/two-argument forms, with the app's full typecheck and test suite passing.
