### PR TITLE
docs: add client setup to the SvelteKit adapter page

### DIFF
--- a/apps/content/docs/adapters/svelte-kit.mdx
+++ b/apps/content/docs/adapters/svelte-kit.mdx
@@ -42,60 +42,30 @@ export const DELETE = handle
 The `handler` can be any supported oRPC handler, such as [RPCHandler](/docs/rpc/handler), [OpenAPIHandler](/docs/openapi/handler), or another custom handler.
 :::
 
-## Optimize SSR
+## Client
 
-To reduce HTTP requests and improve latency during SSR, you can utilize [Svelte's special `fetch`](https://svelte.dev/docs/kit/web-standards#Fetch-APIs) during SSR. Below is a quick setup, see [Optimizing SSR](/docs/recipes/optimizing-ssr) for more details.
-
-<CodeGroup>
+During SSR, use [SvelteKit's `fetch`](https://svelte.dev/docs/kit/load#Making-fetch-requests), which forwards the `cookie` and `authorization` headers and calls the endpoint directly without an HTTP round trip.
 
 ```ts title="src/lib/orpc.ts"
-import type { RouterClient } from '@orpc/server'
-import { createORPCClient } from '@orpc/client'
 import { RPCLink } from '@orpc/client/fetch'
-
-if (import.meta.env.SSR) {
-  await import('./orpc.server')
-}
-
-declare global {
-  var $client: RouterClient<typeof router> | undefined
-}
 
 const link = new RPCLink({
   url: '/rpc',
-  origin: () => {
-    if (typeof window === 'undefined') {
-      throw new Error('This link is not allowed on the server side.')
+  fetch: async (url, init) => {
+    if (import.meta.env.SSR) {
+      const { getRequestEvent } = await import('$app/server')
+      return getRequestEvent().fetch(url, init)
     }
 
-    return window.location.origin
+    return fetch(url, init)
   },
 })
-
-/**
- * Fall back to a browser client when no SSR client is registered.
- */
-export const client: RouterClient<typeof router> = globalThis.$client ?? createORPCClient(link)
 ```
 
-```ts title="src/lib/orpc.server.ts"
-import type { RouterClient } from '@orpc/server'
-import { getRequestEvent } from '$app/server'
-import { createORPCClient } from '@orpc/client'
-import { RPCLink } from '@orpc/client/fetch'
+:::info
+The examples above only show how to configure the link. For examples of creating a typesafe client, see [RPC Link](/docs/rpc/link#typesafe-clients) and [OpenAPI Link](/docs/openapi/link#typesafe-clients).
+:::
 
-if (typeof window !== 'undefined') {
-  throw new Error('This file should only be imported on the server')
-}
+## Optimize SSR
 
-const link = new RPCLink({
-  url: '/rpc',
-  origin: () => getRequestEvent().url.origin,
-  fetch: (url, init) => getRequestEvent().fetch(url, init),
-})
-
-const serverClient: RouterClient<typeof router> = createORPCClient(link)
-globalThis.$client = serverClient
-```
-
-</CodeGroup>
+SvelteKit's `fetch` already skips the HTTP round trip, but requests are still serialized and deserialized. To remove that overhead as well, use a [server-side client](/docs/client/server-side) during SSR as described in [Optimizing SSR](/docs/recipes/optimizing-ssr#using-server-side-client-directly).


### PR DESCRIPTION
Adds a Client section to the SvelteKit adapter page. The link hands requests to SvelteKit's `fetch` during SSR, so the page request's `cookie` and `authorization` headers are forwarded and the endpoint is called in-process without an HTTP round trip, while the browser keeps using the global `fetch`. The Optimize SSR section, whose two-file example duplicated that same mechanism, now points to the server-side client recipe instead.

## Verification

- Snippets pasted verbatim into a fresh SvelteKit 2.70 app against the published `2.0.0-beta.34` packages.
- Production build with adapter-node and the dev server both render the page with the cookie forwarded, with zero HTTP hits on the RPC endpoint during SSR and no `ORIGIN` requirement.
- Browser bundle contains no `$app/server` code on Vite 8 (Rolldown) and Vite 7 (Rollup); type-check passes on both.
- Hydrated page completes a click-triggered call in a real browser against the production build.
- `pnpm docs:validate` passes.
