### PR TITLE
feat!: migrate to @openapi-spec types and target OpenAPI 3.2 with a version option

### DIFF
--- a/apps/content/docs/migrations/from-v1.mdx
+++ b/apps/content/docs/migrations/from-v1.mdx
@@ -1020,10 +1020,11 @@ const spec = await generator.generate(router, {
 
 </CodeGroup>
 
-Two smaller changes in the same area:
+Three smaller changes in the same area:
 
 - The `oo` helper (`oo.spec`) was removed. To customize the operation object, attach [`openapi({ spec })` metadata](/docs/openapi/specification#customizing-the-operation-object) directly on the procedure or router.
 - The `shouldHoistDef` option was replaced by [`customComponentName`](/docs/openapi/specification#hoisting-defs). Root `$defs` are now always hoisted into `components.schemas`; this option only renames them.
+- Documents are generated as OpenAPI 3.2.0 by default. Pass [`version: '3.1.1'`](/docs/openapi/specification#openapi-version) to keep old behavior.
 
 ### `OpenAPIReferencePlugin` renamed and reshaped
 

--- a/apps/content/docs/openapi/specification.mdx
+++ b/apps/content/docs/openapi/specification.mdx
@@ -1,6 +1,6 @@
 ---
 title: "OpenAPI Specification"
-description: "Learn how to configure openapi metadata and generate OpenAPI 3.1 documents from your oRPC contracts and routers with OpenAPIGenerator."
+description: "Learn how to configure openapi metadata and generate OpenAPI 3.2, 3.1, or 3.0 documents from your oRPC contracts and routers with OpenAPIGenerator."
 ---
 
 ## Metadata
@@ -38,7 +38,7 @@ For routing metadata, you can learn more in [OpenAPI Routing](/docs/openapi/rout
 
 ### Customizing the Operation Object
 
-Use `spec` to customize the generated operation object. If `spec` is an object, it replaces the generated operation object entirely. If `spec` is a callback, it receives the final operation object and returns an extended version.
+Use `spec` to customize the generated operation object. If `spec` is an object, it replaces the generated operation object entirely. If `spec` is a callback, it receives the final operation object and returns an extended version. The operation object always follows OpenAPI 3.2, whatever [version](#openapi-version) you generate.
 
 ```ts
 const getPlanet = oc
@@ -131,7 +131,7 @@ In this example, the final `tags` is `undefined`, so no tags are applied to `exa
 
 ## OpenAPI Generator
 
-`OpenAPIGenerator` accepts either a [contract](/docs/contract/router) or a [router](/docs/router) and generates an OpenAPI 3.1 document by default. OpenAPI 3.2 is partially supported.
+`OpenAPIGenerator` turns a [contract](/docs/contract/router) or a [router](/docs/router) into an OpenAPI document.
 
 ```ts
 import { OpenAPIGenerator } from '@orpc/openapi'
@@ -141,6 +141,7 @@ const generator = new OpenAPIGenerator({
 })
 
 const spec = await generator.generate(router, {
+  version: '3.2.0',
   base: {
     info: {
       title: 'Planet API',
@@ -153,17 +154,23 @@ const spec = await generator.generate(router, {
 })
 ```
 
-### QUERY method
+`base` provides the OpenAPI 3.2 document fields to start from, such as `info`, `servers`, or `components`. The `openapi` field comes from `version`.
 
-If your router contains a procedure that uses the `QUERY` method, explicitly set the OpenAPI version to `3.2.0`, because OpenAPI 3.1 does not support `QUERY`.
+### OpenAPI Version
+
+`version` selects the OpenAPI version, `3.2.0` by default. Any `3.0.x`, `3.1.x`, or `3.2.x` value works.
 
 ```ts
 const spec = await generator.generate(router, {
-  base: {
-    openapi: '3.2.0',
-  },
+  version: '3.0.4',
 })
 ```
+
+The document is always built as OpenAPI 3.2, so `base`, [`openapi({ spec })`](#customizing-the-operation-object), and every JSON schema follow 3.2. Older versions come from downgrading the whole document with [`@openapi-spec/downgrader`](https://github.com/middleapi/openapi-spec/blob/main/packages/downgrader/README.md), which converts what the older version can still express and removes the rest.
+
+:::warning
+`QUERY` operations require OpenAPI 3.2. Generating an older version from a router with a `QUERY` procedure throws.
+:::
 
 ### Json Schema Converters
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,10 +39,8 @@ export default antfu({
     'no-restricted-imports': ['error', {
       patterns: [{
         group: [
-          '/json-schema-typed',
-          '/openapi-types',
+          '/@openapi-spec/types',
           '/@standard-schema/spec',
-          '/@hey-api/spec-types',
           '/compression',
         ],
         message: 'Please import from @orpc/* instead',

--- a/packages/json-schema/package.json
+++ b/packages/json-schema/package.json
@@ -45,12 +45,12 @@
     "type:check": "tsc -b"
   },
   "dependencies": {
+    "@openapi-spec/types": "~0.1.0",
     "@orpc/client": "workspace:*",
     "@orpc/contract": "workspace:*",
     "@orpc/server": "workspace:*",
     "@orpc/shared": "workspace:*",
-    "@standard-schema/spec": "^1.1.0",
-    "json-schema-typed": "^8.0.2"
+    "@standard-schema/spec": "^1.1.0"
   },
   "devDependencies": {
     "zod": "^4.5.4"

--- a/packages/json-schema/src/coercer.ts
+++ b/packages/json-schema/src/coercer.ts
@@ -161,7 +161,7 @@ export class JsonSchemaCoercer {
                 : []
 
             const itemSchema: JsonSchema | undefined = Array.isArray(schema.items)
-              ? schema.additionalItems
+              ? schema.additionalItems as JsonSchema | undefined
               : schema.items as JsonSchema | undefined
 
             let shouldUseCoercedItems = false

--- a/packages/json-schema/src/composition-utils.test.ts
+++ b/packages/json-schema/src/composition-utils.test.ts
@@ -1548,15 +1548,16 @@ describe('combineJsonSchemasWithComposition', () => {
       {
         allOf: [{ $ref: '#/$defs/toString' }, { $ref: '#/$defs/valueOf' }],
         $defs: {
-          toString: { type: 'string' },
-          constructor: { type: 'boolean' },
+          // Object.prototype member names get a method contextual type, `satisfies` keeps `type` literal
+          toString: { type: 'string' } satisfies JsonSchema,
+          constructor: { type: 'boolean' } satisfies JsonSchema,
         },
       },
       {
         $ref: '#/$defs/toString',
         $defs: {
-          toString: { type: 'number' },
-          constructor: { type: 'boolean' },
+          toString: { type: 'number' } satisfies JsonSchema,
+          constructor: { type: 'boolean' } satisfies JsonSchema,
         },
       },
     ])).toEqual({
@@ -1581,7 +1582,7 @@ describe('combineJsonSchemasWithComposition', () => {
   it('never lets two renames in the same branch land on the same target', () => {
     // A skips the taken A2..A11 and lands on A12, which A1 would otherwise take as its own first choice
     const taken = Object.fromEntries(
-      ['A', 'A1', 'A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8', 'A9', 'A10', 'A11'].map(name => [name, { type: 'string' }]),
+      ['A', 'A1', 'A2', 'A3', 'A4', 'A5', 'A6', 'A7', 'A8', 'A9', 'A10', 'A11'].map((name): [string, JsonSchema] => [name, { type: 'string' }]),
     )
 
     expect(combineJsonSchemasWithComposition('anyOf', [

--- a/packages/json-schema/src/types.ts
+++ b/packages/json-schema/src/types.ts
@@ -1,13 +1,54 @@
 // eslint-disable-next-line no-restricted-imports
-import type * as Draft2020 from 'json-schema-typed/draft-2020-12'
+import type { OpenAPIV3_2 } from '@openapi-spec/types'
 
 /**
  * A JSON Schema (draft 2020-12) representation used across oRPC's JSON schema tooling.
  *
+ * @remarks
+ * It is also the OpenAPI 3.2 Schema Object, so converted schemas embed into OpenAPI documents as-is.
+ *
  * @see {@link https://orpc.dev/docs/integrations/standard-schema | Standard Schema Integration}
  */
-export type JsonSchema<Value = any> = Draft2020.JSONSchema<Value>
-export type JsonSchemaKeywords = typeof Draft2020.keywords[number]
+export type JsonSchema<Value = any> = OpenAPIV3_2.SchemaObject<Value>
+
+/**
+ * The declared JSON Schema keywords, the index signature is filtered out.
+ */
+export type JsonSchemaKeywords = keyof {
+  [K in keyof OpenAPIV3_2.SchemaObjectFields as string extends K ? never : K]: unknown
+}
+
+export enum JsonSchemaType {
+  Array = 'array',
+  Boolean = 'boolean',
+  Integer = 'integer',
+  Null = 'null',
+  Number = 'number',
+  Object = 'object',
+  String = 'string',
+}
+
+export enum JsonSchemaFormat {
+  Date = 'date',
+  DateTime = 'date-time',
+  Duration = 'duration',
+  Email = 'email',
+  Hostname = 'hostname',
+  IDNEmail = 'idn-email',
+  IDNHostname = 'idn-hostname',
+  IPv4 = 'ipv4',
+  IPv6 = 'ipv6',
+  IRI = 'iri',
+  IRIReference = 'iri-reference',
+  JSONPointer = 'json-pointer',
+  RegEx = 'regex',
+  RelativeJSONPointer = 'relative-json-pointer',
+  Time = 'time',
+  URI = 'uri',
+  URIReference = 'uri-reference',
+  URITemplate = 'uri-template',
+  UUID = 'uuid',
+}
 
 export enum JsonSchemaXNativeType {
   BigInt = 'bigint',
@@ -17,6 +58,3 @@ export enum JsonSchemaXNativeType {
   Set = 'set',
   Map = 'map',
 }
-
-// eslint-disable-next-line no-restricted-imports
-export { Format as JsonSchemaFormat, TypeName as JsonSchemaType } from 'json-schema-typed/draft-2020-12'

--- a/packages/openapi/package.json
+++ b/packages/openapi/package.json
@@ -115,7 +115,8 @@
     }
   },
   "dependencies": {
-    "@hey-api/spec-types": "0.0.0-next-20260408030107",
+    "@openapi-spec/downgrader": "~0.1.0",
+    "@openapi-spec/types": "~0.1.0",
     "@orpc/client": "workspace:*",
     "@orpc/contract": "workspace:*",
     "@orpc/json-schema": "workspace:*",

--- a/packages/openapi/src/meta.ts
+++ b/packages/openapi/src/meta.ts
@@ -2,7 +2,7 @@ import type { AnyProcedureContract, AnySchema, ErrorMap, MetaPlugin } from '@orp
 import type { Lazy } from '@orpc/server'
 import type { Value } from '@orpc/shared'
 import type { StandardBodyHint } from '@standard-server/core'
-import type { OpenAPIOperationObject } from './types'
+import type { OpenAPIV3_2 } from './types'
 import { mergeHttpPath } from '@orpc/shared'
 
 export interface OpenAPIMeta {
@@ -289,6 +289,9 @@ export interface OpenAPIMeta {
    * Pass a plain object to replace entire operation object, or a function that receives the current
    * operation object and returns the modified version.
    *
+   * The operation object always follows OpenAPI 3.2, `OpenAPIGenerator` downgrades it with the
+   * rest of the document when an older version is requested.
+   *
    * **Merging**: When defined multiple times:
    *
    * - Two functions are chained: the most recent function receives the result of the previous one.
@@ -297,7 +300,7 @@ export interface OpenAPIMeta {
    *
    * Explicitly setting `undefined` resets the spec instead of merging.
    */
-  spec?: Value<OpenAPIOperationObject, [current: OpenAPIOperationObject]>
+  spec?: Value<OpenAPIV3_2.OperationObject, [current: OpenAPIV3_2.OperationObject]>
 
   /**
    * Prefix for the path. Useful when you want to apply a common path prefix across multiple procedures.

--- a/packages/openapi/src/openapi-generator-components.test.ts
+++ b/packages/openapi/src/openapi-generator-components.test.ts
@@ -1,5 +1,5 @@
 import type { JsonSchema } from '@orpc/json-schema'
-import type { OpenAPIDocument } from './types'
+import type { OpenAPIV3_2 } from './types'
 import { OpenAPIComponentRegistry } from './openapi-generator-components'
 
 describe('openAPIComponentRegistry', () => {
@@ -7,8 +7,8 @@ describe('openAPIComponentRegistry', () => {
     schemas?: Record<string, any>
     customComponentName?: (defName: string, defSchema: JsonSchema) => string | undefined
   } = {}) {
-    const doc: OpenAPIDocument = {
-      openapi: '3.1.2',
+    const doc: OpenAPIV3_2.OpenAPIObject = {
+      openapi: '3.2.0',
       info: { title: 'API Reference', version: '0.0.0' },
       ...(options.schemas ? { components: { schemas: options.schemas } } : {}),
     }

--- a/packages/openapi/src/openapi-generator-components.ts
+++ b/packages/openapi/src/openapi-generator-components.ts
@@ -1,7 +1,5 @@
-// eslint-disable-next-line no-restricted-imports
-import type { OpenAPIV3_1 } from '@hey-api/spec-types'
 import type { JsonSchema, JsonSchemaConverterDirection } from '@orpc/json-schema'
-import type { OpenAPIDocument } from './types'
+import type { OpenAPIV3_2 } from './types'
 import {
   decodeJsonPointerSegment,
   encodeJsonPointerSegment,
@@ -18,7 +16,7 @@ import { isDeepEqual } from '@orpc/shared'
  */
 export class OpenAPIComponentRegistry {
   constructor(
-    private readonly doc: OpenAPIDocument,
+    private readonly doc: OpenAPIV3_2.OpenAPIObject,
     private readonly customComponentName: ((defName: string, defSchema: JsonSchema) => string | undefined) | undefined,
   ) {}
 
@@ -119,14 +117,14 @@ export class OpenAPIComponentRegistry {
       componentsSchemas[componentName] = rewriteComponentSchemaRefs(
         cleanSchema,
         renameMap,
-      ) as OpenAPIV3_1.SchemaObject
+      )
     }
 
     return rewriteComponentSchemaRefs(rest, renameMap)
   }
 
-  toOpenAPISchema(schema: JsonSchema, direction?: JsonSchemaConverterDirection): OpenAPIV3_1.SchemaObject {
-    return ensureJsonSchemaObject(this.hoistDefs(schema, direction)) as OpenAPIV3_1.SchemaObject
+  toOpenAPISchema(schema: JsonSchema, direction?: JsonSchemaConverterDirection): OpenAPIV3_2.SchemaObject {
+    return ensureJsonSchemaObject(this.hoistDefs(schema, direction))
   }
 }
 

--- a/packages/openapi/src/openapi-generator-operation.test.ts
+++ b/packages/openapi/src/openapi-generator-operation.test.ts
@@ -1,6 +1,6 @@
 import type { AnyProcedureContract, AnySchema, ErrorMap } from '@orpc/contract'
 import type { OpenAPIOperationContext } from './openapi-generator-operation'
-import type { OpenAPIDocument, OpenAPIOperationObject } from './types'
+import type { OpenAPIV3_2 } from './types'
 import { COMMON_ERROR_STATUS_MAP } from '@orpc/client'
 import { asyncIteratorObject, error } from '@orpc/contract'
 import { combineJsonSchemasWithComposition, DelegatingJsonSchemaConverter } from '@orpc/json-schema'
@@ -21,8 +21,8 @@ describe('openAPIGenerator operation builders', () => {
     errorStatusMap?: Record<string, number>
     customErrorResponseBodySchema?: OpenAPIOperationContext['customErrorResponseBodySchema']
   } = {}) {
-    const doc: OpenAPIDocument = {
-      openapi: '3.1.2',
+    const doc: OpenAPIV3_2.OpenAPIObject = {
+      openapi: '3.2.0',
       info: { title: 'API Reference', version: '0.0.0' },
       ...(options.schemas ? { components: { schemas: options.schemas } } : {}),
     }
@@ -47,7 +47,7 @@ describe('openAPIGenerator operation builders', () => {
       customErrorResponseBodySchema: options.customErrorResponseBodySchema,
     }
 
-    const operation: OpenAPIOperationObject = {}
+    const operation: OpenAPIV3_2.OperationObject = {}
 
     return { doc, ctx, operation }
   }
@@ -486,7 +486,7 @@ describe('openAPIGenerator operation builders', () => {
         })],
       }), undefined)
 
-      expect(operation.responses?.[200]).toEqual({
+      expect(operation.responses?.['200']).toEqual({
         description: 'OK',
         content: {
           'application/json': { schema: { type: 'object' } },
@@ -513,7 +513,7 @@ describe('openAPIGenerator operation builders', () => {
         })],
       }), undefined)
 
-      expect(operation.responses?.[200]).toEqual({
+      expect(operation.responses?.['200']).toEqual({
         description: 'OK',
         content: {
           'multipart/form-data': {
@@ -533,7 +533,7 @@ describe('openAPIGenerator operation builders', () => {
         outputs: [asyncIteratorObject(testSchema({ type: 'string' }))],
       }), undefined)
 
-      expect(operation.responses?.[200]).toEqual({
+      expect(operation.responses?.['200']).toEqual({
         description: 'OK',
         content: {
           'text/event-stream': {
@@ -670,7 +670,7 @@ describe('openAPIGenerator operation builders', () => {
         },
       }))
 
-      expect(operation.responses?.[400]).toEqual({
+      expect(operation.responses?.['400']).toEqual({
         description: 'Second bad request',
         content: {
           'application/json': {
@@ -684,7 +684,7 @@ describe('openAPIGenerator operation builders', () => {
           },
         },
       })
-      expect(operation.responses?.[408]).toEqual({
+      expect(operation.responses?.['408']).toEqual({
         description: '408',
         content: {
           'application/json': {
@@ -751,7 +751,7 @@ describe('openAPIGenerator operation builders', () => {
 
       buildErrorResponse(ctx, operation, testDef({ errors: { '---': {} } }))
 
-      expect((operation.responses?.[500] as any).content['application/json'].schema.oneOf[0]).toEqual({
+      expect((operation.responses?.['500'] as any).content['application/json'].schema.oneOf[0]).toEqual({
         $ref: '#/components/schemas/Error',
       })
     })
@@ -772,7 +772,7 @@ describe('openAPIGenerator operation builders', () => {
         },
       }))
 
-      expect((operation.responses?.[409] as any).content['application/json'].schema.oneOf[0]).toEqual({
+      expect((operation.responses?.['409'] as any).content['application/json'].schema.oneOf[0]).toEqual({
         $ref: '#/components/schemas/Conflict2',
       })
       expect(doc.components?.schemas?.Conflict).toEqual({ type: 'string' })
@@ -797,7 +797,7 @@ describe('openAPIGenerator operation builders', () => {
         },
       }))
 
-      expect(operation.responses?.[403]).toEqual({
+      expect(operation.responses?.['403']).toEqual({
         description: 'Access denied',
         content: {
           'application/json': {
@@ -852,11 +852,11 @@ describe('openAPIGenerator operation builders', () => {
         },
       ], 400)
 
-      expect((operation.responses?.[400] as any).content['application/json'].schema).toEqual({
+      expect((operation.responses?.['400'] as any).content['application/json'].schema).toEqual({
         type: 'object',
         description: 'custom-400',
       })
-      expect((operation.responses?.[404] as any).content['application/json'].schema).toEqual(
+      expect((operation.responses?.['404'] as any).content['application/json'].schema).toEqual(
         expect.objectContaining({ oneOf: expect.any(Array) }),
       )
     })

--- a/packages/openapi/src/openapi-generator-operation.ts
+++ b/packages/openapi/src/openapi-generator-operation.ts
@@ -1,11 +1,9 @@
-// eslint-disable-next-line no-restricted-imports
-import type { OpenAPIV3_1 } from '@hey-api/spec-types'
 import type { AnyProcedureContract, AnySchema } from '@orpc/contract'
 import type { JsonObjectSchemaEntry, JsonSchema, JsonSchemaConverterDirection } from '@orpc/json-schema'
 import type { Value } from '@orpc/shared'
 import type { OpenAPIMeta } from './meta'
 import type { OpenAPIComponentRegistry } from './openapi-generator-components'
-import type { OpenAPIOperationObject } from './types'
+import type { OpenAPIV3_2 } from './types'
 import type { getDynamicPathParams } from './utils'
 import { getAsyncIteratorObjectSchemaDetails } from '@orpc/contract'
 import {
@@ -84,7 +82,7 @@ interface RequestParts {
 
 export function buildRequest(
   ctx: OpenAPIOperationContext,
-  operation: OpenAPIOperationObject,
+  operation: OpenAPIV3_2.OperationObject,
   def: AnyProcedureContract['~orpc'],
   meta: OpenAPIMeta | undefined,
   dynamicPathParams: DynamicPathParam[] | undefined,
@@ -193,7 +191,7 @@ function extractDetailedRequestParts(schema: JsonSchema): RequestParts {
 
 function renderPathParameters(
   ctx: OpenAPIOperationContext,
-  operation: OpenAPIOperationObject,
+  operation: OpenAPIV3_2.OperationObject,
   dynamicParams: string[] | undefined,
   paramsEntries: JsonObjectSchemaEntry[] | undefined,
   paramsStyles: OpenAPIMeta['paramsStyles'],
@@ -229,7 +227,7 @@ function renderPathParameters(
     }
 
     const style = paramsStyles?.[name]
-    const parameter: Exclude<OpenAPIOperationObject['parameters'], undefined>[number] = {
+    const parameter: OpenAPIV3_2.ParameterObject = {
       in: 'path',
       required: true,
       name,
@@ -251,13 +249,13 @@ function renderPathParameters(
 
 function renderQueryParameters(
   ctx: OpenAPIOperationContext,
-  operation: OpenAPIOperationObject,
+  operation: OpenAPIV3_2.OperationObject,
   queryEntries: JsonObjectSchemaEntry[] | undefined,
   queryStyles: OpenAPIMeta['queryStyles'],
 ): void {
   for (const [name, schema, optional] of queryEntries ?? []) {
     const style = queryStyles?.[name]
-    const parameter: Exclude<OpenAPIOperationObject['parameters'], undefined>[number] = {
+    const parameter: OpenAPIV3_2.ParameterObject = {
       in: 'query',
       name,
       schema: ctx.registry.toOpenAPISchema(schema, 'input'),
@@ -305,7 +303,7 @@ function renderQueryParameters(
 
 function renderHeaderParameters(
   ctx: OpenAPIOperationContext,
-  operation: OpenAPIOperationObject,
+  operation: OpenAPIV3_2.OperationObject,
   headersEntries: JsonObjectSchemaEntry[] | undefined,
 ): void {
   for (const [name, schema, optional] of headersEntries ?? []) {
@@ -321,7 +319,7 @@ function renderHeaderParameters(
 
 export function buildSuccessResponse(
   ctx: OpenAPIOperationContext,
-  operation: OpenAPIOperationObject,
+  operation: OpenAPIV3_2.OperationObject,
   def: AnyProcedureContract['~orpc'],
   meta: OpenAPIMeta | undefined,
 ): void {
@@ -334,7 +332,7 @@ export function buildSuccessResponse(
 
     if (iteratorDetails) {
       operation.responses ??= {}
-      operation.responses[status] = {
+      operation.responses[toResponseStatusKey(status)] = {
         description,
         content: toAsyncIteratorObjectContent(
           ctx,
@@ -352,7 +350,7 @@ export function buildSuccessResponse(
 
   if (isUnconstrainedSchema(schema) || outputStructure === 'compact') {
     operation.responses ??= {}
-    operation.responses[status] = {
+    operation.responses[toResponseStatusKey(status)] = {
       description,
       content: toBodyContent(ctx, 'output', schema),
     }
@@ -360,7 +358,7 @@ export function buildSuccessResponse(
   }
 
   for (const [responseStatus, parts] of extractDetailedResponseParts(schema, status)) {
-    const responseObject: OpenAPIV3_1.ResponseObject = {
+    const responseObject: OpenAPIV3_2.ResponseObject = {
       description: parts.descriptions.length ? parts.descriptions.join(', ') : description,
     }
 
@@ -380,8 +378,15 @@ export function buildSuccessResponse(
     }
 
     operation.responses ??= {}
-    operation.responses[responseStatus] = responseObject
+    operation.responses[toResponseStatusKey(responseStatus)] = responseObject
   }
+}
+
+/**
+ * Formats a numeric HTTP status as a Responses Object key.
+ */
+function toResponseStatusKey(status: number): `${1 | 2 | 3 | 4 | 5}${string}` {
+  return String(status) as `${1 | 2 | 3 | 4 | 5}${string}`
 }
 
 /**
@@ -442,7 +447,7 @@ function extractDetailedResponseParts(
 
 export function buildErrorResponse(
   ctx: OpenAPIOperationContext,
-  operation: OpenAPIOperationObject,
+  operation: OpenAPIV3_2.OperationObject,
   def: AnyProcedureContract['~orpc'],
 ): void {
   const definitionsByStatus = new Map<number, OpenAPIErrorBodyDefinition[]>()
@@ -503,14 +508,14 @@ export function buildErrorResponse(
     ])
 
     operation.responses ??= {}
-    operation.responses[status] = {
+    operation.responses[toResponseStatusKey(status)] = {
       description: descriptions.length ? descriptions.join(', ') : status.toString(),
       content: {
         'application/json': {
           schema: ctx.registry.toOpenAPISchema(responseSchema, 'output'),
         },
       },
-    } satisfies OpenAPIV3_1.ResponseObject
+    } satisfies OpenAPIV3_2.ResponseObject
   }
 }
 
@@ -591,7 +596,7 @@ function toAsyncIteratorObjectContent(
   }
 }
 
-function toBodyContent(ctx: OpenAPIOperationContext, direction: JsonSchemaConverterDirection, schema: JsonSchema): Record<string, OpenAPIV3_1.MediaTypeObject> {
+function toBodyContent(ctx: OpenAPIOperationContext, direction: JsonSchemaConverterDirection, schema: JsonSchema): Record<string, OpenAPIV3_2.MediaTypeObject> {
   const fileSchemasByMediaType = new Map<string, JsonSchema[]>()
 
   const rest = flattenJsonUnionSchema(schema).filter((s) => {
@@ -611,7 +616,7 @@ function toBodyContent(ctx: OpenAPIOperationContext, direction: JsonSchemaConver
     return false
   })
 
-  const content: Record<string, OpenAPIV3_1.MediaTypeObject> = {}
+  const content: Record<string, OpenAPIV3_2.MediaTypeObject> = {}
 
   if (rest.length > 0) {
     const restSchema = fileSchemasByMediaType.size ? combineJsonSchemasWithComposition('anyOf', rest) : schema

--- a/packages/openapi/src/openapi-generator.test-d.ts
+++ b/packages/openapi/src/openapi-generator.test-d.ts
@@ -1,0 +1,33 @@
+import type { OpenAPIDocument, OpenAPIV3_0, OpenAPIV3_1, OpenAPIV3_2, OpenAPIVersion } from './types'
+import { OpenAPIGenerator } from './openapi-generator'
+
+describe('openAPIGenerator.generate', () => {
+  const generator = new OpenAPIGenerator()
+
+  it('returns the document type of the requested version', () => {
+    expectTypeOf(generator.generate({})).resolves.toEqualTypeOf<OpenAPIV3_2.OpenAPIObject>()
+    expectTypeOf(generator.generate({}, {})).resolves.toEqualTypeOf<OpenAPIV3_2.OpenAPIObject>()
+    expectTypeOf(generator.generate({}, { version: '3.2.0' })).resolves.toEqualTypeOf<OpenAPIV3_2.OpenAPIObject>()
+    expectTypeOf(generator.generate({}, { version: '3.2.7' })).resolves.toEqualTypeOf<OpenAPIV3_2.OpenAPIObject>()
+    expectTypeOf(generator.generate({}, { version: '3.1.2' })).resolves.toEqualTypeOf<OpenAPIV3_1.OpenAPIObject>()
+    expectTypeOf(generator.generate({}, { version: '3.1.0' })).resolves.toEqualTypeOf<OpenAPIV3_1.OpenAPIObject>()
+    expectTypeOf(generator.generate({}, { version: '3.0.4' })).resolves.toEqualTypeOf<OpenAPIV3_0.OpenAPIObject>()
+    expectTypeOf(generator.generate({}, { version: '3.0.0' })).resolves.toEqualTypeOf<OpenAPIV3_0.OpenAPIObject>()
+  })
+
+  it('widens to every supported document when the version is not a literal', () => {
+    const version = '3.1.2' as OpenAPIVersion
+
+    expectTypeOf(generator.generate({}, { version })).resolves.toEqualTypeOf<OpenAPIDocument<OpenAPIVersion>>()
+    expectTypeOf(generator.generate({}, { version: undefined })).resolves.toEqualTypeOf<OpenAPIDocument<OpenAPIVersion>>()
+  })
+
+  it('rejects unsupported versions and the openapi field in base', () => {
+    // @ts-expect-error unsupported version
+    generator.generate({}, { version: '4.0.0' })
+    // @ts-expect-error the patch segment is required
+    generator.generate({}, { version: '3.2' })
+    // @ts-expect-error the openapi field is derived from version
+    generator.generate({}, { base: { openapi: '3.2.0' } })
+  })
+})

--- a/packages/openapi/src/openapi-generator.test.ts
+++ b/packages/openapi/src/openapi-generator.test.ts
@@ -10,7 +10,7 @@ describe('openAPIGenerator basic & options', () => {
 
   it('starts from the default base document', async () => {
     await expect(generator.generate({})).resolves.toEqual({
-      openapi: '3.1.2',
+      openapi: '3.2.0',
       info: {
         title: 'API Reference',
         version: '0.0.0',
@@ -18,14 +18,12 @@ describe('openAPIGenerator basic & options', () => {
     })
   })
 
-  it('generates QUERY operations in an explicit OpenAPI 3.2 document', async () => {
+  it('generates QUERY operations in the default OpenAPI 3.2 document', async () => {
     const doc = await generator.generate({
       search: oc
         .meta(openapi({ method: 'QUERY', path: '/search' }))
         .input(z.object({ term: z.string() }))
         .output(z.object({ result: z.string() })),
-    }, {
-      base: { openapi: '3.2.0' },
     })
 
     expect(doc.openapi).toBe('3.2.0')
@@ -56,11 +54,11 @@ describe('openAPIGenerator basic & options', () => {
     }))
   })
 
-  it('rejects QUERY operations unless the base document uses OpenAPI 3.2', async () => {
+  it('rejects QUERY operations when an older OpenAPI version is requested', async () => {
     await expect(generator.generate({
       search: oc.meta(openapi({ method: 'QUERY', path: '/search' })),
-    })).rejects.toThrow(
-      'QUERY operations require OpenAPI 3.2. Set base.openapi to \'3.2.0\'.',
+    }, { version: '3.1.2' })).rejects.toThrow(
+      'QUERY operations require OpenAPI 3.2, but version "3.1.2" was requested.',
     )
   })
 
@@ -83,7 +81,7 @@ describe('openAPIGenerator basic & options', () => {
     })
 
     expect(serializer.serialize).toHaveBeenCalledWith({
-      openapi: '3.1.2',
+      openapi: '3.2.0',
       info: {
         title: 'Planet API',
         version: '1.2.3',
@@ -95,7 +93,7 @@ describe('openAPIGenerator basic & options', () => {
     })
 
     expect(doc).toEqual({
-      openapi: '3.1.2',
+      openapi: '3.2.0',
       info: {
         title: 'Planet API',
         version: '1.2.3',
@@ -488,5 +486,84 @@ describe('openAPIGenerator basic & options', () => {
 
     expect(error).not.toBeInstanceOf(OpenAPIGeneratorError)
     expect(error.message).toBe('converter exploded')
+  })
+})
+
+describe('openAPIGenerator version', () => {
+  const generator = new OpenAPIGenerator({ converters: [testSchemaConverter] })
+
+  const router = {
+    planet: oc
+      .meta(openapi({ method: 'GET', path: '/planets/{id}' }))
+      .input(testSchema({ type: 'object', properties: { id: { type: 'string' } }, required: ['id'] }))
+      .output(testSchema({ type: 'object', properties: { name: { type: ['string', 'null'] } } })),
+  }
+
+  const planetPath = {
+    get: {
+      operationId: 'planet',
+      parameters: [
+        { in: 'path', name: 'id', required: true, schema: { type: 'string' } },
+      ],
+      responses: {
+        200: {
+          description: 'OK',
+          content: {
+            'application/json': {
+              schema: { type: 'object', properties: { name: { type: ['string', 'null'] } } },
+            },
+          },
+        },
+      },
+    },
+  }
+
+  it.each(['3.2.0', '3.2.7'] as const)('generates OpenAPI %s', async (version) => {
+    await expect(generator.generate(router, { version })).resolves.toEqual({
+      openapi: version,
+      info: { title: 'API Reference', version: '0.0.0' },
+      paths: { '/planets/{id}': planetPath },
+    })
+  })
+
+  it.each(['3.1.2', '3.1.0'] as const)('downgrades to OpenAPI %s', async (version) => {
+    await expect(generator.generate(router, { version })).resolves.toEqual({
+      openapi: version,
+      info: { title: 'API Reference', version: '0.0.0' },
+      paths: { '/planets/{id}': planetPath },
+    })
+  })
+
+  it.each(['3.0.4', '3.0.0'] as const)('downgrades to OpenAPI %s', async (version) => {
+    await expect(generator.generate(router, { version })).resolves.toEqual({
+      openapi: version,
+      info: { title: 'API Reference', version: '0.0.0' },
+      paths: {
+        '/planets/{id}': {
+          get: {
+            ...planetPath.get,
+            responses: {
+              200: {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    schema: { type: 'object', properties: { name: { type: 'string', nullable: true } } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+  })
+
+  it('serializes non-JSON values after downgrading', async () => {
+    const doc = await generator.generate({}, {
+      version: '3.0.4',
+      base: { info: { 'title': 'Planet API', 'version': '1.0.0', 'x-generated-at': new Date('2020-01-01T00:00:00.000Z') } },
+    })
+
+    expect(doc.info['x-generated-at']).toBe('2020-01-01T00:00:00.000Z')
   })
 })

--- a/packages/openapi/src/openapi-generator.ts
+++ b/packages/openapi/src/openapi-generator.ts
@@ -4,7 +4,8 @@ import type { AnyProcedure, AnyRouter } from '@orpc/server'
 import type { Value } from '@orpc/shared'
 import type { OpenAPIMeta } from './meta'
 import type { OpenAPIErrorBodyDefinition, OpenAPIOperationContext } from './openapi-generator-operation'
-import type { OpenAPIDocument, OpenAPIOperationObject } from './types'
+import type { OpenAPIDocument, OpenAPIV3_2, OpenAPIVersion } from './types'
+import { downgradeSpecV31ToV30, downgradeSpecV32ToV31 } from '@openapi-spec/downgrader'
 import { COMMON_ERROR_STATUS_MAP } from '@orpc/client'
 import { combineJsonSchemasWithComposition, DelegatingJsonSchemaConverter, StandardJsonSchemaConverter } from '@orpc/json-schema'
 import { walkProcedureContractsAsync } from '@orpc/server'
@@ -34,8 +35,22 @@ export interface OpenAPIGeneratorOptions {
   serializer?: Pick<OpenAPISerializer, keyof OpenAPISerializer> | undefined
 }
 
-export interface OpenAPIGeneratorGenerateOptions {
-  base?: Partial<OpenAPIDocument> | undefined
+export interface OpenAPIGeneratorGenerateOptions<TVersion extends OpenAPIVersion> {
+  /**
+   * The OpenAPI version of the generated document.
+   * The document is generated as OpenAPI 3.2 and downgraded when an older version is requested.
+   * The minor version selects the conversion, the document carries the exact value, such as `3.1.0`.
+   *
+   * @default '3.2.0'
+   */
+  version?: TVersion | undefined
+
+  /**
+   * OpenAPI 3.2 document fields to start from, such as `info`, `servers`, or `components`.
+   * They are downgraded with the rest of the document when an older `version` is requested.
+   * The `openapi` field is derived from `version`.
+   */
+  base?: Partial<Omit<OpenAPIV3_2.OpenAPIObject, 'openapi'>> | undefined
 
   /**
    * Root-level `$defs` are always moved into `components.schemas`.
@@ -63,6 +78,7 @@ export interface OpenAPIGeneratorGenerateOptions {
    *
    * @remarks
    * - Return `null | undefined` to use the default error response body shaper.
+   * - The schema is an OpenAPI 3.2 Schema Object, it is downgraded with the rest of the document when an older `version` is requested.
    */
   customErrorResponseBodySchema?: Value<
     JsonSchema | undefined | null,
@@ -95,10 +111,15 @@ export class OpenAPIGenerator {
     ])
   }
 
-  async generate(router: RouterContract | AnyRouter, options: OpenAPIGeneratorGenerateOptions = {}): Promise<OpenAPIDocument> {
-    const doc: OpenAPIDocument = {
+  async generate<TVersion extends OpenAPIVersion = '3.2.0'>(
+    router: RouterContract | AnyRouter,
+    options: OpenAPIGeneratorGenerateOptions<TVersion> = {},
+  ): Promise<OpenAPIDocument<TVersion>> {
+    const version: OpenAPIVersion = options.version ?? '3.2.0'
+
+    const doc: OpenAPIV3_2.OpenAPIObject = {
       ...clone(options.base),
-      openapi: options.base?.openapi ?? '3.1.2',
+      openapi: '3.2.0',
       info: options.base?.info ?? { title: 'API Reference', version: '0.0.0' },
     }
 
@@ -122,9 +143,9 @@ export class OpenAPIGenerator {
 
         const method = (meta?.method ?? DEFAULT_OPENAPI_METHOD).toLowerCase() as Lowercase<NonNullable<OpenAPIMeta['method']>>
 
-        if (method === 'query' && doc.openapi !== '3.2.0') {
+        if (method === 'query' && !version.startsWith('3.2.')) {
           throw new OpenAPIGeneratorError(
-            `QUERY operations require OpenAPI 3.2. Set base.openapi to '3.2.0'.`,
+            `QUERY operations require OpenAPI 3.2, but version "${version}" was requested.`,
           )
         }
 
@@ -133,7 +154,7 @@ export class OpenAPIGenerator {
         const dynamicPathParams = getDynamicPathParams(httpPath)
         const openApiPath = toOpenAPIPath(httpPath, dynamicPathParams)
 
-        let operation: OpenAPIOperationObject
+        let operation: OpenAPIV3_2.OperationObject
 
         if (meta?.spec !== undefined && typeof meta.spec !== 'function') {
           operation = meta.spec
@@ -174,7 +195,8 @@ export class OpenAPIGenerator {
       )
     }
 
-    return this.serializer.serialize(doc, { asFormData: false, useFormDataForBlobFields: false }) as OpenAPIDocument
+    const versioned = toVersionedOpenAPIDocument(doc, version)
+    return this.serializer.serialize(versioned, { asFormData: false, useFormDataForBlobFields: false }) as OpenAPIDocument<TVersion>
   }
 
   private convertSchema(schema: AnySchema | undefined, direction: JsonSchemaConverterDirection): [JsonSchema, boolean] {
@@ -194,6 +216,16 @@ export class OpenAPIGenerator {
       results.every(([, optional]) => optional),
     ]
   }
+}
+
+function toVersionedOpenAPIDocument(doc: OpenAPIV3_2.OpenAPIObject, version: OpenAPIVersion): OpenAPIDocument<OpenAPIVersion> {
+  const downgraded = version.startsWith('3.2.')
+    ? doc
+    : version.startsWith('3.1.')
+      ? downgradeSpecV32ToV31(doc)
+      : downgradeSpecV31ToV30(downgradeSpecV32ToV31(doc))
+
+  return { ...downgraded, openapi: version } as OpenAPIDocument<OpenAPIVersion>
 }
 
 function strip$schemaField(schema: JsonSchema): JsonSchema {

--- a/packages/openapi/src/plugins/openapi-reference.test.ts
+++ b/packages/openapi/src/plugins/openapi-reference.test.ts
@@ -1,4 +1,4 @@
-import type { OpenAPIDocument } from '../types'
+import type { OpenAPIDocument, OpenAPIVersion } from '../types'
 import { OpenAPIReferenceHandlerPlugin } from './openapi-reference'
 
 describe('openAPIReferenceHandlerPlugin', () => {
@@ -6,7 +6,7 @@ describe('openAPIReferenceHandlerPlugin', () => {
     vi.clearAllMocks()
   })
 
-  function createSpec(title = 'Example API'): OpenAPIDocument {
+  function createSpec(title = 'Example API'): OpenAPIDocument<OpenAPIVersion> {
     return {
       openapi: '3.1.0',
       info: {
@@ -14,7 +14,7 @@ describe('openAPIReferenceHandlerPlugin', () => {
         version: '1.0.0',
       },
       paths: {},
-    } as OpenAPIDocument
+    } as OpenAPIDocument<OpenAPIVersion>
   }
 
   function getInterceptor(

--- a/packages/openapi/src/plugins/openapi-reference.ts
+++ b/packages/openapi/src/plugins/openapi-reference.ts
@@ -4,7 +4,7 @@ import type { Promisable, Value } from '@orpc/shared'
 import type { ApiReferenceConfiguration as ScalarProviderConfig } from '@scalar/api-reference'
 import type { StandardUrl } from '@standard-server/core'
 import type { SwaggerUIOptions } from 'swagger-ui'
-import type { OpenAPIDocument } from '../types'
+import type { OpenAPIDocument, OpenAPIVersion } from '../types'
 import { getOpenTelemetryConfig, matchesHttpPath, mergeHttpPath, stringifyJSON, toArray, value } from '@orpc/shared'
 
 export type OpenAPIReferenceHandlerPluginProvider = 'scalar' | 'swagger'
@@ -23,7 +23,7 @@ export interface OpenAPIReferenceHandlerPluginOptions<T extends Context, TProvid
    * A static or dynamic OpenAPI document to serve.
    * Receives routing interceptor options when provided as a function.
    */
-  spec: Value<Promisable<OpenAPIDocument>, [StandardHandlerRoutingInterceptorOptions<T>]>
+  spec: Value<Promisable<OpenAPIDocument<OpenAPIVersion>>, [StandardHandlerRoutingInterceptorOptions<T>]>
 
   /**
    * Determines whether the docs UI and OpenAPI JSON are allowed to be served for a request.

--- a/packages/openapi/src/types.test-d.ts
+++ b/packages/openapi/src/types.test-d.ts
@@ -1,16 +1,18 @@
 import type { Client, ORPCError } from '@orpc/client'
 import type { RouterContractClient } from '@orpc/contract'
 import type { AsyncIteratorClass } from '@orpc/shared'
-import type { JsonifiedClient, JsonifiedValue, OpenAPIDocument } from './types'
+import type { JsonifiedClient, JsonifiedValue, OpenAPIDocument, OpenAPIV3_0, OpenAPIV3_1, OpenAPIV3_2 } from './types'
 import { asyncIteratorObject, oc } from '@orpc/contract'
 import z from 'zod'
 
 describe('OpenAPIDocument', () => {
-  it('narrowly supports OpenAPI 3.2 QUERY path items', () => {
-    expectTypeOf<OpenAPIDocument['openapi']>().toEqualTypeOf<'3.1.0' | '3.1.1' | '3.1.2' | '3.2.0'>()
-
-    expectTypeOf<NonNullable<OpenAPIDocument['paths']>['/search']['query']>()
-      .toEqualTypeOf<NonNullable<OpenAPIDocument['paths']>['/search']['post']>()
+  it('resolves the document type of a version, patch segment ignored', () => {
+    expectTypeOf<OpenAPIDocument<'3.0.0'>>().toEqualTypeOf<OpenAPIV3_0.OpenAPIObject>()
+    expectTypeOf<OpenAPIDocument<'3.0.4'>>().toEqualTypeOf<OpenAPIV3_0.OpenAPIObject>()
+    expectTypeOf<OpenAPIDocument<'3.1.0'>>().toEqualTypeOf<OpenAPIV3_1.OpenAPIObject>()
+    expectTypeOf<OpenAPIDocument<'3.1.2'>>().toEqualTypeOf<OpenAPIV3_1.OpenAPIObject>()
+    expectTypeOf<OpenAPIDocument<'3.2.0'>>().toEqualTypeOf<OpenAPIV3_2.OpenAPIObject>()
+    expectTypeOf<OpenAPIDocument<'3.2.7'>>().toEqualTypeOf<OpenAPIV3_2.OpenAPIObject>()
   })
 })
 

--- a/packages/openapi/src/types.ts
+++ b/packages/openapi/src/types.ts
@@ -1,22 +1,27 @@
 // eslint-disable-next-line no-restricted-imports
-import type { OpenAPIV3_1 } from '@hey-api/spec-types'
+import type { OpenAPIV3_0, OpenAPIV3_1, OpenAPIV3_2 } from '@openapi-spec/types'
 import type { AnyNestedClient, Client, ORPCError } from '@orpc/client'
 import type { AsyncIteratorClass } from '@orpc/shared'
 
-export type OpenAPIOperationObject = OpenAPIV3_1.OperationObject
+// eslint-disable-next-line no-restricted-imports
+export type { OpenAPIV3_0, OpenAPIV3_1, OpenAPIV3_2 } from '@openapi-spec/types'
 
 /**
- * An OpenAPI 3.1 document with the OpenAPI 3.2 QUERY additions used by oRPC.
- * This type does not claim support for the complete OpenAPI 3.2 specification.
+ * An OpenAPI version `OpenAPIGenerator` can target: any `3.0.x`, `3.1.x`, or `3.2.x` value.
+ *
+ * @see {@link https://orpc.dev/docs/openapi/specification#openapi-version | OpenAPI Specification - OpenAPI Version}
  */
-export type OpenAPIDocument = Omit<OpenAPIV3_1.Document, 'openapi' | 'paths'> & {
-  openapi: OpenAPIV3_1.Document['openapi'] | '3.2.0'
-  paths?: undefined | OpenAPIV3_1.PathsObject & {
-    [path: `/${string}`]: OpenAPIV3_1.PathItemObject & {
-      query?: OpenAPIOperationObject | undefined
-    }
-  }
-}
+export type OpenAPIVersion = `3.0.${number}` | `3.1.${number}` | `3.2.${number}`
+
+/**
+ * The OpenAPI document of the given version.
+ *
+ * @see {@link https://orpc.dev/docs/openapi/specification#openapi-version | OpenAPI Specification - OpenAPI Version}
+ */
+export type OpenAPIDocument<TVersion extends OpenAPIVersion>
+  = TVersion extends `3.0.${string}` ? OpenAPIV3_0.OpenAPIObject
+    : TVersion extends `3.1.${string}` ? OpenAPIV3_1.OpenAPIObject
+      : OpenAPIV3_2.OpenAPIObject
 
 export type JsonifiedValue<T>
   = T extends string ? T

--- a/packages/openapi/tests/openapi-generator/crud.test.ts
+++ b/packages/openapi/tests/openapi-generator/crud.test.ts
@@ -172,7 +172,7 @@ describe('openAPIGenerator e2e: crud api', () => {
     }))
 
     // the list response references the same hoisted Planet component
-    expect((doc.paths?.['/api/v1/planets']?.get?.responses?.[200] as any).content['application/json'].schema).toEqual({
+    expect((doc.paths?.['/api/v1/planets']?.get?.responses?.['200'] as any).content['application/json'].schema).toEqual({
       type: 'array',
       items: { $ref: '#/components/schemas/Planet' },
     })

--- a/packages/openapi/tests/openapi-generator/event-streaming.test.ts
+++ b/packages/openapi/tests/openapi-generator/event-streaming.test.ts
@@ -50,7 +50,7 @@ describe('openAPIGenerator e2e: server-sent event streaming', () => {
       },
     })
 
-    expect(doc.paths?.['/chat']?.post?.responses?.[200]).toEqual({
+    expect(doc.paths?.['/chat']?.post?.responses?.['200']).toEqual({
       description: 'OK',
       content: {
         'text/event-stream': {
@@ -91,7 +91,7 @@ describe('openAPIGenerator e2e: server-sent event streaming', () => {
         .output(asyncIteratorObject(z.object({ title: z.string() }))),
     })
 
-    const schema = (doc.paths?.['/notifications']?.get?.responses?.[200] as any).content['text/event-stream'].schema
+    const schema = (doc.paths?.['/notifications']?.get?.responses?.['200'] as any).content['text/event-stream'].schema
 
     expect(schema.oneOf[1]).toEqual({
       type: 'object',

--- a/packages/openapi/tests/openapi-generator/file-transfer.test.ts
+++ b/packages/openapi/tests/openapi-generator/file-transfer.test.ts
@@ -57,7 +57,7 @@ describe('openAPIGenerator e2e: file upload and download', () => {
         .output(z.file()),
     })
 
-    expect(doc.paths?.['/documents/{id}']?.get?.responses?.[200]).toEqual({
+    expect(doc.paths?.['/documents/{id}']?.get?.responses?.['200']).toEqual({
       description: 'OK',
       content: {
         '*/*': {
@@ -78,7 +78,7 @@ describe('openAPIGenerator e2e: file upload and download', () => {
         ])),
     })
 
-    expect(doc.paths?.['/planets/export']?.get?.responses?.[200]).toEqual({
+    expect(doc.paths?.['/planets/export']?.get?.responses?.['200']).toEqual({
       description: 'OK',
       content: {
         'application/json': {

--- a/packages/openapi/tests/openapi-generator/reusable-components.test.ts
+++ b/packages/openapi/tests/openapi-generator/reusable-components.test.ts
@@ -23,7 +23,7 @@ describe('openAPIGenerator e2e: reusable component schemas', () => {
         .output(z.object({ category: Category })),
     })
 
-    expect((doc.paths?.['/categories/{name}']?.get?.responses?.[200] as any).content['application/json'].schema).toEqual(
+    expect((doc.paths?.['/categories/{name}']?.get?.responses?.['200'] as any).content['application/json'].schema).toEqual(
       expect.objectContaining({
         properties: {
           category: { $ref: '#/components/schemas/Category' },
@@ -103,7 +103,7 @@ describe('openAPIGenerator e2e: reusable component schemas', () => {
       expect((doc.paths?.[path]?.post?.requestBody as any).content['application/json'].schema.properties).toEqual({
         planet: { $ref: '#/components/schemas/Planet' },
       })
-      expect((doc.paths?.[path]?.post?.responses?.[200] as any).content['application/json'].schema.properties).toEqual({
+      expect((doc.paths?.[path]?.post?.responses?.['200'] as any).content['application/json'].schema.properties).toEqual({
         planet: { $ref: '#/components/schemas/PlanetOutput' },
       })
     }

--- a/packages/openapi/tests/openapi-generator/typed-errors.test.ts
+++ b/packages/openapi/tests/openapi-generator/typed-errors.test.ts
@@ -59,7 +59,7 @@ describe('openAPIGenerator e2e: typed errors', () => {
       },
     })
 
-    expect(doc.paths?.['/planets/{id}']?.get?.responses?.[404]).toEqual(expect.objectContaining({
+    expect(doc.paths?.['/planets/{id}']?.get?.responses?.['404']).toEqual(expect.objectContaining({
       content: {
         'application/json': {
           schema: {
@@ -147,7 +147,7 @@ describe('openAPIGenerator e2e: typed errors', () => {
       },
     })
 
-    expect(doc.paths?.['/planets/{id}']?.get?.responses?.[410]).toEqual({
+    expect(doc.paths?.['/planets/{id}']?.get?.responses?.['410']).toEqual({
       description: 'Planet is gone',
       content: {
         'application/json': {

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -49,8 +49,7 @@
     "zod": ">=4.5.0"
   },
   "dependencies": {
-    "@orpc/json-schema": "workspace:*",
-    "json-schema-typed": "^8.0.2"
+    "@orpc/json-schema": "workspace:*"
   },
   "devDependencies": {
     "zod": "^4.5.4"

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -49,6 +49,7 @@
     "zod": ">=4.5.0"
   },
   "dependencies": {
+    "@openapi-spec/types": "~0.1.0",
     "@orpc/json-schema": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,6 +576,9 @@ importers:
 
   packages/json-schema:
     dependencies:
+      '@openapi-spec/types':
+        specifier: ~0.1.0
+        version: 0.1.0
       '@orpc/client':
         specifier: workspace:*
         version: link:../client
@@ -591,9 +594,6 @@ importers:
       '@standard-schema/spec':
         specifier: ^1.1.0
         version: 1.1.0
-      json-schema-typed:
-        specifier: ^8.0.2
-        version: 8.0.2
     devDependencies:
       zod:
         specifier: ^4.5.4
@@ -731,9 +731,12 @@ importers:
 
   packages/openapi:
     dependencies:
-      '@hey-api/spec-types':
-        specifier: 0.0.0-next-20260408030107
-        version: 0.0.0-next-20260408030107
+      '@openapi-spec/downgrader':
+        specifier: ~0.1.0
+        version: 0.1.0
+      '@openapi-spec/types':
+        specifier: ~0.1.0
+        version: 0.1.0
       '@orpc/client':
         specifier: workspace:*
         version: link:../client
@@ -1058,9 +1061,6 @@ importers:
       '@orpc/json-schema':
         specifier: workspace:*
         version: link:../json-schema
-      json-schema-typed:
-        specifier: ^8.0.2
-        version: 8.0.2
     devDependencies:
       zod:
         specifier: ^4.5.4
@@ -2815,12 +2815,6 @@ packages:
     peerDependencies:
       vue: ^3.2.0
 
-  '@hey-api/spec-types@0.0.0-next-20260408030107':
-    resolution: {integrity: sha512-P5DKr4dpZ7lmZpZt2bc2KWuzU9vl4GZcN7VrjchZF1WWKNGZFnwWhBxZo1t6P2muOCopIvqD2Fvp5os4QiitKA==}
-
-  '@hey-api/types@0.1.4':
-    resolution: {integrity: sha512-thWfawrDIP7wSI9ioT13I5soaaqB5vAPIiZmgD8PbeEVKNrkonc0N/Sjj97ezl7oQgusZmaNphGdMKipPO6IBg==}
-
   '@hono/node-server@2.1.1':
     resolution: {integrity: sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==}
     engines: {node: '>=20'}
@@ -3770,6 +3764,12 @@ packages:
 
   '@openapi-contrib/openapi-schema-to-json-schema@3.2.0':
     resolution: {integrity: sha512-Gj6C0JwCr8arj0sYuslWXUBSP/KnUlEGnPW4qxlXvAl543oaNQgMgIgkQUA6vs5BCCvwTEiL8m/wdWzfl4UvSw==}
+
+  '@openapi-spec/downgrader@0.1.0':
+    resolution: {integrity: sha512-za2h8wGa4BFy2+AiKJHutt8BS2ua7Fw7vgNMmAtLyFbreozWHkXRVBRVA86sczyLY1ZN9Gw4rITygs90ehztQg==}
+
+  '@openapi-spec/types@0.1.0':
+    resolution: {integrity: sha512-5m9GUj5ekwmJ5uXH0yctarqLGckGc8X7pX65dirukZDUAGmrUx5lKovvWA7YvEBKd480Q7R2oG3nE5C+SoVgNw==}
 
   '@opentelemetry/api-logs@0.200.0':
     resolution: {integrity: sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==}
@@ -14163,12 +14163,6 @@ snapshots:
       '@tanstack/vue-virtual': 3.13.36(vue@3.5.42(typescript@6.0.3))
       vue: 3.5.42(typescript@6.0.3)
 
-  '@hey-api/spec-types@0.0.0-next-20260408030107':
-    dependencies:
-      '@hey-api/types': 0.1.4
-
-  '@hey-api/types@0.1.4': {}
-
   '@hono/node-server@2.1.1(hono@4.13.5)':
     dependencies:
       hono: 4.13.5
@@ -15008,6 +15002,12 @@ snapshots:
   '@openapi-contrib/openapi-schema-to-json-schema@3.2.0':
     dependencies:
       fast-deep-equal: 3.1.3
+
+  '@openapi-spec/downgrader@0.1.0':
+    dependencies:
+      '@openapi-spec/types': 0.1.0
+
+  '@openapi-spec/types@0.1.0': {}
 
   '@opentelemetry/api-logs@0.200.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1058,6 +1058,9 @@ importers:
 
   packages/zod:
     dependencies:
+      '@openapi-spec/types':
+        specifier: ~0.1.0
+        version: 0.1.0
       '@orpc/json-schema':
         specifier: workspace:*
         version: link:../json-schema

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,3 +47,5 @@ minimumReleaseAgeExclude:
   - '@standard-server/shared@0.9.0'
   - '@standard-server/aws-lambda@0.9.0'
   - '@standard-server/fastify@0.9.0'
+  - '@openapi-spec/downgrader@0.1.0'
+  - '@openapi-spec/types@0.1.0'

--- a/skills/orpc-openapi/SKILL.md
+++ b/skills/orpc-openapi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orpc-openapi
-description: "Expose an oRPC router as a spec-compliant OpenAPI HTTP API. Use when a project depends on @orpc/openapi, or for defining REST-style routes on oRPC procedures (openapi() metadata or .route with method, path, successStatus), serving them with OpenAPIHandler alongside RPCHandler, coercing query and path strings with Smart Coercion, calling an OpenAPI-shaped API with OpenAPILink, generating an OpenAPI 3.1 document with OpenAPIGenerator, or serving Scalar or Swagger docs with the OpenAPI Reference plugin. Biases toward retrieval from the oRPC docs over pre-trained knowledge. For contract-first work (defining contracts with oc, implementing them with implement, or generating a contract from an existing OpenAPI spec), use the orpc-contract skill; for plain RPC serving, core builder, middleware, or client work with no REST exposure, use the orpc skill instead."
+description: "Expose an oRPC router as a spec-compliant OpenAPI HTTP API. Use when a project depends on @orpc/openapi, or for defining REST-style routes on oRPC procedures (openapi() metadata or .route with method, path, successStatus), serving them with OpenAPIHandler alongside RPCHandler, coercing query and path strings with Smart Coercion, calling an OpenAPI-shaped API with OpenAPILink, generating an OpenAPI 3.2 (or 3.1, 3.0) document with OpenAPIGenerator, or serving Scalar or Swagger docs with the OpenAPI Reference plugin. Biases toward retrieval from the oRPC docs over pre-trained knowledge. For contract-first work (defining contracts with oc, implementing them with implement, or generating a contract from an existing OpenAPI spec), use the orpc-contract skill; for plain RPC serving, core builder, middleware, or client work with no REST exposure, use the orpc skill instead."
 license: MIT
 ---
 
@@ -106,7 +106,7 @@ To ship a contract to clients without bundling server code, minify it to JSON an
 
 ## Spec document and interactive docs
 
-`OpenAPIGenerator` turns a router or contract into an OpenAPI 3.1 document. `OpenAPIReferenceHandlerPlugin` serves the spec at `/spec.json` and a Scalar UI at `/` under the handler prefix (change with `specPath`/`docsPath`, or set `provider: 'swagger'` for Swagger UI):
+`OpenAPIGenerator` turns a router or contract into an OpenAPI 3.2 document (pass any `3.1.x` or `3.0.x` `version` for tools that stop at an older version; `QUERY` procedures need 3.2). `OpenAPIReferenceHandlerPlugin` serves the spec at `/spec.json` and a Scalar UI at `/` under the handler prefix (change with `specPath`/`docsPath`, or set `provider: 'swagger'` for Swagger UI):
 
 ```ts
 import { OpenAPIGenerator } from '@orpc/openapi'
@@ -129,7 +129,7 @@ const handler = new OpenAPIHandler(router, {
 })
 ```
 
-Enrich the document through `openapi` metadata: `operationId`, `summary`, `description`, `tags`, `successDescription`, and a `spec` callback that receives the generated operation object and returns an extended one (security requirements, extra responses). Converters also exist for Valibot (`@orpc/valibot`) and ArkType (`@orpc/arktype`); schemas without a matching converter fall back to Standard JSON Schema conversion.
+Enrich the document through `openapi` metadata: `operationId`, `summary`, `description`, `tags`, `successDescription`, and a `spec` callback that receives the generated operation object and returns an extended one (security requirements, extra responses). Write `spec` and `base` as OpenAPI 3.2 objects even when generating 3.1 or 3.0; the generator downgrades the whole document. Converters also exist for Valibot (`@orpc/valibot`) and ArkType (`@orpc/arktype`); schemas without a matching converter fall back to Standard JSON Schema conversion.
 
 Verify the wiring before declaring success: request `/spec.json` under the handler prefix and one routed endpoint, and confirm the method, path, and status you configured.
 

--- a/skills/orpc/SKILL.md
+++ b/skills/orpc/SKILL.md
@@ -17,7 +17,7 @@ Package map:
 - `@orpc/server`: the `os` builder, routers, middleware, `RPCHandler`, server-side clients (`call`, `createRouterClient`), `implement` for mocks
 - `@orpc/client`: `createORPCClient`, `RPCLink`, `safe`, `createSafeClient`, `isDefinedError`
 - `@orpc/contract`: contract-first API definitions implemented separately from their logic (see the `orpc-contract` skill)
-- `@orpc/openapi`: `OpenAPIHandler`, `OpenAPILink`, OpenAPI 3.1 spec generation
+- `@orpc/openapi`: `OpenAPIHandler`, `OpenAPILink`, OpenAPI 3.2 spec generation
 - Integration packages such as `@orpc/tanstack-query` and `@orpc/nest`
 
 ## Define procedures

--- a/tests/plugins/all-plugins.test.ts
+++ b/tests/plugins/all-plugins.test.ts
@@ -58,8 +58,8 @@ const contract = {
     .output(z.object({ value: z.number() })),
 }
 
-const spec: OpenAPIDocument = {
-  openapi: '3.1.1',
+const spec: OpenAPIDocument<'3.2.0'> = {
+  openapi: '3.2.0',
   info: { title: 'All Plugins', version: '1.0.0' },
 }
 


### PR DESCRIPTION
Replaces `json-schema-typed` and `@hey-api/spec-types` with `@openapi-spec/types`, so `JsonSchema` is the OpenAPI 3.2 Schema Object and `@orpc/openapi` re-exports the `OpenAPIV3_0`, `OpenAPIV3_1`, and `OpenAPIV3_2` namespaces. `OpenAPIGenerator` now builds OpenAPI 3.2 documents and takes a `version` option that downgrades to 3.1 or 3.0 through `@openapi-spec/downgrader`, with the return type following the requested version.

## Breaking changes

- `generate()` emits `3.2.0` by default (was `3.1.2`). Pass `version: '3.1.2'` to keep 3.1 documents. `base` no longer accepts `openapi`.
- `OpenAPIDocument` requires a version argument; `OpenAPIDocument<OpenAPIVersion>` is the union of every supported document. `OpenAPIOperationObject` is replaced by `OpenAPIV3_2.OperationObject`.
- `JsonSchemaKeywords` is derived from the 3.2 Schema Object, so legacy keywords such as `additionalItems` are no longer part of it.

## Behavior

- Any `3.0.x`, `3.1.x`, or `3.2.x` `version` is accepted. The minor version selects the conversion and the document carries the exact requested value.
- Everything authored (`base`, `openapi({ spec })`, converter output) stays OpenAPI 3.2 and is downgraded with the rest of the document, so `type: ['string', 'null']` becomes `nullable: true` in 3.0 output.
- Downgrading runs before serialization: the serializer output is not made of plain objects and the downgrader would pass it through untouched.
- QUERY operations still require 3.2 and throw when an older version is requested.

## Docs

- The specification page documents `version` in its own section, and the v1 migration guide notes the new default.

## Testing

- Version tests compare whole output documents for `3.2.0`, `3.2.7`, `3.1.2`, `3.1.0`, `3.0.4`, and `3.0.0`, with type tests for the version-dependent return type.
- Root type check, lint, the docs JSDoc backlink checker, and both package builds pass.
