### PR TITLE
chore: declare pnpm via devEngines.packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,13 @@
   "type": "module",
   "version": "2.0.0-beta.35",
   "private": true,
-  "packageManager": "pnpm@12.0.0",
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "^12.0.0",
+      "onFail": "download"
+    }
+  },
   "scripts": {
     "prepare": "simple-git-hooks",
     "type:check": "pnpm run -r type:check && tsc",


### PR DESCRIPTION
Declares pnpm through `devEngines.packageManager` (`^12.0.0`, `onFail: download`) instead of the exact `packageManager` field. Any pnpm 12.x can now bootstrap the repo, and `pnpm install` switches to the version pinned in `pnpm-lock.yaml`, which stays 12.0.0.

## Behavior

- CI needs no workflow changes: `pnpm/action-setup@v6` reads the range from `devEngines`.
- `pnpm-lock.yaml` is unchanged, since pnpm treats the existing 12.0.0 pin as satisfying the range.
- Commands other than install can run on a newer 12.x. In testing, `pnpm runtime set` ran as 12.3.4 while `pnpm i` ran as 12.0.0.
- Running `npm` or `npx` from the repo root now fails with `EBADDEVENGINES`, because npm enforces `devEngines`. No script or workflow step in the repo does that.

## Testing

- `CI=true pnpm i` passes when started from pnpm 12.0.0, 12.3.4 (`latest`) and 12.4.1, and always installs with the pinned 12.0.0.
- The CI test job sequence (`pnpm runtime set node 22`, `pnpm runtime set bun 1`, then `CI=true pnpm i`) passes, and the pin survives the runtime edits.
- `sherif` and `eslint` pass.
