### PR TITLE
docs(openapi): pass version 3.1.1 in the v1 migration generator example

### DIFF
--- a/apps/content/docs/migrations/from-v1.mdx
+++ b/apps/content/docs/migrations/from-v1.mdx
@@ -999,6 +999,7 @@ const generator = new OpenAPIGenerator({
 })
 
 const spec = await generator.generate(router, {
+  version: '3.1.1',
   base: {
     info: { title: 'My App', version: '0.0.0' },
   },
@@ -1024,7 +1025,7 @@ Three smaller changes in the same area:
 
 - The `oo` helper (`oo.spec`) was removed. To customize the operation object, attach [`openapi({ spec })` metadata](/docs/openapi/specification#customizing-the-operation-object) directly on the procedure or router.
 - The `shouldHoistDef` option was replaced by [`customComponentName`](/docs/openapi/specification#hoisting-defs). Root `$defs` are now always hoisted into `components.schemas`; this option only renames them.
-- Documents are generated as OpenAPI 3.2.0 by default. Pass [`version: '3.1.1'`](/docs/openapi/specification#openapi-version) to keep old behavior.
+- Documents are generated as OpenAPI 3.2.0 by default. The example above passes [`version: '3.1.1'`](/docs/openapi/specification#openapi-version) to keep the v1 behavior.
 
 ### `OpenAPIReferencePlugin` renamed and reshaped
 


### PR DESCRIPTION
The v2 snippet in the `OpenAPIGenerator` migration section now passes `version: '3.1.1'`, so following the example produces the same OpenAPI version as the v1 code it replaces. The note below the example explains that documents default to OpenAPI 3.2.0 and that the option keeps the v1 behavior.

## Docs

- Migration readers no longer get a silent 3.1 to 3.2 document change when copying the v2 example.
- The version bullet points at the example instead of repeating the option.