### PR TITLE
refactor(publisher): share Redis adapter logic through BaseRedisPublisher

### DIFF
--- a/packages/bun/src/redis-publisher.ts
+++ b/packages/bun/src/redis-publisher.ts
@@ -1,14 +1,9 @@
-import type { RPCJsonSerialization } from '@orpc/client'
-import type { PublisherOptions, PublisherSubscribeListenerOptions } from '@orpc/publisher'
-import type { Promisable, Public, ThrowableError } from '@orpc/shared'
-import type { EventMeta } from '@standard-server/core'
+import type { BaseRedisPublisherOptions, RedisStreamEntry, RedisStreamTrimOptions } from '@orpc/publisher/base-redis'
+import type { Promisable } from '@orpc/shared'
 import type { RedisClient } from 'bun'
-import { RPCJsonSerializer } from '@orpc/client'
-import { Publisher } from '@orpc/publisher'
-import { once, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
-import { getEventMeta, unwrapEvent, withEventMeta } from '@standard-server/core'
+import { BaseRedisPublisher } from '@orpc/publisher/base-redis'
 
-export interface BunRedisPublisherOptions extends PublisherOptions {
+export interface BunRedisPublisherOptions extends BaseRedisPublisherOptions {
   /**
    * Redis subscriber instance.
    * Pub/Sub takes over the connection, so a client with subscriptions
@@ -17,50 +12,6 @@ export interface BunRedisPublisherOptions extends PublisherOptions {
    * @default redis.duplicate() (lazily created on first listen)
    */
   subscriber?: undefined | Promisable<RedisClient>
-
-  /**
-   * The prefix to use for Redis keys.
-   *
-   * @default ''
-   */
-  prefix?: string
-
-  /**
-   * Serializer for serialize and deserialize payloads.
-   *
-   * @default RPCJsonSerializer
-   */
-  serializer?: undefined | Public<RPCJsonSerializer>
-
-  /**
-   * Configuration for event resume support.
-   *
-   * When enabled, published events are temporarily stored so new
-   * subscribers can resume from a previous position using `lastEventId`.
-   *
-   * @default { enabled: false }
-   */
-  resume?: {
-    /**
-     * Whether event resume support is enabled.
-     *
-     * When enabled, published events are temporarily stored so new
-     * subscribers can resume from a previous position using `lastEventId`.
-     *
-     * @default false
-     */
-    enabled: boolean
-
-    /**
-     * How long (in seconds) to retain events for resume.
-     *
-     * Expired events are cleaned up lazily for performance reasons, so
-     * some events may remain available slightly longer than this period.
-     *
-     * @default 300 (5 min)
-     */
-    seconds?: number
-  }
 }
 
 /**
@@ -69,167 +20,52 @@ export interface BunRedisPublisherOptions extends PublisherOptions {
  *
  * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher Helpers - Adapters}
  */
-export class BunRedisPublisher<T extends Record<string, object>> extends Publisher<T> {
+export class BunRedisPublisher<T extends Record<string, object>> extends BaseRedisPublisher<T> {
   private subscriber: BunRedisPublisherOptions['subscriber']
-  private readonly prefix: Exclude<BunRedisPublisherOptions['prefix'], undefined>
-  private readonly serializer: Exclude<BunRedisPublisherOptions['serializer'], undefined>
-  private readonly resumeEnabled: boolean
-  private readonly resumeSeconds: number
-
-  /**
-   * The exactness of the `XTRIM` command.
-   * Used for testing purpose.
-   */
-  private readonly xTrimExactness: '~' | '=' = '~'
 
   constructor(
     private readonly redis: RedisClient,
-    options: BunRedisPublisherOptions = {},
+    { subscriber, ...options }: BunRedisPublisherOptions = {},
   ) {
     super(options)
 
-    this.prefix = options.prefix ?? ''
-    this.serializer = options.serializer ?? new RPCJsonSerializer()
-    this.resumeEnabled = options.resume?.enabled ?? false
-    this.resumeSeconds = options.resume?.seconds ?? 300
-    this.subscriber = options.subscriber
+    this.subscriber = subscriber
   }
 
-  private readonly firstPublishTimeMap: Map<string, number> = new Map()
-  async publish<K extends keyof T & string>(event: K, payload: T[K]): Promise<void> {
-    const redisKey = `${this.prefix}${event}`
-    const data = this.serializePayload(payload)
-    let id: string | undefined
-
-    if (this.resumeEnabled) {
-      const now = Date.now()
-
-      // Remove expired resume windows.
-      // The next publish for a stale event will perform trimming again.
-      for (const [event, firstPublishTime] of this.firstPublishTimeMap) {
-        if (firstPublishTime + this.resumeSeconds * 1000 < now) {
-          this.firstPublishTimeMap.delete(event)
-        }
-      }
-
-      if (!this.firstPublishTimeMap.has(event)) {
-        this.firstPublishTimeMap.set(event, now)
-
-        const result = await Promise.all([
-          this.redis.send('XADD', [redisKey, '*', 'data', stringifyJSON(data)]),
-          this.redis.send('XTRIM', [redisKey, 'MINID', this.xTrimExactness, `${now - this.resumeSeconds * 1000}-0`]),
-          // Use a 2x TTL so events published near the end of the resume window
-          // are not expired before the next window updates the key expiration.
-          this.redis.expire(redisKey, this.resumeSeconds * 2),
-        ])
-
-        id = result[0] as string
-      }
-      else {
-        id = await this.redis.send('XADD', [redisKey, '*', 'data', stringifyJSON(data)]) as string
-      }
-    }
-
-    await this.redis.publish(redisKey, stringifyJSON({ data, id }))
+  protected async publishMessage(channel: string, message: string): Promise<void> {
+    await this.redis.publish(channel, message)
   }
 
-  protected async subscribeListener<K extends keyof T & string>(
-    event: K,
-    originalListener: (payload: T[K]) => void,
-    { lastEventId, onError }: PublisherSubscribeListenerOptions = {},
-  ): Promise<() => Promise<void>> {
-    const redisKey = `${this.prefix}${event}`
-
-    let pendingPayloads: T[K][] | undefined = []
-    const resumedIds = new Set<string>()
-
-    const deduplicatingListener = (payload: T[K]) => {
-      if (pendingPayloads) {
-        pendingPayloads.push(payload)
-        return
-      }
-
-      const id = getEventMeta(payload)?.id
-      if (id !== undefined && resumedIds.has(id)) { // Already delivered during resume.
-        return
-      }
-
-      originalListener(payload)
-    }
-
-    const redisListener = (message: string) => {
-      try {
-        const { id, data } = parseEmptyableJSON(message) as any
-        const payload = this.deserializePayload(id, data)
-        deduplicatingListener(payload as any)
-      }
-      catch (error) {
-        // Can happen if the published message has an unexpected format.
-        onError?.(error as ThrowableError)
-      }
-    }
-
+  protected async subscribeChannel(channel: string, listener: (message: unknown) => void): Promise<() => Promise<void>> {
     this.subscriber ??= this.redis.duplicate()
     const subscriber = await this.subscriber
 
-    try {
-      const subscribePromise = subscriber.subscribe(redisKey, redisListener)
+    await subscriber.subscribe(channel, listener)
 
-      try {
-        if (this.resumeEnabled && lastEventId !== undefined) {
-          /**
-           * [Object: null prototype] {
-           *    "redis:9d1536ca-8952-4e35-ae79-d466074f9436:orders": [
-           *        [ "1782700569588-0", [ "data", "{\"payload\":{\"json\":{\"order\":3}}}" ] ]
-           *    ],
-           * }
-           */
-          const results = await this.redis.send('XREAD', ['STREAMS', redisKey, lastEventId])
-
-          if (results && results[redisKey]) {
-            const messages = results[redisKey]
-
-            for (const [id, message] of messages) {
-              const rawData = message[1]
-              const data = parseEmptyableJSON(rawData as string)
-              const payload = this.deserializePayload(id, data as any)
-              resumedIds.add(id)
-              originalListener(payload as T[K])
-            }
-          }
-        }
-      }
-      finally {
-        const pending = pendingPayloads
-        pendingPayloads = undefined
-
-        for (const payload of pending) {
-          deduplicatingListener(payload)
-        }
-      }
-
-      await subscribePromise
+    return async () => {
+      await subscriber.unsubscribe(channel, listener)
     }
-    catch (error) {
-      await subscriber.unsubscribe(redisKey, redisListener)
-      throw error
-    }
-
-    return once(async () => {
-      await subscriber.unsubscribe(redisKey, redisListener)
-    })
   }
 
-  private serializePayload(payload: object): { payload: RPCJsonSerialization, meta?: undefined | EventMeta } {
-    const [original, meta] = unwrapEvent(payload)
-    const { json, meta: jsonMeta } = this.serializer.serialize(original)
-    return { payload: { json, meta: jsonMeta }, meta }
+  protected async addStreamEntry(key: string, data: string, trim?: RedisStreamTrimOptions): Promise<string> {
+    if (!trim) {
+      return await this.redis.send('XADD', [key, '*', 'data', data]) as string
+    }
+
+    // Bun pipelines these, so they reach Redis in order within one round trip.
+    const [id] = await Promise.all([
+      this.redis.send('XADD', [key, '*', 'data', data]),
+      this.redis.send('XTRIM', [key, 'MINID', trim.exactness, trim.minId]),
+      this.redis.expire(key, trim.expireSeconds),
+    ])
+
+    return id as string
   }
 
-  private deserializePayload(id: string | undefined, { payload, meta }: { payload: RPCJsonSerialization, meta?: undefined | EventMeta }): object {
-    return withEventMeta(
-      this.serializer.deserialize(payload) as object,
-      id === undefined ? { ...meta } : { ...meta, id },
-    )
+  protected async readStreamEntries(key: string, lastId: string): Promise<RedisStreamEntry[]> {
+    const results = await this.redis.send('XREAD', ['STREAMS', key, lastId])
+    const entries: Array<[id: string, fields: [name: string, value: string]]> = results?.[key] ?? []
+
+    return entries.map(([id, fields]) => ({ id, data: fields[1] }))
   }
 }

--- a/packages/publisher/package.json
+++ b/packages/publisher/package.json
@@ -34,6 +34,11 @@
         "import": "./dist/index.mjs",
         "default": "./dist/index.mjs"
       },
+      "./base-redis": {
+        "types": "./dist/adapters/base-redis.d.mts",
+        "import": "./dist/adapters/base-redis.mjs",
+        "default": "./dist/adapters/base-redis.mjs"
+      },
       "./memory": {
         "types": "./dist/adapters/memory.d.mts",
         "import": "./dist/adapters/memory.mjs",
@@ -54,6 +59,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": "./src/index.ts",
+    "./base-redis": "./src/adapters/base-redis.ts",
     "./memory": "./src/adapters/memory.ts",
     "./redis": "./src/adapters/redis.ts",
     "./upstash": "./src/adapters/upstash.ts"

--- a/packages/publisher/src/adapters/base-redis.test.ts
+++ b/packages/publisher/src/adapters/base-redis.test.ts
@@ -1,0 +1,234 @@
+import type { BaseRedisPublisherOptions, RedisStreamEntry } from './base-redis'
+import { promiseWithResolvers } from '@orpc/shared'
+import { getEventMeta, withEventMeta } from '@standard-server/core'
+import { BaseRedisPublisher } from './base-redis'
+
+class FakeRedis {
+  readonly channels = new Map<string, Set<(message: string) => void>>()
+  readonly streams = new Map<string, RedisStreamEntry[]>()
+  private lastId = 0
+
+  publish(channel: string, message: string): void {
+    this.channels.get(channel)?.forEach(listener => listener(message))
+  }
+
+  subscribe(channel: string, listener: (message: string) => void): () => void {
+    const listeners = this.channels.get(channel) ?? new Set()
+    this.channels.set(channel, listeners.add(listener))
+
+    return () => {
+      listeners.delete(listener)
+
+      if (listeners.size === 0) {
+        this.channels.delete(channel)
+      }
+    }
+  }
+
+  xadd(key: string, data: string): string {
+    const entry = { id: `${++this.lastId}-0`, data }
+    this.streams.set(key, [...this.streams.get(key) ?? [], entry])
+    return entry.id
+  }
+
+  xread(key: string, lastId: string): RedisStreamEntry[] {
+    return this.streams.get(key)?.filter(entry => Number.parseInt(entry.id) > Number.parseInt(lastId)) ?? []
+  }
+}
+
+class FakeRedisPublisher<T extends Record<string, object> = Record<string, object>> extends BaseRedisPublisher<T> {
+  constructor(private readonly redis: FakeRedis, options?: BaseRedisPublisherOptions) {
+    super(options)
+  }
+
+  protected async publishMessage(channel: string, message: string): Promise<void> {
+    this.redis.publish(channel, message)
+  }
+
+  protected async subscribeChannel(channel: string, listener: (message: unknown) => void): Promise<() => Promise<void>> {
+    const unsubscribe = this.redis.subscribe(channel, listener)
+    return async () => unsubscribe()
+  }
+
+  protected async addStreamEntry(key: string, data: string): Promise<string> {
+    return this.redis.xadd(key, data)
+  }
+
+  protected async readStreamEntries(key: string, lastId: string): Promise<RedisStreamEntry[]> {
+    return this.redis.xread(key, lastId)
+  }
+}
+
+describe('baseRedisPublisher', () => {
+  let redis: FakeRedis
+
+  beforeEach(() => {
+    redis = new FakeRedis()
+  })
+
+  it('delivers live events between publishers sharing a server and prefix', async () => {
+    const source = new FakeRedisPublisher(redis, { prefix: 'app:' })
+    const target = new FakeRedisPublisher(redis, { prefix: 'app:' })
+    const other = new FakeRedisPublisher(redis, { prefix: 'other:' })
+    const listener = vi.fn()
+    const otherListener = vi.fn()
+
+    const unsubscribe = await target.subscribe('orders', listener)
+    const unsubscribeOther = await other.subscribe('orders', otherListener)
+    await source.publish('orders', { order: 1 })
+    await source.publish('orders', withEventMeta({ order: 2 }, { id: 'custom', comments: ['audit'] }))
+
+    expect([...redis.channels.keys()]).toEqual(['app:orders', 'other:orders'])
+    expect(listener.mock.calls.map(call => call[0])).toEqual([{ order: 1 }, { order: 2 }])
+    expect(getEventMeta(listener.mock.calls[0]![0])).toBeUndefined()
+    expect(getEventMeta(listener.mock.calls[1]![0])).toEqual({ id: 'custom', comments: ['audit'] })
+    expect(otherListener).not.toHaveBeenCalled()
+
+    await unsubscribe()
+    await unsubscribeOther()
+
+    expect(redis.channels.size).toBe(0)
+  })
+
+  it('uses a stable wire format for stream entries and messages', async () => {
+    const publisher = new FakeRedisPublisher(redis, { resume: { enabled: true } })
+    const messages: string[] = []
+    redis.subscribe('orders', message => messages.push(message))
+
+    await publisher.publish('orders', withEventMeta({ order: 1, at: new Date('2024-01-01') }, { comments: ['audit'] }))
+
+    const [entry] = redis.streams.get('orders')!
+    expect(entry!.data).toBe('{"payload":{"json":{"order":1,"at":"2024-01-01T00:00:00.000Z"},"meta":[["date","at"]]},"meta":{"comments":["audit"]}}')
+    expect(messages).toEqual([`{"data":${entry!.data},"id":"${entry!.id}"}`])
+  })
+
+  it('skips streams when resume is disabled', async () => {
+    const publisher = new FakeRedisPublisher(redis)
+    const addStreamEntry = vi.spyOn(publisher as any, 'addStreamEntry')
+    const readStreamEntries = vi.spyOn(publisher as any, 'readStreamEntries')
+    const listener = vi.fn()
+
+    const unsubscribe = await publisher.subscribe('orders', listener, { lastEventId: '0' })
+    await publisher.publish('orders', { order: 1 })
+
+    expect(listener).toHaveBeenCalledExactlyOnceWith({ order: 1 })
+    expect(getEventMeta(listener.mock.calls[0]![0])).toBeUndefined()
+    expect(addStreamEntry).not.toHaveBeenCalled()
+    expect(readStreamEntries).not.toHaveBeenCalled()
+
+    await unsubscribe()
+  })
+
+  it('trims once per resume window per channel', async ({ onTestFinished }) => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(1_000_000)
+    onTestFinished(() => now.mockRestore())
+    const publisher = new FakeRedisPublisher(redis, { prefix: 'app:', resume: { enabled: true, seconds: 10 } })
+    ;(publisher as any).xTrimExactness = '='
+    const addStreamEntry = vi.spyOn(publisher as any, 'addStreamEntry')
+
+    await publisher.publish('orders', { order: 1 })
+    await publisher.publish('orders', { order: 2 })
+    await publisher.publish('invoices', { invoice: 1 })
+    now.mockReturnValue(1_010_001)
+    await publisher.publish('orders', { order: 3 })
+
+    expect(addStreamEntry.mock.calls.map(([key, , trim]) => [key, trim])).toEqual([
+      ['app:orders', { minId: '990000-0', exactness: '=', expireSeconds: 20 }],
+      ['app:orders', undefined],
+      ['app:invoices', { minId: '990000-0', exactness: '=', expireSeconds: 20 }],
+      ['app:orders', { minId: '1000001-0', exactness: '=', expireSeconds: 20 }],
+    ])
+  })
+
+  it('resumes missed events and deduplicates those that also arrive live', async () => {
+    const publisher = new FakeRedisPublisher(redis, { resume: { enabled: true } })
+    const liveListener = vi.fn()
+    const unsubscribeLive = await publisher.subscribe('orders', liveListener)
+    await publisher.publish('orders', { order: 1 })
+    await publisher.publish('orders', { order: 2 })
+    await unsubscribeLive()
+
+    const resumeGate = promiseWithResolvers<void>()
+    vi.spyOn(publisher as any, 'readStreamEntries').mockImplementationOnce(async (key: any, lastId: any) => {
+      await resumeGate.promise
+      return redis.xread(key, lastId)
+    })
+    const listener = vi.fn()
+
+    const [unsubscribe] = await Promise.all([
+      publisher.subscribe('orders', listener, { lastEventId: getEventMeta(liveListener.mock.calls[0]![0])?.id }),
+      publisher.publish('orders', { order: 3 })
+        .then(() => publisher.publish('orders', { order: 4 }))
+        .then(() => resumeGate.resolve()),
+    ])
+    await publisher.publish('orders', { order: 5 })
+
+    expect(listener.mock.calls.map(call => call[0].order)).toEqual([2, 3, 4, 5])
+    expect(listener.mock.calls.map(call => getEventMeta(call[0])?.id)).toEqual(redis.streams.get('orders')!.slice(1).map(entry => entry.id))
+
+    await unsubscribe()
+  })
+
+  it('routes onError to the channel subscription and reports malformed messages through it', async () => {
+    const publisher = new FakeRedisPublisher(redis)
+    const subscribeChannel = vi.spyOn(publisher as any, 'subscribeChannel')
+    const listener = vi.fn()
+    const onError = vi.fn()
+
+    const unsubscribe = await publisher.subscribe('orders', listener, { onError })
+    redis.publish('orders', 'invalid')
+
+    expect(subscribeChannel).toHaveBeenCalledWith('orders', expect.any(Function), onError)
+    expect(listener).not.toHaveBeenCalled()
+    expect(onError).toHaveBeenCalledExactlyOnceWith(expect.any(SyntaxError))
+
+    await unsubscribe()
+  })
+
+  it('releases the subscription when resuming fails', async () => {
+    const publisher = new FakeRedisPublisher(redis, { resume: { enabled: true } })
+    vi.spyOn(publisher as any, 'readStreamEntries').mockRejectedValueOnce(new Error('XREAD failed'))
+
+    await expect(publisher.subscribe('orders', vi.fn(), { lastEventId: '0' })).rejects.toThrow('XREAD failed')
+
+    expect(redis.channels.size).toBe(0)
+  })
+
+  it('propagates subscription failures', async () => {
+    const publisher = new FakeRedisPublisher(redis, { resume: { enabled: true } })
+    vi.spyOn(publisher as any, 'subscribeChannel').mockRejectedValueOnce(new Error('SUBSCRIBE failed'))
+
+    await expect(publisher.subscribe('orders', vi.fn(), { lastEventId: '0' })).rejects.toThrow('SUBSCRIBE failed')
+  })
+
+  it('makes the unsubscribe handle idempotent', async () => {
+    const publisher = new FakeRedisPublisher(redis)
+    const unsubscribeChannel = vi.fn(async () => {})
+    vi.spyOn(publisher as any, 'subscribeChannel').mockResolvedValueOnce(unsubscribeChannel)
+
+    const unsubscribe = await publisher.subscribe('orders', vi.fn())
+    await Promise.all([unsubscribe(), unsubscribe(), unsubscribe()])
+
+    expect(unsubscribeChannel).toHaveBeenCalledTimes(1)
+  })
+
+  it('accepts messages and stream entries already parsed by the client', async () => {
+    const publisher = new FakeRedisPublisher(redis, { resume: { enabled: true } })
+    let deliver!: (message: unknown) => void
+    vi.spyOn(publisher as any, 'subscribeChannel').mockImplementationOnce(async (_channel: any, listener: any) => {
+      deliver = listener
+      return async () => {}
+    })
+    vi.spyOn(publisher as any, 'readStreamEntries').mockResolvedValueOnce([{ id: '1-0', data: { payload: { json: { order: 1 } } } }])
+    const listener = vi.fn()
+
+    const unsubscribe = await publisher.subscribe('orders', listener, { lastEventId: '0' })
+    deliver({ id: '2-0', data: { payload: { json: { order: 2 } }, meta: { comments: ['audit'] } } })
+
+    expect(listener.mock.calls.map(call => call[0])).toEqual([{ order: 1 }, { order: 2 }])
+    expect(getEventMeta(listener.mock.calls[0]![0])).toEqual({ id: '1-0' })
+    expect(getEventMeta(listener.mock.calls[1]![0])).toEqual({ id: '2-0', comments: ['audit'] })
+
+    await unsubscribe()
+  })
+})

--- a/packages/publisher/src/adapters/base-redis.test.ts
+++ b/packages/publisher/src/adapters/base-redis.test.ts
@@ -254,4 +254,24 @@ describe('baseRedisPublisher', () => {
 
     await unsubscribe()
   })
+
+  it('releases the subscription when a listener throws while flushing queued events', async () => {
+    const publisher = new FakeRedisPublisher(redis)
+    const subscribeGate = promiseWithResolvers<void>()
+    vi.spyOn(publisher as any, 'subscribeChannel').mockImplementationOnce(async (channel: any, listener: any) => {
+      const unsubscribe = redis.subscribe(channel, listener)
+      await subscribeGate.promise
+      return async () => unsubscribe()
+    })
+    const listener = vi.fn(() => {
+      throw new Error('listener failed')
+    })
+
+    const subscribing = publisher.subscribe('orders', listener)
+    await publisher.publish('orders', { order: 1 })
+    subscribeGate.resolve()
+
+    await expect(subscribing).rejects.toThrow('listener failed')
+    expect(redis.channels.size).toBe(0)
+  })
 })

--- a/packages/publisher/src/adapters/base-redis.test.ts
+++ b/packages/publisher/src/adapters/base-redis.test.ts
@@ -231,4 +231,27 @@ describe('baseRedisPublisher', () => {
 
     await unsubscribe()
   })
+
+  it('does not lose events published while the subscription is being established', async () => {
+    // Reading the stream before Pub/Sub is live opens a window: an event published
+    // after the read but before the subscription is neither replayed nor delivered.
+    const publisher = new FakeRedisPublisher(redis, { resume: { enabled: true } })
+    const subscribeGate = promiseWithResolvers<void>()
+    vi.spyOn(publisher as any, 'subscribeChannel').mockImplementationOnce(async (channel: any, listener: any) => {
+      await subscribeGate.promise
+      const unsubscribe = redis.subscribe(channel, listener)
+      return async () => unsubscribe()
+    })
+    const listener = vi.fn()
+
+    await publisher.publish('orders', { order: 1 })
+    const subscribing = publisher.subscribe('orders', listener, { lastEventId: redis.streams.get('orders')![0]!.id })
+    await publisher.publish('orders', { order: 2 })
+    subscribeGate.resolve()
+    const unsubscribe = await subscribing
+
+    expect(listener.mock.calls.map(call => call[0])).toEqual([{ order: 2 }])
+
+    await unsubscribe()
+  })
 })

--- a/packages/publisher/src/adapters/base-redis.ts
+++ b/packages/publisher/src/adapters/base-redis.ts
@@ -231,29 +231,27 @@ export abstract class BaseRedisPublisher<T extends Record<string, object>> exten
       }
     }
 
-    const subscribePromise = this.subscribeChannel(channel, messageListener, onError)
+    // Subscribe first so no event can slip between the stream read and live delivery.
+    const unsubscribe = await this.subscribeChannel(channel, messageListener, onError)
 
-    try {
+    if (this.resumeEnabled && lastEventId !== undefined) {
       try {
-        if (this.resumeEnabled && lastEventId !== undefined) {
-          for (const { id, data } of await this.readStreamEntries(channel, lastEventId)) {
-            resumedIds.add(id)
-            listener(this.deserializePayload(id, parseIfText(data) as SerializedEvent) as T[K])
-          }
+        for (const { id, data } of await this.readStreamEntries(channel, lastEventId)) {
+          resumedIds.add(id)
+          listener(this.deserializePayload(id, parseIfText(data) as SerializedEvent) as T[K])
         }
       }
-      finally {
-        const pending = pendingPayloads
-        pendingPayloads = undefined
-        pending.forEach(deduplicatingListener)
+      catch (error) {
+        await unsubscribe()
+        throw error
       }
+    }
 
-      return once(await subscribePromise)
-    }
-    catch (error) {
-      await subscribePromise.then(unsubscribe => unsubscribe(), () => {})
-      throw error
-    }
+    const pending = pendingPayloads
+    pendingPayloads = undefined
+    pending.forEach(deduplicatingListener)
+
+    return once(unsubscribe)
   }
 
   private serializePayload(payload: object): SerializedEvent {

--- a/packages/publisher/src/adapters/base-redis.ts
+++ b/packages/publisher/src/adapters/base-redis.ts
@@ -1,0 +1,275 @@
+import type { RPCJsonSerialization } from '@orpc/client'
+import type { Public, ThrowableError } from '@orpc/shared'
+import type { EventMeta } from '@standard-server/core'
+import type { PublisherOptions, PublisherSubscribeListenerOptions } from '../publisher'
+import { RPCJsonSerializer } from '@orpc/client'
+import { once, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
+import { getEventMeta, unwrapEvent, withEventMeta } from '@standard-server/core'
+import { Publisher } from '../publisher'
+
+/**
+ * Options shared by every Redis-backed publisher adapter.
+ *
+ * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher Helpers - Adapters}
+ */
+export interface BaseRedisPublisherOptions extends PublisherOptions {
+  /**
+   * The prefix to use for Redis keys.
+   *
+   * @default ''
+   */
+  prefix?: string
+
+  /**
+   * Serializer for serialize and deserialize payloads.
+   *
+   * @default RPCJsonSerializer
+   */
+  serializer?: undefined | Public<RPCJsonSerializer>
+
+  /**
+   * Configuration for event resume support.
+   *
+   * When enabled, published events are temporarily stored so new
+   * subscribers can resume from a previous position using `lastEventId`.
+   *
+   * @default { enabled: false }
+   */
+  resume?: {
+    /**
+     * Whether event resume support is enabled.
+     *
+     * When enabled, published events are temporarily stored so new
+     * subscribers can resume from a previous position using `lastEventId`.
+     *
+     * @default false
+     */
+    enabled: boolean
+
+    /**
+     * How long (in seconds) to retain events for resume.
+     *
+     * Expired events are cleaned up lazily for performance reasons, so
+     * some events may remain available slightly longer than this period.
+     *
+     * @default 300 (5 min)
+     */
+    seconds?: number
+  }
+}
+
+/**
+ * An entry of the Redis Stream that stores events for resume.
+ *
+ * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher Helpers - Adapters}
+ */
+export interface RedisStreamEntry {
+  /**
+   * The entry ID assigned by Redis, which doubles as the event ID.
+   */
+  id: string
+
+  /**
+   * The `data` field, as JSON text or already parsed by clients that deserialize automatically.
+   */
+  data: unknown
+}
+
+/**
+ * Trimming to apply to a Redis Stream while adding an entry.
+ *
+ * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher Helpers - Adapters}
+ */
+export interface RedisStreamTrimOptions {
+  /**
+   * Entries with an ID lower than this one are removed (`XTRIM key MINID minId`).
+   */
+  minId: string
+
+  /**
+   * Whether trimming is exact (`=`) or approximate (`~`).
+   */
+  exactness: '~' | '='
+
+  /**
+   * Time to live to set on the stream key, in seconds (`EXPIRE key seconds`).
+   */
+  expireSeconds: number
+}
+
+interface SerializedEvent {
+  payload: RPCJsonSerialization
+  meta?: undefined | EventMeta
+}
+
+/**
+ * Base class for Redis-backed publisher adapters. It owns the key naming, the
+ * message format, and the resume logic, so every adapter built on it can exchange
+ * events with the others regardless of the Redis client in use.
+ *
+ * Extend it and implement the abstract methods to support another Redis client.
+ *
+ * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher Helpers - Adapters}
+ */
+export abstract class BaseRedisPublisher<T extends Record<string, object>> extends Publisher<T> {
+  protected readonly prefix: string
+  protected readonly serializer: Public<RPCJsonSerializer>
+  protected readonly resumeEnabled: boolean
+  protected readonly resumeSeconds: number
+
+  /**
+   * Tests switch this to `=` for deterministic trimming.
+   */
+  protected readonly xTrimExactness: '~' | '=' = '~'
+
+  private readonly lastTrimTimes = new Map<string, number>()
+
+  constructor({ prefix, serializer, resume, ...options }: BaseRedisPublisherOptions = {}) {
+    super(options)
+
+    this.prefix = prefix ?? ''
+    this.serializer = serializer ?? new RPCJsonSerializer()
+    this.resumeEnabled = resume?.enabled ?? false
+    this.resumeSeconds = resume?.seconds ?? 300
+  }
+
+  /**
+   * Sends a message to a Pub/Sub channel (`PUBLISH channel message`).
+   */
+  protected abstract publishMessage(channel: string, message: string): Promise<void>
+
+  /**
+   * Listens for messages on a Pub/Sub channel (`SUBSCRIBE channel`) and resolves
+   * with a function that stops listening (`UNSUBSCRIBE channel`).
+   *
+   * Messages reach the listener as JSON text, or already parsed by clients that
+   * deserialize automatically. The listener may be invoked as soon as the subscription is established, even
+   * before the returned promise settles. When the promise rejects, nothing may be
+   * left subscribed. `onError` reports failures of the established subscription,
+   * such as a lost connection.
+   */
+  protected abstract subscribeChannel(
+    channel: string,
+    listener: (message: unknown) => void,
+    onError?: (error: ThrowableError) => void,
+  ): Promise<() => Promise<void>>
+
+  /**
+   * Appends an entry to a stream (`XADD key * data <data>`) and resolves with its ID.
+   * When `trim` is provided, also trims the stream and refreshes its TTL,
+   * preferably within the same round trip.
+   */
+  protected abstract addStreamEntry(key: string, data: string, trim?: RedisStreamTrimOptions): Promise<string>
+
+  /**
+   * Reads the entries with an ID greater than `lastId` (`XREAD STREAMS key lastId`), oldest first.
+   */
+  protected abstract readStreamEntries(key: string, lastId: string): Promise<RedisStreamEntry[]>
+
+  async publish<K extends keyof T & string>(event: K, payload: T[K]): Promise<void> {
+    const channel = `${this.prefix}${event}`
+    const data = this.serializePayload(payload)
+    let id: string | undefined
+
+    if (this.resumeEnabled) {
+      const now = Date.now()
+      const windowMs = this.resumeSeconds * 1000
+
+      for (const [trimmedChannel, trimTime] of this.lastTrimTimes) {
+        if (trimTime + windowMs < now) {
+          this.lastTrimTimes.delete(trimmedChannel)
+        }
+      }
+
+      if (this.lastTrimTimes.has(channel)) {
+        id = await this.addStreamEntry(channel, stringifyJSON(data))
+      }
+      else {
+        this.lastTrimTimes.set(channel, now)
+
+        id = await this.addStreamEntry(channel, stringifyJSON(data), {
+          minId: `${now - windowMs}-0`,
+          exactness: this.xTrimExactness,
+          // 2x so entries added late in a window outlive it until the next trim refreshes the TTL.
+          expireSeconds: this.resumeSeconds * 2,
+        })
+      }
+    }
+
+    await this.publishMessage(channel, stringifyJSON({ data, id }))
+  }
+
+  protected async subscribeListener<K extends keyof T & string>(
+    event: K,
+    listener: (payload: T[K]) => void,
+    { lastEventId, onError }: PublisherSubscribeListenerOptions = {},
+  ): Promise<() => Promise<void>> {
+    const channel = `${this.prefix}${event}`
+
+    let pendingPayloads: T[K][] | undefined = []
+    const resumedIds = new Set<string>()
+
+    const deduplicatingListener = (payload: T[K]) => {
+      if (pendingPayloads) {
+        pendingPayloads.push(payload)
+        return
+      }
+
+      const id = getEventMeta(payload)?.id
+      if (id === undefined || !resumedIds.has(id)) {
+        listener(payload)
+      }
+    }
+
+    const messageListener = (message: unknown) => {
+      try {
+        const { id, data } = parseIfText(message) as { id?: string, data: SerializedEvent }
+        deduplicatingListener(this.deserializePayload(id, data) as T[K])
+      }
+      catch (error) {
+        onError?.(error as ThrowableError)
+      }
+    }
+
+    const subscribePromise = this.subscribeChannel(channel, messageListener, onError)
+
+    try {
+      try {
+        if (this.resumeEnabled && lastEventId !== undefined) {
+          for (const { id, data } of await this.readStreamEntries(channel, lastEventId)) {
+            resumedIds.add(id)
+            listener(this.deserializePayload(id, parseIfText(data) as SerializedEvent) as T[K])
+          }
+        }
+      }
+      finally {
+        const pending = pendingPayloads
+        pendingPayloads = undefined
+        pending.forEach(deduplicatingListener)
+      }
+
+      return once(await subscribePromise)
+    }
+    catch (error) {
+      await subscribePromise.then(unsubscribe => unsubscribe(), () => {})
+      throw error
+    }
+  }
+
+  private serializePayload(payload: object): SerializedEvent {
+    const [original, meta] = unwrapEvent(payload)
+    const { json, meta: jsonMeta } = this.serializer.serialize(original)
+    return { payload: { json, meta: jsonMeta }, meta }
+  }
+
+  private deserializePayload(id: string | undefined, { payload, meta }: SerializedEvent): object {
+    return withEventMeta(
+      this.serializer.deserialize(payload) as object,
+      id === undefined ? { ...meta } : { ...meta, id },
+    )
+  }
+}
+
+function parseIfText(value: unknown): unknown {
+  return typeof value === 'string' ? parseEmptyableJSON(value) : value
+}

--- a/packages/publisher/src/adapters/base-redis.ts
+++ b/packages/publisher/src/adapters/base-redis.ts
@@ -234,22 +234,22 @@ export abstract class BaseRedisPublisher<T extends Record<string, object>> exten
     // Subscribe first so no event can slip between the stream read and live delivery.
     const unsubscribe = await this.subscribeChannel(channel, messageListener, onError)
 
-    if (this.resumeEnabled && lastEventId !== undefined) {
-      try {
+    try {
+      if (this.resumeEnabled && lastEventId !== undefined) {
         for (const { id, data } of await this.readStreamEntries(channel, lastEventId)) {
           resumedIds.add(id)
           listener(this.deserializePayload(id, parseIfText(data) as SerializedEvent) as T[K])
         }
       }
-      catch (error) {
-        await unsubscribe()
-        throw error
-      }
-    }
 
-    const pending = pendingPayloads
-    pendingPayloads = undefined
-    pending.forEach(deduplicatingListener)
+      const pending = pendingPayloads
+      pendingPayloads = undefined
+      pending.forEach(deduplicatingListener)
+    }
+    catch (error) {
+      await unsubscribe()
+      throw error
+    }
 
     return once(unsubscribe)
   }

--- a/packages/publisher/src/adapters/redis.ts
+++ b/packages/publisher/src/adapters/redis.ts
@@ -1,14 +1,8 @@
-import type { RPCJsonSerialization } from '@orpc/client'
-import type { Public, ThrowableError } from '@orpc/shared'
-import type { EventMeta } from '@standard-server/core'
 import type { RedisClientType } from 'redis'
-import type { PublisherOptions, PublisherSubscribeListenerOptions } from '../publisher'
-import { RPCJsonSerializer } from '@orpc/client'
-import { once, parseEmptyableJSON, stringifyJSON } from '@orpc/shared'
-import { getEventMeta, unwrapEvent, withEventMeta } from '@standard-server/core'
-import { Publisher } from '../publisher'
+import type { BaseRedisPublisherOptions, RedisStreamEntry, RedisStreamTrimOptions } from './base-redis'
+import { BaseRedisPublisher } from './base-redis'
 
-export interface RedisPublisherOptions extends PublisherOptions {
+export interface RedisPublisherOptions extends BaseRedisPublisherOptions {
   /**
    * Redis subscriber instance.
    * Pub/Sub takes over the connection, so a client with subscriptions
@@ -17,50 +11,6 @@ export interface RedisPublisherOptions extends PublisherOptions {
    * @default redis.duplicate()
    */
   subscriber?: undefined | RedisClientType<any, any, any, any, any>
-
-  /**
-   * The prefix to use for Redis keys.
-   *
-   * @default ''
-   */
-  prefix?: string
-
-  /**
-   * Serializer for serialize and deserialize payloads.
-   *
-   * @default RPCJsonSerializer
-   */
-  serializer?: undefined | Public<RPCJsonSerializer>
-
-  /**
-   * Configuration for event resume support.
-   *
-   * When enabled, published events are temporarily stored so new
-   * subscribers can resume from a previous position using `lastEventId`.
-   *
-   * @default { enabled: false }
-   */
-  resume?: {
-    /**
-     * Whether event resume support is enabled.
-     *
-     * When enabled, published events are temporarily stored so new
-     * subscribers can resume from a previous position using `lastEventId`.
-     *
-     * @default false
-     */
-    enabled: boolean
-
-    /**
-     * How long (in seconds) to retain events for resume.
-     *
-     * Expired events are cleaned up lazily for performance reasons, so
-     * some events may remain available slightly longer than this period.
-     *
-     * @default 300 (5 min)
-     */
-    seconds?: number
-  }
 }
 
 /**
@@ -69,169 +19,61 @@ export interface RedisPublisherOptions extends PublisherOptions {
  *
  * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher Helpers - Adapters}
  */
-export class RedisPublisher<T extends Record<string, object>> extends Publisher<T> {
+export class RedisPublisher<T extends Record<string, object>> extends BaseRedisPublisher<T> {
   private readonly subscriber: Exclude<RedisPublisherOptions['subscriber'], undefined>
-  private readonly prefix: Exclude<RedisPublisherOptions['prefix'], undefined>
-  private readonly serializer: Exclude<RedisPublisherOptions['serializer'], undefined>
-  private readonly resumeEnabled: boolean
-  private readonly resumeSeconds: number
-
-  /**
-   * The exactness of the `XTRIM` command.
-   * Used for testing purpose.
-   */
-  private readonly xTrimExactness: '~' | '=' = '~'
 
   constructor(
     private readonly redis: RedisClientType<any, any, any, any, any>,
-    options: RedisPublisherOptions = {},
+    { subscriber, ...options }: RedisPublisherOptions = {},
   ) {
     super(options)
 
-    this.prefix = options.prefix ?? ''
-    this.serializer = options.serializer ?? new RPCJsonSerializer()
-    this.resumeEnabled = options.resume?.enabled ?? false
-    this.resumeSeconds = options.resume?.seconds ?? 300
-    this.subscriber = options.subscriber ?? redis.duplicate()
+    this.subscriber = subscriber ?? redis.duplicate()
   }
 
-  private readonly firstPublishTimeMap: Map<string, number> = new Map()
-  async publish<K extends keyof T & string>(event: K, payload: T[K]): Promise<void> {
-    const redisKey = `${this.prefix}${event}`
-    const data = this.serializePayload(payload)
-    let id: string | undefined
-
-    if (!this.redis.isOpen) {
-      await this.redis.connect()
-    }
-
-    if (this.resumeEnabled) {
-      const now = Date.now()
-
-      // Remove expired resume windows.
-      // The next publish for a stale event will perform trimming again.
-      for (const [event, firstPublishTime] of this.firstPublishTimeMap) {
-        if (firstPublishTime + this.resumeSeconds * 1000 < now) {
-          this.firstPublishTimeMap.delete(event)
-        }
-      }
-
-      if (!this.firstPublishTimeMap.has(event)) {
-        this.firstPublishTimeMap.set(event, now)
-
-        const result = await this.redis.multi()
-          .xAdd(redisKey, '*', { data: stringifyJSON(data) })
-          .xTrim(redisKey, 'MINID', `${now - this.resumeSeconds * 1000}-0`, { strategyModifier: this.xTrimExactness })
-          // Use a 2x TTL so events published near the end of the resume window
-          // are not expired before the next window updates the key expiration.
-          .expire(redisKey, this.resumeSeconds * 2)
-          .exec()
-
-        id = result[0] as unknown as string
-      }
-      else {
-        id = await this.redis.xAdd(redisKey, '*', { data: stringifyJSON(data) }) as string
-      }
-    }
-
-    await this.redis.publish(redisKey, stringifyJSON({ data, id }))
+  protected async publishMessage(channel: string, message: string): Promise<void> {
+    await connectIfNeeded(this.redis)
+    await this.redis.publish(channel, message)
   }
 
-  protected async subscribeListener<K extends keyof T & string>(
-    event: K,
-    originalListener: (payload: T[K]) => void,
-    { lastEventId, onError }: PublisherSubscribeListenerOptions = {},
-  ): Promise<() => Promise<void>> {
-    const redisKey = `${this.prefix}${event}`
+  protected async subscribeChannel(channel: string, listener: (message: unknown) => void): Promise<() => Promise<void>> {
+    await connectIfNeeded(this.subscriber)
+    await this.subscriber.subscribe(channel, listener)
 
-    if (!this.subscriber.isOpen) {
-      await this.subscriber.connect()
+    return async () => {
+      await this.subscriber.unsubscribe(channel, listener)
     }
-
-    let pendingPayloads: T[K][] | undefined = []
-    const resumedIds = new Set<string>()
-
-    const deduplicatingListener = (payload: T[K]) => {
-      if (pendingPayloads) {
-        pendingPayloads.push(payload)
-        return
-      }
-
-      const id = getEventMeta(payload)?.id
-      if (id !== undefined && resumedIds.has(id)) { // Already delivered during resume.
-        return
-      }
-
-      originalListener(payload)
-    }
-
-    const redisListener = (message: string) => {
-      try {
-        const { id, data } = parseEmptyableJSON(message) as any
-        const payload = this.deserializePayload(id, data)
-        deduplicatingListener(payload as any)
-      }
-      catch (error) {
-        // Can happen if the published message has an unexpected format.
-        onError?.(error as ThrowableError)
-      }
-    }
-
-    try {
-      const subscribePromise = this.subscriber.subscribe(redisKey, redisListener)
-
-      try {
-        if (this.resumeEnabled && lastEventId !== undefined) {
-          if (!this.redis.isOpen) {
-            await this.redis.connect()
-          }
-
-          const results = await this.redis.xRead({ key: redisKey, id: lastEventId })
-
-          if (results && results[0]) {
-            const { messages } = results[0]
-
-            for (const { id, message } of messages) {
-              const rawData = message.data
-              const data = parseEmptyableJSON(rawData as string)
-              const payload = this.deserializePayload(id, data as any)
-              resumedIds.add(id)
-              originalListener(payload as T[K])
-            }
-          }
-        }
-      }
-      finally {
-        const pending = pendingPayloads
-        pendingPayloads = undefined
-
-        for (const payload of pending) {
-          deduplicatingListener(payload)
-        }
-      }
-
-      await subscribePromise
-    }
-    catch (error) {
-      await this.subscriber.unsubscribe(redisKey, redisListener)
-      throw error
-    }
-
-    return once(async () => {
-      await this.subscriber.unsubscribe(redisKey, redisListener)
-    })
   }
 
-  private serializePayload(payload: object): { payload: RPCJsonSerialization, meta?: undefined | EventMeta } {
-    const [original, meta] = unwrapEvent(payload)
-    const { json, meta: jsonMeta } = this.serializer.serialize(original)
-    return { payload: { json, meta: jsonMeta }, meta }
+  protected async addStreamEntry(key: string, data: string, trim?: RedisStreamTrimOptions): Promise<string> {
+    await connectIfNeeded(this.redis)
+
+    if (!trim) {
+      return await this.redis.xAdd(key, '*', { data }) as string
+    }
+
+    const [id] = await this.redis.multi()
+      .xAdd(key, '*', { data })
+      .xTrim(key, 'MINID', trim.minId, { strategyModifier: trim.exactness })
+      .expire(key, trim.expireSeconds)
+      .exec()
+
+    return id as unknown as string
   }
 
-  private deserializePayload(id: string | undefined, { payload, meta }: { payload: RPCJsonSerialization, meta?: undefined | EventMeta }): object {
-    return withEventMeta(
-      this.serializer.deserialize(payload) as object,
-      id === undefined ? { ...meta } : { ...meta, id },
-    )
+  protected async readStreamEntries(key: string, lastId: string): Promise<RedisStreamEntry[]> {
+    await connectIfNeeded(this.redis)
+
+    const results = await this.redis.xRead({ key, id: lastId })
+
+    const entries: Array<{ id: string, message: Record<string, string> }> = results?.[0]?.messages ?? []
+
+    return entries.map(({ id, message }) => ({ id, data: message.data! }))
+  }
+}
+
+async function connectIfNeeded(client: RedisClientType<any, any, any, any, any>): Promise<void> {
+  if (!client.isOpen) {
+    await client.connect()
   }
 }

--- a/packages/publisher/src/adapters/upstash.test.ts
+++ b/packages/publisher/src/adapters/upstash.test.ts
@@ -468,17 +468,166 @@ describe.concurrent(
       const onError = vi.fn()
 
       const unsubscribe = await publisher.subscribe(event, listener, { onError })
-      const subscription = (publisher as any).subscriptionMap.get(event)
+      const channel = `${(publisher as any).prefix}${event}`
+      const subscription = (publisher as any).subscriptionMap.get(channel)
 
       if (!subscription) {
         throw new Error('No active subscription found')
       }
 
-      ;(publisher as any).onErrorsMap.delete(event)
-      ;(publisher as any).subscriptionMap.delete(event)
+      ;(publisher as any).onErrorsMap.delete(channel)
+      ;(publisher as any).subscriptionMap.delete(channel)
 
       await expect(unsubscribe()).resolves.toBeUndefined()
       await subscription.unsubscribe()
+    })
+
+    it('works with clients that disable automatic deserialization', async () => {
+      const publisher = createTestingPublisher({ resume: { enabled: true, seconds: 10 } }, {
+        useRedis: new Redis({
+          url: UPSTASH_REDIS_REST_URL,
+          token: UPSTASH_REDIS_REST_TOKEN,
+          automaticDeserialization: false,
+        }),
+      })
+      const event = 'orders'
+      const listener = vi.fn()
+
+      const unsubscribe = await publisher.subscribe(event, listener)
+      await publisher.publish(event, withEventMeta({ order: 1 }, { comments: ['audit'] }))
+
+      await vi.waitFor(() => {
+        expect(listener).toHaveBeenCalledTimes(1)
+      })
+
+      expect(listener.mock.calls[0]![0]).toEqual({ order: 1 })
+      expect(getEventMeta(listener.mock.calls[0]![0])).toEqual({ id: expect.any(String), comments: ['audit'] })
+
+      await unsubscribe()
+
+      const resumed = vi.fn()
+      const unsubscribeResume = await publisher.subscribe(event, resumed, { lastEventId: '0' })
+
+      await vi.waitFor(() => {
+        expect(resumed).toHaveBeenCalledTimes(1)
+      })
+
+      expect(resumed.mock.calls[0]![0]).toEqual(listener.mock.calls[0]![0])
+
+      await unsubscribeResume()
+    })
+
+    it('delivers to every listener even when one unsubscribes itself while receiving', async () => {
+      const publisher = createTestingPublisher()
+      const event = 'self-unsubscribe'
+      let unsubscribeFirst: () => Promise<void>
+      const first = vi.fn(() => {
+        void unsubscribeFirst()
+      })
+      const second = vi.fn()
+
+      unsubscribeFirst = await publisher.subscribe(event, first)
+      const unsubscribeSecond = await publisher.subscribe(event, second)
+
+      await publisher.publish(event, { order: 1 })
+
+      await vi.waitFor(() => {
+        expect(first).toHaveBeenCalledTimes(1)
+        expect(second).toHaveBeenCalledTimes(1)
+      })
+
+      await unsubscribeSecond()
+    })
+
+    it('establishes a single subscription when waiters retry after a failed attempt', async () => {
+      const invalidRedis = new Redis({ url: 'http://invalid:6379', token: 'invalid' })
+      let failNext = true
+      let subscribes = 0
+      const flakyRedis = new Proxy(redis, {
+        get(target, p) {
+          if (p === 'subscribe') {
+            return (...args: [string]) => {
+              if (failNext) {
+                failNext = false
+                return invalidRedis.subscribe(...args)
+              }
+
+              subscribes++
+              return getOrBind(target, p)(...args)
+            }
+          }
+
+          return getOrBind(target, p)
+        },
+      })
+      const publisher = createTestingPublisher({}, { useRedis: flakyRedis })
+      const event = 'retry'
+      const listener1 = vi.fn()
+      const listener2 = vi.fn()
+      const listener3 = vi.fn()
+
+      const results = await Promise.allSettled([
+        publisher.subscribe(event, listener1),
+        publisher.subscribe(event, listener2),
+        publisher.subscribe(event, listener3),
+      ])
+
+      expect(results.map(result => result.status)).toEqual(['rejected', 'fulfilled', 'fulfilled'])
+      expect(subscribes).toBe(1)
+
+      await publisher.publish(event, { order: 1 })
+      await sleep(1000)
+
+      expect(listener1).not.toHaveBeenCalled()
+      expect(listener2).toHaveBeenCalledTimes(1)
+      expect(listener3).toHaveBeenCalledTimes(1)
+
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          await result.value()
+        }
+      }
+    })
+
+    it('fan-outs subscription errors to every registered onError handler', async () => {
+      const handlers = new Map<string, Array<(event: unknown) => void>>()
+      const emit = (type: string, event: unknown) => handlers.get(type)?.forEach(handler => handler(event))
+      const fakeSubscription = {
+        on: (type: string, handler: (event: unknown) => void) => {
+          handlers.set(type, [...handlers.get(type) ?? [], handler])
+        },
+        unsubscribe: vi.fn(async () => {}),
+      }
+      const fakeRedis = new Proxy(redis, {
+        get(target, p) {
+          if (p === 'subscribe') {
+            return () => {
+              queueMicrotask(() => emit('subscribe', 1))
+              return fakeSubscription
+            }
+          }
+
+          return getOrBind(target, p)
+        },
+      })
+      const publisher = createTestingPublisher({}, { useRedis: fakeRedis })
+      const event = 'connection-lost'
+      const onError1 = vi.fn()
+      const onError2 = vi.fn()
+
+      const unsubscribe1 = await publisher.subscribe(event, vi.fn(), { onError: onError1 })
+      const unsubscribe2 = await publisher.subscribe(event, vi.fn(), { onError: onError2 })
+
+      const error = new Error('connection lost')
+      emit('error', error)
+
+      expect(onError1).toHaveBeenCalledExactlyOnceWith(error)
+      expect(onError2).toHaveBeenCalledExactlyOnceWith(error)
+
+      await unsubscribe1()
+      await unsubscribe2()
+
+      expect(fakeSubscription.unsubscribe).toHaveBeenCalledTimes(1)
     })
   },
 )

--- a/packages/publisher/src/adapters/upstash.test.ts
+++ b/packages/publisher/src/adapters/upstash.test.ts
@@ -590,27 +590,13 @@ describe.concurrent(
     })
 
     it('fan-outs subscription errors to every registered onError handler', async () => {
-      const handlers = new Map<string, Array<(event: unknown) => void>>()
-      const emit = (type: string, event: unknown) => handlers.get(type)?.forEach(handler => handler(event))
-      const fakeSubscription = {
-        on: (type: string, handler: (event: unknown) => void) => {
-          handlers.set(type, [...handlers.get(type) ?? [], handler])
-        },
-        unsubscribe: vi.fn(async () => {}),
-      }
-      const fakeRedis = new Proxy(redis, {
-        get(target, p) {
-          if (p === 'subscribe') {
-            return () => {
-              queueMicrotask(() => emit('subscribe', 1))
-              return fakeSubscription
-            }
-          }
-
-          return getOrBind(target, p)
-        },
+      const subscription = createFakeSubscription()
+      const publisher = createTestingPublisher({}, {
+        useRedis: withFakeSubscribe(redis, () => {
+          queueMicrotask(() => subscription.emit('subscribe', 1))
+          return subscription
+        }),
       })
-      const publisher = createTestingPublisher({}, { useRedis: fakeRedis })
       const event = 'connection-lost'
       const onError1 = vi.fn()
       const onError2 = vi.fn()
@@ -619,7 +605,7 @@ describe.concurrent(
       const unsubscribe2 = await publisher.subscribe(event, vi.fn(), { onError: onError2 })
 
       const error = new Error('connection lost')
-      emit('error', error)
+      subscription.emit('error', error)
 
       expect(onError1).toHaveBeenCalledExactlyOnceWith(error)
       expect(onError2).toHaveBeenCalledExactlyOnceWith(error)
@@ -627,7 +613,64 @@ describe.concurrent(
       await unsubscribe1()
       await unsubscribe2()
 
-      expect(fakeSubscription.unsubscribe).toHaveBeenCalledTimes(1)
+      expect(subscription.unsubscribe).toHaveBeenCalledTimes(1)
+    })
+
+    it('tears down a subscription that fails before it is established', async () => {
+      const subscription = createFakeSubscription()
+      subscription.unsubscribe.mockRejectedValueOnce(new Error('abort failed'))
+      const publisher = createTestingPublisher({}, {
+        useRedis: withFakeSubscribe(redis, () => {
+          queueMicrotask(() => subscription.emit('error', new Error('connection refused')))
+          return subscription
+        }),
+      })
+
+      await expect(publisher.subscribe('unreachable', vi.fn())).rejects.toThrow('connection refused')
+
+      expect(subscription.unsubscribe).toHaveBeenCalledTimes(1)
+    })
+
+    it('opens a fresh subscription when subscribing while the previous one is being torn down', async () => {
+      const dedicatedRedis = new Redis({ url: UPSTASH_REDIS_REST_URL, token: UPSTASH_REDIS_REST_TOKEN })
+      const subscribeSpy = vi.spyOn(dedicatedRedis, 'subscribe')
+      const publisher = createTestingPublisher({}, { useRedis: dedicatedRedis })
+      const event = 'resubscribe'
+      const first = vi.fn()
+      const second = vi.fn()
+
+      const unsubscribeFirst = await publisher.subscribe(event, first)
+      const [, unsubscribeSecond] = await Promise.all([unsubscribeFirst(), publisher.subscribe(event, second)])
+      await publisher.publish(event, { order: 1 })
+
+      await vi.waitFor(() => {
+        expect(second).toHaveBeenCalledTimes(1)
+      })
+
+      expect(first).not.toHaveBeenCalled()
+      expect(subscribeSpy).toHaveBeenCalledTimes(2)
+
+      await unsubscribeSecond()
     })
   },
 )
+
+function createFakeSubscription() {
+  const handlers = new Map<string, Array<(event: unknown) => void>>()
+
+  return {
+    on: (type: string, handler: (event: unknown) => void) => {
+      handlers.set(type, [...handlers.get(type) ?? [], handler])
+    },
+    emit: (type: string, event: unknown) => handlers.get(type)?.forEach(handler => handler(event)),
+    unsubscribe: vi.fn(async () => {}),
+  }
+}
+
+function withFakeSubscribe(redis: Redis, subscribe: () => unknown): Redis {
+  return new Proxy(redis, {
+    get(target, p) {
+      return p === 'subscribe' ? subscribe : getOrBind(target, p)
+    },
+  })
+}

--- a/packages/publisher/src/adapters/upstash.test.ts
+++ b/packages/publisher/src/adapters/upstash.test.ts
@@ -618,7 +618,6 @@ describe.concurrent(
 
     it('tears down a subscription that fails before it is established', async () => {
       const subscription = createFakeSubscription()
-      subscription.unsubscribe.mockRejectedValueOnce(new Error('abort failed'))
       const publisher = createTestingPublisher({}, {
         useRedis: withFakeSubscribe(redis, () => {
           queueMicrotask(() => subscription.emit('error', new Error('connection refused')))

--- a/packages/publisher/src/adapters/upstash.ts
+++ b/packages/publisher/src/adapters/upstash.ts
@@ -1,58 +1,10 @@
-import type { RPCJsonSerialization } from '@orpc/client'
-import type { Public, ThrowableError } from '@orpc/shared'
-import type { EventMeta } from '@standard-server/core'
+import type { ThrowableError } from '@orpc/shared'
 import type { Redis } from '@upstash/redis'
-import type { PublisherOptions, PublisherSubscribeListenerOptions } from '../publisher'
-import { RPCJsonSerializer } from '@orpc/client'
-import { once } from '@orpc/shared'
-import { getEventMeta, unwrapEvent, withEventMeta } from '@standard-server/core'
-import { Publisher } from '../publisher'
+import type { BaseRedisPublisherOptions, RedisStreamEntry, RedisStreamTrimOptions } from './base-redis'
+import { promiseWithResolvers } from '@orpc/shared'
+import { BaseRedisPublisher } from './base-redis'
 
-export interface UpstashPublisherOptions extends PublisherOptions {
-  /**
-   * The prefix to use for Redis keys.
-   *
-   * @default ''
-   */
-  prefix?: string
-
-  /**
-   * Serializer for serialize and deserialize payloads.
-   *
-   * @default RPCJsonSerializer
-   */
-  serializer?: undefined | Public<RPCJsonSerializer>
-
-  /**
-   * Configuration for event resume support.
-   *
-   * When enabled, published events are temporarily stored so new
-   * subscribers can resume from a previous position using `lastEventId`.
-   *
-   * @default { enabled: false }
-   */
-  resume?: {
-    /**
-     * Whether event resume support is enabled.
-     *
-     * When enabled, published events are temporarily stored so new
-     * subscribers can resume from a previous position using `lastEventId`.
-     *
-     * @default false
-     */
-    enabled: boolean
-
-    /**
-     * How long (in seconds) to retain events for resume.
-     *
-     * Expired events are cleaned up lazily for performance reasons, so
-     * some events may remain available slightly longer than this period.
-     *
-     * @default 300 (5 min)
-     */
-    seconds?: number
-  }
-}
+export interface UpstashPublisherOptions extends BaseRedisPublisherOptions {}
 
 /**
  * Publisher adapter for Upstash Redis. Distributes events across processes via
@@ -60,274 +12,142 @@ export interface UpstashPublisherOptions extends PublisherOptions {
  *
  * @see {@link https://orpc.dev/docs/helpers/publisher#adapters | Publisher Helpers - Adapters}
  */
-export class UpstashPublisher<T extends Record<string, object>> extends Publisher<T> {
-  private readonly prefix: string
-  private readonly serializer: Public<RPCJsonSerializer>
-  private readonly listenersMap = new Map<keyof T, Array<(payload: any) => void>>()
-  private readonly onErrorsMap = new Map<keyof T, Array<(error: ThrowableError) => void>>()
-  private readonly subscriptionMap = new Map<keyof T, ReturnType<typeof this.redis.subscribe>>() // Upstash subscription objects
-  private readonly resumeEnabled: boolean
-  private readonly resumeSeconds: number
-
-  /**
-   * The exactness of the `XTRIM` command.
-   * Used for testing purpose.
-   */
-  private readonly xTrimExactness: '~' | '=' = '~'
+export class UpstashPublisher<T extends Record<string, object>> extends BaseRedisPublisher<T> {
+  private readonly listenersMap = new Map<string, Array<(message: unknown) => void>>()
+  private readonly onErrorsMap = new Map<string, Array<(error: ThrowableError) => void>>()
+  private readonly subscriptionMap = new Map<string, ReturnType<Redis['subscribe']>>()
+  private readonly pendingSubscriptionsMap = new Map<string, Promise<void>>()
 
   constructor(
     private readonly redis: Redis,
-    { resume, prefix, serializer, ...options }: UpstashPublisherOptions = {},
+    options: UpstashPublisherOptions = {},
   ) {
     super(options)
-    this.prefix = prefix ?? ''
-    this.resumeEnabled = resume?.enabled ?? false
-    this.resumeSeconds = resume?.seconds ?? 300
-    this.serializer = serializer ?? new RPCJsonSerializer()
   }
 
-  private readonly firstPublishTimeMap: Map<string, number> = new Map()
-  async publish<K extends keyof T & string>(event: K, payload: T[K]): Promise<void> {
-    const redisKey = `${this.prefix}${event}`
-    const data = this.serializePayload(payload)
-    let id: string | undefined
-
-    if (this.resumeEnabled) {
-      const now = Date.now()
-
-      // Remove expired resume windows.
-      // The next publish for a stale event will perform trimming again.
-      for (const [event, firstPublishTime] of this.firstPublishTimeMap) {
-        if (firstPublishTime + this.resumeSeconds * 1000 < now) {
-          this.firstPublishTimeMap.delete(event)
-        }
-      }
-
-      if (!this.firstPublishTimeMap.has(event)) {
-        this.firstPublishTimeMap.set(event, now)
-
-        const results = await this.redis.multi()
-          .xadd(redisKey, '*', { data })
-          .xtrim(redisKey, { strategy: 'MINID', exactness: this.xTrimExactness, threshold: `${now - this.resumeSeconds * 1000}-0` })
-          // Use a 2x TTL so events published near the end of the resume window
-          // are not expired before the next window updates the key expiration.
-          .expire(redisKey, this.resumeSeconds * 2)
-          .exec()
-
-        id = results[0]
-      }
-      else {
-        id = await this.redis.xadd(redisKey, '*', { data })
-      }
-    }
-
-    await this.redis.publish(redisKey, { id, data })
+  protected async publishMessage(channel: string, message: string): Promise<void> {
+    await this.redis.publish(channel, message)
   }
 
-  protected async subscribeListener<K extends keyof T & string>(
-    event: K,
-    originalListener: (payload: T[K]) => void,
-    { lastEventId, onError }: PublisherSubscribeListenerOptions = {},
+  protected async subscribeChannel(
+    channel: string,
+    listener: (message: unknown) => void,
+    onError?: (error: ThrowableError) => void,
   ): Promise<() => Promise<void>> {
-    const redisKey = `${this.prefix}${event}`
-
-    let pendingPayloads: T[K][] | undefined = []
-    const resumedIds = new Set<string>()
-
-    const deduplicatingListener = (payload: T[K]) => {
-      // queue payload while resuming missed events
-      if (pendingPayloads) {
-        pendingPayloads.push(payload)
-        return
-      }
-
-      const id = getEventMeta(payload)?.id
-      if (id !== undefined && resumedIds.has(id)) { // Already delivered during resume.
-        return
-      }
-
-      originalListener(payload)
-    }
-
-    // Register locally before subscribing to Redis.
-    // Messages may arrive while the subscription is being established.
-    // and prevent unsubscribe while existing listener for event
-    let listeners = this.listenersMap.get(event)
-    if (!listeners) {
-      this.listenersMap.set(event, listeners = [])
-    }
-    listeners.push(deduplicatingListener)
+    // Registered before subscribing so messages that arrive meanwhile are not lost.
+    push(this.listenersMap, channel, listener)
 
     try {
-      const subscribeEventPromise = this.subscribeEvent(event)
-
-      try {
-        if (this.resumeEnabled && lastEventId !== undefined) {
-          const results = await this.redis.xread(redisKey, lastEventId)
-          if (results && results[0]) {
-            const [_, items] = results[0] as any
-
-            for (const [id, fields] of items) {
-              const data = fields[1]! // [key: 'data', value, ...]
-              const payload = this.deserializePayload(id, data)
-              resumedIds.add(id)
-              originalListener(payload as T[K])
-            }
-          }
-        }
-      }
-      finally {
-        const pending = pendingPayloads
-        pendingPayloads = undefined
-
-        for (const payload of pending) {
-          deduplicatingListener(payload)
-        }
-      }
-
-      await subscribeEventPromise
+      await this.subscribeIfNeeded(channel)
     }
     catch (error) {
-      listeners.splice(listeners.indexOf(deduplicatingListener), 1)
-      if (listeners.length === 0) {
-        this.listenersMap.delete(event)
-      }
-
-      await this.unsubscribeEvent(event)
+      remove(this.listenersMap, channel, listener)
+      await this.unsubscribeIfUnused(channel)
       throw error
     }
 
-    // Register error listeners only after subscription and resume succeeds.
-    // Subscription or resume failures are reported directly via the rejected promise.
+    // Registered after subscribing because a failed subscription rejects instead.
     if (onError) {
-      let onErrors = this.onErrorsMap.get(event)
-      if (!onErrors) {
-        this.onErrorsMap.set(event, onErrors = [])
-      }
-      onErrors.push(onError)
+      push(this.onErrorsMap, channel, onError)
     }
 
-    // once allows unsub safely execute multiple times
-    return once(async () => {
-      listeners.splice(listeners.indexOf(deduplicatingListener), 1)
+    return async () => {
+      remove(this.listenersMap, channel, listener)
 
       if (onError) {
-        const onErrors = this.onErrorsMap.get(event)
-        if (onErrors) {
-          onErrors.splice(onErrors.indexOf(onError), 1)
-        }
+        remove(this.onErrorsMap, channel, onError)
       }
 
-      // no need to check onErrors here, it always has lower length than listeners
-      if (listeners.length === 0) {
-        this.listenersMap.delete(event)
-        this.onErrorsMap.delete(event)
-      }
-
-      await this.unsubscribeEvent(event)
-    })
+      await this.unsubscribeIfUnused(channel)
+    }
   }
 
-  private readonly pendingSubscriptionsMap = new Map<keyof T, Promise<void>>()
-  private async subscribeEvent(event: keyof T & string): Promise<void> {
-    const redisKey = `${this.prefix}${event}`
-
-    // Another caller is currently establishing the subscription.
-    // Wait for it to finish before checking whether a new subscription is still needed.
-    const pending = this.pendingSubscriptionsMap.get(event)
-    if (pending) {
-      try {
-        await pending
-      }
-      catch {
-        // The previous subscription attempt failed.
-        // Continue and attempt to establish a new subscription.
-      }
+  protected async addStreamEntry(key: string, data: string, trim?: RedisStreamTrimOptions): Promise<string> {
+    if (!trim) {
+      return this.redis.xadd(key, '*', { data })
     }
 
-    if (this.subscriptionMap.has(event)) {
+    const [id] = await this.redis.multi()
+      .xadd(key, '*', { data })
+      .xtrim(key, { strategy: 'MINID', exactness: trim.exactness, threshold: trim.minId })
+      .expire(key, trim.expireSeconds)
+      .exec()
+
+    return id
+  }
+
+  protected async readStreamEntries(key: string, lastId: string): Promise<RedisStreamEntry[]> {
+    const results = await this.redis.xread(key, lastId) as null | Array<[
+      key: string,
+      entries: Array<[id: string, fields: [name: string, value: unknown]]>,
+    ]>
+
+    return results?.[0]?.[1].map(([id, fields]) => ({ id, data: fields[1] })) ?? []
+  }
+
+  private async subscribeIfNeeded(channel: string): Promise<void> {
+    while (this.pendingSubscriptionsMap.has(channel)) {
+      await this.pendingSubscriptionsMap.get(channel)!.catch(() => {})
+    }
+
+    if (this.subscriptionMap.has(channel)) {
       return
     }
 
-    const dispatchErrorForEvent = (error: ThrowableError) => {
-      const onErrors = this.onErrorsMap.get(event)
-      onErrors?.forEach(onError => onError(error))
-    }
+    const { promise, resolve, reject } = promiseWithResolvers<void>()
+    const subscription = this.redis.subscribe(channel)
 
-    const subscription = this.redis.subscribe(redisKey)
-    subscription.on('message', (message) => {
-      try {
-        const listeners = this.listenersMap.get(event)
-
-        if (listeners) {
-          const { id, data } = message.message as any
-          const payload = this.deserializePayload(id, data)
-          listeners.forEach(listener => listener(payload))
-        }
-      }
-      catch (error) {
-        // Can happen if the published message has an unexpected format.
-        dispatchErrorForEvent(error as ThrowableError)
-      }
-    })
-
-    let resolvePromise: () => void
-    let rejectPromise: (error: Error) => void
-    const promise = new Promise<void>((resolve, reject) => {
-      resolvePromise = resolve
-      rejectPromise = reject
-    })
-
+    subscription.on('subscribe', () => resolve())
     subscription.on('error', (error) => {
-      rejectPromise(error)
-      dispatchErrorForEvent(error)
+      reject(error)
+      this.onErrorsMap.get(channel)?.slice().forEach(onError => onError(error))
+    })
+    subscription.on('message', ({ message }) => {
+      // Snapshot, since a listener may unsubscribe itself mid-dispatch.
+      this.listenersMap.get(channel)?.slice().forEach(listener => listener(message))
     })
 
-    subscription.on('subscribe', () => {
-      resolvePromise()
-    })
+    this.pendingSubscriptionsMap.set(channel, promise)
 
     try {
-      this.pendingSubscriptionsMap.set(event, promise)
       await promise
-      this.subscriptionMap.set(event, subscription) // set after subscription is ready
+      this.subscriptionMap.set(channel, subscription)
     }
     finally {
-      this.pendingSubscriptionsMap.delete(event)
+      this.pendingSubscriptionsMap.delete(channel)
     }
   }
 
-  private async unsubscribeEvent(event: keyof T & string): Promise<void> {
-    // Another caller is currently establishing the subscription.
-    // Wait for it to finish before checking whether a subscription is existed.
-    const pending = this.pendingSubscriptionsMap.get(event)
-    if (pending) {
-      try {
-        await pending
-      }
-      catch {}
-    }
+  private async unsubscribeIfUnused(channel: string): Promise<void> {
+    // No need to await a pending attempt: its owner still holds a listener, which blocks teardown below.
+    const subscription = this.subscriptionMap.get(channel)
 
-    const subscription = this.subscriptionMap.get(event)
-
-    // no need to check onErrors here, it always has lower length than listeners
-    if (!this.listenersMap.has(event) && subscription) {
-      // Remove before awaiting to prevent race conditions.
-      this.subscriptionMap.delete(event)
+    if (subscription && !this.listenersMap.has(channel)) {
+      this.subscriptionMap.delete(channel) // before awaiting, so concurrent callers skip it
       await subscription.unsubscribe()
     }
   }
+}
 
-  private serializePayload(payload: object): { payload: RPCJsonSerialization, meta?: undefined | EventMeta } {
-    const [original, meta] = unwrapEvent(payload)
-    const { json, meta: jsonMeta } = this.serializer.serialize(original)
-    return { payload: { json, meta: jsonMeta }, meta }
+function push<K, V>(map: Map<K, V[]>, key: K, value: V): void {
+  let values = map.get(key)
+
+  if (!values) {
+    map.set(key, values = [])
   }
 
-  private deserializePayload(id: string | undefined, { payload, meta }: { payload: RPCJsonSerialization, meta?: undefined | EventMeta }): object {
-    return withEventMeta(
-      this.serializer.deserialize(payload) as object,
-      id === undefined ? { ...meta } : { ...meta, id },
-    )
+  values.push(value)
+}
+
+function remove<K, V>(map: Map<K, V[]>, key: K, value: V): void {
+  const values = map.get(key)
+  const index = values?.indexOf(value) ?? -1
+
+  if (index !== -1) {
+    values!.splice(index, 1)
+  }
+
+  if (values?.length === 0) {
+    map.delete(key)
   }
 }

--- a/packages/publisher/src/adapters/upstash.ts
+++ b/packages/publisher/src/adapters/upstash.ts
@@ -113,6 +113,10 @@ export class UpstashPublisher<T extends Record<string, object>> extends BaseRedi
       await promise
       this.subscriptionMap.set(channel, subscription)
     }
+    catch (error) {
+      subscription.unsubscribe().catch(() => {})
+      throw error
+    }
     finally {
       this.pendingSubscriptionsMap.delete(channel)
     }

--- a/packages/publisher/src/adapters/upstash.ts
+++ b/packages/publisher/src/adapters/upstash.ts
@@ -87,7 +87,7 @@ export class UpstashPublisher<T extends Record<string, object>> extends BaseRedi
 
   private async subscribeIfNeeded(channel: string): Promise<void> {
     while (this.pendingSubscriptionsMap.has(channel)) {
-      await this.pendingSubscriptionsMap.get(channel)!.catch(() => {})
+      await this.pendingSubscriptionsMap.get(channel)!.catch(() => {}) // a failed attempt is reported to its owner; waiters retry
     }
 
     if (this.subscriptionMap.has(channel)) {
@@ -114,7 +114,7 @@ export class UpstashPublisher<T extends Record<string, object>> extends BaseRedi
       this.subscriptionMap.set(channel, subscription)
     }
     catch (error) {
-      subscription.unsubscribe().catch(() => {})
+      await subscription.unsubscribe()
       throw error
     }
     finally {


### PR DESCRIPTION
Extracts the Redis pub/sub and stream logic shared by the node-redis, Upstash, and Bun publisher adapters into an abstract `BaseRedisPublisher`, exported from the new `@orpc/publisher/base-redis` subpath. Each adapter now implements only four client-specific primitives (`publishMessage`, `subscribeChannel`, `addStreamEntry`, `readStreamEntries`). Because the base owns key naming, the message format, and resume handling, every adapter built on it interoperates with the others by construction, and supporting another Redis client means implementing those four methods.

The wire format is unchanged, so existing deployments keep working and the existing node-redis/Bun cross-adapter compatibility tests pass unmodified. The three adapters together shrink by roughly 650 lines.

## Fixes (all adapters)

- Resuming with `lastEventId` now waits for the Pub/Sub subscription before reading the stream. Previously both started together, so an event published after the stream read but before the subscription was live was neither replayed nor delivered. Costs one extra round trip when resuming.
- A listener that throws while events queued during subscription setup are flushed now releases the subscription before `subscribe()` rejects, instead of leaking it.

## Fixes (Upstash adapter)

- A listener that unsubscribes itself while receiving a message no longer causes the next listener on the same channel to miss that message.
- When a subscription attempt fails while other subscribers are waiting on it, only one of them retries. Previously several could retry at once, opening duplicate SSE subscriptions that leaked and delivered every message twice.
- A subscription that errors before it is acknowledged is now closed explicitly, and waiting subscribers retry only after that teardown completes.
- Clients created with `automaticDeserialization: false` now work. The adapter passes the client's values through as-is and the base parses text only when it receives text.
- `onError` handlers are attached as soon as the subscription is established rather than after replay finishes. Note that `@upstash/redis` only raises `error` before the acknowledgement or on parse failures; a dropped established stream is never reported by the SDK, which predates this PR and cannot be detected from the adapter.

## Testing

- New unit test for the base against an in-memory fake adapter. It pins the exact message and stream-entry format so any future format change fails loudly, and reproduces the lost-event window above (the test fails on the previous ordering).
- node-redis, Upstash, and Bun suites pass against real servers, with a regression test for each fix, including subscribing to a channel while its previous subscription is being torn down.
- `@orpc/publisher` sits at 100% statement, branch, function, and line coverage; `@orpc/bun`'s Redis publisher at 100% functions and lines. The Codecov patch check reports Upstash as uncovered because fork PRs do not receive the repository secrets its tests need.
