### PR TITLE
fix(openapi): add titles to generated error schemas

### DIFF
--- a/packages/openapi/src/openapi-generator-operation.test.ts
+++ b/packages/openapi/src/openapi-generator-operation.test.ts
@@ -699,6 +699,7 @@ describe('openAPIGenerator operation builders', () => {
       })
 
       expect(doc.components?.schemas?.BadRequest).toEqual({
+        title: 'BAD_REQUEST',
         type: 'object',
         properties: {
           defined: { const: true },
@@ -710,6 +711,7 @@ describe('openAPIGenerator operation builders', () => {
         required: ['defined', 'code', 'status', 'message', 'data'],
       })
       expect(doc.components?.schemas?.BadRequest2).toEqual({
+        title: 'BAD_REQUEST_2',
         type: 'object',
         properties: {
           defined: { const: true },
@@ -721,6 +723,7 @@ describe('openAPIGenerator operation builders', () => {
         required: ['defined', 'code', 'status', 'message'],
       })
       expect(doc.components?.schemas?.UndefinedError).toEqual({
+        title: 'UndefinedError',
         type: 'object',
         properties: {
           defined: { const: false },
@@ -812,6 +815,7 @@ describe('openAPIGenerator operation builders', () => {
       })
 
       expect(doc.components?.schemas?.Forbidden).toEqual({
+        title: 'FORBIDDEN',
         type: 'object',
         properties: {
           defined: { const: true },

--- a/packages/openapi/src/openapi-generator-operation.ts
+++ b/packages/openapi/src/openapi-generator-operation.ts
@@ -475,6 +475,7 @@ export function buildErrorResponse(
   }
 
   const undefinedErrorSchema = ctx.registry.register('UndefinedError', {
+    title: 'UndefinedError',
     type: 'object',
     properties: {
       defined: { const: false },
@@ -495,14 +496,17 @@ export function buildErrorResponse(
     )
     const responseSchema = customBodySchema ?? combineJsonSchemasWithComposition('oneOf', [
       ...definitions.map(({ code, dataJsonSchema, dataOptional }) => {
-        return ctx.registry.register(toErrorComponentName(code), combineJsonObjectSchemaEntries([
-          ['defined', { const: true }, false],
-          ['code', { const: code }, false],
-          ['status', { const: status }, false],
-          // avoid using the defaultMessage here to improve component reusability
-          ['message', { type: 'string' }, false],
-          ['data', ctx.registry.hoistDefs(dataJsonSchema, 'output'), dataOptional],
-        ]))
+        return ctx.registry.register(toErrorComponentName(code), {
+          title: code,
+          ...combineJsonObjectSchemaEntries([
+            ['defined', { const: true }, false],
+            ['code', { const: code }, false],
+            ['status', { const: status }, false],
+            // avoid using the defaultMessage here to improve component reusability
+            ['message', { type: 'string' }, false],
+            ['data', ctx.registry.hoistDefs(dataJsonSchema, 'output'), dataOptional],
+          ]),
+        })
       }),
       undefinedErrorSchema,
     ])

--- a/packages/openapi/src/openapi-generator.test.ts
+++ b/packages/openapi/src/openapi-generator.test.ts
@@ -558,6 +558,38 @@ describe('openAPIGenerator version', () => {
     })
   })
 
+  it.each(['3.2.0', '3.1.0', '3.0.3'] as const)('preserves error titles in OpenAPI %s', async (version) => {
+    const doc = await generator.generate({
+      create: oc.meta(openapi({ method: 'POST', path: '/penguins' })).errors({
+        PENGUIN_NAME_BANNED: {},
+        PENGUIN_COLONY_FULL: {},
+      }),
+    }, {
+      version,
+      errorStatusMap: { PENGUIN_NAME_BANNED: 400, PENGUIN_COLONY_FULL: 400 },
+    })
+
+    const response = doc.paths?.['/penguins']?.post?.responses?.['400']
+    expect(response).toMatchObject({
+      content: {
+        'application/json': {
+          schema: {
+            oneOf: [
+              { $ref: '#/components/schemas/PenguinNameBanned' },
+              { $ref: '#/components/schemas/PenguinColonyFull' },
+              { $ref: '#/components/schemas/UndefinedError' },
+            ],
+          },
+        },
+      },
+    })
+    expect(doc.components?.schemas).toMatchObject({
+      PenguinNameBanned: { title: 'PENGUIN_NAME_BANNED' },
+      PenguinColonyFull: { title: 'PENGUIN_COLONY_FULL' },
+      UndefinedError: { title: 'UndefinedError' },
+    })
+  })
+
   it('serializes non-JSON values after downgrading', async () => {
     const doc = await generator.generate({}, {
       version: '3.0.4',

--- a/packages/openapi/tests/openapi-generator/typed-errors.test.ts
+++ b/packages/openapi/tests/openapi-generator/typed-errors.test.ts
@@ -77,6 +77,7 @@ describe('openAPIGenerator e2e: typed errors', () => {
     const doc = await generator.generate(router)
 
     expect(doc.components?.schemas?.Conflict).toEqual({
+      title: 'CONFLICT',
       type: 'object',
       properties: {
         defined: { const: true },
@@ -95,6 +96,7 @@ describe('openAPIGenerator e2e: typed errors', () => {
     })
 
     expect(doc.components?.schemas?.UndefinedError).toEqual({
+      title: 'UndefinedError',
       type: 'object',
       properties: {
         defined: { const: false },
@@ -104,6 +106,41 @@ describe('openAPIGenerator e2e: typed errors', () => {
         data: {},
       },
       required: ['defined', 'code', 'status', 'message'],
+    })
+  })
+
+  it.each(['3.2.0', '3.1.0', '3.0.3'] as const)('titles error components after their codes so oneOf branches sharing a status stay distinguishable in OpenAPI %s', async (version) => {
+    const doc = await generator.generate({
+      createPlanet: oc
+        .meta(openapi({ method: 'POST', path: '/planets' }))
+        .errors({
+          PLANET_NAME_TAKEN: { data: z.object({ existingId: z.string() }) },
+          PLANET_QUOTA_EXCEEDED: {},
+        })
+        .input(z.object({ name: z.string() })),
+    }, {
+      version,
+      errorStatusMap: { PLANET_NAME_TAKEN: 409, PLANET_QUOTA_EXCEEDED: 409 },
+    })
+
+    expect(doc.paths?.['/planets']?.post?.responses?.['409']).toEqual(expect.objectContaining({
+      content: {
+        'application/json': {
+          schema: {
+            oneOf: [
+              { $ref: '#/components/schemas/PlanetNameTaken' },
+              { $ref: '#/components/schemas/PlanetQuotaExceeded' },
+              { $ref: '#/components/schemas/UndefinedError' },
+            ],
+          },
+        },
+      },
+    }))
+
+    expect(doc.components?.schemas).toEqual({
+      PlanetNameTaken: expect.objectContaining({ title: 'PLANET_NAME_TAKEN' }),
+      PlanetQuotaExceeded: expect.objectContaining({ title: 'PLANET_QUOTA_EXCEEDED' }),
+      UndefinedError: expect.objectContaining({ title: 'UndefinedError' }),
     })
   })
 


### PR DESCRIPTION
When several errors share an HTTP status, Swagger UI displays their `oneOf` branches as anonymous `#0`, `#1`, etc. Add the original error code as each generated component's `title`, and use `UndefinedError` for the fallback. Titles survive OpenAPI 3.0, 3.1 and 3.2 generation.

Related to #1580. In Swagger UI 5.32.14, this labels the individual branches (for example, `#0 PENGUIN_NAME_BANNED`); the union summary still reads `(object | object | object)`.

Validation:
- All 416 OpenAPI tests pass, including regression coverage for all three OpenAPI versions.
- `pnpm exec tsc -b packages/openapi` and ESLint on the changed files pass.
- Verified the generated document in Swagger UI 5.32.14. Compared with the beta.34 reproduction, paths and components differ only by the added titles.

Resolves #1580
