### PR TITLE
feat(publisher)!: serialize payloads with RPCJsonSerializer

### DIFF
--- a/apps/content/docs/helpers/publisher.mdx
+++ b/apps/content/docs/helpers/publisher.mdx
@@ -121,7 +121,7 @@ const publisher = new RedisPublisher<Events>(client, {
   /**
    * Serializer for serialize and deserialize payloads.
    *
-   * @default RPCSerializer
+   * @default RPCJsonSerializer
    */
   serializer: undefined,
 
@@ -166,7 +166,7 @@ const publisher = new UpstashPublisher<Events>(redis, {
   /**
    * Serializer for serialize and deserialize payloads.
    *
-   * @default RPCSerializer
+   * @default RPCJsonSerializer
    */
   serializer: undefined,
 
@@ -218,7 +218,7 @@ const publisher = new BunRedisPublisher<Events>(redis, {
   /**
    * Serializer for serialize and deserialize payloads.
    *
-   * @default RPCSerializer
+   * @default RPCJsonSerializer
    */
   serializer: undefined,
 
@@ -309,7 +309,7 @@ export default {
       /**
        * Serializer for serialize and deserialize payloads.
        *
-       * @default RPCSerializer
+       * @default RPCJsonSerializer
        */
       serializer: undefined,
 

--- a/apps/content/docs/integrations/tanstack-query.mdx
+++ b/apps/content/docs/integrations/tanstack-query.mdx
@@ -510,7 +510,7 @@ When [server-side rendering](/docs/recipes/optimizing-ssr) with [TanStack Query 
 
 ### Custom Serializers
 
-If needed, you can extend the default TanStack Query serializer to support additional types supported by oRPC. Learn more about [RPC Serializers](/docs/rpc/serializer).
+If needed, you can extend the default TanStack Query serializer to support additional types supported by oRPC. Learn more about the [RPC JSON Serializer](/docs/rpc/serializer#rpc-json-serializer).
 
 ```ts
 import { RPCJsonSerializer } from '@orpc/client'

--- a/apps/content/docs/migrations/from-v1.mdx
+++ b/apps/content/docs/migrations/from-v1.mdx
@@ -1130,7 +1130,7 @@ orpc.live.experimental_liveOptions({ input: {} })
 
 </CodeGroup>
 
-`experimental_defaults` became `scoped`, and the hydration serializer changed from `StandardRPCJsonSerializer` to `RPCSerializer` (see [Custom serializers](#custom-serializers-use-a-serializer-instance)).
+`experimental_defaults` became `scoped`, and the hydration serializer changed from `StandardRPCJsonSerializer` to `RPCJsonSerializer` (see [RPC JSON Serializer](/docs/rpc/serializer#rpc-json-serializer)).
 
 ### SWR and Pinia Colada
 
@@ -1200,7 +1200,7 @@ Base64Url, Cookie, Encryption, and Signing helpers are unchanged in `@orpc/serve
 
 ### Publisher
 
-The package is now `@orpc/publisher`. The resume option was restructured, and the Redis adapter switched from `ioredis` to `node-redis`. See [Publisher Helpers](/docs/helpers/publisher).
+The package is now `@orpc/publisher`. The resume option was restructured, `customJsonSerializers` became a `serializer` instance (see [RPC JSON Serializer](/docs/rpc/serializer#rpc-json-serializer)), and the Redis adapter switched from `ioredis` to `node-redis`. See [Publisher Helpers](/docs/helpers/publisher).
 
 <CodeGroup>
 

--- a/apps/content/docs/rpc/serializer.mdx
+++ b/apps/content/docs/rpc/serializer.mdx
@@ -85,6 +85,30 @@ const link = new RPCLink({
 
 :::
 
+## RPC JSON Serializer
+
+`RPCJsonSerializer` is the JSON layer behind `RPCSerializer`. Use it directly wherever only JSON is accepted.
+
+```ts twoslash
+import { RPCJsonSerializer } from '@orpc/client'
+
+const serializer = new RPCJsonSerializer({
+  handlers: {
+    // same handlers as RPCSerializer
+  },
+})
+
+const { json, meta } = serializer.serialize({
+  name: 'John',
+  createdAt: new Date('2024-01-01'),
+})
+// json: { name: 'John', createdAt: '2024-01-01T00:00:00.000Z' }
+// meta: [['date', 'createdAt']]
+
+const data = serializer.deserialize({ json, meta })
+// data: { name: 'John', createdAt: Date }
+```
+
 ## Serialization Format
 
 In most cases, serialized data includes two optional fields: `json` and `meta`. `json` contains JSON-serializable data. `meta` contains the metadata needed to deserialize values.
@@ -190,5 +214,5 @@ If the receiver mistakenly handles this payload as a regular (non-stream) body, 
 
 ## Learn More
 
-The serializer is a small, self-contained module, making it easy to understand.
-To explore its behavior in detail, see the [source code](https://github.com/middleapi/orpc/blob/main/packages/client/src/rpc-serializer.ts).
+The serializers are small, self-contained modules, making them easy to understand.
+To explore their behavior in detail, see the source code of [`RPCSerializer`](https://github.com/middleapi/orpc/blob/main/packages/client/src/rpc-serializer.ts) and [`RPCJsonSerializer`](https://github.com/middleapi/orpc/blob/main/packages/client/src/rpc-json-serializer.ts).

--- a/packages/bun/src/redis-publisher.test.ts
+++ b/packages/bun/src/redis-publisher.test.ts
@@ -1,5 +1,5 @@
 import type { BunRedisPublisherOptions } from './redis-publisher'
-import { RPCSerializer } from '@orpc/client'
+import { RPCJsonSerializer } from '@orpc/client'
 import { getOrBind, promiseWithResolvers, sleep } from '@orpc/shared'
 import { getEventMeta, withEventMeta } from '@standard-server/core'
 import { RedisClient } from 'bun'
@@ -249,7 +249,7 @@ describe.skipIf(!REDIS_URL)('bun redis publisher', () => {
       }
     }
 
-    const serializer = new RPCSerializer({
+    const serializer = new RPCJsonSerializer({
       handlers: {
         person: {
           condition: p => p instanceof Person,

--- a/packages/bun/src/redis-publisher.ts
+++ b/packages/bun/src/redis-publisher.ts
@@ -1,8 +1,9 @@
+import type { RPCJsonSerialization } from '@orpc/client'
 import type { PublisherOptions, PublisherSubscribeListenerOptions } from '@orpc/publisher'
-import type { Promisable, ThrowableError } from '@orpc/shared'
+import type { Promisable, Public, ThrowableError } from '@orpc/shared'
 import type { EventMeta } from '@standard-server/core'
 import type { RedisClient } from 'bun'
-import { RPCSerializer } from '@orpc/client'
+import { RPCJsonSerializer } from '@orpc/client'
 import { Publisher } from '@orpc/publisher'
 import { once, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
 import { getEventMeta, unwrapEvent, withEventMeta } from '@standard-server/core'
@@ -27,9 +28,9 @@ export interface BunRedisPublisherOptions extends PublisherOptions {
   /**
    * Serializer for serialize and deserialize payloads.
    *
-   * @default RPCSerializer
+   * @default RPCJsonSerializer
    */
-  serializer?: undefined | Pick<RPCSerializer, keyof RPCSerializer>
+  serializer?: undefined | Public<RPCJsonSerializer>
 
   /**
    * Configuration for event resume support.
@@ -88,7 +89,7 @@ export class BunRedisPublisher<T extends Record<string, object>> extends Publish
     super(options)
 
     this.prefix = options.prefix ?? ''
-    this.serializer = options.serializer ?? new RPCSerializer()
+    this.serializer = options.serializer ?? new RPCJsonSerializer()
     this.resumeEnabled = options.resume?.enabled ?? false
     this.resumeSeconds = options.resume?.seconds ?? 300
     this.subscriber = options.subscriber
@@ -219,12 +220,13 @@ export class BunRedisPublisher<T extends Record<string, object>> extends Publish
     })
   }
 
-  private serializePayload(payload: object): { payload: unknown, meta?: undefined | EventMeta } {
+  private serializePayload(payload: object): { payload: RPCJsonSerialization, meta?: undefined | EventMeta } {
     const [original, meta] = unwrapEvent(payload)
-    return { payload: this.serializer.serialize(original, { useFormDataForBlobFields: false }), meta }
+    const { json, meta: jsonMeta } = this.serializer.serialize(original)
+    return { payload: { json, meta: jsonMeta }, meta }
   }
 
-  private deserializePayload(id: string | undefined, { payload, meta }: { payload: unknown, meta?: undefined | EventMeta }): object {
+  private deserializePayload(id: string | undefined, { payload, meta }: { payload: RPCJsonSerialization, meta?: undefined | EventMeta }): object {
     return withEventMeta(
       this.serializer.deserialize(payload) as object,
       id === undefined ? { ...meta } : { ...meta, id },

--- a/packages/bun/tests/rpc/__shared__/client-server.ts
+++ b/packages/bun/tests/rpc/__shared__/client-server.ts
@@ -1,9 +1,10 @@
 import type { AnyRouter, Context, RouterClient } from '@orpc/server'
+import type { Public } from '@orpc/shared'
 import { RPCSerializer } from '@orpc/client'
 
 export interface ClientServerTestOptions {
   context?: Context
-  serializer?: Pick<RPCSerializer, keyof RPCSerializer>
+  serializer?: Public<RPCSerializer>
 }
 
 export interface CreateClientServerTest {

--- a/packages/client/src/adapters/standard/rpc-link-codec.ts
+++ b/packages/client/src/adapters/standard/rpc-link-codec.ts
@@ -1,4 +1,4 @@
-import type { Promisable, Value } from '@orpc/shared'
+import type { Promisable, Public, Value } from '@orpc/shared'
 import type { StandardHeaders, StandardLazyResponse, StandardRequest, StandardUrl } from '@standard-server/core'
 import type { ClientContext, ClientOptions } from '../../types'
 import type { StandardLinkCodec, StandardLinkCodecDecodedResponse } from '../standard'
@@ -50,7 +50,7 @@ export interface RPCLinkCodecOptions<T extends ClientContext> {
   /**
    * Override the default RPC serializer.
    */
-  serializer?: Pick<RPCSerializer, keyof RPCSerializer>
+  serializer?: Public<RPCSerializer>
 }
 
 const END_SLASH_REGEX = /\/$/

--- a/packages/client/src/rpc-json-serializer.ts
+++ b/packages/client/src/rpc-json-serializer.ts
@@ -177,7 +177,7 @@ export interface RPCJsonSerializerOptions {
  * Serializes and deserializes native types like Date, BigInt, Set, and Map
  * into a JSON value plus separate metadata describing how to restore them.
  *
- * @see {@link https://orpc.dev/docs/integrations/tanstack-query#custom-serializers | TanStack Query Integration - Custom Serializers}
+ * @see {@link https://orpc.dev/docs/rpc/serializer#rpc-json-serializer | RPC Serializer - RPC JSON Serializer}
  */
 export class RPCJsonSerializer {
   private readonly handlers: Exclude<RPCJsonSerializerOptions['handlers'], undefined>

--- a/packages/cloudflare/src/publisher.test.ts
+++ b/packages/cloudflare/src/publisher.test.ts
@@ -1,4 +1,4 @@
-import { RPCSerializer } from '@orpc/client'
+import { RPCJsonSerializer } from '@orpc/client'
 import { getEventMeta, withEventMeta } from '@standard-server/core'
 import { sleep } from '@standard-server/shared'
 import { reset } from 'cloudflare:test'
@@ -158,7 +158,7 @@ describe('durable publisher', () => {
       ) {}
     }
 
-    const serializer = new RPCSerializer({
+    const serializer = new RPCJsonSerializer({
       handlers: {
         person: {
           condition: p => p instanceof Person,
@@ -171,7 +171,7 @@ describe('durable publisher', () => {
     const getStubByName = vi.fn((namespace, event) => namespace.getByName(event))
     const publisher = new DurablePublisher<any>(env.PUBLISHER_DON, {
       prefix: 'prefix:',
-      serializer: serializer as any,
+      serializer,
       getStubByName,
     })
 
@@ -230,7 +230,7 @@ describe('durable publisher', () => {
 
   it('reports bad messages and socket errors but keeps good ones', async () => {
     const socket = makeSocket()
-    const serializer = new RPCSerializer()
+    const serializer = new RPCJsonSerializer()
     const stub = {
       fetch: vi.fn(async () => ({
         webSocket: socket as unknown as WebSocket,

--- a/packages/cloudflare/src/publisher.ts
+++ b/packages/cloudflare/src/publisher.ts
@@ -1,6 +1,6 @@
 import type { PublisherOptions, PublisherSubscribeListenerOptions } from '@orpc/publisher'
 import type { Public } from '@orpc/shared'
-import { RPCSerializer } from '@orpc/client'
+import { RPCJsonSerializer } from '@orpc/client'
 import { Publisher } from '@orpc/publisher'
 import { isTypescriptObject, stringifyJSON } from '@orpc/shared'
 import { unwrapEvent, withEventMeta } from '@standard-server/core'
@@ -16,9 +16,9 @@ export interface DurablePublisherOptions extends PublisherOptions {
   /**
    * Serializer for serialize and deserialize payloads.
    *
-   * @default RPCSerializer
+   * @default RPCJsonSerializer
    */
-  serializer?: undefined | Public<RPCSerializer>
+  serializer?: undefined | Public<RPCJsonSerializer>
 
   /**
    * Custom function to get the Durable Object stub for publishing.
@@ -36,7 +36,7 @@ export interface DurablePublisherOptions extends PublisherOptions {
  */
 export class DurablePublisher<T extends Record<string, object>> extends Publisher<T> {
   private readonly prefix: string
-  private readonly serializer: Public<RPCSerializer>
+  private readonly serializer: Public<RPCJsonSerializer>
   private readonly getStubByName: Exclude<DurablePublisherOptions['getStubByName'], undefined>
 
   constructor(
@@ -45,7 +45,7 @@ export class DurablePublisher<T extends Record<string, object>> extends Publishe
   ) {
     super(options)
     this.prefix = prefix ?? ''
-    this.serializer = options.serializer ?? new RPCSerializer()
+    this.serializer = options.serializer ?? new RPCJsonSerializer()
     this.getStubByName = getStubByName ?? ((namespace, event) => namespace.getByName(event))
   }
 
@@ -53,11 +53,12 @@ export class DurablePublisher<T extends Record<string, object>> extends Publishe
     const stub = this.getStubByName(this.namespace, this.prefix + event)
 
     const [data, meta] = unwrapEvent(payload)
+    const { json, meta: jsonMeta } = this.serializer.serialize(data)
 
     const response = await stub.fetch('http://localhost/publish', {
       method: 'POST',
       body: stringifyJSON({
-        data: this.serializer.serialize(data, { useFormDataForBlobFields: false }),
+        data: { json, meta: jsonMeta },
         meta,
       }),
       headers: {

--- a/packages/openapi/src/adapters/standard/openapi-handler-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-handler-codec.ts
@@ -1,7 +1,7 @@
 import type { AnyORPCError } from '@orpc/client'
 import type { AnyProcedure, AnyRouter, Context } from '@orpc/server'
 import type { StandardHandlerCodec, StandardHandlerCodecResolvedProcedure, StandardHandlerHandleOptions } from '@orpc/server/standard'
-import type { Promisable } from '@orpc/shared'
+import type { Promisable, Public } from '@orpc/shared'
 import type { StandardLazyRequest, StandardResponse } from '@standard-server/core'
 import type { OpenAPIMeta } from '../../meta'
 import type { OpenAPIMatcherOptions } from './openapi-matcher'
@@ -23,7 +23,7 @@ export interface OpenAPIHandlerCodecCoreOptions<_T extends Context> {
   /**
    * Override the default OpenAPI serializer.
    */
-  serializer?: Pick<OpenAPISerializer, keyof OpenAPISerializer>
+  serializer?: Public<OpenAPISerializer>
 
   /**
    * Mapping ORPCError Code -> HTTP Status Code
@@ -46,7 +46,7 @@ export interface OpenAPIHandlerCodecCoreOptions<_T extends Context> {
 }
 
 export class OpenAPIHandlerCodecCore<T extends Context> {
-  private readonly serializer: Pick<OpenAPISerializer, keyof OpenAPISerializer>
+  private readonly serializer: Public<OpenAPISerializer>
   private readonly errorStatusMap: Exclude<OpenAPIHandlerCodecOptions<T>['errorStatusMap'], undefined>
   private readonly customErrorResponseBodySerializer: OpenAPIHandlerCodecOptions<T>['customErrorResponseBodyEncoder']
 

--- a/packages/openapi/src/adapters/standard/openapi-link-codec.ts
+++ b/packages/openapi/src/adapters/standard/openapi-link-codec.ts
@@ -1,7 +1,7 @@
 import type { AnyORPCError, ClientContext, ClientOptions } from '@orpc/client'
 import type { StandardLinkCodec, StandardLinkCodecDecodedResponse } from '@orpc/client/standard'
 import type { AnyProcedureContract, RouterContract } from '@orpc/contract'
-import type { Promisable, Value } from '@orpc/shared'
+import type { Promisable, Public, Value } from '@orpc/shared'
 import type { StandardHeaders, StandardLazyResponse, StandardRequest, StandardUrl } from '@standard-server/core'
 import type { OpenAPIMeta } from '../../meta'
 import { createORPCErrorFromJson, createORPCErrorFromMalformedResponse, isORPCErrorJson } from '@orpc/client'
@@ -37,7 +37,7 @@ export interface OpenAPILinkCodecOptions<T extends ClientContext> {
   /**
    * Override the default OpenAPI serializer.
    */
-  serializer?: Pick<OpenAPISerializer, keyof OpenAPISerializer>
+  serializer?: Public<OpenAPISerializer>
 
   /**
    * Customize how an error response body is converted into an ORPC error.

--- a/packages/openapi/src/openapi-generator.ts
+++ b/packages/openapi/src/openapi-generator.ts
@@ -1,7 +1,7 @@
 import type { AnyProcedureContract, AnySchema, RouterContract } from '@orpc/contract'
 import type { JsonSchema, JsonSchemaConverter, JsonSchemaConverterDirection } from '@orpc/json-schema'
 import type { AnyProcedure, AnyRouter } from '@orpc/server'
-import type { Value } from '@orpc/shared'
+import type { Public, Value } from '@orpc/shared'
 import type { OpenAPIMeta } from './meta'
 import type { OpenAPIErrorBodyDefinition, OpenAPIOperationContext } from './openapi-generator-operation'
 import type { OpenAPIDocument, OpenAPIV3_2, OpenAPIVersion } from './types'
@@ -32,7 +32,7 @@ export interface OpenAPIGeneratorOptions {
   /**
    * The serializer used to serialize the generated OpenAPI documentation
    */
-  serializer?: Pick<OpenAPISerializer, keyof OpenAPISerializer> | undefined
+  serializer?: Public<OpenAPISerializer> | undefined
 }
 
 export interface OpenAPIGeneratorGenerateOptions<TVersion extends OpenAPIVersion> {
@@ -100,7 +100,7 @@ export interface OpenAPIGeneratorGenerateOptions<TVersion extends OpenAPIVersion
  * @see {@link https://orpc.dev/docs/openapi/specification#openapi-generator | OpenAPI Specification - OpenAPI Generator}
  */
 export class OpenAPIGenerator {
-  private readonly serializer: Pick<OpenAPISerializer, keyof OpenAPISerializer>
+  private readonly serializer: Public<OpenAPISerializer>
   private readonly converter: Pick<JsonSchemaConverter, 'convert'>
 
   constructor(options: OpenAPIGeneratorOptions = {}) {

--- a/packages/publisher/src/adapters/redis.test.ts
+++ b/packages/publisher/src/adapters/redis.test.ts
@@ -1,6 +1,6 @@
 import type { RedisClientType } from 'redis'
 import type { RedisPublisherOptions } from './redis'
-import { RPCSerializer } from '@orpc/client'
+import { RPCJsonSerializer } from '@orpc/client'
 import { getOrBind, promiseWithResolvers, sleep } from '@orpc/shared'
 import { getEventMeta, withEventMeta } from '@standard-server/core'
 import { createClient } from 'redis'
@@ -251,7 +251,7 @@ describe.concurrent('redisPublisher', { skip: !REDIS_URL, timeout: 20_000 }, () 
       }
     }
 
-    const serializer = new RPCSerializer({
+    const serializer = new RPCJsonSerializer({
       handlers: {
         person: {
           condition: p => p instanceof Person,

--- a/packages/publisher/src/adapters/redis.ts
+++ b/packages/publisher/src/adapters/redis.ts
@@ -1,8 +1,9 @@
-import type { ThrowableError } from '@orpc/shared'
+import type { RPCJsonSerialization } from '@orpc/client'
+import type { Public, ThrowableError } from '@orpc/shared'
 import type { EventMeta } from '@standard-server/core'
 import type { RedisClientType } from 'redis'
 import type { PublisherOptions, PublisherSubscribeListenerOptions } from '../publisher'
-import { RPCSerializer } from '@orpc/client'
+import { RPCJsonSerializer } from '@orpc/client'
 import { once, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
 import { getEventMeta, unwrapEvent, withEventMeta } from '@standard-server/core'
 import { Publisher } from '../publisher'
@@ -27,9 +28,9 @@ export interface RedisPublisherOptions extends PublisherOptions {
   /**
    * Serializer for serialize and deserialize payloads.
    *
-   * @default RPCSerializer
+   * @default RPCJsonSerializer
    */
-  serializer?: undefined | Pick<RPCSerializer, keyof RPCSerializer>
+  serializer?: undefined | Public<RPCJsonSerializer>
 
   /**
    * Configuration for event resume support.
@@ -88,7 +89,7 @@ export class RedisPublisher<T extends Record<string, object>> extends Publisher<
     super(options)
 
     this.prefix = options.prefix ?? ''
-    this.serializer = options.serializer ?? new RPCSerializer()
+    this.serializer = options.serializer ?? new RPCJsonSerializer()
     this.resumeEnabled = options.resume?.enabled ?? false
     this.resumeSeconds = options.resume?.seconds ?? 300
     this.subscriber = options.subscriber ?? redis.duplicate()
@@ -221,12 +222,13 @@ export class RedisPublisher<T extends Record<string, object>> extends Publisher<
     })
   }
 
-  private serializePayload(payload: object): { payload: unknown, meta?: undefined | EventMeta } {
+  private serializePayload(payload: object): { payload: RPCJsonSerialization, meta?: undefined | EventMeta } {
     const [original, meta] = unwrapEvent(payload)
-    return { payload: this.serializer.serialize(original, { useFormDataForBlobFields: false }), meta }
+    const { json, meta: jsonMeta } = this.serializer.serialize(original)
+    return { payload: { json, meta: jsonMeta }, meta }
   }
 
-  private deserializePayload(id: string | undefined, { payload, meta }: { payload: unknown, meta?: undefined | EventMeta }): object {
+  private deserializePayload(id: string | undefined, { payload, meta }: { payload: RPCJsonSerialization, meta?: undefined | EventMeta }): object {
     return withEventMeta(
       this.serializer.deserialize(payload) as object,
       id === undefined ? { ...meta } : { ...meta, id },

--- a/packages/publisher/src/adapters/upstash.test.ts
+++ b/packages/publisher/src/adapters/upstash.test.ts
@@ -1,5 +1,5 @@
 import type { UpstashPublisherOptions } from './upstash'
-import { RPCSerializer } from '@orpc/client'
+import { RPCJsonSerializer } from '@orpc/client'
 import { getOrBind, promiseWithResolvers, sleep } from '@orpc/shared'
 import { getEventMeta, withEventMeta } from '@standard-server/core'
 import { Redis } from '@upstash/redis'
@@ -306,7 +306,7 @@ describe.concurrent(
         ) { }
       }
 
-      const serializer = new RPCSerializer({
+      const serializer = new RPCJsonSerializer({
         handlers: {
           person: {
             condition: p => p instanceof Person,

--- a/packages/publisher/src/adapters/upstash.ts
+++ b/packages/publisher/src/adapters/upstash.ts
@@ -1,8 +1,9 @@
-import type { ThrowableError } from '@orpc/shared'
+import type { RPCJsonSerialization } from '@orpc/client'
+import type { Public, ThrowableError } from '@orpc/shared'
 import type { EventMeta } from '@standard-server/core'
 import type { Redis } from '@upstash/redis'
 import type { PublisherOptions, PublisherSubscribeListenerOptions } from '../publisher'
-import { RPCSerializer } from '@orpc/client'
+import { RPCJsonSerializer } from '@orpc/client'
 import { once } from '@orpc/shared'
 import { getEventMeta, unwrapEvent, withEventMeta } from '@standard-server/core'
 import { Publisher } from '../publisher'
@@ -18,9 +19,9 @@ export interface UpstashPublisherOptions extends PublisherOptions {
   /**
    * Serializer for serialize and deserialize payloads.
    *
-   * @default RPCSerializer
+   * @default RPCJsonSerializer
    */
-  serializer?: undefined | Pick<RPCSerializer, keyof RPCSerializer>
+  serializer?: undefined | Public<RPCJsonSerializer>
 
   /**
    * Configuration for event resume support.
@@ -61,7 +62,7 @@ export interface UpstashPublisherOptions extends PublisherOptions {
  */
 export class UpstashPublisher<T extends Record<string, object>> extends Publisher<T> {
   private readonly prefix: string
-  private readonly serializer: Pick<RPCSerializer, keyof RPCSerializer>
+  private readonly serializer: Public<RPCJsonSerializer>
   private readonly listenersMap = new Map<keyof T, Array<(payload: any) => void>>()
   private readonly onErrorsMap = new Map<keyof T, Array<(error: ThrowableError) => void>>()
   private readonly subscriptionMap = new Map<keyof T, ReturnType<typeof this.redis.subscribe>>() // Upstash subscription objects
@@ -82,7 +83,7 @@ export class UpstashPublisher<T extends Record<string, object>> extends Publishe
     this.prefix = prefix ?? ''
     this.resumeEnabled = resume?.enabled ?? false
     this.resumeSeconds = resume?.seconds ?? 300
-    this.serializer = serializer ?? new RPCSerializer()
+    this.serializer = serializer ?? new RPCJsonSerializer()
   }
 
   private readonly firstPublishTimeMap: Map<string, number> = new Map()
@@ -317,12 +318,13 @@ export class UpstashPublisher<T extends Record<string, object>> extends Publishe
     }
   }
 
-  private serializePayload(payload: object): { payload: unknown, meta?: undefined | EventMeta } {
+  private serializePayload(payload: object): { payload: RPCJsonSerialization, meta?: undefined | EventMeta } {
     const [original, meta] = unwrapEvent(payload)
-    return { payload: this.serializer.serialize(original, { useFormDataForBlobFields: false }), meta }
+    const { json, meta: jsonMeta } = this.serializer.serialize(original)
+    return { payload: { json, meta: jsonMeta }, meta }
   }
 
-  private deserializePayload(id: string | undefined, { payload, meta }: { payload: unknown, meta?: undefined | EventMeta }): object {
+  private deserializePayload(id: string | undefined, { payload, meta }: { payload: RPCJsonSerialization, meta?: undefined | EventMeta }): object {
     return withEventMeta(
       this.serializer.deserialize(payload) as object,
       id === undefined ? { ...meta } : { ...meta, id },

--- a/packages/server/src/adapters/standard/rpc-handler-codec.ts
+++ b/packages/server/src/adapters/standard/rpc-handler-codec.ts
@@ -1,5 +1,5 @@
 import type { AnyORPCError } from '@orpc/client'
-import type { Promisable, Value } from '@orpc/shared'
+import type { Promisable, Public, Value } from '@orpc/shared'
 import type { StandardLazyRequest, StandardResponse } from '@standard-server/core'
 import type { Context } from '../../context'
 import type { AnyProcedure } from '../../procedure'
@@ -16,7 +16,7 @@ export interface RPCHandlerCodecOptions<T extends Context> extends RPCMatcherOpt
   /**
    * Override the default RPC serializer.
    */
-  serializer?: Pick<RPCSerializer, keyof RPCSerializer>
+  serializer?: Public<RPCSerializer>
 
   /**
    * Resolve HTTP status for encoded successful outputs.
@@ -39,7 +39,7 @@ export interface RPCHandlerCodecOptions<T extends Context> extends RPCMatcherOpt
 
 export class RPCHandlerCodec<T extends Context> implements StandardHandlerCodec<T> {
   private readonly matcher: RPCMatcher
-  private readonly serializer: Pick<RPCSerializer, keyof RPCSerializer>
+  private readonly serializer: Public<RPCSerializer>
   private readonly errorStatusMap: Exclude<RPCHandlerCodecOptions<T>['errorStatusMap'], undefined>
   private readonly outputStatus: RPCHandlerCodecOptions<T>['outputStatus']
 

--- a/tests/batch/__shared__/client-server.ts
+++ b/tests/batch/__shared__/client-server.ts
@@ -1,13 +1,14 @@
 import type { RPCSerializer } from '@orpc/client'
 import type { BatchLinkPluginMode } from '@orpc/client/plugins'
 import type { AnyRouter, Context, RouterClient } from '@orpc/server'
+import type { Public } from '@orpc/shared'
 import { defaultSerializer } from '../../rpc/__shared__/client-server'
 
 export interface BatchClientServerTestOptions {
   context?: Context
   method?: 'GET' | 'POST' | 'QUERY'
   mode?: BatchLinkPluginMode
-  serializer?: Pick<RPCSerializer, keyof RPCSerializer>
+  serializer?: Public<RPCSerializer>
 }
 
 export interface BatchClientServerTest<T extends AnyRouter> {

--- a/tests/openapi/__shared__/client-server.ts
+++ b/tests/openapi/__shared__/client-server.ts
@@ -1,9 +1,10 @@
 import type { AnyRouter, Context, RouterClient } from '@orpc/server'
+import type { Public } from '@orpc/shared'
 import { OpenAPISerializer } from '@orpc/openapi'
 
 export interface OpenAPIClientServerTestOptions {
   context?: Context
-  serializer?: Pick<OpenAPISerializer, keyof OpenAPISerializer>
+  serializer?: Public<OpenAPISerializer>
 }
 
 export interface CreateOpenAPIClientServerTest {

--- a/tests/rpc/__shared__/client-server.ts
+++ b/tests/rpc/__shared__/client-server.ts
@@ -1,9 +1,10 @@
 import type { AnyRouter, Context, RouterClient } from '@orpc/server'
+import type { Public } from '@orpc/shared'
 import { RPCSerializer } from '@orpc/client'
 
 export interface ClientServerTestOptions {
   context?: Context
-  serializer?: Pick<RPCSerializer, keyof RPCSerializer>
+  serializer?: Public<RPCSerializer>
 }
 
 export interface CreateClientServerTest {


### PR DESCRIPTION
Publisher adapters (Redis, Upstash, Bun Redis, Cloudflare Durable) now serialize payloads with `RPCJsonSerializer` instead of `RPCSerializer`, and their `serializer` option expects an `RPCJsonSerializer`-shaped instance. The stored and published message format is unchanged, so existing streams and mixed-version processes keep working. `RPCJsonSerializer` is now documented on the RPC Serializer page.

## Breaking

- `serializer` on `RedisPublisher`, `UpstashPublisher`, `BunRedisPublisher`, and `DurablePublisher` is `Public<RPCJsonSerializer>`. Passing an `RPCSerializer` instance no longer type-checks; it takes the same `handlers` option, so custom types migrate by swapping the class.

## Docs

- New "RPC JSON Serializer" section on the RPC Serializer page, with the `RPCJsonSerializer` JSDoc backlink pointing to it.
- TanStack Query and v1 migration pages link to that section; the migration guide no longer claims hydration uses `RPCSerializer`, and the Publisher section mentions the `serializer` option.

## Refactor

- `Pick<X, keyof X>` replaced by `Public<X>` everywhere it appeared: RPC and OpenAPI codecs, the OpenAPI generator, and the shared test helpers.

## Testing

- Adapter tests use `RPCJsonSerializer`; the Cloudflare workerd suite passes, including the custom-handler round trip through a real Durable Object.
- Redis and Upstash suites need live servers and skip locally, so a temporary mock-Redis round trip covered built-in types, a custom handler, the malformed-message error path, and the unchanged wire shape.
- Root, bun, and cloudflare type-checks, eslint, the JSDoc backlink checker, and `blume validate --strict` all pass.
