### PR TITLE
fix(valibot): upgrade @valibot/to-json-schema to 1.8.0

### DIFF
--- a/packages/valibot/package.json
+++ b/packages/valibot/package.json
@@ -46,11 +46,11 @@
     "type:check": "tsc -b"
   },
   "peerDependencies": {
-    "valibot": ">=1.0.0"
+    "valibot": ">=1.5.0"
   },
   "dependencies": {
     "@orpc/json-schema": "workspace:*",
-    "@valibot/to-json-schema": "^1.5.0"
+    "@valibot/to-json-schema": "^1.8.0"
   },
   "devDependencies": {
     "valibot": "^1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1046,8 +1046,8 @@ importers:
         specifier: workspace:*
         version: link:../json-schema
       '@valibot/to-json-schema':
-        specifier: ^1.5.0
-        version: 1.7.1(valibot@1.5.0(typescript@6.0.3))
+        specifier: ^1.8.0
+        version: 1.8.0(valibot@1.5.0(typescript@6.0.3))
     devDependencies:
       valibot:
         specifier: ^1.5.0
@@ -6173,10 +6173,10 @@ packages:
   '@upstash/redis@1.38.3':
     resolution: {integrity: sha512-vtS0BonQHU6kDSWvHTISh+LOuLIEk+jeMXebv20CDJ/aHGOG085SGa8OpI+I+Ow8WgPFhqH23XG8kQ2LXXRnag==}
 
-  '@valibot/to-json-schema@1.7.1':
-    resolution: {integrity: sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==}
+  '@valibot/to-json-schema@1.8.0':
+    resolution: {integrity: sha512-a0M+uwCuQZEPAo65NYkFSJ14O5c213KoSZmPdoCfuFvUhfULi4T2Z6Tpjv6lTVMW9RoLm74RpRAjNEa43KcN+g==}
     peerDependencies:
-      valibot: ^1.4.0
+      valibot: ^1.5.0
 
   '@vercel/analytics@1.6.1':
     resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
@@ -18017,7 +18017,7 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@valibot/to-json-schema@1.7.1(valibot@1.5.0(typescript@6.0.3))':
+  '@valibot/to-json-schema@1.8.0(valibot@1.5.0(typescript@6.0.3))':
     dependencies:
       valibot: 1.5.0(typescript@6.0.3)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -40,21 +40,4 @@ allowBuilds:
 # Entries go inert once the version ages past it, so prune them on the next bump
 # instead of letting versions accumulate.
 minimumReleaseAgeExclude:
-  - '@standard-server/core@0.9.0'
-  - '@standard-server/fetch@0.9.0'
-  - '@standard-server/node@0.9.0'
-  - '@standard-server/peer@0.9.0'
-  - '@standard-server/shared@0.9.0'
-  - '@standard-server/aws-lambda@0.9.0'
-  - '@standard-server/fastify@0.9.0'
-  - '@openapi-spec/downgrader@0.1.0'
-  - '@openapi-spec/types@0.1.0'
-  - '@cloudflare/workerd-darwin-64@1.20260907.1'
-  - '@cloudflare/workerd-darwin-arm64@1.20260907.1'
-  - '@cloudflare/workerd-linux-64@1.20260907.1'
-  - '@cloudflare/workerd-linux-arm64@1.20260907.1'
-  - '@cloudflare/workerd-windows-64@1.20260907.1'
-  - miniflare@5.20260907.0-alpha
-  - workerd@1.20260907.1
-  - wrangler@4.129.1
-  - '@cloudflare/vite-plugin@1.54.5'
+  - '@valibot/to-json-schema@1.8.0'


### PR DESCRIPTION
Upgrades `@valibot/to-json-schema` from 1.7.1 to 1.8.0. Generated OpenAPI documents are now reproducible: 1.8.0 allocates `$defs` reference ids per conversion rather than from a module-global counter, so regenerating a document in the same process no longer renames its components. No oRPC source changes were needed; `ValibotToJsonSchemaConverter` is drop-in compatible.

## Fixes

- OpenAPI output is stable across generations. A document with two recursive Valibot schemas previously produced `components.schemas` named `0,1,2,3`, then `4,5,6,7` on the next call in the same process.
- A supplied definition is no longer silently overwritten. With `definitions: { 0: PlanetSchema }`, an anonymous recursive schema claimed `$defs/0` and replaced Planet, leaving `$ref`s resolving to the wrong schema.
- Documents are smaller: that same router drops from four components to two, since identical input and output conversions now share one.
- Repeated constraints keep the stricter bound instead of the last one written. `v.pipe(v.number(), v.minValue(5), v.minValue(1))` previously widened to `minimum: 1`.

## Compatibility

`@orpc/valibot`'s `valibot` peer range moves from `>=1.0.0` to `>=1.5.0`, matching the peer 1.8.0 declares for itself.

This one is worth a reviewer's judgement, because valibot 1.4.x does still work in practice: `@valibot/to-json-schema` has no runtime imports from valibot, and the full suite passes on 1.4.2 with 1.8.0 installed. The bump makes the advertised range deliverable rather than fixing a break. Consumers on 1.4.x already get an unmet-peer warning today from the transitive dependency while the published `>=1.0.0` claims support, and neither pnpm nor npm hard-fails on it.

## Housekeeping

Pruned the `minimumReleaseAgeExclude` entries that have aged past the gate, as that list's own comment asks, leaving only the new `@valibot/to-json-schema@1.8.0`. A full `pnpm install` passes and pnpm re-adds none of them.

## Testing

- `pnpm vitest run` — 3353 passed, 47 skipped
- `pnpm type:check` — clean
- `pnpm lint` — clean
- `pnpm peers check` — no unmet valibot peer

Both fixes were verified by running the same code against 1.7.1 and 1.8.0. A scratch consumer project also confirmed that with the currently published `@orpc/valibot@2.0.0-beta.35`, a valibot 1.4.x install already resolves `@valibot/to-json-schema@1.8.0` and warns once pnpm's release-age gate lapses.

Noted separately while reviewing, pre-existing and untouched here: converting a `v.set()` or `v.map()` whose element schema is recursive emits a `$defs` block nested under `items` while the `$ref` to it stays root-absolute, so that reference dangles.