### PR TITLE
docs(effect): fix direct-call error-handling example to use safe()

### DIFF
--- a/apps/content/docs/integrations/effect.mdx
+++ b/apps/content/docs/integrations/effect.mdx
@@ -170,7 +170,7 @@ const procedure = os.handler(handlerGen(function* ({ errors }) {
   return 'Success'
 }))
 
-const [error, result] = await call(procedure)
+const [error, data] = await safe(call(procedure))
 
 if (isInferableError(error)) {
   // typesafe error handling


### PR DESCRIPTION
The "Typesafe Errors" example in the Effect integration guide destructures the result of `call(procedure)` as a tuple:

```ts
const [error, result] = await call(procedure)
```

`call` returns the output directly (or throws), so as written the error path never reaches `isInferableError` and the success path destructures the string `'Success'`. Switched to `await safe(call(procedure))`, matching the `safe` idiom used elsewhere in the docs.
